### PR TITLE
Replace obscuro-playground with go-obscuro

### DIFF
--- a/dockerfiles/enclave.Dockerfile
+++ b/dockerfiles/enclave.Dockerfile
@@ -1,8 +1,8 @@
 FROM ghcr.io/edgelesssys/ego-dev:latest
 
-RUN git clone https://github.com/obscuronet/obscuro-playground
-RUN cd obscuro-playground/go/obscuronode/enclave/main && ego-go build && ego sign main
+RUN git clone https://github.com/obscuronet/go-obscuro
+RUN cd go-obscuro/go/obscuronode/enclave/main && ego-go build && ego sign main
 
 ENV OE_SIMULATION=1
-ENTRYPOINT ["ego", "run", "obscuro-playground/go/obscuronode/enclave/main/main"]
+ENTRYPOINT ["ego", "run", "go-obscuro/go/obscuronode/enclave/main/main"]
 EXPOSE 11000

--- a/dockerfiles/enclave_local_build.Dockerfile
+++ b/dockerfiles/enclave_local_build.Dockerfile
@@ -1,10 +1,10 @@
 FROM ghcr.io/edgelesssys/ego-dev:latest
 
 # build the enclave from the current branch
-RUN mkdir /home/obscuro-playground
-COPY . /home/obscuro-playground
-RUN cd /home/obscuro-playground/go/obscuronode/enclave/main && ego-go build && ego sign main
+RUN mkdir /home/go-obscuro
+COPY . /home/go-obscuro
+RUN cd /home/go-obscuro/go/obscuronode/enclave/main && ego-go build && ego sign main
 
 ENV OE_SIMULATION=1
-ENTRYPOINT ["ego", "run", "/home/obscuro-playground/go/obscuronode/enclave/main/main"]
+ENTRYPOINT ["ego", "run", "/home/go-obscuro/go/obscuronode/enclave/main/main"]
 EXPOSE 11000

--- a/dockerfiles/plain_go_enclave_local.Dockerfile
+++ b/dockerfiles/plain_go_enclave_local.Dockerfile
@@ -1,9 +1,9 @@
 FROM golang:1.17-alpine
 
 # build the enclave from the current branch
-RUN mkdir /home/obscuro-playground
-COPY . /home/obscuro-playground
-WORKDIR /home/obscuro-playground/go/obscuronode/enclave/main
+RUN mkdir /home/go-obscuro
+COPY . /home/go-obscuro
+WORKDIR /home/go-obscuro/go/obscuronode/enclave/main
 RUN apk add build-base
 ENV CGO_ENABLED=1
 # Download all the dependencies

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/obscuronet/obscuro-playground
+module github.com/obscuronet/go-obscuro
 
 go 1.17
 

--- a/go/ethclient/erc20contractlib/erc20_contract_lib.go
+++ b/go/ethclient/erc20contractlib/erc20_contract_lib.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
+	"github.com/obscuronet/go-obscuro/go/obscurocommon"
 )
 
 const methodBytesLen = 4

--- a/go/ethclient/erc20contractlib/obscuro_ERC20_contract_ABI.go
+++ b/go/ethclient/erc20contractlib/obscuro_ERC20_contract_ABI.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/obscuronet/obscuro-playground/go/log"
-	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
+	"github.com/obscuronet/go-obscuro/go/log"
+	"github.com/obscuronet/go-obscuro/go/obscurocommon"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 )

--- a/go/ethclient/interface.go
+++ b/go/ethclient/interface.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
+	"github.com/obscuronet/go-obscuro/go/obscurocommon"
 )
 
 // EthClient defines the interface for RPC communications with the ethereum nodes

--- a/go/ethclient/l1_client.go
+++ b/go/ethclient/l1_client.go
@@ -6,13 +6,13 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/config"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/config"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
-	"github.com/obscuronet/obscuro-playground/go/log"
-	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
+	"github.com/obscuronet/go-obscuro/go/log"
+	"github.com/obscuronet/go-obscuro/go/obscurocommon"
 )
 
 // gethRPCClient implements the EthClient interface and allows connection to a real ethereum node

--- a/go/ethclient/mgmtcontractlib/mgmt_contract_lib.go
+++ b/go/ethclient/mgmtcontractlib/mgmt_contract_lib.go
@@ -8,12 +8,12 @@ import (
 	"math/big"
 	"strings"
 
-	"github.com/obscuronet/obscuro-playground/go/log"
+	"github.com/obscuronet/go-obscuro/go/log"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
+	"github.com/obscuronet/go-obscuro/go/obscurocommon"
 )
 
 const methodBytesLen = 4

--- a/go/obscurocommon/encoding.go
+++ b/go/obscurocommon/encoding.go
@@ -3,7 +3,7 @@ package obscurocommon
 import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rlp"
