### PR TITLE
Monitor goroutine leaks

### DIFF
--- a/go/obscuronode/enclave/server.go
+++ b/go/obscuronode/enclave/server.go
@@ -157,8 +157,8 @@ func (s *server) RoundWinner(_ context.Context, request *generated.RoundWinnerRe
 }
 
 func (s *server) Stop(context.Context, *generated.StopRequest) (*generated.StopResponse, error) {
-	err := s.enclave.Stop()
 	defer s.rpcServer.GracefulStop()
+	err := s.enclave.Stop()
 	return &generated.StopResponse{}, err
 }
 

--- a/go/obscuronode/enclave/server.go
+++ b/go/obscuronode/enclave/server.go
@@ -158,7 +158,7 @@ func (s *server) RoundWinner(_ context.Context, request *generated.RoundWinnerRe
 
 func (s *server) Stop(context.Context, *generated.StopRequest) (*generated.StopResponse, error) {
 	err := s.enclave.Stop()
-	s.rpcServer.GracefulStop()
+	defer s.rpcServer.GracefulStop()
 	return &generated.StopResponse{}, err
 }
 

--- a/go/obscuronode/host/host.go
+++ b/go/obscuronode/host/host.go
@@ -538,8 +538,9 @@ func (a *Node) monitorBlocks() {
 				latestBlkHeader.Number.Uint64())
 			a.RPCNewHead(obscurocommon.EncodeBlock(block), obscurocommon.EncodeBlock(blockParent))
 
+		// this timeout ensures we don't leak the goroutine
 		case <-time.After(1 * time.Second):
-			// check for interrupt
+			// break out of select and check for interrupt on the for loop
 		}
 	}
 }

--- a/integration/simulation/network/geth_network.go
+++ b/integration/simulation/network/geth_network.go
@@ -113,17 +113,14 @@ func (n *networkInMemGeth) Create(params *params.SimParams, stats *stats.Stats) 
 }
 
 func (n *networkInMemGeth) TearDown() {
+	defer n.gethNetwork.StopNodes()
 	for _, client := range n.obscuroClients {
 		temp := client
 		go func() {
+			defer (*temp).Stop()
 			_ = (*temp).Call(nil, obscuroclient.RPCStopHost)
-			(*temp).Stop()
 		}()
 	}
-
-	n.gethNetwork.StopNodes()
-	// double tap. todo: this is probably unnecessary
-	defer n.gethNetwork.StopNodes()
 }
 
 func createEthClientConnection(id int64, port uint, wallet wallet.Wallet, contractAddr common.Address) ethclient.EthClient {

--- a/integration/simulation/network/geth_network.go
+++ b/integration/simulation/network/geth_network.go
@@ -115,11 +115,15 @@ func (n *networkInMemGeth) Create(params *params.SimParams, stats *stats.Stats) 
 func (n *networkInMemGeth) TearDown() {
 	for _, client := range n.obscuroClients {
 		temp := client
-		go (*temp).Call(nil, obscuroclient.RPCStopHost) //nolint:errcheck
-		go (*temp).Stop()
+		go func() {
+			_ = (*temp).Call(nil, obscuroclient.RPCStopHost)
+			(*temp).Stop()
+		}()
 	}
 
 	n.gethNetwork.StopNodes()
+	// double tap. todo: this is probably unnecessary
+	defer n.gethNetwork.StopNodes()
 }
 
 func createEthClientConnection(id int64, port uint, wallet wallet.Wallet, contractAddr common.Address) ethclient.EthClient {

--- a/integration/simulation/network/inmemory.go
+++ b/integration/simulation/network/inmemory.go
@@ -82,8 +82,10 @@ func (n *basicNetworkOfInMemoryNodes) Create(params *params.SimParams, stats *st
 func (n *basicNetworkOfInMemoryNodes) TearDown() {
 	for _, client := range n.obscuroClients {
 		temp := client
-		go (*temp).Call(nil, obscuroclient.RPCStopHost) //nolint:errcheck
-		go (*temp).Stop()
+		go func() {
+			_ = (*temp).Call(nil, obscuroclient.RPCStopHost)
+			go (*temp).Stop()
+		}()
 	}
 
 	for _, node := range n.ethNodes {

--- a/integration/simulation/network/inmemory.go
+++ b/integration/simulation/network/inmemory.go
@@ -83,8 +83,8 @@ func (n *basicNetworkOfInMemoryNodes) TearDown() {
 	for _, client := range n.obscuroClients {
 		temp := client
 		go func() {
+			defer (*temp).Stop()
 			_ = (*temp).Call(nil, obscuroclient.RPCStopHost)
-			go (*temp).Stop()
 		}()
 	}
 

--- a/integration/simulation/simulation_tester.go
+++ b/integration/simulation/simulation_tester.go
@@ -17,7 +17,11 @@ import (
 
 // testSimulation encapsulates the shared logic for simulating and testing various types of nodes.
 func testSimulation(t *testing.T, netw network.Network, params *params.SimParams) {
-	log.Info("goroutine leak monitor - simulation start - %d go routines currently running", runtime.NumGoroutine())
+	defer func() {
+		// wait until clean up is complete before we log the lingering goroutine count
+		log.Info("goroutine leak monitor - simulation end - %d goroutines currently running", runtime.NumGoroutine())
+	}()
+	log.Info("goroutine leak monitor - simulation start - %d goroutines currently running", runtime.NumGoroutine())
 	rand.Seed(time.Now().UnixNano())
 	uuid.EnableRandPool()
 
@@ -49,5 +53,4 @@ func testSimulation(t *testing.T, netw network.Network, params *params.SimParams
 
 	// generate and print the final stats
 	t.Logf("Simulation results:%+v", NewOutputStats(&simulation))
-	log.Info("goroutine leak monitor - simulation end - %d go routines currently running", runtime.NumGoroutine())
 }


### PR DESCRIPTION
Some goroutines are leaking from simulations and are still running when the next simulation starts. This seems to be causing some issues and it would be good to reduce them over time/be able to rule it out as a contributor to flakey builds.

This change just adds logging at the beginning and end of sims to output number of running goroutines and does some refactors that might help (or at least shouldn't hurt). My very unscientific testing suggests it's knocked out about 50 leaked goroutines by the time the 3 sims have finished.

The changes mostly just add defers to try to guarantee cleanups will happen in the case of unexpected errors (reduce red herrings at least, even if the tests fail anyway). And I noticed from the log dump that about 15-20 goroutines were from the monitorBlocks() in host.go so I tweaked that to check for interrupts.