### PR TITLE
Allows adding of full rollup to node DB.

### DIFF
--- a/go/obscuronode/host/host.go
+++ b/go/obscuronode/host/host.go
@@ -397,7 +397,7 @@ func (a *Node) storeBlockProcessingResult(result nodecommon.BlockSubmissionRespo
 	// only update the node rollup headers if the enclave has found a new rollup head
 	if result.FoundNewHead {
 		// adding a header will update the head if it has a higher height
-		a.DB().AddRollupHeader(result.RollupHead)
+		a.DB().AddRollup(&result.ProducedRollup)
 	}
 
 	// adding a header will update the head if it has a higher height

--- a/go/obscuronode/host/hostdb.go
+++ b/go/obscuronode/host/hostdb.go
@@ -74,7 +74,12 @@ func (n *DB) GetCurrentRollupHead() *nodecommon.Header {
 func (n *DB) GetRollupHeader(hash common.Hash) *nodecommon.Header {
 	n.rollupLock.RLock()
 	defer n.rollupLock.RUnlock()
-	return n.rollupDB[hash].Header
+
+	rollup := n.rollupDB[hash]
+	if rollup != nil {
+		return rollup.Header
+	}
+	return nil
 }
 
 // AddRollup adds an ExtRollup to the known rollups.

--- a/go/obscuronode/host/hostdb.go
+++ b/go/obscuronode/host/hostdb.go
@@ -18,7 +18,7 @@ type DB struct {
 
 	rollupLock        sync.RWMutex
 	currentRollupHead common.Hash
-	rollupDB          map[common.Hash]*nodecommon.Header
+	rollupDB          map[common.Hash]*nodecommon.ExtRollup
 
 	submittedLock    sync.RWMutex
 	submittedRollups map[common.Hash]common.Hash
@@ -28,7 +28,7 @@ type DB struct {
 func NewDB() *DB {
 	return &DB{
 		blockDB:          map[common.Hash]*types.Header{},
-		rollupDB:         map[common.Hash]*nodecommon.Header{},
+		rollupDB:         map[common.Hash]*nodecommon.ExtRollup{},
 		submittedRollups: map[common.Hash]common.Hash{},
 	}
 }
@@ -74,20 +74,20 @@ func (n *DB) GetCurrentRollupHead() *nodecommon.Header {
 func (n *DB) GetRollupHeader(hash common.Hash) *nodecommon.Header {
 	n.rollupLock.RLock()
 	defer n.rollupLock.RUnlock()
-	return n.rollupDB[hash]
+	return n.rollupDB[hash].Header
 }
 
-// AddRollupHeader adds a RollupHeader to the known headers
-func (n *DB) AddRollupHeader(header *nodecommon.Header) {
+// AddRollup adds an ExtRollup to the known rollups.
+func (n *DB) AddRollup(rollup *nodecommon.ExtRollup) {
 	n.rollupLock.Lock()
 	defer n.rollupLock.Unlock()
 
-	n.rollupDB[header.Hash()] = header
+	n.rollupDB[rollup.Header.Hash()] = rollup
 
 	// update the head if the new height is greater than the existing one
-	currentRollupHead := n.rollupDB[n.currentRollupHead]
-	if currentRollupHead == nil || currentRollupHead.Number < header.Number {
-		n.currentRollupHead = header.Hash()
+	currentHeadRollup := n.rollupDB[n.currentRollupHead]
+	if currentHeadRollup == nil || currentHeadRollup.Header.Number < rollup.Header.Number {
+		n.currentRollupHead = rollup.Header.Hash()
 	}
 }
 

--- a/go/obscuronode/host/hostdb.go
+++ b/go/obscuronode/host/hostdb.go
@@ -90,8 +90,8 @@ func (n *DB) AddRollup(rollup *nodecommon.ExtRollup) {
 	n.rollupDB[rollup.Header.Hash()] = rollup
 
 	// update the head if the new height is greater than the existing one
-	currentHeadRollup := n.rollupDB[n.currentRollupHead]
-	if currentHeadRollup == nil || currentHeadRollup.Header.Number < rollup.Header.Number {
+	currentRollupHead := n.rollupDB[n.currentRollupHead]
+	if currentRollupHead == nil || currentRollupHead.Header.Number < rollup.Header.Number {
 		n.currentRollupHead = rollup.Header.Hash()
 	}
 }


### PR DESCRIPTION
### Why is this change needed?

Allows the list of encrypted transactions to be returned to Obscuroscan, so they can be inspected and decrypted as part of devnet.

### What changes were made as part of this PR:

- list of changes
- Is this a functional or refactoring PR ( it needs to be one or the other)

### What are the key areas to look at