-	"github.com/obscuronet/obscuro-playground/go/log"
+	"github.com/obscuronet/go-obscuro/go/log"
 )
 
 func EncodeBlock(b *types.Block) EncodedBlock {

--- a/go/obscuronode/enclave/attestation.go
+++ b/go/obscuronode/enclave/attestation.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/edgelesssys/ego/enclave"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
+	"github.com/obscuronet/go-obscuro/go/obscurocommon"
 )
 
 type IDData struct {

--- a/go/obscuronode/enclave/core/crypto.go
+++ b/go/obscuronode/enclave/core/crypto.go
@@ -2,8 +2,8 @@ package core
 
 import (
 	"github.com/ethereum/go-ethereum/rlp"
-	"github.com/obscuronet/obscuro-playground/go/log"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
+	"github.com/obscuronet/go-obscuro/go/log"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/nodecommon"
 )
 
 // todo - this should become an elaborate data structure

--- a/go/obscuronode/enclave/core/rollup.go
+++ b/go/obscuronode/enclave/core/rollup.go
@@ -4,8 +4,8 @@ import (
 	"sync/atomic"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
+	"github.com/obscuronet/go-obscuro/go/obscurocommon"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/nodecommon"
 )
 
 // Rollup Data structure only for the internal use of the enclave since transactions are in clear

--- a/go/obscuronode/enclave/core/rollup_test.go
+++ b/go/obscuronode/enclave/core/rollup_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/rlp"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
-	"github.com/obscuronet/obscuro-playground/integration/datagenerator"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/nodecommon"
+	"github.com/obscuronet/go-obscuro/integration/datagenerator"
 )
 
 func TestSerialiseL2Tx(t *testing.T) {

--- a/go/obscuronode/enclave/core/types.go
+++ b/go/obscuronode/enclave/core/types.go
@@ -2,7 +2,7 @@ package core
 
 import (
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/nodecommon"
 )
 
 // L2Txs Todo - is this type useful?

--- a/go/obscuronode/enclave/db/db.go
+++ b/go/obscuronode/enclave/db/db.go
@@ -3,13 +3,13 @@ package db
 import (
 	"sync"
 
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/core"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/enclave/core"
 
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/nodecommon"
 
 	"github.com/ethereum/go-ethereum/common"
 
-	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
+	"github.com/obscuronet/go-obscuro/go/obscurocommon"
 )
 
 // InMemoryDB lives purely in the encrypted memory space of an enclave.

--- a/go/obscuronode/enclave/db/interfaces.go
+++ b/go/obscuronode/enclave/db/interfaces.go
@@ -5,9 +5,9 @@ import (
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethdb"
-	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/core"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
+	"github.com/obscuronet/go-obscuro/go/obscurocommon"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/enclave/core"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/nodecommon"
 )
 
 // BlockResolver stores new blocks and returns information on existing blocks

--- a/go/obscuronode/enclave/db/storage.go
+++ b/go/obscuronode/enclave/db/storage.go
@@ -4,14 +4,14 @@ import (
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/ethdb"
-	"github.com/obscuronet/obscuro-playground/go/log"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/core"
-	obscurorawdb "github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/rawdb"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
+	"github.com/obscuronet/go-obscuro/go/log"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/enclave/core"
+	obscurorawdb "github.com/obscuronet/go-obscuro/go/obscuronode/enclave/rawdb"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/nodecommon"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
+	"github.com/obscuronet/go-obscuro/go/obscurocommon"
 )
 
 type storageImpl struct {

--- a/go/obscuronode/enclave/enclave.go
+++ b/go/obscuronode/enclave/enclave.go
@@ -11,28 +11,28 @@ import (
 	"math/big"
 	"sync"
 
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/sql"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/enclave/sql"
 
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/ethdb"
 
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/config"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/config"
 
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/evm"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/enclave/evm"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/obscuronet/obscuro-playground/go/ethclient/erc20contractlib"
-	"github.com/obscuronet/obscuro-playground/go/ethclient/mgmtcontractlib"
-	"github.com/obscuronet/obscuro-playground/go/log"
-	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/db"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/mempool"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
+	"github.com/obscuronet/go-obscuro/go/ethclient/erc20contractlib"
+	"github.com/obscuronet/go-obscuro/go/ethclient/mgmtcontractlib"
+	"github.com/obscuronet/go-obscuro/go/log"
+	"github.com/obscuronet/go-obscuro/go/obscurocommon"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/enclave/db"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/enclave/mempool"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/nodecommon"
 
-	obscurocore "github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/core"
+	obscurocore "github.com/obscuronet/go-obscuro/go/obscuronode/enclave/core"
 )
 
 const msgNoRollup = "could not fetch rollup"

--- a/go/obscuronode/enclave/enclave_test.go
+++ b/go/obscuronode/enclave/enclave_test.go
@@ -4,7 +4,7 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/obscuronet/obscuro-playground/integration/datagenerator"
+	"github.com/obscuronet/go-obscuro/integration/datagenerator"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"

--- a/go/obscuronode/enclave/enclaverunner/cli.go
+++ b/go/obscuronode/enclave/enclaverunner/cli.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/naoina/toml"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/config"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/config"
 )
 
 // EnclaveConfigToml is the structure that an enclave's .toml config is parsed into.

--- a/go/obscuronode/enclave/enclaverunner/enclave_runner.go
+++ b/go/obscuronode/enclave/enclaverunner/enclave_runner.go
@@ -6,12 +6,12 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/config"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/config"
 
-	"github.com/obscuronet/obscuro-playground/go/ethclient/erc20contractlib"
-	"github.com/obscuronet/obscuro-playground/go/ethclient/mgmtcontractlib"
-	"github.com/obscuronet/obscuro-playground/go/log"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave"
+	"github.com/obscuronet/go-obscuro/go/ethclient/erc20contractlib"
+	"github.com/obscuronet/go-obscuro/go/ethclient/mgmtcontractlib"
+	"github.com/obscuronet/go-obscuro/go/log"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/enclave"
 )
 
 // TODO - Replace with the genesis.json of Obscuro's L1 network.

--- a/go/obscuronode/enclave/evm/chain_context.go
+++ b/go/obscuronode/enclave/evm/chain_context.go
@@ -4,7 +4,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/db"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/enclave/db"
 )
 
 // ObscuroChainContext - basic implementation of the ChainContext needed for the EVM integration

--- a/go/obscuronode/enclave/evm/evm_facade.go
+++ b/go/obscuronode/enclave/evm/evm_facade.go
@@ -4,9 +4,9 @@ import (
 	"math"
 	"math/big"
 
-	"github.com/obscuronet/obscuro-playground/go/ethclient/erc20contractlib"
+	"github.com/obscuronet/go-obscuro/go/ethclient/erc20contractlib"
 
-	"github.com/obscuronet/obscuro-playground/go/log"
+	"github.com/obscuronet/go-obscuro/go/log"
 
 	"github.com/ethereum/go-ethereum/common"
 	core2 "github.com/ethereum/go-ethereum/core"
@@ -15,9 +15,9 @@ import (
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
-	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/db"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
+	"github.com/obscuronet/go-obscuro/go/obscurocommon"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/enclave/db"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/nodecommon"
 )
 
 // These are hardcoded values necessary as an intermediary step.

--- a/go/obscuronode/enclave/evm/utils.go
+++ b/go/obscuronode/enclave/evm/utils.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rlp"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/nodecommon"
 )
 
 // Perform the conversion between an Obscuro header and an Ethereum header that the EVM understands

--- a/go/obscuronode/enclave/l1_blockchain.go
+++ b/go/obscuronode/enclave/l1_blockchain.go
@@ -130,7 +130,7 @@ func createEngine(dataDir string, chainConfig *params.ChainConfig, db ethdb.Data
 			DatasetsOnDisk:   ethconfig.Defaults.Ethash.DatasetsOnDisk,   // Default.
 			DatasetsLockMmap: ethconfig.Defaults.Ethash.DatasetsLockMmap, // Default.
 			NotifyFull:       false,                                      // Default.
-		}, nil, false)                                      // Defaults.
+		}, nil, false) // Defaults.
 		interface{}(engine).(*ethash.Ethash).SetThreads(-1) // Disables CPU mining.
 	}
 	return beacon.New(engine)

--- a/go/obscuronode/enclave/l1_blockchain.go
+++ b/go/obscuronode/enclave/l1_blockchain.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"path"
 
-	"github.com/obscuronet/obscuro-playground/go/log"
+	"github.com/obscuronet/go-obscuro/go/log"
 
 	"github.com/ethereum/go-ethereum/consensus/clique"
 
@@ -130,7 +130,7 @@ func createEngine(dataDir string, chainConfig *params.ChainConfig, db ethdb.Data
 			DatasetsOnDisk:   ethconfig.Defaults.Ethash.DatasetsOnDisk,   // Default.
 			DatasetsLockMmap: ethconfig.Defaults.Ethash.DatasetsLockMmap, // Default.
 			NotifyFull:       false,                                      // Default.
-		}, nil, false) // Defaults.
+		}, nil, false)                                      // Defaults.
 		interface{}(engine).(*ethash.Ethash).SetThreads(-1) // Disables CPU mining.
 	}
 	return beacon.New(engine)

--- a/go/obscuronode/enclave/main/main.go
+++ b/go/obscuronode/enclave/main/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/enclaverunner"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/enclave/enclaverunner"
 )
 
 // Runs an Obscuro enclave as a standalone process.

