### PR TITLE
Next Nonce Issue

### DIFF
--- a/integration/simulation/transaction_injector.go
+++ b/integration/simulation/transaction_injector.go
@@ -346,13 +346,14 @@ func readNonce(cl *obscuroclient.Client, a common.Address) uint64 {
 	return result
 }
 
+// NextNonce waits for the previous transaction to be recorded - returns a value if a timeout has passed
 func NextNonce(cl *obscuroclient.Client, w wallet.Wallet) uint64 {
-	// only returns the nonce when the previous transaction was recorded
-	for {
+	for startTime := time.Now(); time.Since(startTime) < 2*time.Second; time.Sleep(time.Millisecond) {
 		result := readNonce(cl, w.Address())
 		if result == w.GetNonce() {
 			return w.GetNonceAndIncrement()
 		}
-		time.Sleep(time.Millisecond)
 	}
+	log.Error("Unable get the correct nonce for %s. Expected: %d , got: %d", w.Address(), w.GetNonce(), readNonce(cl, w.Address()))
+	return readNonce(cl, w.Address())
 }

--- a/integration/simulation/transaction_injector.go
+++ b/integration/simulation/transaction_injector.go
@@ -348,12 +348,12 @@ func readNonce(cl *obscuroclient.Client, a common.Address) uint64 {
 
 // NextNonce waits for the previous transaction to be recorded - returns a value if a timeout has passed
 func NextNonce(cl *obscuroclient.Client, w wallet.Wallet) uint64 {
-	for startTime := time.Now(); time.Since(startTime) < 2*time.Second; time.Sleep(time.Millisecond) {
+	for startTime := time.Now(); time.Since(startTime) < 5*time.Second; time.Sleep(time.Millisecond) {
 		result := readNonce(cl, w.Address())
 		if result == w.GetNonce() {
 			return w.GetNonceAndIncrement()
 		}
 	}
-	log.Error("Unable get the correct nonce for %s. Expected: %d , got: %d", w.Address(), w.GetNonce(), readNonce(cl, w.Address()))
-	return readNonce(cl, w.Address())
+	log.Panic("Unable get the correct nonce for %s. Expected: %d , got: %d", w.Address(), w.GetNonce(), readNonce(cl, w.Address()))
+	return 0
 }


### PR DESCRIPTION
There's an issue with 
```
func NextNonce(cl *obscuroclient.Client, w wallet.Wallet) uint64 {
	// only returns the nonce when the previous transaction was recorded
	for {
		result := readNonce(cl, w.Address())
		if result == w.GetNonce() {
			return w.GetNonceAndIncrement()
		}
		time.Sleep(time.Millisecond)
	}
}
```

If this breaks for some reason, no other transaction goes through (for that wallet).
If no other tx goes through that's fine because the validate_chain doesn't expect any tx.
But this creates a go routine that never ends.


