### PR TITLE
Add config to turn-on persistent enclave database

### DIFF
--- a/go/obscuronode/config/enclave_config.go
+++ b/go/obscuronode/config/enclave_config.go
@@ -46,6 +46,6 @@ func DefaultEnclaveConfig() EnclaveConfig {
 		ERC20ContractAddresses:    []*common.Address{},
 		WriteToLogs:               false,
 		LogPath:                   "enclave_logs.txt",
-		UseInMemoryDB:             false,
+		UseInMemoryDB:             true,
 	}
 }

--- a/go/obscuronode/config/enclave_config.go
+++ b/go/obscuronode/config/enclave_config.go
@@ -28,6 +28,8 @@ type EnclaveConfig struct {
 	WriteToLogs bool
 	// The path that the node's logs are written to
 	LogPath string
+	// Whether enclave should use in-memory or persistent storage
+	UseInMemoryDb bool
 }
 
 // DefaultEnclaveConfig returns an EnclaveConfig with default values.
@@ -44,5 +46,6 @@ func DefaultEnclaveConfig() EnclaveConfig {
 		ERC20ContractAddresses:    []*common.Address{},
 		WriteToLogs:               false,
 		LogPath:                   "enclave_logs.txt",
+		UseInMemoryDb:             false,
 	}
 }

--- a/go/obscuronode/config/enclave_config.go
+++ b/go/obscuronode/config/enclave_config.go
@@ -29,7 +29,7 @@ type EnclaveConfig struct {
 	// The path that the node's logs are written to
 	LogPath string
 	// Whether enclave should use in-memory or persistent storage
-	UseInMemoryDb bool
+	UseInMemoryDB bool
 }
 
 // DefaultEnclaveConfig returns an EnclaveConfig with default values.
@@ -46,6 +46,6 @@ func DefaultEnclaveConfig() EnclaveConfig {
 		ERC20ContractAddresses:    []*common.Address{},
 		WriteToLogs:               false,
 		LogPath:                   "enclave_logs.txt",
-		UseInMemoryDb:             false,
+		UseInMemoryDB:             false,
 	}
 }

--- a/go/obscuronode/enclave/db/interfaces.go
+++ b/go/obscuronode/enclave/db/interfaces.go
@@ -4,6 +4,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
 	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/core"
 	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
@@ -76,3 +77,8 @@ type Storage interface {
 	SharedSecretStorage
 	BlockStateStorage
 }
+
+// EthDBConnector is an abstraction for constructing/validating/connecting-to an eth-compatible key-value store.
+// The DB might be a simple in-memory map, a SQL DB for testing or a trusted enclave-based EdgelessDB instance.
+// Implementation should handle validation/attestation in the case of a secure DB
+type EthDBConnector func() (ethdb.Database, error)

--- a/go/obscuronode/enclave/db/storage.go
+++ b/go/obscuronode/enclave/db/storage.go
@@ -22,10 +22,9 @@ type storageImpl struct {
 	nodeID  uint64
 }
 
