### PR TITLE
Remove unusued tempdb

### DIFF
--- a/go/obscuronode/enclave/db/interfaces.go
+++ b/go/obscuronode/enclave/db/interfaces.go
@@ -1,13 +1,11 @@
 package db
 
 import (
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
 	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/core"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
 )
 
 // BlockResolver stores new blocks and returns information on existing blocks
@@ -40,10 +38,6 @@ type RollupResolver interface {
 	StoreRollup(rollup *core.Rollup)
 	// ParentRollup returns the rollup's parent rollup
 	ParentRollup(rollup *core.Rollup) *core.Rollup
-	// FetchRollupTxs returns all transactions in a given rollup keyed by hash and true, or (nil, false) if the rollup is unknown
-	FetchRollupTxs(rollup *core.Rollup) (map[common.Hash]nodecommon.L2Tx, bool)
-	// StoreRollupTxs overwrites the transactions associated with a given rollup
-	StoreRollupTxs(rollup *core.Rollup, newTxs map[common.Hash]nodecommon.L2Tx)
 	// StoreGenesisRollup stores the rollup genesis
 	StoreGenesisRollup(rol *core.Rollup)
 	// FetchGenesisRollup returns the rollup genesis

--- a/go/obscuronode/enclave/db/storage.go
+++ b/go/obscuronode/enclave/db/storage.go
@@ -15,15 +15,13 @@ import (
 )
 
 type storageImpl struct {
-	tempDB  *InMemoryDB // todo - has to be replaced completely by the ethdb.Database
 	db      ethdb.Database
 	stateDB state.Database
 	nodeID  uint64
 }
 
-func NewStorage(tempDB *InMemoryDB, backingDB ethdb.Database, nodeID uint64) Storage {
+func NewStorage(backingDB ethdb.Database, nodeID uint64) Storage {
 	return &storageImpl{
-		tempDB:  tempDB,
 		db:      backingDB,
 		stateDB: state.NewDatabase(backingDB),
 		nodeID:  nodeID,
@@ -91,16 +89,6 @@ func (s *storageImpl) FetchHeadBlock() *types.Block {
 	s.assertSecretAvailable()
 	b, _ := s.FetchBlock(rawdb.ReadHeadHeaderHash(s.db))
 	return b
-}
-
-func (s *storageImpl) FetchRollupTxs(r *core.Rollup) (map[common.Hash]nodecommon.L2Tx, bool) {
-	s.assertSecretAvailable()
-	return s.tempDB.FetchRollupTxs(r)
-}
-
-func (s *storageImpl) StoreRollupTxs(r *core.Rollup, newTxs map[common.Hash]nodecommon.L2Tx) {
-	s.assertSecretAvailable()
-	s.tempDB.StoreRollupTxs(r, newTxs)
 }
 
 func (s *storageImpl) StoreSecret(secret core.SharedEnclaveSecret) {

--- a/go/obscuronode/enclave/enclave.go
+++ b/go/obscuronode/enclave/enclave.go
@@ -643,7 +643,6 @@ func NewEnclave(
 	erc20ContractLib erc20contractlib.ERC20ContractLib,
 	collector StatsCollector,
 ) nodecommon.Enclave {
-	tempDB := db.NewInMemoryDB()
 	nodeShortID := obscurocommon.ShortAddress(config.HostID)
 
 	connect := getDBConnector(config)
@@ -651,7 +650,7 @@ func NewEnclave(
 	if err != nil {
 		log.Panic("Failed to connect to backing database - %s", err)
 	}
-	storage := db.NewStorage(tempDB, backingDB, nodeShortID)
+	storage := db.NewStorage(backingDB, nodeShortID)
 
 	var l1Blockchain *core.BlockChain
 	if config.ValidateL1Blocks {

--- a/go/obscuronode/enclave/rawdb/schema.go
+++ b/go/obscuronode/enclave/rawdb/schema.go
@@ -13,6 +13,7 @@ var (
 	rollupBodyPrefix         = []byte("or")  // rollupBodyPrefix + num (uint64 big endian) + hash -> rollup body
 	rollupHeaderNumberPrefix = []byte("oH")  // headerNumberPrefix + hash -> num (uint64 big endian)
 	blockStatePrefix         = []byte("obs") // headerNumberPrefix + hash -> num (uint64 big endian)
+
 )
 
 // encodeRollupNumber encodes a rollup number as big endian uint64

--- a/go/obscuronode/enclave/utils.go
+++ b/go/obscuronode/enclave/utils.go
@@ -20,22 +20,17 @@ func findTxsNotIncluded(head *core.Rollup, txs []nodecommon.L2Tx, s db.RollupRes
 	return removeExisting(txs, included)
 }
 
-func allIncludedTransactions(b *core.Rollup, s db.RollupResolver) map[common.Hash]nodecommon.L2Tx {
-	val, found := s.FetchRollupTxs(b)
-	if found {
-		return val
-	}
-	if b.Header.Number == obscurocommon.L2GenesisHeight {
-		return makeMap(b.Transactions)
+func allIncludedTransactions(r *core.Rollup, s db.RollupResolver) map[common.Hash]nodecommon.L2Tx {
+	if r.Header.Number == obscurocommon.L2GenesisHeight {
+		return makeMap(r.Transactions)
 	}
 	newMap := make(map[common.Hash]nodecommon.L2Tx)
-	for k, v := range allIncludedTransactions(s.ParentRollup(b), s) {
+	for k, v := range allIncludedTransactions(s.ParentRollup(r), s) {
 		newMap[k] = v
 	}
-	for _, tx := range b.Transactions {
+	for _, tx := range r.Transactions {
 		newMap[tx.Hash()] = tx
 	}
-	s.StoreRollupTxs(b, newMap)
 	return newMap
 }
 


### PR DESCRIPTION
### Why is this change needed?

- to remove the last vestige of the old in memory db 

### What changes were made as part of this PR:

- functional PR
- remove the tempDb, and the functions that were using it, since the transactions were already in the rollup

### What are the key areas to look at
- N/A