### PR TITLE
dont executed workflow on pull requests

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -3,8 +3,6 @@ name: Build PR
 
 on:
   push:
-    branches:
-      - main
 
 jobs:
   build:

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -2,7 +2,7 @@ name: Build PR
 # Builds and runs tests on each push to a branch PR'ed against main.
 
 on:
-  pull_request:
+  push:
     branches:
       - main
 


### PR DESCRIPTION
According to [this](https://github.community/t/self-hosted-runner-security-with-public-repositories/17860/15), this change should be enough to prevent forked repos to run actions