### PR TITLE
Fix duplicate rollups flaky tests

### DIFF
--- a/go/obscuronode/enclave/state.go
+++ b/go/obscuronode/enclave/state.go
@@ -84,7 +84,6 @@ func updateState(
 		obscurocommon.ShortHash(bs.HeadRollup),
 	))
 
-	bss.SetBlockState(b.Hash(), bs, head)
 	if bs.FoundNewRollup {
 		// todo - root
 		_, err := stateDB.Commit(true)
@@ -92,6 +91,7 @@ func updateState(
 			log.Panic("could not commit new rollup to state DB. Cause: %s", err)
 		}
 	}
+	bss.SetBlockState(b.Hash(), bs, head)
 
 	return bs
 }

--- a/go/obscuronode/host/host.go
+++ b/go/obscuronode/host/host.go
@@ -400,6 +400,8 @@ func (a *Node) handleRoundWinner(result nodecommon.BlockSubmissionResponse) func
 				Rollup: nodecommon.EncodeRollup(winnerRollup.ToRollup()),
 			}
 
+			// That handler can get called multiple times for the same height. And it will return the same winner rollup.
+			// In case the winning rollup belongs to the current enclave it will be submitted again, which is inefficient.
 			if !a.DB().WasSubmitted(winnerRollup.Header.Hash()) {
 				a.broadcastTx(a.mgmtContractLib.CreateRollup(tx, a.ethWallet.GetNonceAndIncrement()))
 				a.DB().AddSubmittedRollup(winnerRollup.Header.Hash())

--- a/go/obscuronode/host/host.go
+++ b/go/obscuronode/host/host.go
@@ -400,7 +400,10 @@ func (a *Node) handleRoundWinner(result nodecommon.BlockSubmissionResponse) func
 				Rollup: nodecommon.EncodeRollup(winnerRollup.ToRollup()),
 			}
 
-			a.broadcastTx(a.mgmtContractLib.CreateRollup(tx, a.ethWallet.GetNonceAndIncrement()))
+			if !a.DB().WasSubmitted(winnerRollup.Header.Hash()) {
+				a.broadcastTx(a.mgmtContractLib.CreateRollup(tx, a.ethWallet.GetNonceAndIncrement()))
+				a.DB().AddSubmittedRollup(winnerRollup.Header.Hash())
+			}
 		}
 	}
 }

--- a/integration/ethereummock/mock_l1_network.go
+++ b/integration/ethereummock/mock_l1_network.go
@@ -85,7 +85,7 @@ func printBlock(b *types.Block, m Node) string {
 		switch l1Tx := t.(type) {
 		case *obscurocommon.L1RollupTx:
 			r := nodecommon.DecodeRollupOrPanic(l1Tx.Rollup)
-			txs = append(txs, fmt.Sprintf("r_%d", obscurocommon.ShortHash(r.Hash())))
+			txs = append(txs, fmt.Sprintf("r_%d(nonce=%d)", obscurocommon.ShortHash(r.Hash()), tx.Nonce()))
 
 		case *obscurocommon.L1DepositTx:
 			var to uint64


### PR DESCRIPTION
- fix a flakyness where there was no root trie available when asking for the head 
- check that the rollup wasn't submitted already