### PR TITLE
Increase test times a bit and decrease waiting time to allow more tim…

### DIFF
--- a/integration/simulation/network/obscuro_node_utils.go
+++ b/integration/simulation/network/obscuro_node_utils.go
@@ -51,7 +51,6 @@ func startInMemoryObscuroNodes(params *params.SimParams, stats *stats.Stats, gen
 	for _, m := range obscuroNodes {
 		t := m
 		go t.Start()
-		time.Sleep(params.AvgBlockDuration / 10)
 	}
 
 	// Create a handle to each node
@@ -59,6 +58,7 @@ func startInMemoryObscuroNodes(params *params.SimParams, stats *stats.Stats, gen
 	for i, node := range obscuroNodes {
 		obscuroClients[i] = host.NewInMemObscuroClient(node)
 	}
+	time.Sleep(100 * time.Millisecond)
 	return obscuroClients
 }
 

--- a/integration/simulation/network/obscuro_node_utils.go
+++ b/integration/simulation/network/obscuro_node_utils.go
@@ -104,6 +104,19 @@ func startStandaloneObscuroNodes(params *params.SimParams, stats *stats.Stats, g
 		time.Sleep(params.AvgBlockDuration / 3)
 	}
 
+	// wait for the clients to be connected
+	for i, client := range obscuroClients {
+		started := false
+		for !started {
+			err := client.Call(nil, obscuroclient.RPCGetID)
+			started = err == nil
+			if !started {
+				fmt.Printf("Could not connect to client %d. Err %s. Retrying..\n", i, err)
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
+	}
+
 	return obscuroClients, nodeP2pAddrs
 }
 

--- a/integration/simulation/simulation.go
+++ b/integration/simulation/simulation.go
@@ -37,7 +37,7 @@ func (s *Simulation) Start() {
 	s.WaitForObscuroGenesis()
 
 	// arbitrary sleep to wait for RPC clients to get up and running
-	time.Sleep(5 * time.Second)
+	time.Sleep(1 * time.Second)
 
 	timer := time.Now()
 	log.Info("Starting injection")

--- a/integration/simulation/simulation_docker_test.go
+++ b/integration/simulation/simulation_docker_test.go
@@ -46,7 +46,7 @@ func TestDockerNodesMonteCarloSimulation(t *testing.T) {
 	simParams := params.SimParams{
 		NumberOfNodes:         numberOfNodes,
 		AvgBlockDuration:      1 * time.Second,
-		SimulationTime:        30 * time.Second,
+		SimulationTime:        35 * time.Second,
 		L1EfficiencyThreshold: 0.2,
 		// Very hard to have precision here as blocks are continually produced and not dependent on the simulation execution thread
 		L2EfficiencyThreshold:     0.6, // nodes might produce rollups because they receive a new block

--- a/integration/simulation/simulation_full_network_test.go
+++ b/integration/simulation/simulation_full_network_test.go
@@ -53,7 +53,7 @@ func TestFullNetworkMonteCarloSimulation(t *testing.T) {
 	simParams := &params.SimParams{
 		NumberOfNodes:         numberOfNodes,
 		AvgBlockDuration:      1 * time.Second,
-		SimulationTime:        30 * time.Second,
+		SimulationTime:        35 * time.Second,
 		L1EfficiencyThreshold: 0.2,
 		// Very hard to have precision here as blocks are continually produced and not dependent on the simulation execution thread
 		L2EfficiencyThreshold:     0.6, // nodes might produce rollups because they receive a new block

--- a/integration/simulation/simulation_geth_in_mem_test.go
+++ b/integration/simulation/simulation_geth_in_mem_test.go
@@ -49,7 +49,7 @@ func TestGethSimulation(t *testing.T) {
 	simParams := &params.SimParams{
 		NumberOfNodes:         numberOfNodes,
 		AvgBlockDuration:      1 * time.Second,
-		SimulationTime:        30 * time.Second,
+		SimulationTime:        35 * time.Second,
 		L1EfficiencyThreshold: 0.2,
 		// Very hard to have precision here as blocks are continually produced and not dependent on the simulation execution thread
 		L2EfficiencyThreshold:     0.6, // nodes might produce rollups because they receive a new block


### PR DESCRIPTION
### Why is this change needed?

Tests are failing because there are < 5 withdrawal transactions.
This highlights a problem that there is too little time now for actual tx processing, since we've been adding more waiting times.
The solution is to reduce the waiting times a bit and to increase the test time

There is a change in "[obscuro_node_utils.go]" to wait for all rpc connections to the obscuro hosts to be available before proceeding. This should fix the error that "could not deploy", and allow us to sleep less to wait for rpc connections

### What changes were made as part of this PR:

- see above
-functional pr

### What are the key areas to look at
N/A