### PR TITLE
genesis production does not need a known block in the enclave

### DIFF
--- a/go/obscuronode/enclave/enclave.go
+++ b/go/obscuronode/enclave/enclave.go
@@ -146,13 +146,8 @@ func (e *enclaveImpl) start(block types.Block) {
 
 func (e *enclaveImpl) ProduceGenesis(blkHash common.Hash) nodecommon.BlockSubmissionResponse {
 	rolGenesis := obscurocore.NewRollup(blkHash, nil, obscurocommon.L2GenesisHeight, common.HexToAddress("0x0"), []nodecommon.L2Tx{}, []nodecommon.Withdrawal{}, obscurocommon.GenerateNonce(), common.BigToHash(big.NewInt(0)))
-	b, f := e.storage.FetchBlock(blkHash)
-	if !f {
-		log.Panic("Could not find the block used as proof for the genesis rollup.")
-	}
 	return nodecommon.BlockSubmissionResponse{
 		ProducedRollup: rolGenesis.ToExtRollup(),
-		BlockHeader:    b.Header(),
 		IngestedBlock:  true,
 	}
 }


### PR DESCRIPTION
Why is this needed
- Will break node bootstrap from network. As this assumes the block is already known by the enclave.
