### PR TITLE
Fail fast in geth nodes test when ports are not available

### DIFF
--- a/integration/gethnetwork/geth_network.go
+++ b/integration/gethnetwork/geth_network.go
@@ -88,6 +88,8 @@ const (
 		  "balance": "1000000000000000000000"
 		}`
 	genesisJSONAddrKey = "address"
+
+	wsPortOffset = 100
 )
 
 // GethNetwork is a network of Geth nodes, built using the provided Geth binary.
@@ -154,7 +156,7 @@ func NewGethNetwork(portStart int, gethBinaryPath string, numNodes int, blockTim
 		passwordFilePath: passwordFile.Name(),
 		WebSocketPorts:   make([]uint, numNodes),
 		commStartPort:    portStart,
-		wsStartPort:      portStart + 100,
+		wsStartPort:      portStart + wsPortOffset,
 	}
 
 	// We create an account for each node.
@@ -362,10 +364,9 @@ func EnsurePortsAreAvailable(startPort int, numberNodes int) error {
 
 	for i := 0; i < numberNodes; i++ {
 		wg.Add(2)
-		go ensurePortAvailable(wg, mu, &unavailablePorts, startPort+i)     // commsPort
-		go ensurePortAvailable(wg, mu, &unavailablePorts, startPort+100+i) // wsPort
+		go ensurePortAvailable(wg, mu, &unavailablePorts, startPort+i)              // commsPort
+		go ensurePortAvailable(wg, mu, &unavailablePorts, startPort+wsPortOffset+i) // wsPort
 	}
-
 	wg.Wait()
 
 	if len(unavailablePorts) > 0 {

--- a/integration/simulation/network/geth_network.go
+++ b/integration/simulation/network/geth_network.go
@@ -40,11 +40,6 @@ func (n *networkInMemGeth) Create(params *params.SimParams, stats *stats.Stats) 
 		panic(err)
 	}
 
-	err = gethnetwork.EnsurePortsAreAvailable(params.StartPort, params.NumberOfNodes)
-	if err != nil {
-		panic(err)
-	}
-
 	// convert the wallets to strings
 	walletAddresses := make([]string, params.NumberOfObscuroWallets)
 	for i := 0; i < params.NumberOfObscuroWallets; i++ {

--- a/integration/simulation/network/geth_network.go
+++ b/integration/simulation/network/geth_network.go
@@ -40,6 +40,11 @@ func (n *networkInMemGeth) Create(params *params.SimParams, stats *stats.Stats) 
 		panic(err)
 	}
 
+	err = gethnetwork.EnsurePortsAreAvailable(params.StartPort, params.NumberOfNodes)
+	if err != nil {
+		panic(err)
+	}
+
 	// convert the wallets to strings
 	walletAddresses := make([]string, params.NumberOfObscuroWallets)
 	for i := 0; i < params.NumberOfObscuroWallets; i++ {


### PR DESCRIPTION
This just adds a crude check of all the ports that the geth binaries will be running with are available before the simulation network is started and fails quickly if not.

I don't know if this is a big problem or if this is the best way to deal with it but it's bitten me multiple times locally and it would be nice to rule it out on the build servers.

I managed to get myself into the bad state somehow locally, can see the processes lurking here while no test is running:
<img width="852" alt="Screenshot 2022-05-22 at 20 56 00" src="https://user-images.githubusercontent.com/98158711/169713659-091abd83-434f-4c3d-b1ac-09a93eeb76fe.png">

And on this branch the test fails immediately with:
<img width="1651" alt="Screenshot 2022-05-22 at 20 56 13" src="https://user-images.githubusercontent.com/98158711/169713668-2a3de4b5-6ef8-4d9a-a894-9ce55ba8a603.png">

Then I resolve it with something like:
<img width="334" alt="Screenshot 2022-05-22 at 21 03 24" src="https://user-images.githubusercontent.com/98158711/169713718-20948174-2535-43b5-a9bc-b96a1cc6229f.png">

And the test starts running fully again.