### PR TITLE
Bumps timeout for retrieving nonce.

### DIFF
--- a/integration/simulation/transaction_injector.go
+++ b/integration/simulation/transaction_injector.go
@@ -26,7 +26,7 @@ import (
 	stats2 "github.com/obscuronet/obscuro-playground/integration/simulation/stats"
 )
 
-const timeoutMillis = 10000 // The timeout in millis to wait for an updated nonce for a wallet.
+const timeoutMillis = 30000 // The timeout in millis to wait for an updated nonce for a wallet.
 
 // TransactionInjector is a structure that generates, issues and tracks transactions
 type TransactionInjector struct {

--- a/integration/simulation/transaction_injector.go
+++ b/integration/simulation/transaction_injector.go
@@ -353,16 +353,19 @@ func NextNonce(cl obscuroclient.Client, w wallet.Wallet) uint64 {
 
 	// only returns the nonce when the previous transaction was recorded
 	for {
-		result := readNonce(cl, w.Address())
-		if result == w.GetNonce() {
+		remoteNonce := readNonce(cl, w.Address())
+		localNonce := w.GetNonce()
+		if remoteNonce == localNonce {
 			return w.GetNonceAndIncrement()
 		}
-		counter++
-
-		if counter > timeoutMillis {
-			panic("Transaction injector failed to retrieve nonce after ten seconds...")
+		if remoteNonce > localNonce {
+			panic("remote nonce exceeds local nonce")
 		}
 
+		counter++
+		if counter > timeoutMillis {
+			panic("transaction injector failed to retrieve nonce after thirty seconds")
+		}
 		time.Sleep(time.Millisecond)
 	}
 }


### PR DESCRIPTION
### Why is this change needed?

The timeout kept getting hit. It's not clear to me whether this is a genuine timeout or a failure. But increasing it should reduce flaky failures.

Also panics if remote nonce exceeds local nonce, which should never happen.

### What changes were made as part of this PR:

- Functional

### What are the key areas to look at

N/A