### PR TITLE
More meaningful error for the missing blockhead nil pointer in sims

### DIFF
--- a/integration/simulation/utils.go
+++ b/integration/simulation/utils.go
@@ -54,6 +54,10 @@ func getCurrentBlockHeadHeight(client *obscuroclient.Client) int64 {
 		panic(fmt.Errorf("simulation failed due to failed %s RPC call. Cause: %w", method, err))
 	}
 
+	if blockHead == nil || blockHead.Number == nil {
+		panic(fmt.Errorf("simulation failed - no current block head found in RPC response from host"))
+	}
+
 	return blockHead.Number.Int64()
 }
 


### PR DESCRIPTION
Quite often see nil pointer when failing to get a current blockhead because a node has been knocked out for some reason, sticking an error on it so it can be more recognisable.