--- a/go/obscuronode/enclave/mempool/interface.go
+++ b/go/obscuronode/enclave/mempool/interface.go
@@ -2,7 +2,7 @@ package mempool
 
 import (
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/nodecommon"
 )
 
 type Manager interface {

--- a/go/obscuronode/enclave/mempool/manager.go
+++ b/go/obscuronode/enclave/mempool/manager.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/nodecommon"
 )
 
 type mempoolManager struct {

--- a/go/obscuronode/enclave/rawdb/accessors_chain.go
+++ b/go/obscuronode/enclave/rawdb/accessors_chain.go
@@ -4,13 +4,13 @@ import (
 	"bytes"
 	"encoding/binary"
 
-	"github.com/obscuronet/obscuro-playground/go/log"
+	"github.com/obscuronet/go-obscuro/go/log"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/rlp"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/core"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/enclave/core"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/nodecommon"
 )
 
 func ReadRollup(db ethdb.KeyValueReader, hash common.Hash) *core.Rollup {

--- a/go/obscuronode/enclave/rawdb/accessors_metadata.go
+++ b/go/obscuronode/enclave/rawdb/accessors_metadata.go
@@ -4,8 +4,8 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/rlp"
-	"github.com/obscuronet/obscuro-playground/go/log"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/core"
+	"github.com/obscuronet/go-obscuro/go/log"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/enclave/core"
 )
 
 func ReadSharedSecret(db ethdb.KeyValueReader) *core.SharedEnclaveSecret {

--- a/go/obscuronode/enclave/server.go
+++ b/go/obscuronode/enclave/server.go
@@ -7,19 +7,19 @@ import (
 	"net"
 
 	"github.com/naoina/toml"
-	"github.com/obscuronet/obscuro-playground/go/log"
+	"github.com/obscuronet/go-obscuro/go/log"
 
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/config"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/config"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rlp"
-	"github.com/obscuronet/obscuro-playground/go/ethclient/erc20contractlib"
-	"github.com/obscuronet/obscuro-playground/go/ethclient/mgmtcontractlib"
-	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon/rpc"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon/rpc/generated"
+	"github.com/obscuronet/go-obscuro/go/ethclient/erc20contractlib"
+	"github.com/obscuronet/go-obscuro/go/ethclient/mgmtcontractlib"
+	"github.com/obscuronet/go-obscuro/go/obscurocommon"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/nodecommon"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/nodecommon/rpc"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/nodecommon/rpc/generated"
 	"google.golang.org/grpc"
 )
 

--- a/go/obscuronode/enclave/state.go
+++ b/go/obscuronode/enclave/state.go
@@ -6,19 +6,19 @@ import (
 	"sort"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/evm"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/enclave/evm"
 
 	"github.com/ethereum/go-ethereum/core/state"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/core"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/db"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/enclave/core"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/enclave/db"
 
-	"github.com/obscuronet/obscuro-playground/go/ethclient/mgmtcontractlib"
+	"github.com/obscuronet/go-obscuro/go/ethclient/mgmtcontractlib"
 
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/obscuronet/obscuro-playground/go/ethclient/erc20contractlib"
-	"github.com/obscuronet/obscuro-playground/go/log"
-	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
+	"github.com/obscuronet/go-obscuro/go/ethclient/erc20contractlib"
+	"github.com/obscuronet/go-obscuro/go/log"
+	"github.com/obscuronet/go-obscuro/go/obscurocommon"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/nodecommon"
 )
 
 // Determine the new canonical L2 head and calculate the State

--- a/go/obscuronode/enclave/utils.go
+++ b/go/obscuronode/enclave/utils.go
@@ -3,14 +3,14 @@ package enclave
 import (
 	"fmt"
 
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/core"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/db"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/enclave/core"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/enclave/db"
 
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/nodecommon"
 
 	"github.com/ethereum/go-ethereum/common"
 
-	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
+	"github.com/obscuronet/go-obscuro/go/obscurocommon"
 )
 
 // findTxsNotIncluded - given a list of transactions, it keeps only the ones that were not included in the block

--- a/go/obscuronode/host/client_api_obscuro.go
+++ b/go/obscuronode/host/client_api_obscuro.go
@@ -3,7 +3,7 @@ package host
 import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/nodecommon"
 )
 
 // ObscuroAPI implements Obscuro-specific JSON RPC operations.

--- a/go/obscuronode/host/client_server.go
+++ b/go/obscuronode/host/client_server.go
@@ -4,7 +4,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/obscuronet/obscuro-playground/go/log"
+	"github.com/obscuronet/go-obscuro/go/log"
 
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/rpc"

--- a/go/obscuronode/host/enclave_client.go
+++ b/go/obscuronode/host/enclave_client.go
@@ -9,18 +9,18 @@ import (
 
 	"google.golang.org/grpc/connectivity"
 
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/config"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/config"
 
-	"github.com/obscuronet/obscuro-playground/go/log"
+	"github.com/obscuronet/go-obscuro/go/log"
 
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon/rpc"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon/rpc/generated"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/nodecommon/rpc"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/nodecommon/rpc/generated"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rlp"
-	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
+	"github.com/obscuronet/go-obscuro/go/obscurocommon"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/nodecommon"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"

--- a/go/obscuronode/host/host.go
+++ b/go/obscuronode/host/host.go
@@ -12,13 +12,13 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/naoina/toml"
-	"github.com/obscuronet/obscuro-playground/go/ethclient"
-	"github.com/obscuronet/obscuro-playground/go/ethclient/mgmtcontractlib"
-	"github.com/obscuronet/obscuro-playground/go/log"
-	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/config"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/wallet"
+	"github.com/obscuronet/go-obscuro/go/ethclient"
+	"github.com/obscuronet/go-obscuro/go/ethclient/mgmtcontractlib"
+	"github.com/obscuronet/go-obscuro/go/log"
+	"github.com/obscuronet/go-obscuro/go/obscurocommon"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/config"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/nodecommon"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/wallet"
 )
 
 // Node this will become the Obscuro "Node" type

--- a/go/obscuronode/host/hostdb.go
+++ b/go/obscuronode/host/hostdb.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/core/types"
 
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/nodecommon"
 
 	"github.com/ethereum/go-ethereum/common"
 )

--- a/go/obscuronode/host/hostrunner/cli.go
+++ b/go/obscuronode/host/hostrunner/cli.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/naoina/toml"
 
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/config"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/config"
 
 	"github.com/ethereum/go-ethereum/common"
 )

--- a/go/obscuronode/host/hostrunner/host_runner.go
+++ b/go/obscuronode/host/hostrunner/host_runner.go
@@ -6,16 +6,16 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/obscuronet/obscuro-playground/go/ethclient"
+	"github.com/obscuronet/go-obscuro/go/ethclient"
 
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/config"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/config"
 
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/wallet"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/wallet"
 
-	"github.com/obscuronet/obscuro-playground/go/ethclient/mgmtcontractlib"
-	"github.com/obscuronet/obscuro-playground/go/log"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/host"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/host/p2p"
+	"github.com/obscuronet/go-obscuro/go/ethclient/mgmtcontractlib"
+	"github.com/obscuronet/go-obscuro/go/log"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/host"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/host/p2p"
 )
 
 // RunHost runs an Obscuro host as a standalone process.

--- a/go/obscuronode/host/in_mem_obscuro_client.go
+++ b/go/obscuronode/host/in_mem_obscuro_client.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/obscuroclient"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/nodecommon"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/obscuroclient"
 )
 
 // An in-memory implementation of `clientserver.Client` that speaks directly to the node.

--- a/go/obscuronode/host/interfaces.go
+++ b/go/obscuronode/host/interfaces.go
@@ -3,8 +3,8 @@ package host
 import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
+	"github.com/obscuronet/go-obscuro/go/obscurocommon"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/nodecommon"
 )
 
 // P2PCallback -the glue between the P2p layer and the node. Notifies the node when rollups and transactions are received from peers

--- a/go/obscuronode/host/main/main.go
+++ b/go/obscuronode/host/main/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/host/hostrunner"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/host/hostrunner"
 )
 
 // Runs an Obscuro host as a standalone process.

--- a/go/obscuronode/host/p2p/p2p.go
+++ b/go/obscuronode/host/p2p/p2p.go
@@ -5,16 +5,16 @@ import (
 	"net"
 	"sync/atomic"
 
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/config"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/config"
 
-	"github.com/obscuronet/obscuro-playground/go/log"
+	"github.com/obscuronet/go-obscuro/go/log"
 
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/host"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/host"
 
 	"github.com/ethereum/go-ethereum/rlp"
-	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
+	"github.com/obscuronet/go-obscuro/go/obscurocommon"
 
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/nodecommon"
 )
 
 // TODO - Provide configurable timeouts on P2P connections.

