### PR TITLE
Updates Docker copy instruction.

### DIFF
--- a/dockerfiles/enclave_local_build.Dockerfile
+++ b/dockerfiles/enclave_local_build.Dockerfile
@@ -2,7 +2,7 @@ FROM ghcr.io/edgelesssys/ego-dev:latest
 
 # build the enclave from the current branch
 RUN mkdir /home/obscuro-playground
-COPY ./ /home/obscuro-playground
+COPY . /home/obscuro-playground
 RUN cd /home/obscuro-playground/go/obscuronode/enclave/main && ego-go build && ego sign main
 
 ENV OE_SIMULATION=1


### PR DESCRIPTION
### Why is this change needed?

I updated Docker and the old copy syntax for our enclave-local Docker image, `COPY ./ /home/obscuro-playground`, doesn't work.

### What changes were made as part of this PR:

Changed the syntax to `COPY . /home/obscuro-playground` (no `/` after the first `.`)

### What are the key areas to look at

That one line.