### PR TITLE
Log error and retry if failed to get IP address after azure deployment

### DIFF
--- a/tools/azuredeployer/enclavedeployer/README.md
+++ b/tools/azuredeployer/enclavedeployer/README.md
@@ -17,7 +17,7 @@ of simulation mode.
 * Start the enclave service outside of simulation mode using the following command, replacing `$1` with an integer 
   representing the 20 bytes of the node's address:
 
-      sudo docker run -e OE_SIMULATION=0 --privileged -v /dev/sgx:/dev/sgx -p 11000:11000/tcp obscuro_enclave --nodeID $1 --address :11000
+      sudo docker run -e OE_SIMULATION=0 --privileged -v /dev/sgx:/dev/sgx -p 11000:11000/tcp obscuro_enclave --hostID $1 --address :11000
 
 The enclave service is now running and exposed on port 11000.
 
@@ -42,6 +42,6 @@ at the top of the script, e.g. you could add a number
     resourceGroupName     = "ObscuroEnclaveService2"
 
 Note the IP logged out at the end of each run to SSH to the box (and to configure them into simulation_multi_azure_enclaves_test.go).
-Don't forget to increment the nodeID parameter when you call the `docker run` command above.
+Don't forget to increment the hostID parameter when you call the `docker run` command above.
 
 Each of these resource groups will need to be deleted separately through the Azure dashboard webapp when you are finished with them.


### PR DESCRIPTION
### Why is this change needed?

- Tudor ran an enclave deployment and the script failed to retrieve the IP address and swallowed the client error

### What changes were made as part of this PR:

- log out the client error if it fails to get the IP address
- add a few retries after sleeps in case it's a time-sensitive issue
- update the nodeID -> hostID param on enclave call README

### What are the key areas to look at
Small change, just the tweaks listed above