### PR TITLE
Enables websockets for simulation nodes.

### DIFF
--- a/integration/simulation/network/network_utils.go
+++ b/integration/simulation/network/network_utils.go
@@ -29,9 +29,10 @@ import (
 const (
 	Localhost                  = "127.0.0.1"
 	DefaultWsPortOffset        = 100 // The default offset between a Geth node's port and websocket ports.
-	DefaultHostP2pOffset       = 200 //  The default offset for the host P2p
-	DefaultHostRPCOffset       = 400 //  The default offset for the host RPC
-	DefaultEnclaveOffset       = 300 //  The default offset between a Geth nodes port and the enclave ports. Used in Socket Simulations.
+	DefaultHostP2pOffset       = 200 // The default offset for the host P2p
+	DefaultEnclaveOffset       = 300 // The default offset between a Geth nodes port and the enclave ports. Used in Socket Simulations.
+	DefaultHostRPCHTTPOffset   = 400 // The default offset for the host's RPC HTTP port
+	DefaultHostRPCWSOffset     = 500 // The default offset for the host's RPC websocket port
 	ClientRPCTimeoutSecs       = 5
 	DefaultL1ConnectionTimeout = 15 * time.Second
 )
@@ -104,6 +105,7 @@ func createSocketObscuroNode(
 	enclaveAddr string,
 	clientRPCHost string,
 	clientRPCPortHTTP uint64,
+	clientRPCPortWS uint64,
 	ethWallet wallet.Wallet,
 	mgmtContractLib mgmtcontractlib.MgmtContractLib,
 	ethClient ethclient.EthClient,
@@ -114,7 +116,8 @@ func createSocketObscuroNode(
 		GossipRoundDuration:    avgGossipPeriod,
 		HasClientRPCHTTP:       true,
 		ClientRPCPortHTTP:      clientRPCPortHTTP,
-		HasClientRPCWebsockets: false,
+		HasClientRPCWebsockets: true,
+		ClientRPCPortWS:        clientRPCPortWS,
 		ClientRPCHost:          clientRPCHost,
 		ClientRPCTimeout:       ClientRPCTimeoutSecs * time.Second,
 		EnclaveRPCTimeout:      ClientRPCTimeoutSecs * time.Second,

--- a/integration/simulation/network/obscuro_node_utils.go
+++ b/integration/simulation/network/obscuro_node_utils.go
@@ -78,7 +78,8 @@ func startStandaloneObscuroNodes(params *params.SimParams, stats *stats.Stats, g
 		isGenesis := i == 0
 
 		// We use the convention to determine the rpc ports of the node
-		nodeRPCPortHTTP := params.StartPort + DefaultHostRPCOffset + i
+		nodeRPCPortHTTP := params.StartPort + DefaultHostRPCHTTPOffset + i
+		nodeRPCPortWS := params.StartPort + DefaultHostRPCWSOffset + i
 
 		// create a remote enclave server
 		obscuroNodes[i] = createSocketObscuroNode(
@@ -91,6 +92,7 @@ func startStandaloneObscuroNodes(params *params.SimParams, stats *stats.Stats, g
 			enclaveAddresses[i],
 			Localhost,
 			uint64(nodeRPCPortHTTP),
+			uint64(nodeRPCPortWS),
 			params.Wallets.NodeWallets[i],
 			params.MgmtContractLib,
 			gethClients[i],


### PR DESCRIPTION
### Why is this change needed?

Simulation socket nodes don't currently expose an RPC websocket port. This will block the integration testing of the wallet extension.

### What changes were made as part of this PR:

Functional.

Enables websocket ports for socket simulation nodes.

### What are the key areas to look at
