### PR TITLE
refactor integration tests

### DIFF
--- a/integration/simulation/network/azureenclave.go
+++ b/integration/simulation/network/azureenclave.go
@@ -2,19 +2,12 @@ package network
 
 import (
 	"fmt"
-	"math/big"
 	"time"
 
 	"github.com/obscuronet/obscuro-playground/go/ethclient/erc20contractlib"
 	"github.com/obscuronet/obscuro-playground/go/ethclient/mgmtcontractlib"
-	"github.com/obscuronet/obscuro-playground/go/log"
 	"github.com/obscuronet/obscuro-playground/go/obscuronode/wallet"
-	"github.com/obscuronet/obscuro-playground/integration/erc20contract"
 	"github.com/obscuronet/obscuro-playground/integration/gethnetwork"
-
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/config"
-
-	"github.com/obscuronet/obscuro-playground/integration"
 
 	"github.com/obscuronet/obscuro-playground/go/obscuronode/obscuroclient"
 
@@ -23,10 +16,6 @@ import (
 	"github.com/obscuronet/obscuro-playground/integration/simulation/params"
 
 	"github.com/obscuronet/obscuro-playground/integration/simulation/stats"
-
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/host"
 )
 
 const enclavePort = ":11000"
@@ -34,192 +23,65 @@ const enclavePort = ":11000"
 // creates Obscuro nodes with their own enclave servers that communicate with peers via sockets, wires them up, and populates the network objects
 type networkWithAzureEnclaves struct {
 	gethNetwork  *gethnetwork.GethNetwork
+	gethClients  []ethclient.EthClient
 	wallets      []wallet.Wallet
 	contracts    []string
 	workerWallet wallet.Wallet
 
-	obscuroClients   []*obscuroclient.Client
+	obscuroClients  []obscuroclient.Client
+	azureEnclaveIps []string
+
 	enclaveAddresses []string
 }
 
-func NewNetworkWithAzureEnclaves(enclaveAddresses []string, wallets []wallet.Wallet, workerWallet wallet.Wallet, contracts []string) Network {
-	if len(enclaveAddresses) == 0 {
+func NewNetworkWithAzureEnclaves(enclaveIps []string, wallets []wallet.Wallet, workerWallet wallet.Wallet, contracts []string) Network {
+	if len(enclaveIps) == 0 {
 		panic("Cannot create azure enclaves network without at least one enclave address.")
 	}
 	return &networkWithAzureEnclaves{
-		enclaveAddresses: enclaveAddresses,
-		wallets:          wallets,
-		contracts:        contracts,
-		workerWallet:     workerWallet,
+		azureEnclaveIps: enclaveIps,
+		wallets:         wallets,
+		contracts:       contracts,
+		workerWallet:    workerWallet,
 	}
 }
 
-func (n *networkWithAzureEnclaves) Create(params *params.SimParams, stats *stats.Stats) ([]ethclient.EthClient, []*obscuroclient.Client, []string, error) {
-	// make sure the geth network binaries exist
-	path, err := gethnetwork.EnsureBinariesExist(gethnetwork.LatestVersion)
-	if err != nil {
-		panic(err)
-	}
-
-	// get wallet addresses to prefund them
-	walletAddresses := make([]string, len(n.wallets))
-	for i, w := range n.wallets {
-		walletAddresses[i] = w.Address().String()
-	}
-
-	// kickoff the network with the prefunded wallet addresses
-	n.gethNetwork = gethnetwork.NewGethNetwork(
+func (n *networkWithAzureEnclaves) Create(params *params.SimParams, stats *stats.Stats) ([]ethclient.EthClient, []obscuroclient.Client, []string, error) {
+	params.MgmtContractAddr, params.StableTokenContractAddr, n.gethClients, n.gethNetwork = SetUpGethNetwork(
+		n.wallets,
+		n.workerWallet,
 		params.StartPort,
-		params.StartPort+DefaultWsPortOffset,
-		path,
 		params.NumberOfNodes,
 		int(params.AvgBlockDuration.Seconds()),
-		walletAddresses,
 	)
+	params.MgmtContractLib = mgmtcontractlib.NewMgmtContractLib(params.MgmtContractAddr)
+	params.ERC20ContractLib = erc20contractlib.NewERC20ContractLib(params.MgmtContractAddr, params.StableTokenContractAddr)
 
-	tmpHostConfig := config.HostConfig{
-		L1NodeHost:          Localhost,
-		L1NodeWebsocketPort: n.gethNetwork.WebSocketPorts[0],
-		L1ConnectionTimeout: DefaultL1ConnectionTimeout,
-	}
-	tmpEthClient, err := ethclient.NewEthClient(tmpHostConfig)
-	if err != nil {
-		panic(err)
-	}
-
-	mgmtContractAddr, err := DeployContract(tmpEthClient, n.workerWallet, common.Hex2Bytes(mgmtcontractlib.MgmtContractByteCode))
-	if err != nil {
-		panic(fmt.Sprintf("failed to deploy management contract. Cause: %s", err))
-	}
-	erc20ContractAddr, err := DeployContract(tmpEthClient, n.workerWallet, common.Hex2Bytes(erc20contract.ContractByteCode))
-	if err != nil {
-		panic(fmt.Sprintf("failed to deploy ERC20 contract. Cause: %s", err))
-	}
 	fmt.Printf("Please start the docker image on the azure server with with:\n")
-	for i := 0; i < len(n.enclaveAddresses); i++ {
-		fmt.Printf("sudo docker run -e OE_SIMULATION=0 --privileged -v /dev/sgx:/dev/sgx -p 11000:11000/tcp obscuro_enclave --hostID %d --address :11000 --managementContractAddress %s  --erc20ContractAddresses %s\n", i, mgmtContractAddr.Hex(), erc20ContractAddr.Hex())
+	for i := 0; i < len(n.azureEnclaveIps); i++ {
+		fmt.Printf("sudo docker run -e OE_SIMULATION=0 --privileged -v /dev/sgx:/dev/sgx -p %d:%d/tcp obscuro_enclave --hostID %d --address :11000 --managementContractAddress %s  --erc20ContractAddresses %s\n", enclavePort, enclavePort, i, params.MgmtContractAddr.Hex(), params.StableTokenContractAddr.Hex())
 	}
 	time.Sleep(10 * time.Second)
 
-	params.MgmtContractAddr = mgmtContractAddr
-	params.StableTokenContractAddr = erc20ContractAddr
-	params.MgmtContractLib = mgmtcontractlib.NewMgmtContractLib(mgmtContractAddr)
-	params.ERC20ContractLib = erc20contractlib.NewERC20ContractLib(mgmtContractAddr, erc20ContractAddr)
+	// Start the rest of the enclaves
+	startRemoteEnclaveServers(len(n.azureEnclaveIps), params, stats)
 
-	l1Clients := make([]ethclient.EthClient, params.NumberOfNodes)
-	obscuroNodes := make([]*host.Node, params.NumberOfNodes)
-	n.obscuroClients = make([]*obscuroclient.Client, params.NumberOfNodes)
-	nodeP2pAddrs := make([]string, params.NumberOfNodes)
-
-	for i := 0; i < params.NumberOfNodes; i++ {
-		// We assign a P2P address to each node on the network.
-		nodeP2pAddrs[i] = fmt.Sprintf("%s:%d", Localhost, params.StartPort+DefaultHostP2pOffset+i)
+	n.enclaveAddresses = make([]string, params.NumberOfNodes)
+	for i := 0; i < len(n.azureEnclaveIps); i++ {
+		n.enclaveAddresses[i] = fmt.Sprintf("%s:%d", n.azureEnclaveIps[i], enclavePort)
+	}
+	for i := len(n.azureEnclaveIps); i < params.NumberOfNodes; i++ {
+		n.enclaveAddresses[i] = fmt.Sprintf("%s:%d", Localhost, params.StartPort+DefaultEnclaveOffset+i)
 	}
 
-	// set up nodes with azure enclave
-	for i := 0; i < len(n.enclaveAddresses); i++ {
-		isGenesis := i == 0
-		// create the L1 client, the Obscuro host and enclave service, and the L2 client
-		l1Client := createEthClientConnection(
-			int64(i),
-			n.gethNetwork.WebSocketPorts[i],
-		)
-		rpcAddress := fmt.Sprintf("%s:%d", Localhost, params.StartPort+DefaultHostRPCOffset+i)
-		agg := createSocketObscuroNode(
-			int64(i),
-			isGenesis,
-			params.AvgGossipPeriod,
-			stats,
-			nodeP2pAddrs[i],
-			nodeP2pAddrs,
-			n.enclaveAddresses[i]+enclavePort,
-			rpcAddress,
-			params.NodeEthWallets[i],
-			params.MgmtContractLib,
-			miner,
-		)
-		obscuroClient := obscuroclient.NewClient(rpcAddress)
+	obscuroClients, nodeP2pAddrs := startStandaloneObscuroNodes(params, stats, n.gethClients, n.enclaveAddresses)
+	n.obscuroClients = obscuroClients
 
-		// connect the L1 and L2 nodes
-		agg.ConnectToEthNode(l1Client)
-
-		obscuroNodes[i] = agg
-		n.obscuroClients[i] = &obscuroClient
-		l1Clients[i] = l1Client
-	}
-
-	// set up nodes with mock enclaves
-	for i := len(n.enclaveAddresses); i < params.NumberOfNodes; i++ {
-		l1Client := createEthClientConnection(
-			int64(i),
-			n.gethNetwork.WebSocketPorts[i],
-		)
-
-		// create a remote enclave server
-		nonAzureEnclaveAddress := fmt.Sprintf("%s:%d", Localhost, params.StartPort+DefaultEnclaveOffset+i)
-		enclaveConfig := config.EnclaveConfig{
-			HostID:           common.BigToAddress(big.NewInt(int64(i))),
-			Address:          nonAzureEnclaveAddress,
-			L1ChainID:        integration.EthereumChainID,
-			ObscuroChainID:   integration.ObscuroChainID,
-			WillAttest:       false,
-			ValidateL1Blocks: false,
-			GenesisJSON:      nil,
-			UseInMemoryDB:    true,
-		}
-		_, err := enclave.StartServer(
-			enclaveConfig,
-			params.MgmtContractLib,
-			params.ERC20ContractLib,
-			stats,
-		)
-		if err != nil {
-			panic(fmt.Sprintf("failed to create enclave server: %v", err))
-		}
-
-		// create the in memory l1 and l2 node
-		rpcAddress := fmt.Sprintf("%s:%d", Localhost, params.StartPort+DefaultHostRPCOffset+i)
-		agg := createSocketObscuroNode(
-			int64(i),
-			false,
-			params.AvgGossipPeriod,
-			stats,
-			nodeP2pAddrs[i],
-			nodeP2pAddrs,
-			nonAzureEnclaveAddress,
-			rpcAddress,
-			params.NodeEthWallets[i],
-			params.MgmtContractLib,
-			miner,
-		)
-		obscuroClient := obscuroclient.NewClient(rpcAddress)
-		// connect the L1 and L2 nodes
-		agg.ConnectToEthNode(l1Client)
-
-		obscuroNodes[i] = agg
-		n.obscuroClients[i] = &obscuroClient
-		l1Clients[i] = l1Client
-	}
-
-	for _, m := range obscuroNodes {
-		t := m
-		go t.Start()
-		time.Sleep(params.AvgBlockDuration / 3)
-	}
-
-	return l1Clients, n.obscuroClients, nodeP2pAddrs, nil
+	return n.gethClients, n.obscuroClients, nodeP2pAddrs, nil
 }
 
 func (n *networkWithAzureEnclaves) TearDown() {
-	n.gethNetwork.StopNodes()
-	for _, c := range n.obscuroClients {
-		temp := c
-		go func() {
-			defer (*temp).Stop()
-			err := (*temp).Call(nil, obscuroclient.RPCStopHost)
-			if err != nil {
-				log.Error("Failed to stop node: %s", err)
-			}
-		}()
-	}
+	// First stop the obscuro nodes
+	StopObscuroNodes(n.obscuroClients)
+	StopGethNetwork(n.gethClients, n.gethNetwork)
 }

--- a/integration/simulation/network/azureenclave.go
+++ b/integration/simulation/network/azureenclave.go
@@ -18,7 +18,7 @@ import (
 	"github.com/obscuronet/obscuro-playground/integration/simulation/stats"
 )
 
-const enclavePort = ":11000"
+const enclavePort = 11000
 
 // creates Obscuro nodes with their own enclave servers that communicate with peers via sockets, wires them up, and populates the network objects
 type networkWithAzureEnclaves struct {

--- a/integration/simulation/network/docker_utils.go
+++ b/integration/simulation/network/docker_utils.go
@@ -1,0 +1,97 @@
+package network
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"strings"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/client"
+	"github.com/docker/go-connections/nat"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/enclaverunner"
+)
+
+// Checks the required Docker images exist.
+func dockerImagesAvailable(ctx context.Context, cli *client.Client) bool {
+	images, _ := cli.ImageList(ctx, types.ImageListOptions{})
+	for _, image := range images {
+		for _, tag := range image.RepoTags {
+			if strings.Contains(tag, enclaveDockerImg) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// Creates the test Docker containers.
+func createDockerContainers(ctx context.Context, client *client.Client, numOfNodes int, startPort int, mngmtCtrAddr string, erc20Addr string) map[string]string {
+	var enclavePorts []string
+	for i := 0; i < numOfNodes; i++ {
+		// We assign an enclave port to each enclave service on the network.
+		enclavePorts = append(enclavePorts, fmt.Sprintf("%d", startPort+DefaultEnclaveOffset+i))
+	}
+
+	containerIDs := map[string]string{}
+	for idx, port := range enclavePorts {
+		nodeID := common.BigToAddress(big.NewInt(int64(idx + 1))).Hex()
+		containerConfig := &container.Config{
+			Image: enclaveDockerImg,
+			Cmd: []string{
+				"--" + enclaverunner.HostIDName, nodeID,
+				"--" + enclaverunner.AddressName, enclaveAddress,
+				"--" + enclaverunner.ManagementContractAddressName, mngmtCtrAddr,
+				"--" + enclaverunner.Erc20ContractAddrsName, erc20Addr,
+			},
+		}
+		r := container.Resources{
+			Memory:     2 * 1024 * 1024 * 1024, // 2GB
+			MemorySwap: -1,
+		}
+		hostConfig := &container.HostConfig{
+			PortBindings: nat.PortMap{nat.Port(enclaveDockerPort): []nat.PortBinding{{HostIP: Localhost, HostPort: port}}},
+			Resources:    r,
+		}
+
+		resp, err := client.ContainerCreate(ctx, containerConfig, hostConfig, nil, "")
+		if err != nil {
+			panic(err)
+		}
+		containerIDs[resp.ID] = port
+	}
+
+	return containerIDs
+}
+
+// Stops and removes the test Docker containers.
+func terminateDockerContainers(ctx context.Context, cli *client.Client, containerIDs map[string]string, containerStreams map[string]*types.HijackedResponse) {
+	for id := range containerIDs {
+		if containerStreams[id] != nil {
+			containerStreams[id].Close()
+		}
+		err1 := cli.ContainerStop(ctx, id, nil)
+		if err1 != nil {
+			fmt.Printf("Could not stop the container %v : %s\n", id, err1)
+			continue
+		}
+
+		err2 := cli.ContainerRemove(ctx, id, types.ContainerRemoveOptions{
+			RemoveVolumes: true,
+			RemoveLinks:   false,
+			Force:         true,
+		})
+		if err2 != nil {
+			fmt.Printf("Could not remove the container %v : %s\n", id, err2)
+			continue
+		}
+
+		fmt.Printf("Stopped and removed container %v\n", id)
+	}
+
+	if err := cli.Close(); err != nil {
+		fmt.Printf("Could not close cli: %s\n", err)
+	}
+}

--- a/integration/simulation/network/docker_utils.go
+++ b/integration/simulation/network/docker_utils.go
@@ -37,7 +37,7 @@ func createDockerContainers(ctx context.Context, client *client.Client, numOfNod
 
 	containerIDs := map[string]string{}
 	for idx, port := range enclavePorts {
-		nodeID := common.BigToAddress(big.NewInt(int64(idx + 1))).Hex()
+		nodeID := common.BigToAddress(big.NewInt(int64(idx))).Hex()
 		containerConfig := &container.Config{
 			Image: enclaveDockerImg,
 			Cmd: []string{

--- a/integration/simulation/network/docker_utils.go
+++ b/integration/simulation/network/docker_utils.go
@@ -72,19 +72,19 @@ func terminateDockerContainers(ctx context.Context, cli *client.Client, containe
 		if containerStreams[id] != nil {
 			containerStreams[id].Close()
 		}
-		err1 := cli.ContainerStop(ctx, id, nil)
-		if err1 != nil {
-			fmt.Printf("Could not stop the container %v : %s\n", id, err1)
+		err := cli.ContainerStop(ctx, id, nil)
+		if err != nil {
+			fmt.Printf("Could not stop the container %v : %s\n", id, err)
 			continue
 		}
 
-		err2 := cli.ContainerRemove(ctx, id, types.ContainerRemoveOptions{
+		err = cli.ContainerRemove(ctx, id, types.ContainerRemoveOptions{
 			RemoveVolumes: true,
 			RemoveLinks:   false,
 			Force:         true,
 		})
-		if err2 != nil {
-			fmt.Printf("Could not remove the container %v : %s\n", id, err2)
+		if err != nil {
+			fmt.Printf("Could not remove the container %v : %s\n", id, err)
 			continue
 		}
 

--- a/integration/simulation/network/dockerenclave.go
+++ b/integration/simulation/network/dockerenclave.go
@@ -62,8 +62,7 @@ func NewBasicNetworkOfNodesWithDockerEnclave(wallets []wallet.Wallet, workerWall
 // TODO - Use individual Docker containers for the Obscuro nodes and Ethereum nodes.
 func (n *basicNetworkOfNodesWithDockerEnclave) Create(params *params.SimParams, stats *stats.Stats) ([]ethclient.EthClient, []obscuroclient.Client, []string, error) {
 	// We create Docker client, and finish early if docker or the enclave image are not available.
-	err := n.setupAndCheckDocker()
-	if err != nil {
+	if err := n.setupAndCheckDocker(); err != nil {
 		return nil, nil, nil, err
 	}
 

--- a/integration/simulation/network/dockerenclave.go
+++ b/integration/simulation/network/dockerenclave.go
@@ -33,8 +33,8 @@ const (
 
 // creates Obscuro nodes with their own enclave servers that communicate with peers via sockets, wires them up, and populates the network objects
 type basicNetworkOfNodesWithDockerEnclave struct {
-	obscuroClients []obscuroclient.Client
-
+	obscuroClients   []obscuroclient.Client
+	enclaveAddresses []string
 	// Geth
 	gethNetwork  *gethnetwork.GethNetwork
 	gethClients  []ethclient.EthClient
@@ -81,8 +81,12 @@ func (n *basicNetworkOfNodesWithDockerEnclave) Create(params *params.SimParams, 
 	// Start the enclave docker containers with the right addresses.
 	n.startDockerEnclaves(params, err)
 
+	for i := 0; i < params.NumberOfNodes; i++ {
+		n.enclaveAddresses[i] = fmt.Sprintf("%s:%d", Localhost, params.StartPort+DefaultEnclaveOffset+i)
+	}
+
 	// Start the standalone obscuro nodes connected to the enclaves and to the geth nodes
-	obscuroClients, nodeP2pAddrs := startStandaloneObscuroNodes(params, stats, n.gethClients)
+	obscuroClients, nodeP2pAddrs := startStandaloneObscuroNodes(params, stats, n.gethClients, n.enclaveAddresses)
 	n.obscuroClients = obscuroClients
 
 	return n.gethClients, obscuroClients, nodeP2pAddrs, nil

--- a/integration/simulation/network/dockerenclave.go
+++ b/integration/simulation/network/dockerenclave.go
@@ -3,26 +3,17 @@ package network
 import (
 	"context"
 	"fmt"
-	"math/big"
 	"os"
-	"strings"
-	"time"
 
 	"github.com/docker/docker/pkg/stdcopy"
 
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
-	"github.com/docker/go-connections/nat"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/obscuronet/obscuro-playground/go/ethclient/erc20contractlib"
 	"github.com/obscuronet/obscuro-playground/go/ethclient/mgmtcontractlib"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/config"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/enclaverunner"
 	"github.com/obscuronet/obscuro-playground/go/obscuronode/wallet"
-	"github.com/obscuronet/obscuro-playground/integration/erc20contract"
 	"github.com/obscuronet/obscuro-playground/integration/gethnetwork"
 
 	"github.com/obscuronet/obscuro-playground/go/obscuronode/obscuroclient"
@@ -32,8 +23,6 @@ import (
 	"github.com/obscuronet/obscuro-playground/integration/simulation/params"
 
 	"github.com/obscuronet/obscuro-playground/integration/simulation/stats"
-
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/host"
 )
 
 const (
@@ -44,11 +33,16 @@ const (
 
 // creates Obscuro nodes with their own enclave servers that communicate with peers via sockets, wires them up, and populates the network objects
 type basicNetworkOfNodesWithDockerEnclave struct {
-	obscuroClients   []*obscuroclient.Client
-	gethNetwork      *gethnetwork.GethNetwork
-	wallets          []wallet.Wallet
-	contracts        []string
-	workerWallet     wallet.Wallet
+	obscuroClients []obscuroclient.Client
+
+	// Geth
+	gethNetwork  *gethnetwork.GethNetwork
+	gethClients  []ethclient.EthClient
+	wallets      []wallet.Wallet
+	contracts    []string
+	workerWallet wallet.Wallet
+
+	// Docker
 	ctx              context.Context
 	client           *client.Client
 	containerIDs     map[string]string
@@ -66,72 +60,52 @@ func NewBasicNetworkOfNodesWithDockerEnclave(wallets []wallet.Wallet, workerWall
 
 // Create initializes Obscuro nodes with their own Dockerised enclave servers that communicate with peers via sockets, wires them up, and populates the network objects
 // TODO - Use individual Docker containers for the Obscuro nodes and Ethereum nodes.
-func (n *basicNetworkOfNodesWithDockerEnclave) Create(params *params.SimParams, stats *stats.Stats) ([]ethclient.EthClient, []*obscuroclient.Client, []string, error) {
-	// We create a Docker client.
-	n.ctx = context.Background()
-	cli, err := client.NewClientWithOpts()
+func (n *basicNetworkOfNodesWithDockerEnclave) Create(params *params.SimParams, stats *stats.Stats) ([]ethclient.EthClient, []obscuroclient.Client, []string, error) {
+	// We create Docker client, and finish early if docker or the enclave image are not available.
+	err := n.setupAndCheckDocker()
 	if err != nil {
-		panic(err)
-	}
-	n.client = cli
-	// We check the required Docker images are available.
-	if !dockerImagesAvailable(n.ctx, cli) {
-		// We don't cause the test to fail here, because we want users to be able to run all the tests in the repo
-		// without having to build the Docker images.
-		return nil, nil, nil, fmt.Errorf("this test requires the `%s` Docker image to be built using `dockerfiles/enclave.Dockerfile`. Terminating", enclaveDockerImg)
+		return nil, nil, nil, err
 	}
 
-	// make sure the geth network binaries exist
-	path, err := gethnetwork.EnsureBinariesExist(gethnetwork.LatestVersion)
-	if err != nil {
-		panic(err)
-	}
-
-	// get wallet addresses to prefund them
-	walletAddresses := make([]string, len(n.wallets))
-	for i, w := range n.wallets {
-		walletAddresses[i] = w.Address().String()
-	}
-
-	// kickoff the network with the prefunded wallet addresses
-	n.gethNetwork = gethnetwork.NewGethNetwork(
+	// We start a geth network with all necessary contracts deployed.
+	params.MgmtContractAddr, params.StableTokenContractAddr, n.gethClients, n.gethNetwork = SetUpGethNetwork(
+		n.wallets,
+		n.workerWallet,
 		params.StartPort,
-		params.StartPort+DefaultWsPortOffset,
-		path,
 		params.NumberOfNodes,
 		int(params.AvgBlockDuration.Seconds()),
-		walletAddresses,
 	)
+	params.MgmtContractLib = mgmtcontractlib.NewMgmtContractLib(params.MgmtContractAddr)
+	params.ERC20ContractLib = erc20contractlib.NewERC20ContractLib(params.MgmtContractAddr, params.StableTokenContractAddr)
 
-	tmpHostConfig := config.HostConfig{
-		L1NodeHost:          Localhost,
-		L1NodeWebsocketPort: n.gethNetwork.WebSocketPorts[0],
-		L1ConnectionTimeout: DefaultL1ConnectionTimeout,
-	}
-	tmpEthClient, err := ethclient.NewEthClient(tmpHostConfig)
-	if err != nil {
-		panic(err)
-	}
+	// Start the enclave docker containers with the right addresses.
+	n.startDockerEnclaves(params, err)
 
-	mgmtContractAddr, err := DeployContract(tmpEthClient, n.workerWallet, common.Hex2Bytes(mgmtcontractlib.MgmtContractByteCode))
-	if err != nil {
-		panic(fmt.Sprintf("failed to deploy management contract. Cause: %s", err))
-	}
-	erc20ContractAddr, err := DeployContract(tmpEthClient, n.workerWallet, common.Hex2Bytes(erc20contract.ContractByteCode))
-	if err != nil {
-		panic(fmt.Sprintf("failed to deploy ERC20 contract. Cause: %s", err))
-	}
+	// Start the standalone obscuro nodes connected to the enclaves and to the geth nodes
+	obscuroClients, nodeP2pAddrs := startStandaloneObscuroNodes(params, stats, n.gethClients)
+	n.obscuroClients = obscuroClients
 
+	return n.gethClients, obscuroClients, nodeP2pAddrs, nil
+}
+
+func (n *basicNetworkOfNodesWithDockerEnclave) TearDown() {
+	// First stop the obscuro nodes
+	StopObscuroNodes(n.obscuroClients)
+
+	StopGethNetwork(n.gethClients, n.gethNetwork)
+	terminateDockerContainers(n.ctx, n.client, n.containerIDs, n.containerStreams)
+}
+
+func (n *basicNetworkOfNodesWithDockerEnclave) startDockerEnclaves(params *params.SimParams, err error) {
 	// We create the Docker containers and set up a hook to terminate them at the end of the test.
-	containerIDs := createDockerContainers(n.ctx, cli, params.NumberOfNodes, params.StartPort, mgmtContractAddr.Hex(), erc20ContractAddr.Hex())
-	n.containerIDs = containerIDs
+	n.containerIDs = createDockerContainers(n.ctx, n.client, params.NumberOfNodes, params.StartPort, params.MgmtContractAddr.Hex(), params.StableTokenContractAddr.Hex())
 
 	// We start the Docker containers.
-	for id := range containerIDs {
-		if err = cli.ContainerStart(n.ctx, id, types.ContainerStartOptions{}); err != nil {
+	for id := range n.containerIDs {
+		if err = n.client.ContainerStart(n.ctx, id, types.ContainerStartOptions{}); err != nil {
 			panic(err)
 		}
-		waiter, err := cli.ContainerAttach(n.ctx, id, types.ContainerAttachOptions{
+		waiter, err := n.client.ContainerAttach(n.ctx, id, types.ContainerAttachOptions{
 			Stderr: true,
 			Stdout: true,
 			Stdin:  false,
@@ -150,158 +124,20 @@ func (n *basicNetworkOfNodesWithDockerEnclave) Create(params *params.SimParams, 
 		}
 		n.containerStreams[id] = &waiter
 	}
-
-	params.MgmtContractAddr = mgmtContractAddr
-	params.StableTokenContractAddr = erc20ContractAddr
-	params.MgmtContractLib = mgmtcontractlib.NewMgmtContractLib(mgmtContractAddr)
-	params.ERC20ContractLib = erc20contractlib.NewERC20ContractLib(mgmtContractAddr, erc20ContractAddr)
-
-	l1Clients := make([]ethclient.EthClient, params.NumberOfNodes)
-	obscuroNodes := make([]*host.Node, params.NumberOfNodes)
-	n.obscuroClients = make([]*obscuroclient.Client, params.NumberOfNodes)
-	nodeP2pAddrs := make([]string, params.NumberOfNodes)
-
-	for i := 0; i < params.NumberOfNodes; i++ {
-		// We assign a P2P address to each node on the network.
-		nodeP2pAddrs[i] = fmt.Sprintf("%s:%d", Localhost, params.StartPort+DefaultHostP2pOffset+i)
-	}
-
-	for i := 0; i < params.NumberOfNodes; i++ {
-		isGenesis := i == 0
-
-		// create a remote enclave server
-		enclavePort := uint64(params.StartPort + DefaultEnclaveOffset + i)
-		// create the L1 client, the Obscuro host and enclave service, and the L2 client
-		l1Client := createEthClientConnection(
-			int64(i),
-			n.gethNetwork.WebSocketPorts[i],
-		)
-		rpcAddress := fmt.Sprintf("%s:%d", Localhost, params.StartPort+DefaultHostRPCOffset+i)
-		agg := createSocketObscuroNode(
-			int64(i+1),
-			isGenesis,
-			params.AvgGossipPeriod,
-			stats,
-			nodeP2pAddrs[i],
-			nodeP2pAddrs,
-			fmt.Sprintf("%s:%d", Localhost, enclavePort),
-			rpcAddress,
-			params.NodeEthWallets[i],
-			params.MgmtContractLib,
-		)
-		obscuroClient := obscuroclient.NewClient(rpcAddress)
-
-		// connect the L1 and L2 nodes
-		agg.ConnectToEthNode(l1Client)
-
-		obscuroNodes[i] = agg
-		n.obscuroClients[i] = &obscuroClient
-		l1Clients[i] = l1Client
-	}
-
-	// start each obscuro node
-	for _, m := range obscuroNodes {
-		t := m
-		go t.Start()
-		time.Sleep(params.AvgBlockDuration / 3)
-	}
-
-	return l1Clients, n.obscuroClients, nodeP2pAddrs, nil
 }
 
-func (n *basicNetworkOfNodesWithDockerEnclave) TearDown() {
-	for _, c := range n.obscuroClients {
-		temp := c
-		go func() {
-			err := (*temp).Call(nil, obscuroclient.RPCStopHost)
-			if err != nil {
-				log.Error("Failed to stop node: %s", err)
-			}
-			(*temp).Stop()
-		}()
+func (n *basicNetworkOfNodesWithDockerEnclave) setupAndCheckDocker() error {
+	n.ctx = context.Background()
+	cli, err := client.NewClientWithOpts()
+	if err != nil {
+		panic(err)
 	}
-	n.gethNetwork.StopNodes()
-	terminateDockerContainers(n.ctx, n.client, n.containerIDs, n.containerStreams)
-}
-
-// Checks the required Docker images exist.
-func dockerImagesAvailable(ctx context.Context, cli *client.Client) bool {
-	images, _ := cli.ImageList(ctx, types.ImageListOptions{})
-	for _, image := range images {
-		for _, tag := range image.RepoTags {
-			if strings.Contains(tag, enclaveDockerImg) {
-				return true
-			}
-		}
+	n.client = cli
+	// We check the required Docker images are available.
+	if !dockerImagesAvailable(n.ctx, cli) {
+		// We don't cause the test to fail here, because we want users to be able to run all the tests in the repo
+		// without having to build the Docker images.
+		return fmt.Errorf("this test requires the `%s` Docker image to be built using `dockerfiles/enclave.Dockerfile`. Terminating", enclaveDockerImg)
 	}
-	return false
-}
-
-// Creates the test Docker containers.
-func createDockerContainers(ctx context.Context, client *client.Client, numOfNodes int, startPort int, mngmtCtrAddr string, erc20Addr string) map[string]string {
-	var enclavePorts []string
-	for i := 0; i < numOfNodes; i++ {
-		// We assign an enclave port to each enclave service on the network.
-		enclavePorts = append(enclavePorts, fmt.Sprintf("%d", startPort+DefaultEnclaveOffset+i))
-	}
-
-	containerIDs := map[string]string{}
-	for idx, port := range enclavePorts {
-		nodeID := common.BigToAddress(big.NewInt(int64(idx + 1))).Hex()
-		containerConfig := &container.Config{
-			Image: enclaveDockerImg,
-			Cmd: []string{
-				"--" + enclaverunner.HostIDName, nodeID,
-				"--" + enclaverunner.AddressName, enclaveAddress,
-				"--" + enclaverunner.ManagementContractAddressName, mngmtCtrAddr,
-				"--" + enclaverunner.Erc20ContractAddrsName, erc20Addr,
-			},
-		}
-		r := container.Resources{
-			Memory:     2 * 1024 * 1024 * 1024, // 2GB
-			MemorySwap: -1,
-		}
-		hostConfig := &container.HostConfig{
-			PortBindings: nat.PortMap{nat.Port(enclaveDockerPort): []nat.PortBinding{{HostIP: Localhost, HostPort: port}}},
-			Resources:    r,
-		}
-
-		resp, err := client.ContainerCreate(ctx, containerConfig, hostConfig, nil, "")
-		if err != nil {
-			panic(err)
-		}
-		containerIDs[resp.ID] = port
-	}
-
-	return containerIDs
-}
-
-// Stops and removes the test Docker containers.
-func terminateDockerContainers(ctx context.Context, cli *client.Client, containerIDs map[string]string, containerStreams map[string]*types.HijackedResponse) {
-	for id := range containerIDs {
-		if containerStreams[id] != nil {
-			containerStreams[id].Close()
-		}
-		err1 := cli.ContainerStop(ctx, id, nil)
-		if err1 != nil {
-			fmt.Printf("Could not stop the container %v : %s\n", id, err1)
-			continue
-		}
-
-		err2 := cli.ContainerRemove(ctx, id, types.ContainerRemoveOptions{
-			RemoveVolumes: true,
-			RemoveLinks:   false,
-			Force:         true,
-		})
-		if err2 != nil {
-			fmt.Printf("Could not remove the container %v : %s\n", id, err2)
-			continue
-		}
-
-		fmt.Printf("Stopped and removed container %v\n", id)
-	}
-
-	if err := cli.Close(); err != nil {
-		fmt.Printf("Could not close cli: %s\n", err)
-	}
+	return nil
 }

--- a/integration/simulation/network/dockerenclave.go
+++ b/integration/simulation/network/dockerenclave.go
@@ -210,17 +210,17 @@ func (n *basicNetworkOfNodesWithDockerEnclave) Create(params *params.SimParams, 
 }
 
 func (n *basicNetworkOfNodesWithDockerEnclave) TearDown() {
-	n.gethNetwork.StopNodes()
 	for _, c := range n.obscuroClients {
 		temp := c
 		go func() {
-			defer (*temp).Stop()
 			err := (*temp).Call(nil, obscuroclient.RPCStopHost)
 			if err != nil {
 				log.Error("Failed to stop node: %s", err)
 			}
+			(*temp).Stop()
 		}()
 	}
+	n.gethNetwork.StopNodes()
 	terminateDockerContainers(n.ctx, n.client, n.containerIDs, n.containerStreams)
 }
 

--- a/integration/simulation/network/geth_network.go
+++ b/integration/simulation/network/geth_network.go
@@ -1,36 +1,26 @@
 package network
 
 import (
-	"errors"
-	"fmt"
-	"math/big"
-	"time"
-
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/config"
-
 	"github.com/obscuronet/obscuro-playground/go/obscuronode/wallet"
 
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/obscuronet/obscuro-playground/go/ethclient"
 	"github.com/obscuronet/obscuro-playground/go/ethclient/erc20contractlib"
 	"github.com/obscuronet/obscuro-playground/go/ethclient/mgmtcontractlib"
-	"github.com/obscuronet/obscuro-playground/go/log"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/host"
 	"github.com/obscuronet/obscuro-playground/go/obscuronode/obscuroclient"
-	"github.com/obscuronet/obscuro-playground/integration/erc20contract"
 	"github.com/obscuronet/obscuro-playground/integration/gethnetwork"
-	"github.com/obscuronet/obscuro-playground/integration/simulation/p2p"
 	"github.com/obscuronet/obscuro-playground/integration/simulation/params"
 	"github.com/obscuronet/obscuro-playground/integration/simulation/stats"
 )
 
 type networkInMemGeth struct {
-	obscuroClients []*obscuroclient.Client
-	gethNetwork    *gethnetwork.GethNetwork
-	wallets        []wallet.Wallet
-	contracts      []string
-	workerWallet   wallet.Wallet
+	obscuroClients []obscuroclient.Client
+
+	// geth
+	gethNetwork  *gethnetwork.GethNetwork
+	gethClients  []ethclient.EthClient
+	wallets      []wallet.Wallet
+	contracts    []string
+	workerWallet wallet.Wallet
 }
 
 func NewNetworkInMemoryGeth(wallets []wallet.Wallet, workerWallet wallet.Wallet, contracts []string) Network {
@@ -42,161 +32,29 @@ func NewNetworkInMemoryGeth(wallets []wallet.Wallet, workerWallet wallet.Wallet,
 }
 
 // Create inits and starts the nodes, wires them up, and populates the network objects
-func (n *networkInMemGeth) Create(params *params.SimParams, stats *stats.Stats) ([]ethclient.EthClient, []*obscuroclient.Client, []string, error) {
-	// make sure the geth network binaries exist
-	path, err := gethnetwork.EnsureBinariesExist(gethnetwork.LatestVersion)
-	if err != nil {
-		panic(err)
-	}
-
-	// get wallet addresses to prefund them
-	walletAddresses := make([]string, len(n.wallets))
-	for i, w := range n.wallets {
-		walletAddresses[i] = w.Address().String()
-	}
-
+func (n *networkInMemGeth) Create(params *params.SimParams, stats *stats.Stats) ([]ethclient.EthClient, []obscuroclient.Client, []string, error) {
 	// kickoff the network with the prefunded wallet addresses
-	n.gethNetwork = gethnetwork.NewGethNetwork(
+	params.MgmtContractAddr, params.StableTokenContractAddr, n.gethClients, n.gethNetwork = SetUpGethNetwork(
+		n.wallets,
+		n.workerWallet,
 		params.StartPort,
-		params.StartPort+DefaultWsPortOffset,
-		path,
 		params.NumberOfNodes,
 		int(params.AvgBlockDuration.Seconds()),
-		walletAddresses,
 	)
 
-	tmpHostConfig := config.HostConfig{
-		L1NodeHost:          Localhost,
-		L1NodeWebsocketPort: n.gethNetwork.WebSocketPorts[0],
-		L1ConnectionTimeout: DefaultL1ConnectionTimeout,
-	}
-	tmpEthClient, err := ethclient.NewEthClient(tmpHostConfig)
-	if err != nil {
-		panic(err)
-	}
+	params.MgmtContractLib = mgmtcontractlib.NewMgmtContractLib(params.MgmtContractAddr)
+	params.ERC20ContractLib = erc20contractlib.NewERC20ContractLib(params.MgmtContractAddr, params.StableTokenContractAddr)
 
-	mgmtContractAddr, err := DeployContract(tmpEthClient, n.workerWallet, common.Hex2Bytes(mgmtcontractlib.MgmtContractByteCode))
-	if err != nil {
-		panic(fmt.Sprintf("failed to deploy management contract. Cause: %s", err))
-	}
-	erc20ContractAddr, err := DeployContract(tmpEthClient, n.workerWallet, common.Hex2Bytes(erc20contract.ContractByteCode))
-	if err != nil {
-		panic(fmt.Sprintf("failed to deploy ERC20 contract. Cause: %s", err))
-	}
+	// Start the obscuro nodes and return the handles
+	n.obscuroClients = startInMemoryObscuroNodes(params, stats, n.gethNetwork.GenesisJSON, n.gethClients)
 
-	params.MgmtContractAddr = mgmtContractAddr
-	params.StableTokenContractAddr = erc20ContractAddr
-	params.MgmtContractLib = mgmtcontractlib.NewMgmtContractLib(mgmtContractAddr)
-	params.ERC20ContractLib = erc20contractlib.NewERC20ContractLib(mgmtContractAddr, erc20ContractAddr)
-
-	// Create the obscuro node, each connected to a geth node
-	l1Clients := make([]ethclient.EthClient, params.NumberOfNodes)
-	obscuroNodes := make([]*host.Node, params.NumberOfNodes)
-	n.obscuroClients = make([]*obscuroclient.Client, params.NumberOfNodes)
-
-	for i := 0; i < params.NumberOfNodes; i++ {
-		isGenesis := i == 0
-
-		// create the in memory l1 and l2 node
-		miner := createEthClientConnection(
-			int64(i),
-			n.gethNetwork.WebSocketPorts[i],
-		)
-		agg := createInMemObscuroNode(
-			int64(i),
-			isGenesis,
-			params.MgmtContractLib,
-			params.ERC20ContractLib,
-			params.AvgGossipPeriod,
-			params.AvgBlockDuration,
-			params.AvgNetworkLatency,
-			stats,
-			true,
-			n.gethNetwork.GenesisJSON,
-			params.NodeEthWallets[i],
-		)
-		obscuroClient := host.NewInMemObscuroClient(agg)
-
-		// and connect them to each other
-		agg.ConnectToEthNode(miner)
-
-		obscuroNodes[i] = agg
-		n.obscuroClients[i] = &obscuroClient
-		l1Clients[i] = miner
-	}
-
-	// make sure the aggregators can talk to each other
-	for i := 0; i < params.NumberOfNodes; i++ {
-		mockP2P := obscuroNodes[i].P2p.(*p2p.MockP2P)
-		mockP2P.Nodes = obscuroNodes
-	}
-
-	// start each obscuro node
-	for _, m := range obscuroNodes {
-		t := m
-		go t.Start()
-		time.Sleep(params.AvgBlockDuration / 10)
-	}
-
-	return l1Clients, n.obscuroClients, nil, nil
+	return n.gethClients, n.obscuroClients, nil, nil
 }
 
 func (n *networkInMemGeth) TearDown() {
-	for _, client := range n.obscuroClients {
-		temp := client
-		go func() {
-			_ = (*temp).Call(nil, obscuroclient.RPCStopHost)
-			(*temp).Stop()
-		}()
-	}
-	n.gethNetwork.StopNodes()
-}
+	// Stop the obscuro nodes first
+	StopObscuroNodes(n.obscuroClients)
 
-func createEthClientConnection(id int64, port uint) ethclient.EthClient {
-	hostConfig := config.HostConfig{
-		ID:                  common.BigToAddress(big.NewInt(id)),
-		L1NodeHost:          Localhost,
-		L1NodeWebsocketPort: port,
-		L1ConnectionTimeout: DefaultL1ConnectionTimeout,
-	}
-	ethnode, err := ethclient.NewEthClient(hostConfig)
-	if err != nil {
-		panic(err)
-	}
-	return ethnode
-}
-
-func DeployContract(workerClient ethclient.EthClient, w wallet.Wallet, contractBytes []byte) (*common.Address, error) {
-	deployContractTx := types.LegacyTx{
-		Nonce:    w.GetNonceAndIncrement(),
-		GasPrice: big.NewInt(2000000000),
-		Gas:      1025_000_000,
-		Data:     contractBytes,
-	}
-
-	signedTx, err := w.SignTransaction(&deployContractTx)
-	if err != nil {
-		return nil, err
-	}
-
-	err = workerClient.SendTransaction(signedTx)
-	if err != nil {
-		return nil, err
-	}
-
-	var receipt *types.Receipt
-	for start := time.Now(); time.Since(start) < 80*time.Second; time.Sleep(2 * time.Second) {
-		receipt, err = workerClient.TransactionReceipt(signedTx.Hash())
-		if err == nil && receipt != nil {
-			if receipt.Status != types.ReceiptStatusSuccessful {
-				return nil, errors.New("unable to deploy contract")
-			}
-			break
-		}
-
-		log.Info("Contract deploy tx has not been mined into a block after %s...", time.Since(start))
-	}
-
-	log.Info("Contract successfully deployed to %s", receipt.ContractAddress)
-	return &receipt.ContractAddress, nil
+	// Stop geth last
+	StopGethNetwork(n.gethClients, n.gethNetwork)
 }

--- a/integration/simulation/network/geth_network.go
+++ b/integration/simulation/network/geth_network.go
@@ -142,14 +142,14 @@ func (n *networkInMemGeth) Create(params *params.SimParams, stats *stats.Stats) 
 }
 
 func (n *networkInMemGeth) TearDown() {
-	defer n.gethNetwork.StopNodes()
 	for _, client := range n.obscuroClients {
 		temp := client
 		go func() {
-			defer (*temp).Stop()
 			_ = (*temp).Call(nil, obscuroclient.RPCStopHost)
+			(*temp).Stop()
 		}()
 	}
+	n.gethNetwork.StopNodes()
 }
 
 func createEthClientConnection(id int64, port uint) ethclient.EthClient {

--- a/integration/simulation/network/geth_utils.go
+++ b/integration/simulation/network/geth_utils.go
@@ -1,0 +1,129 @@
+package network
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/obscuronet/obscuro-playground/go/ethclient"
+	"github.com/obscuronet/obscuro-playground/go/ethclient/mgmtcontractlib"
+	"github.com/obscuronet/obscuro-playground/go/log"
+	"github.com/obscuronet/obscuro-playground/go/obscuronode/config"
+	"github.com/obscuronet/obscuro-playground/go/obscuronode/wallet"
+	"github.com/obscuronet/obscuro-playground/integration/erc20contract"
+	"github.com/obscuronet/obscuro-playground/integration/gethnetwork"
+)
+
+func SetUpGethNetwork(wallets []wallet.Wallet, workerWallet wallet.Wallet, StartPort int, nrNodes int, blockDurationSeconds int) (*common.Address, *common.Address, []ethclient.EthClient, *gethnetwork.GethNetwork) {
+	// make sure the geth network binaries exist
+	path, err := gethnetwork.EnsureBinariesExist(gethnetwork.LatestVersion)
+	if err != nil {
+		panic(err)
+	}
+	// get wallet addresses to prefund them
+	walletAddresses := make([]string, len(wallets))
+	for i, w := range wallets {
+		walletAddresses[i] = w.Address().String()
+	}
+
+	// kickoff the network with the prefunded wallet addresses
+	gethNetwork := gethnetwork.NewGethNetwork(
+		StartPort,
+		StartPort+DefaultWsPortOffset,
+		path,
+		nrNodes,
+		blockDurationSeconds,
+		walletAddresses,
+	)
+
+	// connect to the first host to deploy
+	tmpHostConfig := config.HostConfig{
+		L1NodeHost:          Localhost,
+		L1NodeWebsocketPort: gethNetwork.WebSocketPorts[0],
+		L1ConnectionTimeout: DefaultL1ConnectionTimeout,
+	}
+	tmpEthClient, err := ethclient.NewEthClient(tmpHostConfig)
+	if err != nil {
+		panic(err)
+	}
+
+	mgmtContractAddr, err := DeployContract(tmpEthClient, workerWallet, common.Hex2Bytes(mgmtcontractlib.MgmtContractByteCode))
+	if err != nil {
+		panic(fmt.Sprintf("failed to deploy management contract. Cause: %s", err))
+	}
+	erc20ContractAddr, err := DeployContract(tmpEthClient, workerWallet, common.Hex2Bytes(erc20contract.ContractByteCode))
+	if err != nil {
+		panic(fmt.Sprintf("failed to deploy ERC20 contract. Cause: %s", err))
+	}
+
+	ethClients := make([]ethclient.EthClient, nrNodes)
+	for i := 0; i < nrNodes; i++ {
+		ethClients[i] = createEthClientConnection(int64(i), gethNetwork.WebSocketPorts[i])
+	}
+
+	return mgmtContractAddr, erc20ContractAddr, ethClients, gethNetwork
+}
+
+func StopGethNetwork(clients []ethclient.EthClient, netw *gethnetwork.GethNetwork) {
+	// Stop the clients first
+	for _, c := range clients {
+		if c != nil {
+			c.Stop()
+		}
+	}
+	// Stop the nodes second
+	netw.StopNodes()
+}
+
+// DeployContract todo -this should live somewhere else
+func DeployContract(workerClient ethclient.EthClient, w wallet.Wallet, contractBytes []byte) (*common.Address, error) {
+	deployContractTx := types.LegacyTx{
+		Nonce:    w.GetNonceAndIncrement(),
+		GasPrice: big.NewInt(2000000000),
+		Gas:      1025_000_000,
+		Data:     contractBytes,
+	}
+
+	signedTx, err := w.SignTransaction(&deployContractTx)
+	if err != nil {
+		return nil, err
+	}
+
+	err = workerClient.SendTransaction(signedTx)
+	if err != nil {
+		return nil, err
+	}
+
+	var receipt *types.Receipt
+	for start := time.Now(); time.Since(start) < 80*time.Second; time.Sleep(2 * time.Second) {
+		receipt, err = workerClient.TransactionReceipt(signedTx.Hash())
+		if err == nil && receipt != nil {
+			if receipt.Status != types.ReceiptStatusSuccessful {
+				return nil, errors.New("unable to deploy contract")
+			}
+			break
+		}
+
+		log.Info("Contract deploy tx has not been mined into a block after %s...", time.Since(start))
+	}
+
+	log.Info("Contract successfully deployed to %s", receipt.ContractAddress)
+	return &receipt.ContractAddress, nil
+}
+
+func createEthClientConnection(id int64, port uint) ethclient.EthClient {
+	hostConfig := config.HostConfig{
+		ID:                  common.BigToAddress(big.NewInt(id)),
+		L1NodeHost:          Localhost,
+		L1NodeWebsocketPort: port,
+		L1ConnectionTimeout: DefaultL1ConnectionTimeout,
+	}
+	ethnode, err := ethclient.NewEthClient(hostConfig)
+	if err != nil {
+		panic(err)
+	}
+	return ethnode
+}

--- a/integration/simulation/network/inmemory.go
+++ b/integration/simulation/network/inmemory.go
@@ -95,8 +95,8 @@ func (n *basicNetworkOfInMemoryNodes) TearDown() {
 	for _, client := range n.obscuroClients {
 		temp := client
 		go func() {
-			defer (*temp).Stop()
 			_ = (*temp).Call(nil, obscuroclient.RPCStopHost)
+			(*temp).Stop()
 		}()
 	}
 

--- a/integration/simulation/network/inmemory.go
+++ b/integration/simulation/network/inmemory.go
@@ -19,7 +19,7 @@ import (
 
 type basicNetworkOfInMemoryNodes struct {
 	ethNodes       []*ethereum_mock.Node
-	obscuroClients []*obscuroclient.Client
+	obscuroClients []obscuroclient.Client
 }
 
 func NewBasicNetworkOfInMemoryNodes() Network {
@@ -27,11 +27,11 @@ func NewBasicNetworkOfInMemoryNodes() Network {
 }
 
 // Create inits and starts the nodes, wires them up, and populates the network objects
-func (n *basicNetworkOfInMemoryNodes) Create(params *params.SimParams, stats *stats.Stats) ([]ethclient.EthClient, []*obscuroclient.Client, []string, error) {
+func (n *basicNetworkOfInMemoryNodes) Create(params *params.SimParams, stats *stats.Stats) ([]ethclient.EthClient, []obscuroclient.Client, []string, error) {
 	l1Clients := make([]ethclient.EthClient, params.NumberOfNodes)
 	n.ethNodes = make([]*ethereum_mock.Node, params.NumberOfNodes)
 	obscuroNodes := make([]*host.Node, params.NumberOfNodes)
-	n.obscuroClients = make([]*obscuroclient.Client, params.NumberOfNodes)
+	n.obscuroClients = make([]obscuroclient.Client, params.NumberOfNodes)
 
 	for i := 0; i < params.NumberOfNodes; i++ {
 		isGenesis := i == 0
@@ -50,16 +50,16 @@ func (n *basicNetworkOfInMemoryNodes) Create(params *params.SimParams, stats *st
 			false,
 			nil,
 			params.NodeEthWallets[i],
+			miner,
 		)
 		obscuroClient := host.NewInMemObscuroClient(agg)
 
 		// and connect them to each other
-		agg.ConnectToEthNode(miner)
 		miner.AddClient(agg)
 
 		n.ethNodes[i] = miner
 		obscuroNodes[i] = agg
-		n.obscuroClients[i] = &obscuroClient
+		n.obscuroClients[i] = obscuroClient
 		l1Clients[i] = miner
 	}
 
@@ -95,8 +95,8 @@ func (n *basicNetworkOfInMemoryNodes) TearDown() {
 	for _, client := range n.obscuroClients {
 		temp := client
 		go func() {
-			_ = (*temp).Call(nil, obscuroclient.RPCStopHost)
-			(*temp).Stop()
+			_ = temp.Call(nil, obscuroclient.RPCStopHost)
+			temp.Stop()
 		}()
 	}
 

--- a/integration/simulation/network/network.go
+++ b/integration/simulation/network/network.go
@@ -17,6 +17,6 @@ type Network interface {
 	// Create - returns the started Ethereum nodes, the started Obscuro node clients, and the Obscuro nodes' P2P addresses.
 	// Responsible with spinning up all resources required for the test
 	// Return an error in case it cannot start for an expected reason. Otherwise it panics.
-	Create(params *params.SimParams, stats *stats.Stats) ([]ethclient.EthClient, []*obscuroclient.Client, []string, error)
+	Create(params *params.SimParams, stats *stats.Stats) ([]ethclient.EthClient, []obscuroclient.Client, []string, error)
 	TearDown()
 }

--- a/integration/simulation/network/network_utils.go
+++ b/integration/simulation/network/network_utils.go
@@ -4,6 +4,8 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/obscuronet/obscuro-playground/go/ethclient"
+
 	"github.com/obscuronet/obscuro-playground/go/obscuronode/config"
 
 	"github.com/obscuronet/obscuro-playground/go/ethclient/erc20contractlib"
@@ -55,6 +57,7 @@ func createInMemObscuroNode(
 	validateBlocks bool,
 	genesisJSON []byte,
 	ethWallet wallet.Wallet,
+	ethClient ethclient.EthClient,
 ) *host.Node {
 	obscuroInMemNetwork := simp2p.NewMockP2P(avgBlockDuration, avgNetworkLatency)
 
@@ -87,6 +90,7 @@ func createInMemObscuroNode(
 		mgmtContractLib,
 	)
 	obscuroInMemNetwork.CurrentNode = node
+	node.ConnectToEthNode(ethClient)
 	return node
 }
 
@@ -101,6 +105,7 @@ func createSocketObscuroNode(
 	clientServerAddr string,
 	ethWallet wallet.Wallet,
 	mgmtContractLib mgmtcontractlib.MgmtContractLib,
+	ethClient ethclient.EthClient,
 ) *host.Node {
 	hostConfig := config.HostConfig{
 		ID:                  common.BigToAddress(big.NewInt(id)),
@@ -131,6 +136,7 @@ func createSocketObscuroNode(
 		mgmtContractLib,
 	)
 
+	node.ConnectToEthNode(ethClient)
 	return node
 }
 

--- a/integration/simulation/network/obscuro_node_utils.go
+++ b/integration/simulation/network/obscuro_node_utils.go
@@ -147,6 +147,8 @@ func StopObscuroNodes(clients []obscuroclient.Client) {
 	} else {
 		log.Info("Obscuro nodes stopped")
 	}
+	// Wait a bit for the nodes to shut down.
+	time.Sleep(2 * time.Second)
 }
 
 // waitTimeout waits for the waitgroup for the specified max timeout.

--- a/integration/simulation/network/obscuro_node_utils.go
+++ b/integration/simulation/network/obscuro_node_utils.go
@@ -132,15 +132,14 @@ func StopObscuroNodes(clients []obscuroclient.Client) {
 	var wg sync.WaitGroup
 	for _, client := range clients {
 		wg.Add(1)
-		temp := client
-		go func() {
+		go func(c obscuroclient.Client) {
 			defer wg.Done()
-			err := temp.Call(nil, obscuroclient.RPCStopHost)
+			err := c.Call(nil, obscuroclient.RPCStopHost)
 			if err != nil {
 				log.Error("Failed to stop client %s", err)
 			}
-			temp.Stop()
-		}()
+			c.Stop()
+		}(client)
 	}
 	if waitTimeout(&wg, 2*time.Second) {
 		log.Error("Timed out waiting for the obscuro nodes to stop")

--- a/integration/simulation/network/obscuro_node_utils.go
+++ b/integration/simulation/network/obscuro_node_utils.go
@@ -1,0 +1,140 @@
+package network
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/obscuronet/obscuro-playground/go/log"
+
+	"github.com/obscuronet/obscuro-playground/go/ethclient"
+	"github.com/obscuronet/obscuro-playground/go/obscuronode/host"
+	"github.com/obscuronet/obscuro-playground/go/obscuronode/obscuroclient"
+	"github.com/obscuronet/obscuro-playground/integration/simulation/p2p"
+	"github.com/obscuronet/obscuro-playground/integration/simulation/params"
+	"github.com/obscuronet/obscuro-playground/integration/simulation/stats"
+)
+
+func startInMemoryObscuroNodes(params *params.SimParams, stats *stats.Stats, genesisJSON []byte, l1Clients []ethclient.EthClient) []obscuroclient.Client {
+	// Create the in memory obscuro nodes, each connect each to a geth node
+	obscuroNodes := make([]*host.Node, params.NumberOfNodes)
+	for i := 0; i < params.NumberOfNodes; i++ {
+		isGenesis := i == 0
+		obscuroNodes[i] = createInMemObscuroNode(
+			int64(i),
+			isGenesis,
+			params.MgmtContractLib,
+			params.ERC20ContractLib,
+			params.AvgGossipPeriod,
+			params.AvgBlockDuration,
+			params.AvgNetworkLatency,
+			stats,
+			true,
+			genesisJSON,
+			params.NodeEthWallets[i],
+			l1Clients[i],
+		)
+	}
+	// make sure the aggregators can talk to each other
+	for _, m := range obscuroNodes {
+		mockP2P := m.P2p.(*p2p.MockP2P)
+		mockP2P.Nodes = obscuroNodes
+	}
+
+	// start each obscuro node
+	for _, m := range obscuroNodes {
+		t := m
+		go t.Start()
+		time.Sleep(params.AvgBlockDuration / 10)
+	}
+
+	// Create a handle to each node
+	obscuroClients := make([]obscuroclient.Client, params.NumberOfNodes)
+	for i, node := range obscuroNodes {
+		obscuroClients[i] = host.NewInMemObscuroClient(node)
+	}
+	return obscuroClients
+}
+
+func startStandaloneObscuroNodes(params *params.SimParams, stats *stats.Stats, gethClients []ethclient.EthClient) ([]obscuroclient.Client, []string) {
+	// handle to the obscuro clients
+	obscuroClients := make([]obscuroclient.Client, params.NumberOfNodes)
+
+	obscuroNodes := make([]*host.Node, params.NumberOfNodes)
+	nodeP2pAddrs := make([]string, params.NumberOfNodes)
+
+	for i := 0; i < params.NumberOfNodes; i++ {
+		// We assign a P2P address to each node on the network according to the convention.
+		nodeP2pAddrs[i] = fmt.Sprintf("%s:%d", Localhost, params.StartPort+DefaultHostP2pOffset+i)
+	}
+
+	for i := 0; i < params.NumberOfNodes; i++ {
+		isGenesis := i == 0
+
+		// We use the convention to determine the rpc ports of the node and the enclave
+		nodeRpcAddress := fmt.Sprintf("%s:%d", Localhost, params.StartPort+DefaultHostRPCOffset+i)
+		enclaveAddress := fmt.Sprintf("%s:%d", Localhost, params.StartPort+DefaultEnclaveOffset+i)
+
+		// create a remote enclave server
+		obscuroNodes[i] = createSocketObscuroNode(
+			int64(i+1),
+			isGenesis,
+			params.AvgGossipPeriod,
+			stats,
+			nodeP2pAddrs[i],
+			nodeP2pAddrs,
+			enclaveAddress,
+			nodeRpcAddress,
+			params.NodeEthWallets[i],
+			params.MgmtContractLib,
+			gethClients[i],
+		)
+		obscuroClients[i] = obscuroclient.NewClient(nodeRpcAddress)
+	}
+
+	// start each obscuro node
+	for _, m := range obscuroNodes {
+		t := m
+		go t.Start()
+		time.Sleep(params.AvgBlockDuration / 3)
+	}
+
+	return obscuroClients, nodeP2pAddrs
+}
+
+func StopObscuroNodes(clients []obscuroclient.Client) {
+	var wg sync.WaitGroup
+	for _, client := range clients {
+		wg.Add(1)
+		temp := client
+		go func() {
+			defer wg.Done()
+			err := temp.Call(nil, obscuroclient.RPCStopHost)
+			if err != nil {
+				log.Error("Failed to stop client %s", err)
+			}
+			temp.Stop()
+		}()
+	}
+	if waitTimeout(&wg, 2*time.Second) {
+		log.Error("Timed out waiting for the obscuro nodes to stop")
+	} else {
+		log.Info("Obscuro nodes stopped")
+	}
+}
+
+// waitTimeout waits for the waitgroup for the specified max timeout.
+// Returns true if waiting timed out.
+func waitTimeout(wg *sync.WaitGroup, timeout time.Duration) bool {
+	c := make(chan struct{})
+	go func() {
+		defer close(c)
+		wg.Wait()
+	}()
+	select {
+	case <-c:
+		return false // completed normally
+	case <-time.After(timeout):
+		return true // timed out
+	}
+}

--- a/integration/simulation/network/obscuro_node_utils.go
+++ b/integration/simulation/network/obscuro_node_utils.go
@@ -82,7 +82,7 @@ func startStandaloneObscuroNodes(params *params.SimParams, stats *stats.Stats, g
 
 		// create a remote enclave server
 		obscuroNodes[i] = createSocketObscuroNode(
-			int64(i+1),
+			int64(i),
 			isGenesis,
 			params.AvgGossipPeriod,
 			stats,

--- a/integration/simulation/network/obscuro_node_utils.go
+++ b/integration/simulation/network/obscuro_node_utils.go
@@ -78,7 +78,7 @@ func startStandaloneObscuroNodes(params *params.SimParams, stats *stats.Stats, g
 		isGenesis := i == 0
 
 		// We use the convention to determine the rpc ports of the node
-		nodeRpcAddress := fmt.Sprintf("%s:%d", Localhost, params.StartPort+DefaultHostRPCOffset+i)
+		nodeRPCAddress := fmt.Sprintf("%s:%d", Localhost, params.StartPort+DefaultHostRPCOffset+i)
 
 		// create a remote enclave server
 		obscuroNodes[i] = createSocketObscuroNode(
@@ -89,12 +89,12 @@ func startStandaloneObscuroNodes(params *params.SimParams, stats *stats.Stats, g
 			nodeP2pAddrs[i],
 			nodeP2pAddrs,
 			enclaveAddresses[i],
-			nodeRpcAddress,
+			nodeRPCAddress,
 			params.NodeEthWallets[i],
 			params.MgmtContractLib,
 			gethClients[i],
 		)
-		obscuroClients[i] = obscuroclient.NewClient(nodeRpcAddress)
+		obscuroClients[i] = obscuroclient.NewClient(nodeRPCAddress)
 	}
 
 	// start each obscuro node

--- a/integration/simulation/network/socket.go
+++ b/integration/simulation/network/socket.go
@@ -164,16 +164,15 @@ func (n *networkOfSocketNodes) Create(params *params.SimParams, stats *stats.Sta
 }
 
 func (n *networkOfSocketNodes) TearDown() {
-	defer n.gethNetwork.StopNodes()
-
 	for _, client := range n.obscuroClients {
 		temp := client
 		go func() {
-			defer (*temp).Stop()
 			err := (*temp).Call(nil, obscuroclient.RPCStopHost)
+			(*temp).Stop()
 			if err != nil {
 				log.Error("Failed to stop client %s", err)
 			}
 		}()
 	}
+	n.gethNetwork.StopNodes()
 }

--- a/integration/simulation/network/socket.go
+++ b/integration/simulation/network/socket.go
@@ -3,16 +3,11 @@ package network
 import (
 	"fmt"
 	"math/big"
-	"time"
-
-	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/obscuronet/obscuro-playground/go/obscuronode/config"
 
 	"github.com/obscuronet/obscuro-playground/go/ethclient/erc20contractlib"
 	"github.com/obscuronet/obscuro-playground/go/obscuronode/wallet"
-	"github.com/obscuronet/obscuro-playground/integration/erc20contract"
-
 	"github.com/obscuronet/obscuro-playground/integration"
 
 	"github.com/obscuronet/obscuro-playground/go/ethclient/mgmtcontractlib"
@@ -28,16 +23,18 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/host"
 )
 
 // creates Obscuro nodes with their own enclave servers that communicate with peers via sockets, wires them up, and populates the network objects
 type networkOfSocketNodes struct {
-	obscuroClients []*obscuroclient.Client
-	gethNetwork    *gethnetwork.GethNetwork
-	wallets        []wallet.Wallet
-	contracts      []string
-	workerWallet   wallet.Wallet
+	obscuroClients []obscuroclient.Client
+
+	// geth
+	gethNetwork  *gethnetwork.GethNetwork
+	gethClients  []ethclient.EthClient
+	wallets      []wallet.Wallet
+	contracts    []string
+	workerWallet wallet.Wallet
 }
 
 func NewNetworkOfSocketNodes(wallets []wallet.Wallet, workerWallet wallet.Wallet, contracts []string) Network {
@@ -48,66 +45,30 @@ func NewNetworkOfSocketNodes(wallets []wallet.Wallet, workerWallet wallet.Wallet
 	}
 }
 
-func (n *networkOfSocketNodes) Create(params *params.SimParams, stats *stats.Stats) ([]ethclient.EthClient, []*obscuroclient.Client, []string, error) {
-	// make sure the geth network binaries exist
-	path, err := gethnetwork.EnsureBinariesExist(gethnetwork.LatestVersion)
-	if err != nil {
-		panic(err)
-	}
-
-	// get wallet addresses to prefund them
-	walletAddresses := make([]string, len(n.wallets))
-	for i, w := range n.wallets {
-		walletAddresses[i] = w.Address().String()
-	}
-
+func (n *networkOfSocketNodes) Create(params *params.SimParams, stats *stats.Stats) ([]ethclient.EthClient, []obscuroclient.Client, []string, error) {
 	// kickoff the network with the prefunded wallet addresses
-	n.gethNetwork = gethnetwork.NewGethNetwork(
+	params.MgmtContractAddr, params.StableTokenContractAddr, n.gethClients, n.gethNetwork = SetUpGethNetwork(
+		n.wallets,
+		n.workerWallet,
 		params.StartPort,
-		params.StartPort+DefaultWsPortOffset,
-		path,
 		params.NumberOfNodes,
 		int(params.AvgBlockDuration.Seconds()),
-		walletAddresses,
 	)
 
-	tmpHostConfig := config.HostConfig{
-		L1NodeHost:          Localhost,
-		L1NodeWebsocketPort: n.gethNetwork.WebSocketPorts[0],
-		L1ConnectionTimeout: DefaultL1ConnectionTimeout,
-	}
-	tmpEthClient, err := ethclient.NewEthClient(tmpHostConfig)
-	if err != nil {
-		panic(err)
-	}
+	params.MgmtContractLib = mgmtcontractlib.NewMgmtContractLib(params.MgmtContractAddr)
+	params.ERC20ContractLib = erc20contractlib.NewERC20ContractLib(params.MgmtContractAddr, params.StableTokenContractAddr)
 
-	mgmtContractAddr, err := DeployContract(tmpEthClient, n.workerWallet, common.Hex2Bytes(mgmtcontractlib.MgmtContractByteCode))
-	if err != nil {
-		panic(fmt.Sprintf("failed to deploy management contract. Cause: %s", err))
-	}
-	erc20ContractAddr, err := DeployContract(tmpEthClient, n.workerWallet, common.Hex2Bytes(erc20contract.ContractByteCode))
-	if err != nil {
-		panic(fmt.Sprintf("failed to deploy ERC20 contract. Cause: %s", err))
-	}
+	// Start the enclaves
+	startRemoteEnclaveServers(params, stats)
 
-	params.MgmtContractAddr = mgmtContractAddr
-	params.StableTokenContractAddr = erc20ContractAddr
-	params.MgmtContractLib = mgmtcontractlib.NewMgmtContractLib(mgmtContractAddr)
-	params.ERC20ContractLib = erc20contractlib.NewERC20ContractLib(mgmtContractAddr, erc20ContractAddr)
+	obscuroClients, nodeP2pAddrs := startStandaloneObscuroNodes(params, stats, n.gethClients)
+	n.obscuroClients = obscuroClients
 
-	l1Clients := make([]ethclient.EthClient, params.NumberOfNodes)
-	obscuroNodes := make([]*host.Node, params.NumberOfNodes)
-	n.obscuroClients = make([]*obscuroclient.Client, params.NumberOfNodes)
-	nodeP2pAddrs := make([]string, params.NumberOfNodes)
+	return n.gethClients, n.obscuroClients, nodeP2pAddrs, nil
+}
 
+func startRemoteEnclaveServers(params *params.SimParams, stats *stats.Stats) {
 	for i := 0; i < params.NumberOfNodes; i++ {
-		// We assign a P2P address to each node on the network.
-		nodeP2pAddrs[i] = fmt.Sprintf("%s:%d", Localhost, params.StartPort+200+i)
-	}
-
-	for i := 0; i < params.NumberOfNodes; i++ {
-		isGenesis := i == 0
-
 		// create a remote enclave server
 		enclaveAddr := fmt.Sprintf("%s:%d", Localhost, params.StartPort+DefaultEnclaveOffset+i)
 		enclaveConfig := config.EnclaveConfig{
@@ -124,55 +85,13 @@ func (n *networkOfSocketNodes) Create(params *params.SimParams, stats *stats.Sta
 		if err != nil {
 			panic(fmt.Sprintf("failed to create enclave server: %v", err))
 		}
-
-		// create the L1 client, the Obscuro host and enclave service, and the L2 client
-		l1Client := createEthClientConnection(
-			int64(i),
-			n.gethNetwork.WebSocketPorts[i],
-		)
-		obscuroClientAddr := fmt.Sprintf("%s:%d", Localhost, params.StartPort+400+i)
-		obscuroClient := obscuroclient.NewClient(obscuroClientAddr)
-		agg := createSocketObscuroNode(
-			int64(i),
-			isGenesis,
-			params.AvgGossipPeriod,
-			stats,
-			nodeP2pAddrs[i],
-			nodeP2pAddrs,
-			enclaveAddr,
-			obscuroClientAddr,
-			params.NodeEthWallets[i],
-			params.MgmtContractLib,
-		)
-
-		// connect the L1 and L2 nodes
-		agg.ConnectToEthNode(l1Client)
-
-		obscuroNodes[i] = agg
-		n.obscuroClients[i] = &obscuroClient
-		l1Clients[i] = l1Client
 	}
-
-	// start each obscuro node
-	for _, m := range obscuroNodes {
-		t := m
-		go t.Start()
-		time.Sleep(params.AvgBlockDuration / 3)
-	}
-
-	return l1Clients, n.obscuroClients, nodeP2pAddrs, nil
 }
 
 func (n *networkOfSocketNodes) TearDown() {
-	for _, client := range n.obscuroClients {
-		temp := client
-		go func() {
-			err := (*temp).Call(nil, obscuroclient.RPCStopHost)
-			(*temp).Stop()
-			if err != nil {
-				log.Error("Failed to stop client %s", err)
-			}
-		}()
-	}
-	n.gethNetwork.StopNodes()
+	// First stop the obscuro nodes
+	StopObscuroNodes(n.obscuroClients)
+	StopGethNetwork(n.gethClients, n.gethNetwork)
+
+	// stop the enclaves
 }

--- a/integration/simulation/network/socket.go
+++ b/integration/simulation/network/socket.go
@@ -54,6 +54,7 @@ func (n *networkOfSocketNodes) Create(params *params.SimParams, stats *stats.Sta
 	// Start the enclaves
 	startRemoteEnclaveServers(0, params, stats)
 
+	n.enclaveAddresses = make([]string, params.NumberOfNodes)
 	for i := 0; i < params.NumberOfNodes; i++ {
 		n.enclaveAddresses[i] = fmt.Sprintf("%s:%d", Localhost, params.StartPort+DefaultEnclaveOffset+i)
 	}

--- a/integration/simulation/simulation.go
+++ b/integration/simulation/simulation.go
@@ -20,9 +20,9 @@ const initialBalance = 5000
 
 // Simulation represents all the data required to inject transactions on a network
 type Simulation struct {
-	EthClients       []ethclient.EthClient   // the list of mock ethereum clients
-	ObscuroClients   []*obscuroclient.Client // the list of Obscuro host clients
-	ObscuroP2PAddrs  []string                // the P2P addresses of the Obscuro nodes
+	EthClients       []ethclient.EthClient  // the list of mock ethereum clients
+	ObscuroClients   []obscuroclient.Client // the list of Obscuro host clients
+	ObscuroP2PAddrs  []string               // the P2P addresses of the Obscuro nodes
 	AvgBlockDuration uint64
 	TxInjector       *TransactionInjector
 	SimulationTime   time.Duration

--- a/integration/simulation/transaction_injector.go
+++ b/integration/simulation/transaction_injector.go
@@ -40,7 +40,7 @@ type TransactionInjector struct {
 	ethWallets    []wallet.Wallet
 	obsWallets    []wallet.Wallet
 	l1Clients     []ethclient.EthClient
-	l2Clients     []*obscuroclient.Client
+	l2Clients     []obscuroclient.Client
 
 	// addrs and libs
 	erc20ContractAddr *common.Address
@@ -62,7 +62,7 @@ func NewTransactionInjector(
 	ethWallets []wallet.Wallet,
 	mgmtContractAddr *common.Address,
 	erc20ContractAddr *common.Address,
-	l2NodeClients []*obscuroclient.Client,
+	l2NodeClients []obscuroclient.Client,
 	mgmtContractLib mgmtcontractlib.MgmtContractLib,
 	erc20ContractLib erc20contractlib.ERC20ContractLib,
 ) *TransactionInjector {
@@ -166,7 +166,7 @@ func (m *TransactionInjector) deploySingleObscuroERC20(w wallet.Wallet) {
 		panic(err)
 	}
 	encryptedTx := core.EncryptTx(signedTx)
-	err = (*m.rndL2NodeClient()).Call(nil, obscuroclient.RPCSendTransactionEncrypted, encryptedTx)
+	err = m.rndL2NodeClient().Call(nil, obscuroclient.RPCSendTransactionEncrypted, encryptedTx)
 	if err != nil {
 		panic(err)
 	}
@@ -197,7 +197,7 @@ func (m *TransactionInjector) issueRandomTransfers() {
 		encryptedTx := core.EncryptTx(signedTx)
 		m.stats.Transfer()
 
-		err = (*m.rndL2NodeClient()).Call(nil, obscuroclient.RPCSendTransactionEncrypted, encryptedTx)
+		err = m.rndL2NodeClient().Call(nil, obscuroclient.RPCSendTransactionEncrypted, encryptedTx)
 		if err != nil {
 			log.Info("Failed to issue transfer via RPC. Cause: %s", err)
 			continue
@@ -247,7 +247,7 @@ func (m *TransactionInjector) issueRandomWithdrawals() {
 		}
 		encryptedTx := core.EncryptTx(signedTx)
 
-		err = (*m.rndL2NodeClient()).Call(nil, obscuroclient.RPCSendTransactionEncrypted, encryptedTx)
+		err = m.rndL2NodeClient().Call(nil, obscuroclient.RPCSendTransactionEncrypted, encryptedTx)
 		if err != nil {
 			log.Info("Failed to issue withdrawal via RPC. Cause: %s", err)
 			continue
@@ -272,7 +272,7 @@ func (m *TransactionInjector) issueInvalidL2Txs() {
 		signedTx := m.createInvalidSignage(tx, fromWallet)
 		encryptedTx := core.EncryptTx(signedTx)
 
-		err := (*m.rndL2NodeClient()).Call(nil, obscuroclient.RPCSendTransactionEncrypted, encryptedTx)
+		err := m.rndL2NodeClient().Call(nil, obscuroclient.RPCSendTransactionEncrypted, encryptedTx)
 		if err != nil {
 			log.Info("Failed to issue withdrawal via RPC. Cause: %s", err)
 			continue
@@ -307,16 +307,16 @@ func (m *TransactionInjector) rndL1NodeClient() ethclient.EthClient {
 	return m.l1Clients[rand.Intn(len(m.l1Clients))] //nolint:gosec
 }
 
-func (m *TransactionInjector) rndL2NodeClient() *obscuroclient.Client {
+func (m *TransactionInjector) rndL2NodeClient() obscuroclient.Client {
 	return m.l2Clients[rand.Intn(len(m.l2Clients))] //nolint:gosec
 }
 
-func newObscuroTransferTx(from wallet.Wallet, dest common.Address, amount uint64, client *obscuroclient.Client) types.TxData {
+func newObscuroTransferTx(from wallet.Wallet, dest common.Address, amount uint64, client obscuroclient.Client) types.TxData {
 	data := erc20contractlib.CreateTransferTxData(dest, amount)
 	return newTx(data, NextNonce(client, from))
 }
 
-func newObscuroWithdrawalTx(from wallet.Wallet, amount uint64, client *obscuroclient.Client) types.TxData {
+func newObscuroWithdrawalTx(from wallet.Wallet, amount uint64, client obscuroclient.Client) types.TxData {
 	transferERC20data := erc20contractlib.CreateTransferTxData(evm.WithdrawalAddress, amount)
 	return newTx(transferERC20data, NextNonce(client, from))
 }
@@ -337,16 +337,16 @@ func newTx(data []byte, nonce uint64) types.TxData {
 	}
 }
 
-func readNonce(cl *obscuroclient.Client, a common.Address) uint64 {
+func readNonce(cl obscuroclient.Client, a common.Address) uint64 {
 	var result uint64
-	err := (*cl).Call(&result, obscuroclient.RPCNonce, a)
+	err := cl.Call(&result, obscuroclient.RPCNonce, a)
 	if err != nil {
 		panic(err)
 	}
 	return result
 }
 
-func NextNonce(cl *obscuroclient.Client, w wallet.Wallet) uint64 {
+func NextNonce(cl obscuroclient.Client, w wallet.Wallet) uint64 {
 	// only returns the nonce when the previous transaction was recorded
 	for {
 		result := readNonce(cl, w.Address())

--- a/integration/simulation/utils.go
+++ b/integration/simulation/utils.go
@@ -45,11 +45,11 @@ func minMax(arr []uint64) (min uint64, max uint64) {
 }
 
 // Uses the client to retrieve the height of the current block head.
-func getCurrentBlockHeadHeight(client *obscuroclient.Client) int64 {
+func getCurrentBlockHeadHeight(client obscuroclient.Client) int64 {
 	method := obscuroclient.RPCGetCurrentBlockHead
 
 	var blockHead *types.Header
-	err := (*client).Call(&blockHead, method)
+	err := client.Call(&blockHead, method)
 	if err != nil {
 		panic(fmt.Errorf("simulation failed due to failed %s RPC call. Cause: %w", method, err))
 	}
@@ -62,11 +62,11 @@ func getCurrentBlockHeadHeight(client *obscuroclient.Client) int64 {
 }
 
 // Uses the client to retrieve the current rollup head.
-func getCurrentRollupHead(client *obscuroclient.Client) *nodecommon.Header {
+func getCurrentRollupHead(client obscuroclient.Client) *nodecommon.Header {
 	method := obscuroclient.RPCGetCurrentRollupHead
 
 	var result *nodecommon.Header
-	err := (*client).Call(&result, method)
+	err := client.Call(&result, method)
 	if err != nil {
 		panic(fmt.Errorf("simulation failed due to failed %s RPC call. Cause: %w", method, err))
 	}
@@ -75,11 +75,11 @@ func getCurrentRollupHead(client *obscuroclient.Client) *nodecommon.Header {
 }
 
 // Uses the client to retrieve the rollup header with the matching hash.
-func getRollupHeader(client *obscuroclient.Client, hash common.Hash) *nodecommon.Header {
+func getRollupHeader(client obscuroclient.Client, hash common.Hash) *nodecommon.Header {
 	method := obscuroclient.RPCGetRollupHeader
 
 	var result *nodecommon.Header
-	err := (*client).Call(&result, method, hash)
+	err := client.Call(&result, method, hash)
 	if err != nil {
 		panic(fmt.Errorf("simulation failed due to failed %s RPC call. Cause: %w", method, err))
 	}
@@ -88,11 +88,11 @@ func getRollupHeader(client *obscuroclient.Client, hash common.Hash) *nodecommon
 }
 
 // Uses the client to retrieve the transaction with the matching hash.
-func getTransaction(client *obscuroclient.Client, hash common.Hash) *nodecommon.L2Tx {
+func getTransaction(client obscuroclient.Client, hash common.Hash) *nodecommon.L2Tx {
 	method := obscuroclient.RPCGetTransaction
 
 	var result *nodecommon.L2Tx
-	err := (*client).Call(&result, method, hash)
+	err := client.Call(&result, method, hash)
 	if err != nil {
 		panic(fmt.Errorf("simulation failed due to failed %s RPC call. Cause: %w", method, err))
 	}
@@ -101,11 +101,11 @@ func getTransaction(client *obscuroclient.Client, hash common.Hash) *nodecommon.
 }
 
 // Uses the client to retrieve the balance of the wallet with the given address.
-func balance(client *obscuroclient.Client, address common.Address) uint64 {
+func balance(client obscuroclient.Client, address common.Address) uint64 {
 	method := obscuroclient.RPCBalance
 
 	var result uint64
-	err := (*client).Call(&result, method, address)
+	err := client.Call(&result, method, address)
 	if err != nil {
 		panic(fmt.Errorf("simulation failed due to failed %s RPC call. Cause: %w", method, err))
 	}

--- a/integration/simulation/validate_chain.go
+++ b/integration/simulation/validate_chain.go
@@ -163,7 +163,7 @@ const MAX_BLOCK_DELAY = 5 // nolint:revive,stylecheck
 
 func checkBlockchainOfObscuroNode(
 	t *testing.T,
-	nodeClient *obscuroclient.Client,
+	nodeClient obscuroclient.Client,
 	minObscuroHeight uint64,
 	maxEthereumHeight uint64,
 	s *Simulation,
@@ -173,7 +173,7 @@ func checkBlockchainOfObscuroNode(
 ) {
 	defer wg.Done()
 	var nodeID common.Address
-	err := (*nodeClient).Call(&nodeID, obscuroclient.RPCGetID)
+	err := nodeClient.Call(&nodeID, obscuroclient.RPCGetID)
 	if err != nil {
 		t.Errorf("Could not retrieve Obscuro node's address when checking blockchain.")
 	}
@@ -280,7 +280,7 @@ func checkBlockchainOfObscuroNode(
 	heights[nodeIdx] = l2Height
 }
 
-func extractWithdrawals(t *testing.T, nodeClient *obscuroclient.Client, nodeAddr uint64) (totalSuccessfullyWithdrawn uint64, numberOfWithdrawalRequests int) {
+func extractWithdrawals(t *testing.T, nodeClient obscuroclient.Client, nodeAddr uint64) (totalSuccessfullyWithdrawn uint64, numberOfWithdrawalRequests int) {
 	head := getCurrentRollupHead(nodeClient)
 
 	if head == nil {

--- a/tools/networkmanager/inject_txs.go
+++ b/tools/networkmanager/inject_txs.go
@@ -46,7 +46,7 @@ func InjectTransactions(nmConfig Config) {
 		[]wallet.Wallet{l1Wallet},
 		&nmConfig.mgmtContractAddress,
 		&nmConfig.erc20ContractAddress,
-		[]*obscuroclient.Client{&l2Client},
+		[]obscuroclient.Client{l2Client},
 		mgmtcontractlib.NewMgmtContractLib(&nmConfig.mgmtContractAddress),
 		erc20contractlib.NewERC20ContractLib(&nmConfig.mgmtContractAddress, &nmConfig.erc20ContractAddress),
 	)

--- a/tools/obscuroscan/obscuroscan.go
+++ b/tools/obscuroscan/obscuroscan.go
@@ -32,7 +32,7 @@ const (
 // Obscuroscan is a server that allows the monitoring of a running Obscuro network.
 type Obscuroscan struct {
 	server      *http.Server
-	client      *obscuroclient.Client
+	client      obscuroclient.Client
 	contractABI abi.ABI
 }
 
@@ -43,7 +43,7 @@ func NewObscuroscan(address string) *Obscuroscan {
 		panic("could not parse management contract ABI to decrypt rollups")
 	}
 	return &Obscuroscan{
-		client:      &client,
+		client:      client,
 		contractABI: contractABI,
 	}
 }
@@ -79,7 +79,7 @@ func (o *Obscuroscan) Shutdown() {
 // Retrieves the current block header for the Obscuro network.
 func (o *Obscuroscan) getBlockHead(resp http.ResponseWriter, _ *http.Request) {
 	var headBlock *types.Header
-	err := (*o.client).Call(&headBlock, obscuroclient.RPCGetCurrentBlockHead)
+	err := o.client.Call(&headBlock, obscuroclient.RPCGetCurrentBlockHead)
 	if err != nil {
 		logAndSendErr(resp, fmt.Sprintf("could not retrieve head block. Cause: %s", err))
 		return
@@ -101,7 +101,7 @@ func (o *Obscuroscan) getBlockHead(resp http.ResponseWriter, _ *http.Request) {
 func (o *Obscuroscan) getHeadRollup(resp http.ResponseWriter, _ *http.Request) {
 	// TODO - Update logic here once rollups are encrypted.
 	var headRollup *nodecommon.Header
-	err := (*o.client).Call(&headRollup, obscuroclient.RPCGetCurrentRollupHead)
+	err := o.client.Call(&headRollup, obscuroclient.RPCGetCurrentRollupHead)
 	if err != nil {
 		logAndSendErr(resp, fmt.Sprintf("could not retrieve head rollup. Cause: %s", err))
 		return


### PR DESCRIPTION
### Why is this change needed?

The integration tests became quite hard to follow. 
There is a general pattern for all tests except the pure in-memory test:

1. Start a geth network , deploy the contracts, and return the addresses
2. Start up obscuro components
  a) Enclaves. Which can be started inside the obscuro node, standalone process, inside docker or manually in azure
  b) The Obscuro node which can be in memory or standalone and it has to know the address of the enclave.

The stopping order should be:
- first stop the obscuro host. Because this glues everything together, and needs everything up and running until the very end.
- then stop the enclaves and the ethereum network

### What changes were made as part of this PR:
This is mostly a refactoring PR. The only thing that changed functionally is the sequence of stopping resources in TearDown. 

- the geth setup and teardown logic was extracted in functions and move to a file
- starting enclaves was extracted and the rpc addresses of the enclaves are now being passed to the logic that starts the nodes

These changes allow for the `Network.Create` functions to be much more compact

- the `TearDown` now implements the stopping pattern

- the "ethclient.EthClient" interface was being passed around as a pointer.

### What are the key areas to look at
 - The readability of the "azureenclave", "dockerenclave",  "geth_network" and "socket" network setup files