### PR TITLE
During cleanup in CI builds: kill processes on ports 30000-39999

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -21,7 +21,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - name: Clean-up
-        run: sudo pkill -f geth; sudo pkill -f obscuronode; sudo docker stop $(sudo docker ps -a -q); sudo docker rm $(sudo docker ps -a -q); sudo lsof -ti:30000-39999|xargs kill
+        run: sudo lsof -ti:30000-39999|xargs -r kill -9 --verbose
 
       - name: Build Docker images
         run:  docker build -t obscuro_enclave -f dockerfiles/enclave_local_build.Dockerfile .

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -21,7 +21,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - name: Clean-up
-        run: sudo pkill -f geth; sudo pkill -f obscuronode; sudo docker stop $(sudo docker ps -a -q); sudo docker rm $(sudo docker ps -a -q)
+        run: sudo pkill -f geth; sudo pkill -f obscuronode; sudo docker stop $(sudo docker ps -a -q); sudo docker rm $(sudo docker ps -a -q); sudo lsof -ti:30000-39999|xargs kill
 
       - name: Build Docker images
         run:  docker build -t obscuro_enclave -f dockerfiles/enclave_local_build.Dockerfile .

--- a/.github/workflows/manual-build-test.yml
+++ b/.github/workflows/manual-build-test.yml
@@ -22,7 +22,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - name: Clean-up
-        run: sudo pkill -f geth; sudo pkill -f obscuronode; sudo docker stop $(sudo docker ps -a -q); sudo docker rm $(sudo docker ps -a -q);sudo lsof -ti:30000-39999|xargs kill
+        run: sudo lsof -ti:30000-39999|xargs -r kill -9
 
       - name: Build Docker images
         run:  docker build -t obscuro_enclave -f dockerfiles/enclave_local_build.Dockerfile .

--- a/.github/workflows/manual-build-test.yml
+++ b/.github/workflows/manual-build-test.yml
@@ -22,7 +22,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - name: Clean-up
-        run: sudo pkill -f geth; sudo pkill -f obscuronode; sudo docker stop $(sudo docker ps -a -q); sudo docker rm $(sudo docker ps -a -q)
+        run: sudo pkill -f geth; sudo pkill -f obscuronode; sudo docker stop $(sudo docker ps -a -q); sudo docker rm $(sudo docker ps -a -q);sudo lsof -ti:30000-39999|xargs kill
 
       - name: Build Docker images
         run:  docker build -t obscuro_enclave -f dockerfiles/enclave_local_build.Dockerfile .


### PR DESCRIPTION
### Why is this change needed?

We still occasionally see failures where geth nodes fail to start because the test ports are still occupied.

### What changes were made as part of this PR:

- replace the kill commands from before with a port-range based command that covers the range 30000-39999 where we run our tests

### What are the key areas to look at
- happy the command does what it's supposed to do?
- happy it can replace the commands that were there before or should we keep some/all of them?

### Evidence
I ran a build and ran the commands to convince myself they worked as intended. With no build running I saw no output for `lsof -ti:30000-39999`.

With a build running I saw:
![Screenshot 2022-06-06 at 12 55 26](https://user-images.githubusercontent.com/98158711/172157540-27b71df1-7ece-4f26-8c09-24eae0050927.png)

Then I ran `lsof -ti:30000-39999|kill` twice and the second time it output saying there was no input to the kill command (they were dead)