### PR TITLE
Reinstate docker cleanup, ensure sudo commands

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -21,7 +21,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - name: Clean-up
-        run: sudo lsof -ti:30000-39999|xargs -r kill -9 --verbose
+        run: sudo docker stop $(sudo docker ps -a -q); sudo docker rm $(sudo docker ps -a -q);sudo lsof -ti:30000-39999|xargs -r sudo kill -9
 
       - name: Build Docker images
         run:  docker build -t obscuro_enclave -f dockerfiles/enclave_local_build.Dockerfile .

--- a/.github/workflows/manual-build-test.yml
+++ b/.github/workflows/manual-build-test.yml
@@ -22,7 +22,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - name: Clean-up
-        run: sudo lsof -ti:30000-39999|xargs -r kill -9
+        run: sudo docker stop $(sudo docker ps -a -q); sudo docker rm $(sudo docker ps -a -q);sudo lsof -ti:30000-39999|xargs -r sudo kill -9
 
       - name: Build Docker images
         run:  docker build -t obscuro_enclave -f dockerfiles/enclave_local_build.Dockerfile .


### PR DESCRIPTION
### Why is this change needed?

- Concerns that docker containers might not respond well to this shutdown so we reinstate the docker clean-up
- Need sudo on the kill command and --verbose flag seems to be upsetting things

### What changes were made as part of this PR:

- update the clean-up command with above changes

### What are the key areas to look at
- happy with the clean-up changes? I was able to reproduce the error on the CI box and this seemed to fix it