### PR TITLE
fix enclave deploy IP retrieval

### DIFF
--- a/tools/azuredeployer/enclavedeployer/README.md
+++ b/tools/azuredeployer/enclavedeployer/README.md
@@ -27,10 +27,7 @@ re-run the docker build from inside the obscuro-playground dir on the VM:
 
 ## Multiple nodes
 
-You can run the azure_deployer tool multiple times to run more than one node by modifying the resource group name param
-at the top of the script, e.g. you could add a number
-
-    resourceGroupName     = "ObscuroEnclaveService2"
+You can run the azure_deployer tool multiple times to run more than one node.
 
 Note the IP logged out at the end of each run to SSH to the box (and to configure them into simulation_multi_azure_enclaves_test.go).
 

--- a/tools/azuredeployer/enclavedeployer/vm-template.json
+++ b/tools/azuredeployer/enclavedeployer/vm-template.json
@@ -11,7 +11,7 @@
       "type": "String"
     },
     "publicIPAddresses_enclave_service_sgx_ip_name": {
-      "defaultValue": "enclave-service-sgx-ip",
+      "defaultValue": "obscuro-network-ip",
       "type": "String"
     },
     "networkInterfaces_enclave_service_s168_z1_name": {


### PR DESCRIPTION
### Why is this change needed?

- when you run the enclave azure deployer at the moment it fails to get the IP and so fails to run the script that sets up docker and docker image

### What changes were made as part of this PR:

- tweak enclave deploy config to match the network deploy config so the script they both use works for enclave deploy
- also updated an out of date part of the readme

### What are the key areas to look at
- the config change

### Evidence
Failure before the change:
<img width="1657" alt="Screenshot 2022-06-08 at 10 30 58" src="https://user-images.githubusercontent.com/98158711/172586625-41997333-8950-4107-ac35-c183a39c0b0e.png">

Success after the change:
<img width="1139" alt="Screenshot 2022-06-08 at 10 40 53" src="https://user-images.githubusercontent.com/98158711/172586669-d9abb42f-96ca-4b62-a385-f3f4f2296823.png">
