### PR TITLE
Catches nil pointer error.

### DIFF
--- a/integration/simulation/network/dockerenclave.go
+++ b/integration/simulation/network/dockerenclave.go
@@ -273,7 +273,9 @@ func createDockerContainers(ctx context.Context, client *client.Client, numOfNod
 // Stops and removes the test Docker containers.
 func terminateDockerContainers(ctx context.Context, cli *client.Client, containerIDs map[string]string, containerStreams map[string]*types.HijackedResponse) {
 	for id := range containerIDs {
-		containerStreams[id].Close()
+		if containerStreams[id] != nil {
+			containerStreams[id].Close()
+		}
 		// timeout := -time.Nanosecond // A negative timeout means forceful termination.
 		err1 := cli.ContainerStop(ctx, id, nil)
 		if err1 != nil {


### PR DESCRIPTION
### Why is this change needed?

Sometimes the stream is nil and we error out, failing to close the Docker containers

### What changes were made as part of this PR:

- Functional

### What are the key areas to look at