--- a/go/obscuronode/nodecommon/enclave.go
+++ b/go/obscuronode/nodecommon/enclave.go
@@ -3,7 +3,7 @@ package nodecommon
 import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
+	"github.com/obscuronet/go-obscuro/go/obscurocommon"
 )
 
 // Enclave is the interface for interacting with the node's enclave

--- a/go/obscuronode/nodecommon/encoding.go
+++ b/go/obscuronode/nodecommon/encoding.go
@@ -2,8 +2,8 @@ package nodecommon
 
 import (
 	"github.com/ethereum/go-ethereum/rlp"
-	"github.com/obscuronet/obscuro-playground/go/log"
-	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
+	"github.com/obscuronet/go-obscuro/go/log"
+	"github.com/obscuronet/go-obscuro/go/obscurocommon"
 )
 
 func EncodeRollup(r *Rollup) obscurocommon.EncodedRollup {

--- a/go/obscuronode/nodecommon/logging.go
+++ b/go/obscuronode/nodecommon/logging.go
@@ -3,7 +3,7 @@ package nodecommon
 import (
 	"fmt"
 
-	"github.com/obscuronet/obscuro-playground/go/log"
+	"github.com/obscuronet/go-obscuro/go/log"
 )
 
 // LogWithID logs a message at INFO level with the aggregator's identity prepended.

--- a/go/obscuronode/nodecommon/rpc/converters.go
+++ b/go/obscuronode/nodecommon/rpc/converters.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon/rpc/generated"
+	"github.com/obscuronet/go-obscuro/go/obscurocommon"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/nodecommon"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/nodecommon/rpc/generated"
 )
 
 // Functions to convert classes that need to be sent between the host and the enclave to and from their equivalent

--- a/go/obscuronode/nodecommon/types.go
+++ b/go/obscuronode/nodecommon/types.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/ethereum/go-ethereum/core/types"
 
-	"github.com/obscuronet/obscuro-playground/go/hashing"
-	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
+	"github.com/obscuronet/go-obscuro/go/hashing"
+	"github.com/obscuronet/go-obscuro/go/obscurocommon"
 
 	"github.com/ethereum/go-ethereum/common"
 )

--- a/go/obscuronode/obscuroclient/obscuro_client.go
+++ b/go/obscuronode/obscuroclient/obscuro_client.go
@@ -2,7 +2,7 @@ package obscuroclient
 
 import (
 	"github.com/ethereum/go-ethereum/rpc"
-	"github.com/obscuronet/obscuro-playground/go/log"
+	"github.com/obscuronet/go-obscuro/go/log"
 )
 
 type RPCMethod uint8

--- a/go/obscuronode/wallet/wallet.go
+++ b/go/obscuronode/wallet/wallet.go
@@ -5,9 +5,9 @@ import (
 	"math/big"
 	"sync/atomic"
 
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/config"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/config"
 
-	"github.com/obscuronet/obscuro-playground/go/log"
+	"github.com/obscuronet/go-obscuro/go/log"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"

--- a/integration/datagenerator/common.go
+++ b/integration/datagenerator/common.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/core/types"
 
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/nodecommon"
 
 	"github.com/ethereum/go-ethereum/common"
 )

--- a/integration/datagenerator/rollup.go
+++ b/integration/datagenerator/rollup.go
@@ -1,7 +1,7 @@
 package datagenerator
 
 import (
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/nodecommon"
 )
 
 func RandomRollup() nodecommon.Rollup {

--- a/integration/datagenerator/wallet.go
+++ b/integration/datagenerator/wallet.go
@@ -5,9 +5,9 @@ import (
 	"encoding/hex"
 	"math/big"
 
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/config"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/config"
 
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/wallet"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/wallet"
 )
 
 // RandomWallet returns a wallet with a random private key

--- a/integration/ethereummock/db.go
+++ b/integration/ethereummock/db.go
@@ -3,12 +3,12 @@ package ethereummock
 import (
 	"sync"
 
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/core"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/db"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/enclave/core"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/enclave/db"
 
 	"github.com/ethereum/go-ethereum/core/types"
 
-	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
+	"github.com/obscuronet/go-obscuro/go/obscurocommon"
 )
 
 // Received blocks ar stored here

--- a/integration/ethereummock/erc20_contract_lib.go
+++ b/integration/ethereummock/erc20_contract_lib.go
@@ -2,8 +2,8 @@ package ethereummock
 
 import (
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/obscuronet/obscuro-playground/go/ethclient/erc20contractlib"
-	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
+	"github.com/obscuronet/go-obscuro/go/ethclient/erc20contractlib"
+	"github.com/obscuronet/go-obscuro/go/obscurocommon"
 )
 
 type contractLib struct{}

--- a/integration/ethereummock/mgmt_contract_lib.go
+++ b/integration/ethereummock/mgmt_contract_lib.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/obscuronet/obscuro-playground/go/ethclient/mgmtcontractlib"
-	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
+	"github.com/obscuronet/go-obscuro/go/ethclient/mgmtcontractlib"
+	"github.com/obscuronet/go-obscuro/go/obscurocommon"
 )
 
 var (

--- a/integration/ethereummock/mock_l1_network.go
+++ b/integration/ethereummock/mock_l1_network.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/obscuronet/obscuro-playground/go/log"
+	"github.com/obscuronet/go-obscuro/go/log"
 
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/nodecommon"
 
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/host"
+	"github.com/obscuronet/go-obscuro/go/obscurocommon"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/host"
 )
 
 // MockEthNetwork - models a full network including artificial random latencies

--- a/integration/ethereummock/node.go
+++ b/integration/ethereummock/node.go
@@ -9,12 +9,12 @@ import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/obscuronet/obscuro-playground/go/ethclient"
-	"github.com/obscuronet/obscuro-playground/go/ethclient/erc20contractlib"
-	"github.com/obscuronet/obscuro-playground/go/ethclient/mgmtcontractlib"
-	"github.com/obscuronet/obscuro-playground/go/log"
-	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/db"
+	"github.com/obscuronet/go-obscuro/go/ethclient"
+	"github.com/obscuronet/go-obscuro/go/ethclient/erc20contractlib"
+	"github.com/obscuronet/go-obscuro/go/ethclient/mgmtcontractlib"
+	"github.com/obscuronet/go-obscuro/go/log"
+	"github.com/obscuronet/go-obscuro/go/obscurocommon"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/enclave/db"
 )
 
 type L1Network interface {

--- a/integration/ethereummock/utils.go
+++ b/integration/ethereummock/utils.go
@@ -2,8 +2,8 @@ package ethereummock
 
 import (
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/db"
+	"github.com/obscuronet/go-obscuro/go/obscurocommon"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/enclave/db"
 )
 
 // LCA - returns the least common ancestor of the 2 blocks

--- a/integration/gethnetwork/geth_network.go
+++ b/integration/gethnetwork/geth_network.go
@@ -15,7 +15,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/obscuronet/obscuro-playground/go/log"
+	"github.com/obscuronet/go-obscuro/go/log"
 )
 
 const (

--- a/integration/gethnetwork/geth_network_test.go
+++ b/integration/gethnetwork/geth_network_test.go
@@ -8,16 +8,16 @@ import (
 	"testing"
 	"time"
 
-	"github.com/obscuronet/obscuro-playground/go/ethclient"
+	"github.com/obscuronet/go-obscuro/go/ethclient"
 
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/config"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/config"
 
-	"github.com/obscuronet/obscuro-playground/integration"
+	"github.com/obscuronet/go-obscuro/integration"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/obscuronet/obscuro-playground/integration/datagenerator"
+	"github.com/obscuronet/go-obscuro/integration/datagenerator"
 	"gopkg.in/yaml.v3"
 )
 

--- a/integration/gethnetwork/main/main.go
+++ b/integration/gethnetwork/main/main.go
@@ -6,7 +6,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/obscuronet/obscuro-playground/integration/gethnetwork"
+	"github.com/obscuronet/go-obscuro/integration/gethnetwork"
 )
 
 // Spins up a new Geth network.

