### PR TITLE
SQL implementation for enclave persistence

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,9 +13,10 @@ require (
 	github.com/ethereum/go-ethereum v1.10.16
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/websocket v1.4.2
-	github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416
 	github.com/mattn/go-sqlite3 v1.14.13
+	github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416
 	github.com/rs/zerolog v1.26.1
+	github.com/status-im/keycard-go v0.0.0-20190316090335-8537d3370df4
 	github.com/stretchr/testify v1.7.1
 	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,9 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/websocket v1.4.2
 	github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416
+	github.com/mattn/go-sqlite3 v1.14.13
 	github.com/rs/zerolog v1.26.1
+	github.com/stretchr/testify v1.7.1
 	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	google.golang.org/grpc v1.45.0
@@ -37,6 +39,7 @@ require (
 	github.com/VictoriaMetrics/fastcache v1.6.0 // indirect
 	github.com/btcsuite/btcd v0.22.0-beta // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/deckarep/golang-set v1.8.0 // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect
 	github.com/docker/distribution v2.8.1+incompatible // indirect
@@ -67,6 +70,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/tsdb v0.7.1 // indirect
 	github.com/rs/cors v1.7.0 // indirect
 	github.com/shirou/gopsutil v3.21.4-0.20210419000835-c7a38de76ee5+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -439,6 +439,8 @@ github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzp
 github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-sqlite3 v1.11.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
+github.com/mattn/go-sqlite3 v1.14.13 h1:1tj15ngiFfcZzii7yd82foL+ks+ouQcj8j/TPq3fk1I=
+github.com/mattn/go-sqlite3 v1.14.13/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/mattn/go-tty v0.0.0-20180907095812-13ff1204f104/go.mod h1:XPvLUNfbS4fJH25nqRHfWLMa1ONC8Amw+mIA639KxkE=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=

--- a/go/obscuronode/enclave/db/interfaces.go
+++ b/go/obscuronode/enclave/db/interfaces.go
@@ -81,4 +81,4 @@ type Storage interface {
 // EthDBConnector is an abstraction for constructing/validating/connecting-to an eth-compatible key-value store.
 // The DB might be a simple in-memory map, a SQL DB for testing or a trusted enclave-based EdgelessDB instance.
 // Implementation should handle validation/attestation in the case of a secure DB
-type EthDBConnector func() (ethdb.Database, error)
+type EthDBConnector func(nodeID uint64) (ethdb.Database, error)

--- a/go/obscuronode/enclave/db/storage.go
+++ b/go/obscuronode/enclave/db/storage.go
@@ -7,7 +7,6 @@ import (
 	"github.com/obscuronet/obscuro-playground/go/log"
 	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/core"
 	obscurorawdb "github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/rawdb"
-
 	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
 
 	"github.com/ethereum/go-ethereum/common"

--- a/go/obscuronode/enclave/enclaverunner/cli_test.go
+++ b/go/obscuronode/enclave/enclaverunner/cli_test.go
@@ -7,10 +7,12 @@ import (
 	"testing"
 )
 
-const testToml = "/test.toml"
+const (
+	testToml        = "/test.toml"
+	expectedChainID = int64(1377)
+)
 
 func TestConfigIsParsedFromTomlFileIfConfigFlagIsPresent(t *testing.T) {
-	expectedChainID := int64(1377) //nolint
 	wd, err := os.Getwd()
 	if err != nil {
 		panic(err)
@@ -22,7 +24,6 @@ func TestConfigIsParsedFromTomlFileIfConfigFlagIsPresent(t *testing.T) {
 }
 
 func TestConfigIsParsedFromCmdLineFlagsIfConfigFlagIsNotPresent(t *testing.T) {
-	expectedChainID := int64(1377)
 	os.Args = append(os.Args, "--"+l1ChainIDName, strconv.FormatInt(expectedChainID, 10))
 
 	if config := ParseConfig(); config.L1ChainID != expectedChainID {

--- a/go/obscuronode/enclave/sql/README.md
+++ b/go/obscuronode/enclave/sql/README.md
@@ -1,0 +1,3 @@
+This package contains a sql implementation of ethdb.Database.
+
+Note: it seems quite odd to be creating a key value store with a sql database, but this allows us to plug in edgeless DB (which is a mysql-based database) as an enclave-secure persistent storage solution for Obscuro nodes

--- a/go/obscuronode/enclave/sql/batch.go
+++ b/go/obscuronode/enclave/sql/batch.go
@@ -1,0 +1,103 @@
+package sql
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethdb"
+)
+
+// ---- Implement the geth Batch interface, re-using ideas and types from geth's memorydb.go ----
+
+// keyvalue is a key-value tuple that can be flagged with a deletion field to allow creating database write batches.
+type keyvalue struct {
+	key    []byte
+	value  []byte
+	delete bool
+}
+
+type sqlBatch struct {
+	db     *sqlEthDatabase
+	writes []keyvalue
+	size   int
+}
+
+// Put inserts the given value into the batch for later committing.
+func (b *sqlBatch) Put(key, value []byte) error {
+	b.writes = append(b.writes, keyvalue{common.CopyBytes(key), common.CopyBytes(value), false})
+	b.size += len(key) + len(value)
+	return nil
+}
+
+// Delete inserts the a key removal into the batch for later committing.
+func (b *sqlBatch) Delete(key []byte) error {
+	b.writes = append(b.writes, keyvalue{common.CopyBytes(key), nil, true})
+	b.size += len(key)
+	return nil
+}
+
+// ValueSize retrieves the amount of data queued up for writing.
+func (b *sqlBatch) ValueSize() int {
+	return b.size
+}
+
+// Write executes a batch statement with all the updates
+func (b *sqlBatch) Write() error {
+	tx, err := b.db.db.Begin()
+	if err != nil {
+		return fmt.Errorf("failed to prepare batch transaction - %w", err)
+	}
+	pIns, err := tx.Prepare(`insert or replace into kv values(?, ?);`)
+	defer func() { _ = pIns.Close() }()
+	if err != nil {
+		return fmt.Errorf("failed to create batch prepared stmt - %w", err)
+	}
+	pDel, err := tx.Prepare(`delete from kv where kv.key = ?;`)
+	defer func() { _ = pDel.Close() }()
+	if err != nil {
+		return fmt.Errorf("failed to create batch prepared stmt - %w", err)
+	}
+
+	for _, keyvalue := range b.writes {
+		if keyvalue.delete {
+			_, err = pDel.Exec(keyvalue.key)
+			if err != nil {
+				return err
+			}
+		} else {
+			_, err = pIns.Exec(keyvalue.key, keyvalue.value)
+		}
+
+		if err != nil {
+			return fmt.Errorf("failed to exec batch statement. kv=%v, err=%w", keyvalue, err)
+		}
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		return fmt.Errorf("failed to commit batch of writes - %w", err)
+	}
+	return nil
+}
+
+// Reset resets the batch for reuse.
+func (b *sqlBatch) Reset() {
+	b.writes = b.writes[:0]
+	b.size = 0
+}
+
+// Replay replays the batch contents.
+func (b *sqlBatch) Replay(w ethdb.KeyValueWriter) error {
+	for _, keyvalue := range b.writes {
+		if keyvalue.delete {
+			if err := w.Delete(keyvalue.key); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := w.Put(keyvalue.key, keyvalue.value); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/go/obscuronode/enclave/sql/iter.go
+++ b/go/obscuronode/enclave/sql/iter.go
@@ -58,5 +58,7 @@ func (it *iterator) Value() []byte {
 func (it *iterator) Release() {
 	if it.rows != nil {
 		_ = it.rows.Close()
+		it.currKey = ""
+		it.currVal = []byte{}
 	}
 }

--- a/go/obscuronode/enclave/sql/iter.go
+++ b/go/obscuronode/enclave/sql/iter.go
@@ -1,0 +1,62 @@
+package sql
+
+import (
+	"database/sql"
+	"log"
+)
+
+// ---- iterator mostly ported from geth's memorydb.go ----
+
+// iterator can walk over the (potentially partial) keyspace of a memory key
+// value store. Internally it is a wrapper of the sql result iterator
+type iterator struct {
+	rows    *sql.Rows
+	currKey string
+	currVal []byte
+	err     error
+}
+
+// Next calls next on the sql Rows iterator and if there was a next then it sets the curr values for reading
+func (it *iterator) Next() bool {
+	next := it.err == nil && it.rows.Next()
+	if !next {
+		it.currKey = ""
+		it.currVal = []byte{}
+		return false
+	}
+
+	err := it.rows.Scan(&it.currKey, &it.currVal)
+	if err != nil {
+		log.Printf("failed to scan row in sql iterator - %s", err)
+		it.err = err
+	}
+	return true
+}
+
+// Error returns any accumulated error. Exhausting all the key/value pairs
+// is not considered to be an error. A memory iterator cannot encounter errors.
+func (it *iterator) Error() error {
+	return it.err
+}
+
+// Key returns the key of the current key/value pair, or nil if done. The caller
+// should not modify the contents of the returned slice, and its contents may
+// change on the next call to Next.
+func (it *iterator) Key() []byte {
+	return []byte(it.currKey)
+}
+
+// Value returns the value of the current key/value pair, or nil if done. The
+// caller should not modify the contents of the returned slice, and its contents
+// may change on the next call to Next.
+func (it *iterator) Value() []byte {
+	return it.currVal
+}
+
+// Release releases associated resources. Release should always succeed and can
+// be called multiple times without causing error.
+func (it *iterator) Release() {
+	if it.rows != nil {
+		_ = it.rows.Close()
+	}
+}

--- a/go/obscuronode/enclave/sql/sql.go
+++ b/go/obscuronode/enclave/sql/sql.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+
 	"github.com/ethereum/go-ethereum/ethdb"
 )
 

--- a/go/obscuronode/enclave/sql/sql.go
+++ b/go/obscuronode/enclave/sql/sql.go
@@ -1,0 +1,224 @@
+package sql
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/obscuronet/obscuro-playground/go/log"
+
+	"github.com/ethereum/go-ethereum/ethdb"
+)
+
+// sqlEthDatabase implements ethdb.Database
+type sqlEthDatabase struct {
+	db *sql.DB
+}
+
+func CreateSQLEthDatabase(db *sql.DB) (ethdb.Database, error) {
+	s := &sqlEthDatabase{db: db}
+	if err := s.Initialise(); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+func (m *sqlEthDatabase) Initialise() error {
+	stmt := `create table if not exists kv (key text primary key, value blob); delete from kv;`
+	if _, err := m.db.Exec(stmt); err != nil {
+		return fmt.Errorf("failed to initialise sql eth db - %w", err)
+	}
+
+	return nil
+}
+
+func (m *sqlEthDatabase) Has(key []byte) (bool, error) {
+	pFind, err := m.getFindPrepStmt()
+	if err != nil {
+		return false, err
+	}
+	defer pFind.Close()
+
+	err = pFind.QueryRow(key).Scan()
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+func (m *sqlEthDatabase) Get(key []byte) ([]byte, error) {
+	var res []byte
+	pFind, err := m.getFindPrepStmt()
+	if err != nil {
+		return []byte{}, err
+	}
+	defer pFind.Close()
+
+	err = pFind.QueryRow(key).Scan(&res)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+func (m *sqlEthDatabase) Put(key []byte, value []byte) error {
+	pIns, err := m.getInsertPrepStmt()
+	if err != nil {
+		return err
+	}
+	defer pIns.Close()
+
+	_, err = pIns.Exec(key, value)
+	return err
+}
+
+func (m *sqlEthDatabase) Delete(key []byte) error {
+	pDel, err := m.getDeletePrepStmt()
+	if err != nil {
+		return err
+	}
+	defer pDel.Close()
+
+	_, err = pDel.Exec(key)
+	return err
+}
+
+func (m *sqlEthDatabase) Close() error {
+	if err := m.db.Close(); err != nil {
+		return fmt.Errorf("failed to close sql db - %w", err)
+	}
+	return nil
+}
+
+func (m *sqlEthDatabase) NewBatch() ethdb.Batch {
+	log.Trace("SQL :: New batch")
+	return &sqlBatch{
+		db: m,
+	}
+}
+
+func (m *sqlEthDatabase) NewIterator(prefix []byte, start []byte) ethdb.Iterator {
+	pFindLike, err := m.getIteratorPrepStmt()
+	defer func() { _ = pFindLike.Close() }()
+	if err != nil {
+		return &iterator{
+			err: fmt.Errorf("failed to get prepared SQL stmt, iter will be empty, %w", err),
+		}
+	}
+	// todo: make sure we're stringifying that prefix correctly
+	pr := string(prefix)
+	st := string(append(prefix, start...))
+	rows, err := pFindLike.Query(pr+"%", st) //nolint:sqlclosecheck
+	defer func() { _ = pFindLike.Close() }()
+	if err != nil {
+		return &iterator{
+			err: fmt.Errorf("failed to get rows, iter will be empty, %w", err),
+		}
+	}
+	if err = rows.Err(); rows.Err() != nil {
+		return &iterator{
+			err: fmt.Errorf("failed to get rows, iter will be empty, %w", err),
+		}
+	}
+	return &iterator{
+		rows: rows,
+	}
+}
+
+func (m *sqlEthDatabase) Stat(property string) (string, error) {
+	// TODO implement me
+	panic("implement me")
+}
+
+func (m *sqlEthDatabase) Compact(start []byte, limit []byte) error {
+	// TODO implement me
+	panic("implement me")
+}
+
+func (m *sqlEthDatabase) getPrepStmt(query string) (*sql.Stmt, error) {
+	prep, err := m.db.Prepare(query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to prepare statement `%s` - %w", query, err)
+	}
+	return prep, nil
+}
+
+func (m *sqlEthDatabase) getFindPrepStmt() (*sql.Stmt, error) {
+	return m.getPrepStmt(`select kv.value from kv where kv.key = ?;`)
+}
+
+func (m *sqlEthDatabase) getInsertPrepStmt() (*sql.Stmt, error) {
+	return m.getPrepStmt(`insert or replace into kv values(?, ?);`)
+}
+
+func (m *sqlEthDatabase) getDeletePrepStmt() (*sql.Stmt, error) {
+	return m.getPrepStmt(`delete from kv where kv.key = ?;`)
+}
+
+func (m *sqlEthDatabase) getIteratorPrepStmt() (*sql.Stmt, error) {
+	return m.getPrepStmt(`select * from kv where kv.key like ? and kv.key > ?`)
+}
+
+// no-freeze! Copied from the geth in-memory db implementation these ancient method implementations disable the 'freezer'
+
+// errNotSupported is returned if the database doesn't support the required operation.
+var errNotSupported = errors.New("this operation is not supported")
+
+// HasAncient returns an error as we don't have a backing chain freezer.
+func (m *sqlEthDatabase) HasAncient(kind string, number uint64) (bool, error) {
+	return false, errNotSupported
+}
+
+// Ancient returns an error as we don't have a backing chain freezer.
+func (m *sqlEthDatabase) Ancient(kind string, number uint64) ([]byte, error) {
+	return nil, errNotSupported
+}
+
+// AncientRange returns an error as we don't have a backing chain freezer.
+func (m *sqlEthDatabase) AncientRange(kind string, start, max, maxByteSize uint64) ([][]byte, error) {
+	return nil, errNotSupported
+}
+
+// Ancients returns an error as we don't have a backing chain freezer.
+func (m *sqlEthDatabase) Ancients() (uint64, error) {
+	return 0, errNotSupported
+}
+
+// AncientSize returns an error as we don't have a backing chain freezer.
+func (m *sqlEthDatabase) AncientSize(kind string) (uint64, error) {
+	return 0, errNotSupported
+}
+
+// ModifyAncients is not supported.
+func (m *sqlEthDatabase) ModifyAncients(func(ethdb.AncientWriteOp) error) (int64, error) {
+	return 0, errNotSupported
+}
+
+// TruncateAncients returns an error as we don't have a backing chain freezer.
+func (m *sqlEthDatabase) TruncateAncients(items uint64) error {
+	return errNotSupported
+}
+
+// Sync returns an error as we don't have a backing chain freezer.
+func (m *sqlEthDatabase) Sync() error {
+	return errNotSupported
+}
+
+func (m *sqlEthDatabase) ReadAncients(fn func(reader ethdb.AncientReader) error) (err error) {
+	// Unlike other ancient-related methods, this method does not return
+	// errNotSupported when invoked.
+	// The reason for this is that the caller might want to do several things:
+	// 1. Check if something is in freezer,
+	// 2. If not, check leveldb.
+	//
+	// This will work, since the ancient-checks inside 'fn' will return errors,
+	// and the leveldb work will continue.
+	//
+	// If we instead were to return errNotSupported here, then the caller would
+	// have to explicitly check for that, having an extra clause to do the
+	// non-ancient operations.
+	return fn(m)
+}

--- a/go/obscuronode/enclave/sql/sql_test.go
+++ b/go/obscuronode/enclave/sql/sql_test.go
@@ -1,0 +1,118 @@
+package sql
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/ethdb"
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPutAndGetAndDelHappyPath(t *testing.T) {
+	db := createDB(t)
+	defer cleanUp(db)
+
+	putData(t, db, "key1", "val1")
+
+	found, err := db.Get([]byte("key1"))
+	failIfError(t, err, "failed to retrieve value")
+	assert.Equal(t, found, []byte("val1"))
+
+	err = db.Delete([]byte("key1"))
+	failIfError(t, err, "failed to delete entry")
+
+	_, err = db.Get([]byte("key1"))
+	if err == nil {
+		t.Fatal("expected get to fail fetch after deletion")
+	}
+}
+
+func TestIteratorHappyPath(t *testing.T) {
+	db := createDB(t)
+	defer cleanUp(db)
+
+	putData(t, db, "key1", "val1")
+	putData(t, db, "key2", "val2")
+	putData(t, db, "diffKey3", "val3")
+
+	iter := db.NewIterator([]byte("key"), nil)
+	assert.Nil(t, iter.Error())
+
+	assert.True(t, iter.Next())
+	assert.Equal(t, []byte("key1"), iter.Key())
+	assert.Equal(t, []byte("val1"), iter.Value())
+
+	assert.True(t, iter.Next())
+	assert.Equal(t, []byte("key2"), iter.Key())
+	assert.Equal(t, []byte("val2"), iter.Value())
+
+	// we expect the other entry to be filtered by the iterator prefix
+	assert.False(t, iter.Next())
+}
+
+func TestBatchUpdateHappyPath(t *testing.T) {
+	db := createDB(t)
+	defer cleanUp(db)
+
+	batch := db.NewBatch()
+	err := batch.Put([]byte("key1"), []byte("value1"))
+	failIfError(t, err, "failed to insert in batch")
+	err = batch.Put([]byte("key2"), []byte("value2"))
+	failIfError(t, err, "failed to insert in batch")
+	err = batch.Put([]byte("key3"), []byte("value3"))
+	failIfError(t, err, "failed to insert in batch")
+	err = batch.Delete([]byte("key2"))
+	failIfError(t, err, "failed to delete from batch")
+
+	err = batch.Write()
+	failIfError(t, err, "failed to write batch")
+
+	batch.Reset()
+
+	found, err := db.Get([]byte("key3"))
+	failIfError(t, err, "expected key3 to be in the db")
+	assert.Equal(t, found, []byte("value3"))
+
+	_, err = db.Get([]byte("key2"))
+	if err == nil {
+		t.Fatal("expected get to fail fetch after deletion")
+	}
+}
+
+func createDB(t *testing.T) ethdb.Database {
+	// todo: is it valid to use sqlite for testing when we'll be using a mysql-based db?
+	lite := setupSQLite(t)
+	s, err := CreateSQLEthDatabase(lite)
+	if err != nil {
+		panic(err)
+	}
+	return s
+}
+
+func cleanUp(db ethdb.Database) {
+	_ = db.Close()
+}
+
+func putData(t *testing.T, db ethdb.Database, key string, val string) {
+	err := db.Put([]byte(key), []byte(val))
+	failIfError(t, err, "failed to insert into db")
+}
+
+func failIfError(t *testing.T, err error, msg string) {
+	if err != nil {
+		t.Fatal(msg, err)
+	}
+}
+
+func setupSQLite(t *testing.T) *sql.DB {
+	// create temp sqlite db
+	d := t.TempDir()
+	f := filepath.Join(d, "test.db")
+	db, err := sql.Open("sqlite3", f)
+	if err != nil {
+		panic(err)
+	}
+	return db
+}

--- a/go/obscuronode/enclave/sql/sql_test.go
+++ b/go/obscuronode/enclave/sql/sql_test.go
@@ -84,10 +84,10 @@ func TestBatchUpdateHappyPath(t *testing.T) {
 func createDB(t *testing.T) ethdb.Database {
 	// todo: is it valid to use sqlite for testing when we'll be using a mysql-based db?
 	lite := setupSQLite(t)
+	_, err := lite.Exec(createQry)
+	failIfError(t, err, "Failed to create key-value table in test db")
 	s, err := CreateSQLEthDatabase(lite)
-	if err != nil {
-		panic(err)
-	}
+	failIfError(t, err, "Failed to create SQLEthDatabase for test")
 	return s
 }
 

--- a/go/obscuronode/enclave/sql/sql_test.go
+++ b/go/obscuronode/enclave/sql/sql_test.go
@@ -2,9 +2,10 @@ package sql
 
 import (
 	"database/sql"
-	"github.com/status-im/keycard-go/hexutils"
 	"path/filepath"
 	"testing"
+
+	"github.com/status-im/keycard-go/hexutils"
 
 	"github.com/ethereum/go-ethereum/ethdb"
 	_ "github.com/mattn/go-sqlite3"

--- a/go/obscuronode/enclave/sql/sqlite.go
+++ b/go/obscuronode/enclave/sql/sqlite.go
@@ -1,0 +1,40 @@
+package sql
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/ethereum/go-ethereum/ethdb"
+	_ "github.com/mattn/go-sqlite3" // this imports the sqlite driver to make the sql.Open() connection work
+)
+
+const (
+	tempDirName = "temp-obscuro-persistence"
+)
+
+func CreateTemporarySQLiteDB(nodeID uint64) (ethdb.Database, error) {
+	dbFile, err := getTempDBFile(nodeID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temp sqlite DB file - %w", err)
+	}
+	db, err := sql.Open("sqlite3", dbFile)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't create temp sqlite db - %w", err)
+	}
+	return CreateSQLEthDatabase(db)
+}
+
+func getTempDBFile(nodeID uint64) (string, error) {
+	tempDir := filepath.Join("/tmp", tempDirName)
+	err := os.MkdirAll(tempDir, os.ModePerm)
+	if err != nil {
+		return "", fmt.Errorf("failed to create sqlite temp dir - %w", err)
+	}
+	// by using nodeIDs we ensure we overwrite old DBs when starting new tests
+	tempFile := filepath.Join(tempDir, fmt.Sprintf("enclave-%v.db", nodeID))
+	// delete old db if it exists
+	_ = os.Remove(tempFile)
+	return tempFile, nil
+}

--- a/go/obscuronode/enclave/sql/sqlite.go
+++ b/go/obscuronode/enclave/sql/sqlite.go
@@ -12,6 +12,7 @@ import (
 
 const (
 	tempDirName = "temp-obscuro-persistence"
+	createQry   = `create table if not exists kv (key text primary key, value blob); delete from kv;`
 )
 
 func CreateTemporarySQLiteDB(nodeID uint64) (ethdb.Database, error) {
@@ -22,6 +23,10 @@ func CreateTemporarySQLiteDB(nodeID uint64) (ethdb.Database, error) {
 	db, err := sql.Open("sqlite3", dbFile)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't create temp sqlite db - %w", err)
+	}
+
+	if _, err := db.Exec(createQry); err != nil {
+		return nil, fmt.Errorf("failed to create sqlite db table - %w", err)
 	}
 	return CreateSQLEthDatabase(db)
 }

--- a/go/obscuronode/enclave/sql/sqlite.go
+++ b/go/obscuronode/enclave/sql/sqlite.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	tempDirName = "temp-obscuro-persistence"
-	createQry   = `create table if not exists kv (key text primary key, value blob); delete from kv;`
+	createQry   = `create table if not exists kv (key binary(32) primary key, value blob); delete from kv;`
 )
 
 func CreateTemporarySQLiteDB(nodeID uint64) (ethdb.Database, error) {

--- a/integration/simulation/network/socket.go
+++ b/integration/simulation/network/socket.go
@@ -118,7 +118,7 @@ func (n *networkOfSocketNodes) Create(params *params.SimParams, stats *stats.Sta
 			ValidateL1Blocks: false,
 			WillAttest:       false,
 			GenesisJSON:      nil,
-			UseInMemoryDB:    true,
+			UseInMemoryDB:    false,
 		}
 		_, err := enclave.StartServer(enclaveConfig, params.MgmtContractLib, params.ERC20ContractLib, stats)
 		if err != nil {

--- a/integration/simulation/simulation.go
+++ b/integration/simulation/simulation.go
@@ -36,7 +36,9 @@ func (s *Simulation) Start() {
 
 	s.WaitForObscuroGenesis()
 
-	time.Sleep(3 * time.Second)
+	// arbitrary sleep to wait for RPC clients to get up and running
+	time.Sleep(5 * time.Second)
+
 	timer := time.Now()
 	log.Info("Starting injection")
 	go s.TxInjector.Start()


### PR DESCRIPTION
### Why is this change needed?

- As a pre-requisite for using Edgeless DB for the enclave persistence we need a SQL implementation of the ethdb.Database interfaces
- To be able to test that without an SGX-powered enclave we need to be able to start enclave with a basic SQL database

### What changes were made as part of this PR:

- SQL implementation of the parts of the ethdb.Database interfaces that we're using
- Add a dummy sqlite database that spins up with non-secure, persistent enclave servers

### What are the key areas to look at
- the dummy sqlite database setup and its use in the full-network integration test
- the sql implementation of the interfaces - a lot of the code in there is copy-paste from the geth in-mem db and there's some basic test coverage that we can extend if we find gaps