-func NewStorage(db *InMemoryDB, nodeID uint64) Storage {
-	backingDB := rawdb.NewMemoryDatabase()
+func NewStorage(tempDB *InMemoryDB, backingDB ethdb.Database, nodeID uint64) Storage {
 	return &storageImpl{
-		tempDB:  db,
+		tempDB:  tempDB,
 		db:      backingDB,
 		stateDB: state.NewDatabase(backingDB),
 		nodeID:  nodeID,

--- a/go/obscuronode/enclave/enclave.go
+++ b/go/obscuronode/enclave/enclave.go
@@ -8,10 +8,11 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"github.com/ethereum/go-ethereum/core/rawdb"
-	"github.com/ethereum/go-ethereum/ethdb"
 	"math/big"
 	"sync"
+
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/ethdb"
 
 	"github.com/obscuronet/obscuro-playground/go/obscuronode/config"
 
@@ -711,7 +712,7 @@ func DecryptWithPrivateKey(ciphertext []byte, priv *rsa.PrivateKey) ([]byte, err
 
 // getDBConnector creates an appropriate EthDBConnector function based on your config
 func getDBConnector(cfg config.EnclaveConfig) db.EthDBConnector {
-	if cfg.UseInMemoryDb {
+	if cfg.UseInMemoryDB {
 		// not persistent
 		return func() (ethdb.Database, error) {
 			return rawdb.NewMemoryDatabase(), nil

--- a/go/obscuronode/enclave/enclave.go
+++ b/go/obscuronode/enclave/enclave.go
@@ -8,6 +8,8 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/ethdb"
 	"math/big"
 	"sync"
 
@@ -633,9 +635,15 @@ func NewEnclave(
 	erc20ContractLib erc20contractlib.ERC20ContractLib,
 	collector StatsCollector,
 ) nodecommon.Enclave {
-	backingDB := db.NewInMemoryDB()
+	tempDB := db.NewInMemoryDB()
 	nodeShortID := obscurocommon.ShortAddress(config.HostID)
-	storage := db.NewStorage(backingDB, nodeShortID)
+
+	connect := getDBConnector(config)
+	backingDB, err := connect()
+	if err != nil {
+		log.Panic("Failed to connect to backing database - %s", err)
+	}
+	storage := db.NewStorage(tempDB, backingDB, nodeShortID)
 
 	var l1Blockchain *core.BlockChain
 	if config.ValidateL1Blocks {
@@ -699,4 +707,22 @@ func DecryptWithPrivateKey(ciphertext []byte, priv *rsa.PrivateKey) ([]byte, err
 		return nil, fmt.Errorf("failed to decrypt with private key. %w", err)
 	}
 	return plaintext, nil
+}
+
+// getDBConnector creates an appropriate EthDBConnector function based on your config
+func getDBConnector(cfg config.EnclaveConfig) db.EthDBConnector {
+	if cfg.UseInMemoryDb {
+		// not persistent
+		return func() (ethdb.Database, error) {
+			return rawdb.NewMemoryDatabase(), nil
+		}
+	}
+
+	if !cfg.WillAttest {
+		// persistent but not secure in an enclave, we'll connect to a sqlite DB and test out persistence/sql implementations
+		panic("Haven't implemented sql ethdb interface yet")
+	}
+
+	// persistent and with attestation means connecting to edgeless DB in a trusted enclave from a secure enclave
+	panic("Haven't implemented edgeless DB enclave connection yet")
 }

--- a/go/obscuronode/enclave/enclaverunner/cli.go
+++ b/go/obscuronode/enclave/enclaverunner/cli.go
@@ -23,6 +23,7 @@ type EnclaveConfigToml struct {
 	ERC20ContractAddresses    []string
 	WriteToLogs               bool
 	LogPath                   string
+	UseInMemoryDb             bool
 }
 
 // ParseConfig returns a config.EnclaveConfig based on either the file identified by the `config` flag, or the flags
@@ -41,6 +42,7 @@ func ParseConfig() config.EnclaveConfig {
 	erc20ContractAddrs := flag.String(erc20contractAddrsName, "", erc20contractAddrsUsage)
 	writeToLogs := flag.Bool(writeToLogsName, defaultConfig.WriteToLogs, writeToLogsUsage)
 	logPath := flag.String(logPathName, defaultConfig.LogPath, logPathUsage)
+	useInMemoryDB := flag.Bool(useInMemoryDBName, defaultConfig.UseInMemoryDb, useInMemoryDBUsage)
 
 	flag.Parse()
 
@@ -70,6 +72,7 @@ func ParseConfig() config.EnclaveConfig {
 	defaultConfig.ERC20ContractAddresses = erc20contractAddresses
 	defaultConfig.WriteToLogs = *writeToLogs
 	defaultConfig.LogPath = *logPath
+	defaultConfig.UseInMemoryDb = *useInMemoryDB
 
 	return defaultConfig
 }

--- a/go/obscuronode/enclave/enclaverunner/cli.go
+++ b/go/obscuronode/enclave/enclaverunner/cli.go
@@ -23,7 +23,7 @@ type EnclaveConfigToml struct {
 	ERC20ContractAddresses    []string
 	WriteToLogs               bool
 	LogPath                   string
-	UseInMemoryDb             bool
+	UseInMemoryDB             bool
 }
 
 // ParseConfig returns a config.EnclaveConfig based on either the file identified by the `config` flag, or the flags
@@ -42,7 +42,7 @@ func ParseConfig() config.EnclaveConfig {
 	erc20ContractAddrs := flag.String(erc20contractAddrsName, "", erc20contractAddrsUsage)
 	writeToLogs := flag.Bool(writeToLogsName, defaultConfig.WriteToLogs, writeToLogsUsage)
 	logPath := flag.String(logPathName, defaultConfig.LogPath, logPathUsage)
-	useInMemoryDB := flag.Bool(useInMemoryDBName, defaultConfig.UseInMemoryDb, useInMemoryDBUsage)
+	useInMemoryDB := flag.Bool(useInMemoryDBName, defaultConfig.UseInMemoryDB, useInMemoryDBUsage)
 
 	flag.Parse()
 
@@ -72,7 +72,7 @@ func ParseConfig() config.EnclaveConfig {
 	defaultConfig.ERC20ContractAddresses = erc20contractAddresses
 	defaultConfig.WriteToLogs = *writeToLogs
 	defaultConfig.LogPath = *logPath
-	defaultConfig.UseInMemoryDb = *useInMemoryDB
+	defaultConfig.UseInMemoryDB = *useInMemoryDB
 
 	return defaultConfig
 }
@@ -107,5 +107,6 @@ func fileBasedConfig(configPath string) config.EnclaveConfig {
 		ERC20ContractAddresses:    erc20contractAddresses,
 		WriteToLogs:               tomlConfig.WriteToLogs,
 		LogPath:                   tomlConfig.LogPath,
+		UseInMemoryDB:             tomlConfig.UseInMemoryDB,
 	}
 }

--- a/go/obscuronode/enclave/enclaverunner/cli_flags.go
+++ b/go/obscuronode/enclave/enclaverunner/cli_flags.go
@@ -34,4 +34,7 @@ const (
 
 	logPathName  = "logPath"
 	logPathUsage = "The path to use for the enclave service's log file"
+
+	useInMemoryDBName  = "useInMemoryDB"
+	useInMemoryDBUsage = "Whether the enclave will use an in-memory DB rather than persist data"
 )

--- a/go/obscuronode/enclave/enclaverunner/test.toml
+++ b/go/obscuronode/enclave/enclaverunner/test.toml
@@ -8,3 +8,4 @@ managementContractAddress = "0x0000000000000000000000000000000000000000"
 erc20ContractAddresses = []
 writeToLogs = false
 logPath = "enclave_logs.txt"
+useInMemoryDb = true

--- a/integration/simulation/network/azureenclave.go
+++ b/integration/simulation/network/azureenclave.go
@@ -90,6 +90,7 @@ func (n *networkWithAzureEnclaves) Create(params *params.SimParams, stats *stats
 			WillAttest:       false,
 			ValidateL1Blocks: false,
 			GenesisJSON:      nil,
+			UseInMemoryDb:    true,
 		}
 		_, err := enclave.StartServer(
 			enclaveConfig,

--- a/integration/simulation/network/azureenclave.go
+++ b/integration/simulation/network/azureenclave.go
@@ -90,7 +90,7 @@ func (n *networkWithAzureEnclaves) Create(params *params.SimParams, stats *stats
 			WillAttest:       false,
 			ValidateL1Blocks: false,
 			GenesisJSON:      nil,
-			UseInMemoryDb:    true,
+			UseInMemoryDB:    true,
 		}
 		_, err := enclave.StartServer(
 			enclaveConfig,

--- a/integration/simulation/network/network_utils.go
+++ b/integration/simulation/network/network_utils.go
@@ -69,7 +69,7 @@ func createInMemObscuroNode(
 		WillAttest:       false,
 		ValidateL1Blocks: validateBlocks,
 		GenesisJSON:      genesisJSON,
-		UseInMemoryDb:    true,
+		UseInMemoryDB:    true,
 	}
 	enclaveClient := enclave.NewEnclave(enclaveConfig, mgmtContractLib, stableTokenContractLib, stats)
 

--- a/integration/simulation/network/network_utils.go
+++ b/integration/simulation/network/network_utils.go
@@ -69,6 +69,7 @@ func createInMemObscuroNode(
 		WillAttest:       false,
 		ValidateL1Blocks: validateBlocks,
 		GenesisJSON:      genesisJSON,
+		UseInMemoryDb:    true,
 	}
 	enclaveClient := enclave.NewEnclave(enclaveConfig, mgmtContractLib, stableTokenContractLib, stats)
 

--- a/integration/simulation/network/socket.go
+++ b/integration/simulation/network/socket.go
@@ -109,6 +109,7 @@ func (n *networkOfSocketNodes) Create(params *params.SimParams, stats *stats.Sta
 			ValidateL1Blocks: false,
 			WillAttest:       false,
 			GenesisJSON:      nil,
+			UseInMemoryDb:    true,
 		}
 		_, err := enclave.StartServer(enclaveConfig, params.MgmtContractLib, params.ERC20ContractLib, stats)
 		if err != nil {

--- a/integration/simulation/network/socket.go
+++ b/integration/simulation/network/socket.go
@@ -109,7 +109,7 @@ func (n *networkOfSocketNodes) Create(params *params.SimParams, stats *stats.Sta
 			ValidateL1Blocks: false,
 			WillAttest:       false,
 			GenesisJSON:      nil,
-			UseInMemoryDb:    true,
+			UseInMemoryDB:    true,
 		}
 		_, err := enclave.StartServer(enclaveConfig, params.MgmtContractLib, params.ERC20ContractLib, stats)
 		if err != nil {


### PR DESCRIPTION
As a pre-cursor to the edgeless DB work we need a way to tell nodes what DB setup to use. I think there are 3 situations worth using in testing:

- in-memory (quick and clean, default for test scenarios)
- persistent, SQL (integration tests to verify the persistence and the SQL implementation of ethdb key-value store work)
- persistent in-enclave, Edgeless DB (dev testnet, testnet, prod)