### PR TITLE
Increases threshold of txs to consider simulation failed

### DIFF
--- a/integration/simulation/transaction_injector.go
+++ b/integration/simulation/transaction_injector.go
@@ -26,7 +26,7 @@ import (
 	stats2 "github.com/obscuronet/obscuro-playground/integration/simulation/stats"
 )
 
-const timeoutMillis = 10000 // The timeout in millis to wait for an updated nonce for a wallet.
+const timeoutMillis = 30000 // The timeout in millis to wait for an updated nonce for a wallet.
 
 // TransactionInjector is a structure that generates, issues and tracks transactions
 type TransactionInjector struct {

--- a/integration/simulation/transaction_injector.go
+++ b/integration/simulation/transaction_injector.go
@@ -353,16 +353,19 @@ func NextNonce(cl obscuroclient.Client, w wallet.Wallet) uint64 {
 
 	// only returns the nonce when the previous transaction was recorded
 	for {
-		result := readNonce(cl, w.Address())
-		if result == w.GetNonce() {
+		remoteNonce := readNonce(cl, w.Address())
+		localNonce := w.GetNonce()
+		if remoteNonce == localNonce {
 			return w.GetNonceAndIncrement()
 		}
-		counter++
-
-		if counter > timeoutMillis {
-			panic("Transaction injector failed to retrieve nonce after ten seconds...")
+		if remoteNonce > localNonce {
+			panic("remote nonce exceeds local nonce")
 		}
 
+		counter++
+		if counter > timeoutMillis {
+			panic("transaction injector failed to retrieve nonce after thirty seconds")
+		}
 		time.Sleep(time.Millisecond)
 	}
 }

--- a/integration/simulation/validate_chain.go
+++ b/integration/simulation/validate_chain.go
@@ -27,13 +27,13 @@ const txThreshold = 5
 func checkNetworkValidity(t *testing.T, s *Simulation) {
 	// ensure L1 and L2 txs were issued
 	if len(s.TxInjector.counter.l1Transactions) < txThreshold {
-		t.Error("Simulation did not issue any L1 transactions.")
+		t.Errorf("Simulation only issued %d L1 transactions. At least %d expected", len(s.TxInjector.counter.l1Transactions), txThreshold)
 	}
 	if len(s.TxInjector.counter.transferL2Transactions) < txThreshold {
-		t.Error("Simulation did not issue any transfer L2 transactions.")
+		t.Errorf("Simulation only issued %d transfer L2 transactions. At least %d expected", len(s.TxInjector.counter.transferL2Transactions), txThreshold)
 	}
 	if len(s.TxInjector.counter.withdrawalL2Transactions) < txThreshold {
-		t.Error("Simulation did not issue any withdrawal L2 transactions.")
+		t.Errorf("Simulation only issued %d withdrawal L2 transactions. At least %d expected", len(s.TxInjector.counter.withdrawalL2Transactions), txThreshold)
 	}
 
 	l1MaxHeight := checkEthereumBlockchainValidity(t, s)

--- a/integration/simulation/validate_chain.go
+++ b/integration/simulation/validate_chain.go
@@ -16,18 +16,23 @@ import (
 	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
 )
 
+// The threshold number of transactions below which we consider the simulation to have failed. We generally expect far
+// more than this, but this is a sanity check to ensure the simulation doesn't stop after a single transaction of each
+// type, for example.
+const txThreshold = 5
+
 // After a simulation has run, check as much as possible that the outputs of the simulation are expected.
 // For example, all injected transactions were processed correctly, the height of the rollup chain is a function of the total
 // time of the simulation and the average block duration, that all Obscuro nodes are roughly in sync, etc
 func checkNetworkValidity(t *testing.T, s *Simulation) {
 	// ensure L1 and L2 txs were issued
-	if len(s.TxInjector.counter.l1Transactions) == 0 {
+	if len(s.TxInjector.counter.l1Transactions) < txThreshold {
 		t.Error("Simulation did not issue any L1 transactions.")
 	}
-	if len(s.TxInjector.counter.transferL2Transactions) == 0 {
+	if len(s.TxInjector.counter.transferL2Transactions) < txThreshold {
 		t.Error("Simulation did not issue any transfer L2 transactions.")
 	}
-	if len(s.TxInjector.counter.withdrawalL2Transactions) == 0 {
+	if len(s.TxInjector.counter.withdrawalL2Transactions) < txThreshold {
 		t.Error("Simulation did not issue any withdrawal L2 transactions.")
 	}
 


### PR DESCRIPTION
### Why is this change needed?

Previously, the sim could deadlock after one or two transactions, and still be considered a success. We want to catch that edge-case.

### What changes were made as part of this PR:

- Functional

### What are the key areas to look at

N/A