--- a/integration/noderunner/noderunner_test.go
+++ b/integration/noderunner/noderunner_test.go
@@ -8,19 +8,19 @@ import (
 	"testing"
 	"time"
 
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/config"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/config"
 
 	"github.com/ethereum/go-ethereum/core/types"
 
-	"github.com/obscuronet/obscuro-playground/integration"
+	"github.com/obscuronet/go-obscuro/integration"
 
-	"github.com/obscuronet/obscuro-playground/go/log"
+	"github.com/obscuronet/go-obscuro/go/log"
 
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/enclaverunner"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/host/hostrunner"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/obscuroclient"
-	"github.com/obscuronet/obscuro-playground/integration/gethnetwork"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/enclave/enclaverunner"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/host/hostrunner"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/obscuroclient"
+	"github.com/obscuronet/go-obscuro/integration/gethnetwork"
 )
 
 // TODO - Use the HostRunner/EnclaveRunner methods in the socket-based integration tests, and retire this smoketest.

--- a/integration/simulation/network/azureenclave.go
+++ b/integration/simulation/network/azureenclave.go
@@ -5,28 +5,28 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/obscuronet/obscuro-playground/go/ethclient/erc20contractlib"
-	"github.com/obscuronet/obscuro-playground/go/ethclient/mgmtcontractlib"
-	"github.com/obscuronet/obscuro-playground/go/log"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/wallet"
-	"github.com/obscuronet/obscuro-playground/integration/erc20contract"
-	"github.com/obscuronet/obscuro-playground/integration/gethnetwork"
+	"github.com/obscuronet/go-obscuro/go/ethclient/erc20contractlib"
+	"github.com/obscuronet/go-obscuro/go/ethclient/mgmtcontractlib"
+	"github.com/obscuronet/go-obscuro/go/log"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/wallet"
+	"github.com/obscuronet/go-obscuro/integration/erc20contract"
+	"github.com/obscuronet/go-obscuro/integration/gethnetwork"
 
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/config"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/config"
 
-	"github.com/obscuronet/obscuro-playground/integration"
+	"github.com/obscuronet/go-obscuro/integration"
 
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/obscuroclient"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/obscuroclient"
 
-	"github.com/obscuronet/obscuro-playground/go/ethclient"
+	"github.com/obscuronet/go-obscuro/go/ethclient"
 
-	"github.com/obscuronet/obscuro-playground/integration/simulation/params"
+	"github.com/obscuronet/go-obscuro/integration/simulation/params"
 
-	"github.com/obscuronet/obscuro-playground/integration/simulation/stats"
+	"github.com/obscuronet/go-obscuro/integration/simulation/stats"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/host"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/enclave"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/host"
 )
 
 const enclavePort = ":11000"

--- a/integration/simulation/network/dockerenclave.go
+++ b/integration/simulation/network/dockerenclave.go
@@ -17,23 +17,23 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/docker/go-connections/nat"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/obscuronet/obscuro-playground/go/ethclient/erc20contractlib"
-	"github.com/obscuronet/obscuro-playground/go/ethclient/mgmtcontractlib"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/config"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/enclaverunner"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/wallet"
-	"github.com/obscuronet/obscuro-playground/integration/erc20contract"
-	"github.com/obscuronet/obscuro-playground/integration/gethnetwork"
+	"github.com/obscuronet/go-obscuro/go/ethclient/erc20contractlib"
+	"github.com/obscuronet/go-obscuro/go/ethclient/mgmtcontractlib"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/config"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/enclave/enclaverunner"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/wallet"
+	"github.com/obscuronet/go-obscuro/integration/erc20contract"
+	"github.com/obscuronet/go-obscuro/integration/gethnetwork"
 
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/obscuroclient"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/obscuroclient"
 
-	"github.com/obscuronet/obscuro-playground/go/ethclient"
+	"github.com/obscuronet/go-obscuro/go/ethclient"
 
-	"github.com/obscuronet/obscuro-playground/integration/simulation/params"
+	"github.com/obscuronet/go-obscuro/integration/simulation/params"
 
