### PR TITLE
ensure generateKeyPair() not called multiple times

### DIFF
--- a/go/obscuronode/config/host_config.go
+++ b/go/obscuronode/config/host_config.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	defaultRPCTimeoutSecs          = 3
+	defaultRPCTimeoutSecs          = 10
 	defaultL1ConnectionTimeoutSecs = 15
 )
 

--- a/go/obscuronode/enclave/enclave.go
+++ b/go/obscuronode/enclave/enclave.go
@@ -621,6 +621,8 @@ func NewEnclave(
 	}
 
 	privKey := generateKeyPair()
+	serializedPubKey := x509.MarshalPKCS1PublicKey(&privKey.PublicKey)
+	nodecommon.LogWithID(nodeShortID, "Generated public key %s", common.Bytes2Hex(serializedPubKey))
 
 	return &enclaveImpl{
 		nodeID:                      nodeID,
@@ -642,7 +644,7 @@ func NewEnclave(
 		chainID:                     chainID,
 		attestationProvider:         attestationProvider,
 		privateKey:                  privKey,
-		publicKeySerialized:         x509.MarshalPKCS1PublicKey(&privKey.PublicKey),
+		publicKeySerialized:         serializedPubKey,
 	}
 }
 

--- a/go/obscuronode/enclave/enclave.go
+++ b/go/obscuronode/enclave/enclave.go
@@ -61,7 +61,6 @@ type enclaveImpl struct {
 }
 
 func (e *enclaveImpl) IsReady() error {
-	e.generateKeyPair()
 	return nil // The enclave is local so it is always ready
 }
 
@@ -537,8 +536,7 @@ func (e *enclaveImpl) blockStateBlockSubmissionResponse(bs *obscurocore.BlockSta
 
 func (e *enclaveImpl) generateKeyPair() {
 	if len(e.publicKeySerialized) > 0 {
-		// keys already created
-		return
+		panic("This should only be called once, at initialisation time.")
 	}
 	// todo: This should be generated deterministically based on some enclave attributes if possible
 	key, err := rsa.GenerateKey(rand.Reader, 4096)
@@ -627,7 +625,7 @@ func NewEnclave(
 		attestationProvider = &DummyAttestationProvider{}
 	}
 
-	return &enclaveImpl{
+	enclave := &enclaveImpl{
 		nodeID:                      nodeID,
 		nodeShortID:                 nodeShortID,
 		mining:                      mining,
@@ -647,6 +645,8 @@ func NewEnclave(
 		chainID:                     chainID,
 		attestationProvider:         attestationProvider,
 	}
+	enclave.generateKeyPair()
+	return enclave
 }
 
 // EncryptWithPublicKey encrypts data with public key

--- a/go/obscuronode/enclave/server.go
+++ b/go/obscuronode/enclave/server.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/obscuronet/obscuro-playground/go/log"
 	"net"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -70,6 +71,7 @@ func StartServer(
 
 // IsReady returns a nil error to indicate that the server is ready.
 func (s *server) IsReady(context.Context, *generated.IsReadyRequest) (*generated.IsReadyResponse, error) {
+	log.Info("Received isReady request.")
 	errStr := ""
 	if err := s.enclave.IsReady(); err != nil {
 		errStr = err.Error()

--- a/go/obscuronode/enclave/server.go
+++ b/go/obscuronode/enclave/server.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/obscuronet/obscuro-playground/go/log"
 	"net"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -71,7 +70,6 @@ func StartServer(
 
 // IsReady returns a nil error to indicate that the server is ready.
 func (s *server) IsReady(context.Context, *generated.IsReadyRequest) (*generated.IsReadyResponse, error) {
-	log.Info("Received isReady request.")
 	errStr := ""
 	if err := s.enclave.IsReady(); err != nil {
 		errStr = err.Error()

--- a/go/obscuronode/host/host.go
+++ b/go/obscuronode/host/host.go
@@ -112,6 +112,7 @@ func (a *Node) Start() {
 
 	a.waitForEnclave()
 
+	// todo: we should try to recover the key from a previous run of the node here? Before generating or requesting the key.
 	if a.config.IsGenesis {
 		nodecommon.LogWithID(a.shortID, "Node is genesis node. Broadcasting secret.")
 		// Create the shared secret and submit it to the management contract for storage
@@ -123,9 +124,7 @@ func (a *Node) Start() {
 		}
 		a.broadcastTx(a.mgmtContractLib.CreateStoreSecret(l1tx, a.ethWallet.GetNonceAndIncrement()))
 		nodecommon.LogWithID(a.shortID, "Node is genesis node. Secret was broadcasted.")
-	}
-
-	if !a.EnclaveClient.IsInitialised() {
+	} else {
 		a.requestSecret()
 	}
 

--- a/go/obscuronode/host/host.go
+++ b/go/obscuronode/host/host.go
@@ -224,9 +224,9 @@ func (a *Node) IsReady() bool {
 // Waits for enclave to be available, printing a wait message every two seconds.
 func (a *Node) waitForEnclave() {
 	counter := 0
-	for a.EnclaveClient.IsReady() != nil {
+	for err := a.EnclaveClient.IsReady(); err != nil; {
 		if counter >= 20 {
-			nodecommon.LogWithID(a.shortID, "Waiting for enclave. Error: %v", a.EnclaveClient.IsReady())
+			nodecommon.LogWithID(a.shortID, "Waiting for enclave. Error: %v", err)
 			counter = 0
 		}
 

--- a/integration/simulation/simulation_full_network_test.go
+++ b/integration/simulation/simulation_full_network_test.go
@@ -61,6 +61,7 @@ func TestFullNetworkMonteCarloSimulation(t *testing.T) {
 		NodeEthWallets:            nodeWallets,
 		SimEthWallets:             simWallets,
 		StartPort:                 integration.StartPortSimulationFullNetwork,
+		WaitForP2PConnections:     true,
 	}
 
 	simParams.AvgNetworkLatency = simParams.AvgBlockDuration / 15

--- a/integration/simulation/simulation_geth_in_mem_test.go
+++ b/integration/simulation/simulation_geth_in_mem_test.go
@@ -57,6 +57,7 @@ func TestGethSimulation(t *testing.T) {
 		NodeEthWallets:            nodeWallets,
 		SimEthWallets:             simWallets,
 		StartPort:                 integration.StartPortSimulationGethInMem,
+		WaitForP2PConnections:     true,
 	}
 
 	simParams.AvgNetworkLatency = simParams.AvgBlockDuration / 15

--- a/integration/simulation/simulation_tester.go
+++ b/integration/simulation/simulation_tester.go
@@ -60,6 +60,8 @@ func testSimulation(t *testing.T, netw network.Network, params *params.SimParams
 		log.Info("Waiting for P2P connections to be available.")
 	}
 
+	// wait for obscuro clients to be connectable too
+
 	// execute the simulation
 	simulation.Start()
 


### PR DESCRIPTION
Joel found examples of failures to decrypt secrets and the smoking gun was that the node in question had generated its private key more than once.

This PR moves the generateKeyPair() call to be done once at initialization rather than checking the key has been generated when the IsReady() rpc request is made.