### PR TITLE
Adds willAttest flag when running enclave outside of simulation mode.

### DIFF
--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -15,7 +15,7 @@ local machine, and `YYY` is the address of the node that this enclave service is
 By default, the image runs the Obscuro enclave service in SGX simulation mode. To run the enclave service in 
 non-simulation mode instead, run:
 
-    docker run -e OE_SIMULATION=0 --privileged -v /dev/sgx:/dev/sgx -p XXX:11000/tcp obscuro_enclave --hostID YYY --address :11000
+    docker run -e OE_SIMULATION=0 --privileged -v /dev/sgx:/dev/sgx -p XXX:11000/tcp obscuro_enclave --hostID YYY --address :11000 --willAttest=true
 
 Stop and remove all Obscuro docker containers:
 

--- a/tools/azuredeployer/networkdeployer/run.sh
+++ b/tools/azuredeployer/networkdeployer/run.sh
@@ -18,8 +18,8 @@ go-obscuro/integration/gethnetwork/main/geth --numNodes=2 --startPort=12000 --we
 MGMT_CONTRACT_ADDR=$(go-obscuro/tools/networkmanager/main/networkmanager --l1NodePort=12100 --privateKey=$PRIV_KEY_ONE deployMgmtContract)
 ERC20_CONTRACT_ADDR=$(go-obscuro/tools/networkmanager/main/networkmanager --l1NodePort=12100 --privateKey=$PRIV_KEY_ONE deployERC20Contract)
 
-sudo docker run -e OE_SIMULATION=1 --privileged -v /dev/sgx:/dev/sgx -p 127.0.0.1:11000:11000/tcp obscuro_enclave --hostID 1 --address :11000 > ./run_logs.txt 2>&1 &
-sudo docker run -e OE_SIMULATION=1 --privileged -v /dev/sgx:/dev/sgx -p 127.0.0.1:11001:11000/tcp obscuro_enclave --hostID 2 --address :11000 > ./run_logs.txt 2>&1 &
+sudo docker run -e OE_SIMULATION=0 --privileged -v /dev/sgx:/dev/sgx -p 127.0.0.1:11000:11000/tcp obscuro_enclave --hostID 1 --address :11000 --willAttest=true > ./run_logs.txt 2>&1 &
+sudo docker run -e OE_SIMULATION=0 --privileged -v /dev/sgx:/dev/sgx -p 127.0.0.1:11001:11000/tcp obscuro_enclave --hostID 2 --address :11000 --willAttest=true > ./run_logs.txt 2>&1 &
 go-obscuro/go/obscuronode/host/main/host --id=1 --isGenesis=true --p2pAddress=localhost:10000 --peerP2PAddresses=localhost:10001 --enclaveRPCAddress=localhost:11000 --clientRPCAddress=0.0.0.0:13000 --l1NodePort=12100 --privateKey=$PRIV_KEY_ONE > ./run_logs.txt 2>&1 &
 go-obscuro/go/obscuronode/host/main/host --id=2 --isGenesis=false --p2pAddress=localhost:10001 --peerP2PAddresses=localhost:10000 --enclaveRPCAddress=localhost:11001 --clientRPCAddress=localhost:13001 --l1NodePort=12101 --privateKey=$PRIV_KEY_TWO > ./run_logs.txt 2>&1 &
 cd go-obscuro


### PR DESCRIPTION
### Why is this change needed?

We should default to the most "production-like" mode, which includes adding the `willAttest` flag outside of simulation mode.

### What changes were made as part of this PR:

- Functional
- Adds flag to run script and Docker readme

### What are the key areas to look at

N/A