-	"github.com/obscuronet/obscuro-playground/integration/simulation/stats"
+	"github.com/obscuronet/go-obscuro/integration/simulation/stats"
 
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/host"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/host"
 )
 
 const (

--- a/integration/simulation/network/geth_network.go
+++ b/integration/simulation/network/geth_network.go
@@ -6,23 +6,23 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/config"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/config"
 
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/wallet"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/wallet"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/obscuronet/obscuro-playground/go/ethclient"
-	"github.com/obscuronet/obscuro-playground/go/ethclient/erc20contractlib"
-	"github.com/obscuronet/obscuro-playground/go/ethclient/mgmtcontractlib"
-	"github.com/obscuronet/obscuro-playground/go/log"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/host"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/obscuroclient"
-	"github.com/obscuronet/obscuro-playground/integration/erc20contract"
-	"github.com/obscuronet/obscuro-playground/integration/gethnetwork"
-	"github.com/obscuronet/obscuro-playground/integration/simulation/p2p"
-	"github.com/obscuronet/obscuro-playground/integration/simulation/params"
-	"github.com/obscuronet/obscuro-playground/integration/simulation/stats"
+	"github.com/obscuronet/go-obscuro/go/ethclient"
+	"github.com/obscuronet/go-obscuro/go/ethclient/erc20contractlib"
+	"github.com/obscuronet/go-obscuro/go/ethclient/mgmtcontractlib"
+	"github.com/obscuronet/go-obscuro/go/log"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/host"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/obscuroclient"
+	"github.com/obscuronet/go-obscuro/integration/erc20contract"
+	"github.com/obscuronet/go-obscuro/integration/gethnetwork"
+	"github.com/obscuronet/go-obscuro/integration/simulation/p2p"
+	"github.com/obscuronet/go-obscuro/integration/simulation/params"
+	"github.com/obscuronet/go-obscuro/integration/simulation/stats"
 )
 
 type networkInMemGeth struct {

--- a/integration/simulation/network/inmemory.go
+++ b/integration/simulation/network/inmemory.go
@@ -3,18 +3,18 @@ package network
 import (
 	"time"
 
-	"github.com/obscuronet/obscuro-playground/integration/simulation/p2p"
+	"github.com/obscuronet/go-obscuro/integration/simulation/p2p"
 
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/obscuroclient"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/obscuroclient"
 
-	"github.com/obscuronet/obscuro-playground/go/ethclient"
+	"github.com/obscuronet/go-obscuro/go/ethclient"
 
-	"github.com/obscuronet/obscuro-playground/integration/simulation/params"
+	"github.com/obscuronet/go-obscuro/integration/simulation/params"
 
-	"github.com/obscuronet/obscuro-playground/integration/simulation/stats"
+	"github.com/obscuronet/go-obscuro/integration/simulation/stats"
 
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/host"
-	ethereum_mock "github.com/obscuronet/obscuro-playground/integration/ethereummock"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/host"
+	ethereum_mock "github.com/obscuronet/go-obscuro/integration/ethereummock"
 )
 
 type basicNetworkOfInMemoryNodes struct {

--- a/integration/simulation/network/network.go
+++ b/integration/simulation/network/network.go
@@ -1,10 +1,10 @@
 package network
 
 import (
-	"github.com/obscuronet/obscuro-playground/go/ethclient"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/obscuroclient"
-	"github.com/obscuronet/obscuro-playground/integration/simulation/params"
-	"github.com/obscuronet/obscuro-playground/integration/simulation/stats"
+	"github.com/obscuronet/go-obscuro/go/ethclient"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/obscuroclient"
+	"github.com/obscuronet/go-obscuro/integration/simulation/params"
+	"github.com/obscuronet/go-obscuro/integration/simulation/stats"
 )
 
 // Network is responsible with knowing how to manage the lifecycle of networks of Ethereum or Obscuro nodes.

--- a/integration/simulation/network/network_utils.go
+++ b/integration/simulation/network/network_utils.go
@@ -4,24 +4,24 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/config"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/config"
 
-	"github.com/obscuronet/obscuro-playground/go/ethclient/erc20contractlib"
-	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave"
-	"github.com/obscuronet/obscuro-playground/integration"
-	simp2p "github.com/obscuronet/obscuro-playground/integration/simulation/p2p"
+	"github.com/obscuronet/go-obscuro/go/ethclient/erc20contractlib"
+	"github.com/obscuronet/go-obscuro/go/obscurocommon"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/enclave"
+	"github.com/obscuronet/go-obscuro/integration"
+	simp2p "github.com/obscuronet/go-obscuro/integration/simulation/p2p"
 
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/wallet"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/wallet"
 
-	"github.com/obscuronet/obscuro-playground/go/ethclient/mgmtcontractlib"
+	"github.com/obscuronet/go-obscuro/go/ethclient/mgmtcontractlib"
 
-	"github.com/obscuronet/obscuro-playground/integration/simulation/stats"
+	"github.com/obscuronet/go-obscuro/integration/simulation/stats"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/host"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/host/p2p"
-	ethereum_mock "github.com/obscuronet/obscuro-playground/integration/ethereummock"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/host"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/host/p2p"
+	ethereum_mock "github.com/obscuronet/go-obscuro/integration/ethereummock"
 )
 
 const (

--- a/integration/simulation/network/socket.go
+++ b/integration/simulation/network/socket.go
@@ -7,28 +7,28 @@ import (
 
 	"github.com/ethereum/go-ethereum/log"
 
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/config"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/config"
 
-	"github.com/obscuronet/obscuro-playground/go/ethclient/erc20contractlib"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/wallet"
-	"github.com/obscuronet/obscuro-playground/integration/erc20contract"
+	"github.com/obscuronet/go-obscuro/go/ethclient/erc20contractlib"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/wallet"
+	"github.com/obscuronet/go-obscuro/integration/erc20contract"
 
-	"github.com/obscuronet/obscuro-playground/integration"
+	"github.com/obscuronet/go-obscuro/integration"
 
-	"github.com/obscuronet/obscuro-playground/go/ethclient/mgmtcontractlib"
-	"github.com/obscuronet/obscuro-playground/integration/gethnetwork"
+	"github.com/obscuronet/go-obscuro/go/ethclient/mgmtcontractlib"
+	"github.com/obscuronet/go-obscuro/integration/gethnetwork"
 
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/obscuroclient"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/obscuroclient"
 
-	"github.com/obscuronet/obscuro-playground/go/ethclient"
+	"github.com/obscuronet/go-obscuro/go/ethclient"
 
-	"github.com/obscuronet/obscuro-playground/integration/simulation/params"
+	"github.com/obscuronet/go-obscuro/integration/simulation/params"
 
-	"github.com/obscuronet/obscuro-playground/integration/simulation/stats"
+	"github.com/obscuronet/go-obscuro/integration/simulation/stats"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/host"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/enclave"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/host"
 )
 
 // creates Obscuro nodes with their own enclave servers that communicate with peers via sockets, wires them up, and populates the network objects

--- a/integration/simulation/output_stats.go
+++ b/integration/simulation/output_stats.go
@@ -3,8 +3,8 @@ package simulation
 import (
 	"fmt"
 
-	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
+	"github.com/obscuronet/go-obscuro/go/obscurocommon"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/nodecommon"
 )
 
 // OutputStats decouples the processing of data and the collection of statistics

--- a/integration/simulation/p2p/mock_l2_network.go
+++ b/integration/simulation/p2p/mock_l2_network.go
@@ -4,10 +4,10 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/host"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/host"
 
-	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
+	"github.com/obscuronet/go-obscuro/go/obscurocommon"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/nodecommon"
 )
 
 // MockP2P - models a full network of in memory nodes including artificial random latencies

--- a/integration/simulation/params/params.go
+++ b/integration/simulation/params/params.go
@@ -3,10 +3,10 @@ package params
 import (
 	"time"
 
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/wallet"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/wallet"
 
-	"github.com/obscuronet/obscuro-playground/go/ethclient/erc20contractlib"
-	"github.com/obscuronet/obscuro-playground/go/ethclient/mgmtcontractlib"
+	"github.com/obscuronet/go-obscuro/go/ethclient/erc20contractlib"
+	"github.com/obscuronet/go-obscuro/go/ethclient/mgmtcontractlib"
 
 	"github.com/ethereum/go-ethereum/common"
 )

--- a/integration/simulation/simulation.go
+++ b/integration/simulation/simulation.go
@@ -4,16 +4,16 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/obscuroclient"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/obscuroclient"
 
-	"github.com/obscuronet/obscuro-playground/go/ethclient"
+	"github.com/obscuronet/go-obscuro/go/ethclient"
 
-	"github.com/obscuronet/obscuro-playground/integration/simulation/params"
+	"github.com/obscuronet/go-obscuro/integration/simulation/params"
 
-	"github.com/obscuronet/obscuro-playground/integration/simulation/stats"
+	"github.com/obscuronet/go-obscuro/integration/simulation/stats"
 
-	"github.com/obscuronet/obscuro-playground/go/log"
-	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
+	"github.com/obscuronet/go-obscuro/go/log"
+	"github.com/obscuronet/go-obscuro/go/obscurocommon"
 )
 
 const initialBalance = 5000

--- a/integration/simulation/simulation_azure_enclaves_test.go
+++ b/integration/simulation/simulation_azure_enclaves_test.go
@@ -6,15 +6,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/obscuronet/obscuro-playground/go/ethclient/mgmtcontractlib"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/wallet"
-	"github.com/obscuronet/obscuro-playground/integration/erc20contract"
+	"github.com/obscuronet/go-obscuro/go/ethclient/mgmtcontractlib"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/wallet"
+	"github.com/obscuronet/go-obscuro/integration/erc20contract"
 
-	"github.com/obscuronet/obscuro-playground/integration"
-	"github.com/obscuronet/obscuro-playground/integration/datagenerator"
-	"github.com/obscuronet/obscuro-playground/integration/simulation/params"
+	"github.com/obscuronet/go-obscuro/integration"
+	"github.com/obscuronet/go-obscuro/integration/datagenerator"
+	"github.com/obscuronet/go-obscuro/integration/simulation/params"
 
-	"github.com/obscuronet/obscuro-playground/integration/simulation/network"
+	"github.com/obscuronet/go-obscuro/integration/simulation/network"
 )
 
 const azureTestEnv = "AZURE_TEST_ENABLED"

--- a/integration/simulation/simulation_docker_test.go
+++ b/integration/simulation/simulation_docker_test.go
@@ -4,14 +4,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/obscuronet/obscuro-playground/go/ethclient/mgmtcontractlib"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/wallet"
-	"github.com/obscuronet/obscuro-playground/integration/erc20contract"
+	"github.com/obscuronet/go-obscuro/go/ethclient/mgmtcontractlib"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/wallet"
+	"github.com/obscuronet/go-obscuro/integration/erc20contract"
 
