### PR TITLE
add plain go runner enclave docker file for testing

### DIFF
--- a/dockerfiles/plain_go_enclave_local.Dockerfile
+++ b/dockerfiles/plain_go_enclave_local.Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.17-alpine
+
+# build the enclave from the current branch
+RUN mkdir /home/obscuro-playground
+COPY . /home/obscuro-playground
+WORKDIR /home/obscuro-playground/go/obscuronode/enclave/main
+RUN apk add build-base
+ENV CGO_ENABLED=1
+# Download all the dependencies
+RUN go get -d -v ./...
+# Install the package
+RUN go install -v ./...
+EXPOSE 11000
+ENTRYPOINT ["main"]


### PR DESCRIPTION
### Why is this change needed?

- We might want to debug the enclave without running it in ego, and this is a handy docker file to help with that.

### What changes were made as part of this PR:

- A docker file that uses a plain go image that is able to run the enclave was added.
- functional PR

### What are the key areas to look at
N/A