### PR TITLE
Allows injection of transactions into devnet Obscuro network

### DIFF
--- a/go/obscuronode/host/hostrunner/host_runner.go
+++ b/go/obscuronode/host/hostrunner/host_runner.go
@@ -28,7 +28,7 @@ func RunHost(config config.HostConfig) {
 		log.Panic("could not create Ethereum client. Cause: %s", err)
 	}
 
-	ethWallet := wallet.NewInMemoryWalletFromString(config)
+	ethWallet := wallet.NewInMemoryWalletFromConfig(config)
 	nonce, err := l1Client.Nonce(ethWallet.Address())
 	if err != nil {
 		log.Panic("could not retrieve Ethereum account nonce. Cause: %s", err)

--- a/go/obscuronode/wallet/wallet.go
+++ b/go/obscuronode/wallet/wallet.go
@@ -53,7 +53,7 @@ func NewInMemoryWalletFromPK(chainID *big.Int, pk *ecdsa.PrivateKey) Wallet {
 	}
 }
 
-func NewInMemoryWalletFromString(config config.HostConfig) Wallet {
+func NewInMemoryWalletFromConfig(config config.HostConfig) Wallet {
 	privateKey, err := crypto.HexToECDSA(config.PrivateKeyString)
 	if err != nil {
 		log.Panic("could not recover private key from hex. Cause: %s", err)

--- a/integration/datagenerator/wallet.go
+++ b/integration/datagenerator/wallet.go
@@ -20,7 +20,7 @@ func RandomWallet(chainID int64) wallet.Wallet {
 		PrivateKeyString: pk,
 		ChainID:          *big.NewInt(chainID),
 	}
-	return wallet.NewInMemoryWalletFromString(walletConfig)
+	return wallet.NewInMemoryWalletFromConfig(walletConfig)
 }
 
 func randomHex(n int) (string, error) {

--- a/integration/simulation/simulation_tester.go
+++ b/integration/simulation/simulation_tester.go
@@ -2,9 +2,6 @@ package simulation
 
 import (
 	"fmt"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/wallet"
-	"github.com/obscuronet/obscuro-playground/integration"
-	"math/big"
 	"math/rand"
 	"runtime"
 	"testing"
@@ -39,11 +36,6 @@ func testSimulation(t *testing.T, netw network.Network, params *params.SimParams
 		return
 	}
 
-	obsWallets := make([]wallet.Wallet, len(params.SimEthWallets))
-	for i, w := range params.SimEthWallets {
-		obsWallets[i] = wallet.NewInMemoryWalletFromPK(big.NewInt(integration.ObscuroChainID), w.PrivateKey())
-	}
-
 	txInjector := NewTransactionInjector(
 		params.AvgBlockDuration,
 		stats,
@@ -52,7 +44,6 @@ func testSimulation(t *testing.T, netw network.Network, params *params.SimParams
 		params.MgmtContractAddr,
 		params.StableTokenContractAddr,
 		obscuroClients,
-		obsWallets,
 		params.MgmtContractLib,
 		params.ERC20ContractLib,
 	)

--- a/integration/simulation/simulation_tester.go
+++ b/integration/simulation/simulation_tester.go
@@ -2,6 +2,9 @@ package simulation
 
 import (
 	"fmt"
+	"github.com/obscuronet/obscuro-playground/go/obscuronode/wallet"
+	"github.com/obscuronet/obscuro-playground/integration"
+	"math/big"
 	"math/rand"
 	"runtime"
 	"testing"
@@ -36,6 +39,11 @@ func testSimulation(t *testing.T, netw network.Network, params *params.SimParams
 		return
 	}
 
+	obsWallets := make([]wallet.Wallet, len(params.SimEthWallets))
+	for i, w := range params.SimEthWallets {
+		obsWallets[i] = wallet.NewInMemoryWalletFromPK(big.NewInt(integration.ObscuroChainID), w.PrivateKey())
+	}
+
 	txInjector := NewTransactionInjector(
 		params.AvgBlockDuration,
 		stats,
@@ -44,6 +52,7 @@ func testSimulation(t *testing.T, netw network.Network, params *params.SimParams
 		params.MgmtContractAddr,
 		params.StableTokenContractAddr,
 		obscuroClients,
+		obsWallets,
 		params.MgmtContractLib,
 		params.ERC20ContractLib,
 	)

--- a/integration/simulation/transaction_injector.go
+++ b/integration/simulation/transaction_injector.go
@@ -359,7 +359,7 @@ func NextNonce(cl *obscuroclient.Client, w wallet.Wallet) uint64 {
 		}
 		counter++
 
-		if counter > 10000 {
+		if counter > timeoutMillis {
 			panic("Transaction injector failed to retrieve nonce after ten seconds...")
 		}
 

--- a/integration/simulation/transaction_injector.go
+++ b/integration/simulation/transaction_injector.go
@@ -26,7 +26,7 @@ import (
 	stats2 "github.com/obscuronet/obscuro-playground/integration/simulation/stats"
 )
 
-const maxRetries = 13 // The number of times to retry waiting for an updated nonce for a wallet.
+const timeoutMillis = 10000 // The timeout in millis to wait for an updated nonce for a wallet.
 
 // TransactionInjector is a structure that generates, issues and tracks transactions
 type TransactionInjector struct {
@@ -349,7 +349,7 @@ func readNonce(cl *obscuroclient.Client, a common.Address) uint64 {
 }
 
 func NextNonce(cl *obscuroclient.Client, w wallet.Wallet) uint64 {
-	retries := 0
+	counter := 0
 
 	// only returns the nonce when the previous transaction was recorded
 	for {
@@ -357,11 +357,12 @@ func NextNonce(cl *obscuroclient.Client, w wallet.Wallet) uint64 {
 		if result == w.GetNonce() {
 			return w.GetNonceAndIncrement()
 		}
-		time.Sleep(time.Duration(2^retries) * time.Millisecond) // For 13 retries, this is around 17 seconds.
-		retries++
+		counter++
 
-		if retries > maxRetries {
+		if counter > 10000 {
 			panic("Transaction injector failed to retrieve nonce after ten seconds...")
 		}
+
+		time.Sleep(time.Millisecond)
 	}
 }

--- a/integration/simulation/transaction_injector.go
+++ b/integration/simulation/transaction_injector.go
@@ -26,6 +26,8 @@ import (
 	stats2 "github.com/obscuronet/obscuro-playground/integration/simulation/stats"
 )
 
+const timeoutMillis = 10000 // The timeout in millis to wait for an updated nonce for a wallet.
+
 // TransactionInjector is a structure that generates, issues and tracks transactions
 type TransactionInjector struct {
 	// counters
@@ -255,7 +257,6 @@ func (m *TransactionInjector) issueRandomWithdrawals() {
 
 		m.stats.Withdrawal(v)
 		go m.counter.trackWithdrawalL2Tx(*signedTx)
-		println("jjj issued withdrawal")
 	}
 }
 
@@ -371,9 +372,8 @@ func NextNonce(cl *obscuroclient.Client, w wallet.Wallet) uint64 {
 		time.Sleep(time.Millisecond)
 		counter++
 
-		if counter > 10000 {
-			counter = 0
-			log.Info("Transaction injector failed to retrieve nonce after ten seconds...")
+		if counter > timeoutMillis {
+			panic("Transaction injector failed to retrieve nonce after ten seconds...")
 		}
 	}
 }

--- a/integration/simulation/transaction_injector.go
+++ b/integration/simulation/transaction_injector.go
@@ -26,7 +26,7 @@ import (
 	stats2 "github.com/obscuronet/obscuro-playground/integration/simulation/stats"
 )
 
-const maxRetries = 12 // The number of times to retry waiting for an updated nonce for a wallet.
+const maxRetries = 13 // The number of times to retry waiting for an updated nonce for a wallet.
 
 // TransactionInjector is a structure that generates, issues and tracks transactions
 type TransactionInjector struct {
@@ -357,7 +357,7 @@ func NextNonce(cl *obscuroclient.Client, w wallet.Wallet) uint64 {
 		if result == w.GetNonce() {
 			return w.GetNonceAndIncrement()
 		}
-		time.Sleep(time.Duration(2^retries) * time.Millisecond) // For 12 retries, this is around 10 seconds.
+		time.Sleep(time.Duration(2^retries) * time.Millisecond) // For 13 retries, this is around 17 seconds.
 		retries++
 
 		if retries > maxRetries {

--- a/integration/simulation/transaction_injector.go
+++ b/integration/simulation/transaction_injector.go
@@ -63,7 +63,6 @@ func NewTransactionInjector(
 	mgmtContractAddr *common.Address,
 	erc20ContractAddr *common.Address,
 	l2NodeClients []*obscuroclient.Client,
-	obsWallets []wallet.Wallet,
 	mgmtContractLib mgmtcontractlib.MgmtContractLib,
 	erc20ContractLib erc20contractlib.ERC20ContractLib,
 ) *TransactionInjector {
@@ -71,6 +70,10 @@ func NewTransactionInjector(
 
 	interrupt := int32(0)
 
+	obsWallets := make([]wallet.Wallet, len(ethWallets))
+	for i, w := range ethWallets {
+		obsWallets[i] = wallet.NewInMemoryWalletFromPK(big.NewInt(integration.ObscuroChainID), w.PrivateKey())
+	}
 	return &TransactionInjector{
 		issuingWallet:     issuingWallet,
 		avgBlockDuration:  avgBlockDuration,
@@ -252,6 +255,7 @@ func (m *TransactionInjector) issueRandomWithdrawals() {
 
 		m.stats.Withdrawal(v)
 		go m.counter.trackWithdrawalL2Tx(*signedTx)
+		println("jjj issued withdrawal")
 	}
 }
 

--- a/tools/azuredeployer/networkdeployer/run.sh
+++ b/tools/azuredeployer/networkdeployer/run.sh
@@ -7,17 +7,20 @@ rm -f ./run_logs.txt
 touch ./run_logs.txt
 
 PRIV_KEY_ONE="0000000000000000000000000000000000000000000000000000000000000001"
-PUB_KEY_ONE="0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf"
 PRIV_KEY_TWO="0000000000000000000000000000000000000000000000000000000000000002"
-PUB_KEY_TWO="0x2B5AD5c4795c026514f8317c7a215E218DcCD6cF"
+PUB_KEY_ONE_ADDR="0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf"
+PUB_KEY_TWO_ADDR="0x2B5AD5c4795c026514f8317c7a215E218DcCD6cF"
+# The address for private key 0000000000000000000000000000000000000000000000000000000000000003. Can we used as an
+# additional pre-funded address in the Geth network.
+PUB_KEY_THREE_ADDR="0x6813Eb9362372EEF6200f3b1dbC3f819671cBA69"
 
-go-obscuro/integration/gethnetwork/main/geth --numNodes=2 --startPort=12000 --websocketStartPort=12100 --prefundedAddrs=$PUB_KEY_ONE,$PUB_KEY_TWO > ./run_logs.txt 2>&1 &
+go-obscuro/integration/gethnetwork/main/geth --numNodes=2 --startPort=12000 --websocketStartPort=12100 --prefundedAddrs=$PUB_KEY_ONE_ADDR,$PUB_KEY_TWO_ADDR,$PUB_KEY_THREE_ADDR > ./run_logs.txt 2>&1 &
 MGMT_CONTRACT_ADDR=$(go-obscuro/tools/networkmanager/main/networkmanager --l1NodePort=12100 --privateKey=$PRIV_KEY_ONE deployMgmtContract)
 ERC20_CONTRACT_ADDR=$(go-obscuro/tools/networkmanager/main/networkmanager --l1NodePort=12100 --privateKey=$PRIV_KEY_ONE deployERC20Contract)
 
-sudo docker run -e OE_SIMULATION=0 --privileged -v /dev/sgx:/dev/sgx -p 127.0.0.1:11000:11000/tcp obscuro_enclave --hostID 1 --address :11000 > ./run_logs.txt 2>&1 &
-sudo docker run -e OE_SIMULATION=0 --privileged -v /dev/sgx:/dev/sgx -p 127.0.0.1:11001:11000/tcp obscuro_enclave --hostID 2 --address :11000 > ./run_logs.txt 2>&1 &
-go-obscuro/go/obscuronode/host/main/host --id=1 --isGenesis=true --enclaveRPCAddress=localhost:11000 --clientRPCAddress=0.0.0.0:13000 --l1NodePort=12100 --privateKey=$PRIV_KEY_ONE > ./run_logs.txt 2>&1 &
-go-obscuro/go/obscuronode/host/main/host --id=2 --isGenesis=false --enclaveRPCAddress=localhost:11001 --clientRPCAddress=localhost:13001 --l1NodePort=12101 --privateKey=$PRIV_KEY_TWO > ./run_logs.txt 2>&1 &
+sudo docker run -e OE_SIMULATION=1 --privileged -v /dev/sgx:/dev/sgx -p 127.0.0.1:11000:11000/tcp obscuro_enclave --hostID 1 --address :11000 > ./run_logs.txt 2>&1 &
+sudo docker run -e OE_SIMULATION=1 --privileged -v /dev/sgx:/dev/sgx -p 127.0.0.1:11001:11000/tcp obscuro_enclave --hostID 2 --address :11000 > ./run_logs.txt 2>&1 &
+go-obscuro/go/obscuronode/host/main/host --id=1 --isGenesis=true --p2pAddress=localhost:10000 --peerP2PAddresses=localhost:10001 --enclaveRPCAddress=localhost:11000 --clientRPCAddress=0.0.0.0:13000 --l1NodePort=12100 --privateKey=$PRIV_KEY_ONE > ./run_logs.txt 2>&1 &
+go-obscuro/go/obscuronode/host/main/host --id=2 --isGenesis=false --p2pAddress=localhost:10001 --peerP2PAddresses=localhost:10000 --enclaveRPCAddress=localhost:11001 --clientRPCAddress=localhost:13001 --l1NodePort=12101 --privateKey=$PRIV_KEY_TWO > ./run_logs.txt 2>&1 &
 cd go-obscuro
 sudo ./tools/obscuroscan/main/obscuroscan --clientServerAddress=127.0.0.1:13000 --address=0.0.0.0:80 > ../run_logs.txt 2>&1 &

--- a/tools/networkmanager/deploy_contract.go
+++ b/tools/networkmanager/deploy_contract.go
@@ -42,7 +42,7 @@ func DeployContract(config Config) {
 		panic(err)
 	}
 
-	l1Wallet := wallet.NewInMemoryWalletFromString(hostConfig)
+	l1Wallet := wallet.NewInMemoryWalletFromConfig(hostConfig)
 	nonce, err := l1Client.Nonce(l1Wallet.Address())
 	if err != nil {
 		panic(err)

--- a/tools/networkmanager/inject_txs.go
+++ b/tools/networkmanager/inject_txs.go
@@ -2,10 +2,7 @@ package networkmanager
 
 import (
 	"fmt"
-	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/obscuronet/obscuro-playground/integration"
 	"github.com/obscuronet/obscuro-playground/integration/simulation/stats"
-	"math/big"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -46,11 +43,6 @@ func InjectTransactions(nmConfig Config) {
 
 	// todo - joel - better tx injector logging (optional)
 
-	// todo - joel - work out if this can be reverted
-	key, _ := crypto.HexToECDSA("0000000000000000000000000000000000000000000000000000000000000001")
-	obsWallets := make([]wallet.Wallet, 1)
-	obsWallets[0] = wallet.NewInMemoryWalletFromPK(big.NewInt(integration.ObscuroChainID), key)
-
 	txInjector := simulation.NewTransactionInjector(
 		1*time.Second,
 		stats.NewStats(1),
@@ -59,7 +51,6 @@ func InjectTransactions(nmConfig Config) {
 		&nmConfig.mgmtContractAddress,
 		&nmConfig.erc20ContractAddress,
 		[]*obscuroclient.Client{&l2Client},
-		obsWallets,
 		mgmtcontractlib.NewMgmtContractLib(&nmConfig.mgmtContractAddress),
 		erc20contractlib.NewERC20ContractLib(&nmConfig.mgmtContractAddress, &nmConfig.erc20ContractAddress),
 	)

--- a/tools/networkmanager/inject_txs.go
+++ b/tools/networkmanager/inject_txs.go
@@ -25,8 +25,6 @@ func InjectTransactions(nmConfig Config) {
 		ChainID:             nmConfig.chainID,
 	}
 
-	// todo - joel - consider setting up logs
-
 	// TODO - Consider extending this command to support multiple L1 clients and L2 clients.
 	l1Client, err := ethclient.NewEthClient(hostConfig)
 	if err != nil {
@@ -40,8 +38,6 @@ func InjectTransactions(nmConfig Config) {
 		panic(err)
 	}
 	l1Wallet.SetNonce(nonce)
-
-	// todo - joel - better tx injector logging (optional)
 
 	txInjector := simulation.NewTransactionInjector(
 		1*time.Second,

--- a/tools/networkmanager/inject_txs.go
+++ b/tools/networkmanager/inject_txs.go
@@ -2,8 +2,9 @@ package networkmanager
 
 import (
 	"fmt"
-	"github.com/obscuronet/obscuro-playground/integration/simulation/stats"
 	"time"
+
+	"github.com/obscuronet/obscuro-playground/integration/simulation/stats"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/obscuronet/obscuro-playground/go/ethclient"


### PR DESCRIPTION
### Why is this change needed?

As part of https://github.com/obscuronet/obscuro-internal/issues/448, we need the ability to injects txs into an Obscuro devnet.

### What changes were made as part of this PR:

Functional.

* Updates `run.sh` script that runs devnet to give nodes P2P addresses (required for injecting and broadcasting txs)
* Some clean-up in transaction_injector.go:
  * Timeout if hangs for too long trying to get nonce to inject transaction
  * Handles edge cases when trying to select random client/wallet when there is only one

### What are the key areas to look at

Key changes are in the `run.sh` script.