-	"github.com/obscuronet/obscuro-playground/integration"
-	"github.com/obscuronet/obscuro-playground/integration/datagenerator"
-	"github.com/obscuronet/obscuro-playground/integration/simulation/network"
-	"github.com/obscuronet/obscuro-playground/integration/simulation/params"
+	"github.com/obscuronet/go-obscuro/integration"
+	"github.com/obscuronet/go-obscuro/integration/datagenerator"
+	"github.com/obscuronet/go-obscuro/integration/simulation/network"
+	"github.com/obscuronet/go-obscuro/integration/simulation/params"
 )
 
 // This test creates a network of L2 nodes, then injects transactions, and finally checks the resulting output blockchain

--- a/integration/simulation/simulation_full_network_test.go
+++ b/integration/simulation/simulation_full_network_test.go
@@ -5,17 +5,17 @@ import (
 	"testing"
 	"time"
 
-	"github.com/obscuronet/obscuro-playground/go/ethclient/mgmtcontractlib"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/wallet"
-	"github.com/obscuronet/obscuro-playground/integration/erc20contract"
+	"github.com/obscuronet/go-obscuro/go/ethclient/mgmtcontractlib"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/wallet"
+	"github.com/obscuronet/go-obscuro/integration/erc20contract"
 
-	"github.com/obscuronet/obscuro-playground/integration/datagenerator"
+	"github.com/obscuronet/go-obscuro/integration/datagenerator"
 
-	"github.com/obscuronet/obscuro-playground/integration"
+	"github.com/obscuronet/go-obscuro/integration"
 
-	"github.com/obscuronet/obscuro-playground/integration/simulation/params"
+	"github.com/obscuronet/go-obscuro/integration/simulation/params"
 
-	"github.com/obscuronet/obscuro-playground/integration/simulation/network"
+	"github.com/obscuronet/go-obscuro/integration/simulation/network"
 )
 
 // This test creates a network of L2 nodes, then injects transactions, and finally checks the resulting output blockchain.

--- a/integration/simulation/simulation_geth_in_mem_test.go
+++ b/integration/simulation/simulation_geth_in_mem_test.go
@@ -5,15 +5,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/wallet"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/wallet"
 
-	"github.com/obscuronet/obscuro-playground/integration"
+	"github.com/obscuronet/go-obscuro/integration"
 
-	"github.com/obscuronet/obscuro-playground/go/ethclient/mgmtcontractlib"
-	"github.com/obscuronet/obscuro-playground/integration/datagenerator"
-	"github.com/obscuronet/obscuro-playground/integration/erc20contract"
-	"github.com/obscuronet/obscuro-playground/integration/simulation/network"
-	"github.com/obscuronet/obscuro-playground/integration/simulation/params"
+	"github.com/obscuronet/go-obscuro/go/ethclient/mgmtcontractlib"
+	"github.com/obscuronet/go-obscuro/integration/datagenerator"
+	"github.com/obscuronet/go-obscuro/integration/erc20contract"
+	"github.com/obscuronet/go-obscuro/integration/simulation/network"
+	"github.com/obscuronet/go-obscuro/integration/simulation/params"
 )
 
 // TestGethSimulation runs the simulation against a private geth network using Clique (PoA)

--- a/integration/simulation/simulation_in_mem_test.go
+++ b/integration/simulation/simulation_in_mem_test.go
@@ -4,12 +4,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/obscuronet/obscuro-playground/integration"
-	"github.com/obscuronet/obscuro-playground/integration/datagenerator"
-	"github.com/obscuronet/obscuro-playground/integration/simulation/network"
-	"github.com/obscuronet/obscuro-playground/integration/simulation/params"
+	"github.com/obscuronet/go-obscuro/integration"
+	"github.com/obscuronet/go-obscuro/integration/datagenerator"
+	"github.com/obscuronet/go-obscuro/integration/simulation/network"
+	"github.com/obscuronet/go-obscuro/integration/simulation/params"
 
-	ethereum_mock "github.com/obscuronet/obscuro-playground/integration/ethereummock"
+	ethereum_mock "github.com/obscuronet/go-obscuro/integration/ethereummock"
 )
 
 // This test creates a network of in memory L1 and L2 nodes, then injects transactions, and finally checks the resulting output blockchain.

--- a/integration/simulation/simulation_tester.go
+++ b/integration/simulation/simulation_tester.go
@@ -7,11 +7,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/obscuronet/obscuro-playground/integration/simulation/network"
-	"github.com/obscuronet/obscuro-playground/integration/simulation/params"
+	"github.com/obscuronet/go-obscuro/integration/simulation/network"
+	"github.com/obscuronet/go-obscuro/integration/simulation/params"
 
-	"github.com/obscuronet/obscuro-playground/go/log"
-	stats2 "github.com/obscuronet/obscuro-playground/integration/simulation/stats"
+	"github.com/obscuronet/go-obscuro/go/log"
+	stats2 "github.com/obscuronet/go-obscuro/integration/simulation/stats"
 
 	"github.com/google/uuid"
 )

--- a/integration/simulation/stats/stats.go
+++ b/integration/simulation/stats/stats.go
@@ -6,8 +6,8 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 
-	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
+	"github.com/obscuronet/go-obscuro/go/obscurocommon"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/nodecommon"
 )
 
 // Stats - collects information during the simulation. It can be checked programmatically.

--- a/integration/simulation/transaction_injector.go
+++ b/integration/simulation/transaction_injector.go
@@ -6,24 +6,24 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/obscuronet/obscuro-playground/integration/erc20contract"
+	"github.com/obscuronet/go-obscuro/integration/erc20contract"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/evm"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/enclave/evm"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/obscuroclient"
-	"github.com/obscuronet/obscuro-playground/integration"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/obscuroclient"
+	"github.com/obscuronet/go-obscuro/integration"
 
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/obscuronet/obscuro-playground/go/ethclient"
-	"github.com/obscuronet/obscuro-playground/go/ethclient/erc20contractlib"
-	"github.com/obscuronet/obscuro-playground/go/ethclient/mgmtcontractlib"
-	"github.com/obscuronet/obscuro-playground/go/log"
-	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/core"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/wallet"
-	stats2 "github.com/obscuronet/obscuro-playground/integration/simulation/stats"
+	"github.com/obscuronet/go-obscuro/go/ethclient"
+	"github.com/obscuronet/go-obscuro/go/ethclient/erc20contractlib"
+	"github.com/obscuronet/go-obscuro/go/ethclient/mgmtcontractlib"
+	"github.com/obscuronet/go-obscuro/go/log"
+	"github.com/obscuronet/go-obscuro/go/obscurocommon"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/enclave/core"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/wallet"
+	stats2 "github.com/obscuronet/go-obscuro/integration/simulation/stats"
 )
 
 // TransactionInjector is a structure that generates, issues and tracks transactions

--- a/integration/simulation/transaction_injector_counter.go
+++ b/integration/simulation/transaction_injector_counter.go
@@ -3,11 +3,11 @@ package simulation
 import (
 	"sync"
 
-	"github.com/obscuronet/obscuro-playground/go/ethclient/erc20contractlib"
+	"github.com/obscuronet/go-obscuro/go/ethclient/erc20contractlib"
 
-	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/core"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
+	"github.com/obscuronet/go-obscuro/go/obscurocommon"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/enclave/core"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/nodecommon"
 )
 
 type txInjectorCounter struct {

--- a/integration/simulation/utils.go
+++ b/integration/simulation/utils.go
@@ -8,10 +8,10 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/obscuroclient"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/nodecommon"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/obscuroclient"
 
-	"github.com/obscuronet/obscuro-playground/go/log"
+	"github.com/obscuronet/go-obscuro/go/log"
 )
 
 const testLogs = "../.build/simulations/"

--- a/integration/simulation/validate_chain.go
+++ b/integration/simulation/validate_chain.go
@@ -5,15 +5,15 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/obscuroclient"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/obscuroclient"
 
-	"github.com/obscuronet/obscuro-playground/go/ethclient"
+	"github.com/obscuronet/go-obscuro/go/ethclient"
 
 	"github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
+	"github.com/obscuronet/go-obscuro/go/obscurocommon"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/nodecommon"
 )
 
 // After a simulation has run, check as much as possible that the outputs of the simulation are expected.

--- a/tools/azuredeployer/enclavedeployer/README.md
+++ b/tools/azuredeployer/enclavedeployer/README.md
@@ -21,7 +21,7 @@ of simulation mode.
 ## Testing changes
 
 Changes can be tested by checking out a branch on the VM or scp-ing the changed files over to the box. You will need to 
-re-run the docker build from inside the obscuro-playground dir on the VM:
+re-run the docker build from inside the go-obscuro dir on the VM:
 
     sudo docker build -t obscuro_enclave -f dockerfiles/enclave_local_build.Dockerfile .
 

--- a/tools/azuredeployer/enclavedeployer/enclave_deployer.go
+++ b/tools/azuredeployer/enclavedeployer/enclave_deployer.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/obscuronet/obscuro-playground/tools/azuredeployer"
+	"github.com/obscuronet/go-obscuro/tools/azuredeployer"
 )
 
 const (
@@ -11,8 +11,8 @@ const (
 		sudo apt-get update
 		sudo apt-get install -y docker.io
 		sudo systemctl enable --now docker
-		if ! [ -d "obscuro-playground" ]; then git clone https://github.com/obscuronet/obscuro-playground; else :; fi
-		sudo docker build -t obscuro_enclave - < obscuro-playground/dockerfiles/enclave.Dockerfile`
+		if ! [ -d "go-obscuro" ]; then git clone https://github.com/obscuronet/go-obscuro; else :; fi
+		sudo docker build -t obscuro_enclave - < go-obscuro/dockerfiles/enclave.Dockerfile`
 )
 
 func main() {

--- a/tools/azuredeployer/networkdeployer/network_deployer.go
+++ b/tools/azuredeployer/networkdeployer/network_deployer.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/obscuronet/obscuro-playground/tools/azuredeployer"
+	"github.com/obscuronet/go-obscuro/tools/azuredeployer"
 )
 
 const (

--- a/tools/networkmanager/deploy_contract.go
+++ b/tools/networkmanager/deploy_contract.go
@@ -4,12 +4,12 @@ import (
 	"os"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/obscuronet/obscuro-playground/go/ethclient"
-	"github.com/obscuronet/obscuro-playground/go/ethclient/mgmtcontractlib"
-	obscuroconfig "github.com/obscuronet/obscuro-playground/go/obscuronode/config"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/wallet"
-	"github.com/obscuronet/obscuro-playground/integration/erc20contract"
-	"github.com/obscuronet/obscuro-playground/integration/simulation/network"
+	"github.com/obscuronet/go-obscuro/go/ethclient"
+	"github.com/obscuronet/go-obscuro/go/ethclient/mgmtcontractlib"
+	obscuroconfig "github.com/obscuronet/go-obscuro/go/obscuronode/config"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/wallet"
+	"github.com/obscuronet/go-obscuro/integration/erc20contract"
+	"github.com/obscuronet/go-obscuro/integration/simulation/network"
 )
 
 var (

--- a/tools/networkmanager/inject_txs.go
+++ b/tools/networkmanager/inject_txs.go
@@ -5,13 +5,13 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/obscuronet/obscuro-playground/go/ethclient"
-	"github.com/obscuronet/obscuro-playground/go/ethclient/erc20contractlib"
-	"github.com/obscuronet/obscuro-playground/go/ethclient/mgmtcontractlib"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/config"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/obscuroclient"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/wallet"
-	"github.com/obscuronet/obscuro-playground/integration/simulation"
+	"github.com/obscuronet/go-obscuro/go/ethclient"
+	"github.com/obscuronet/go-obscuro/go/ethclient/erc20contractlib"
+	"github.com/obscuronet/go-obscuro/go/ethclient/mgmtcontractlib"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/config"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/obscuroclient"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/wallet"
+	"github.com/obscuronet/go-obscuro/integration/simulation"
 )
 
 func InjectTransactions(nmConfig Config) {

--- a/tools/networkmanager/main/main.go
+++ b/tools/networkmanager/main/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	"github.com/obscuronet/obscuro-playground/tools/networkmanager"
+	"github.com/obscuronet/go-obscuro/tools/networkmanager"
 )
 
 func main() {

--- a/tools/obscuroscan/main/main.go
+++ b/tools/obscuroscan/main/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/obscuronet/obscuro-playground/tools/obscuroscan"
+	"github.com/obscuronet/go-obscuro/tools/obscuroscan"
 )
 
 func main() {

--- a/tools/obscuroscan/obscuroscan.go
+++ b/tools/obscuroscan/obscuroscan.go
@@ -10,13 +10,13 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/obscuronet/obscuro-playground/go/ethclient/mgmtcontractlib"
+	"github.com/obscuronet/go-obscuro/go/ethclient/mgmtcontractlib"
 
 	"github.com/ethereum/go-ethereum/core/types"
 
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/nodecommon"
 
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/obscuroclient"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/obscuroclient"
 )
 
 const (

--- a/tools/obscuroscan/obscuroscan_test.go
+++ b/tools/obscuroscan/obscuroscan_test.go
@@ -10,10 +10,10 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/obscuronet/obscuro-playground/go/ethclient/mgmtcontractlib"
-	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/core"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
+	"github.com/obscuronet/go-obscuro/go/ethclient/mgmtcontractlib"
+	"github.com/obscuronet/go-obscuro/go/obscurocommon"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/enclave/core"
+	"github.com/obscuronet/go-obscuro/go/obscuronode/nodecommon"
 )
 
 const expectedNonce = 777

--- a/tools/walletextension/common.go
+++ b/tools/walletextension/common.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/obscuronet/obscuro-playground/integration/gethnetwork"
+	"github.com/obscuronet/go-obscuro/integration/gethnetwork"
 
 	"github.com/gorilla/websocket"
 )

--- a/tools/walletextension/main/cli.go
+++ b/tools/walletextension/main/cli.go
@@ -4,7 +4,7 @@ import (
 	"flag"
 	"strings"
 
-	"github.com/obscuronet/obscuro-playground/tools/walletextension"
+	"github.com/obscuronet/go-obscuro/tools/walletextension"
 )
 
 const (

--- a/tools/walletextension/main/main.go
+++ b/tools/walletextension/main/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/obscuronet/obscuro-playground/tools/walletextension"
+import "github.com/obscuronet/go-obscuro/tools/walletextension"
 
 func main() {
 	config := parseCLIArgs()

--- a/tools/walletextension/wallet_extension_test.go
+++ b/tools/walletextension/wallet_extension_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/obscuronet/obscuro-playground/integration"
+	"github.com/obscuronet/go-obscuro/integration"
 
 	"github.com/ethereum/go-ethereum/accounts"
 


### PR DESCRIPTION
### Why is this change needed?

- No ticket, quick change that ensures all instances of `obscuro-playground` are now `go-obscuro`

### What changes were made as part of this PR:

- Find and Replace the name everywhere in the repo

### What are the key areas to look at

- All Test pass
- Might be worth checking the AzureDeployer
