### PR TITLE
Renables and fixes first wallet extension test.

### DIFF
--- a/integration/simulation/network/network_utils.go
+++ b/integration/simulation/network/network_utils.go
@@ -125,6 +125,7 @@ func createSocketObscuroNode(
 		EnclaveRPCAddress:      enclaveAddr,
 		P2PAddress:             p2pAddr,
 		AllP2PAddresses:        peerAddrs,
+		ChainID:                config.DefaultHostConfig().ChainID,
 	}
 
 	// create an enclave client

--- a/integration/walletextension/wallet_extension_test.go
+++ b/integration/walletextension/wallet_extension_test.go
@@ -53,18 +53,16 @@ const (
 )
 
 func TestCanMakeNonSensitiveRequestWithoutSubmittingViewingKey(t *testing.T) {
-	t.Skip() // Skipping while support for viewing keys is being implemented.
-
 	stopHandle, err := createObscuroNetwork(int(integration.StartPortWalletExtensionTest + 1))
 	defer stopHandle()
 	if err != nil {
 		t.Fatalf("failed to create test Obscuro network. Cause: %s", err)
 	}
 
-	nodeRPCPort := integration.StartPortWalletExtensionTest + 1 + network.DefaultHostRPCHTTPOffset
+	nodeRPCPort := integration.StartPortWalletExtensionTest + 1 + network.DefaultHostRPCWSOffset
 	walletExtensionConfig := walletextension.Config{
-		WalletExtensionPort: startPort,
-		NodeRPCAddress:      fmt.Sprintf("%s:%d", network.Localhost, nodeRPCPort),
+		WalletExtensionPort:     startPort,
+		NodeRPCWebsocketAddress: fmt.Sprintf("%s:%d", network.Localhost, nodeRPCPort),
 	}
 	walletExtensionAddr := fmt.Sprintf("%s:%d", network.Localhost, integration.StartPortWalletExtensionTest)
 
@@ -80,6 +78,8 @@ func TestCanMakeNonSensitiveRequestWithoutSubmittingViewingKey(t *testing.T) {
 	}
 }
 
+// TODO - Renable these tests once Obscuro node functionality is implemented.
+
 func TestCannotGetBalanceWithoutSubmittingViewingKey(t *testing.T) {
 	t.Skip() // Skipping while support for viewing keys is being implemented.
 
@@ -91,8 +91,8 @@ func TestCannotGetBalanceWithoutSubmittingViewingKey(t *testing.T) {
 
 	nodeRPCPort := integration.StartPortWalletExtensionTest + 1 + network.DefaultHostRPCHTTPOffset
 	walletExtensionConfig := walletextension.Config{
-		WalletExtensionPort: startPort,
-		NodeRPCAddress:      fmt.Sprintf("%s:%d", network.Localhost, nodeRPCPort),
+		WalletExtensionPort:     startPort,
+		NodeRPCWebsocketAddress: fmt.Sprintf("%s:%d", network.Localhost, nodeRPCPort),
 	}
 	walletExtensionAddr := fmt.Sprintf("%s:%d", network.Localhost, integration.StartPortWalletExtensionTest)
 
@@ -121,8 +121,8 @@ func TestCanGetOwnBalanceAfterSubmittingViewingKey(t *testing.T) {
 
 	nodeRPCPort := integration.StartPortWalletExtensionTest + 1 + network.DefaultHostRPCHTTPOffset
 	walletExtensionConfig := walletextension.Config{
-		WalletExtensionPort: startPort,
-		NodeRPCAddress:      fmt.Sprintf("%s:%d", network.Localhost, nodeRPCPort),
+		WalletExtensionPort:     startPort,
+		NodeRPCWebsocketAddress: fmt.Sprintf("%s:%d", network.Localhost, nodeRPCPort),
 	}
 	walletExtensionAddr := fmt.Sprintf("%s:%d", network.Localhost, integration.StartPortWalletExtensionTest)
 
@@ -157,8 +157,8 @@ func TestCannotGetAnothersBalanceAfterSubmittingViewingKey(t *testing.T) {
 
 	nodeRPCPort := integration.StartPortWalletExtensionTest + 1 + network.DefaultHostRPCHTTPOffset
 	walletExtensionConfig := walletextension.Config{
-		WalletExtensionPort: startPort,
-		NodeRPCAddress:      fmt.Sprintf("%s:%d", network.Localhost, nodeRPCPort),
+		WalletExtensionPort:     startPort,
+		NodeRPCWebsocketAddress: fmt.Sprintf("%s:%d", network.Localhost, nodeRPCPort),
 	}
 	walletExtensionAddr := fmt.Sprintf("%s:%d", network.Localhost, integration.StartPortWalletExtensionTest)
 
@@ -194,8 +194,8 @@ func TestCannotCallWithoutSubmittingViewingKey(t *testing.T) {
 
 	nodeRPCPort := integration.StartPortWalletExtensionTest + 1 + network.DefaultHostRPCHTTPOffset
 	walletExtensionConfig := walletextension.Config{
-		WalletExtensionPort: startPort,
-		NodeRPCAddress:      fmt.Sprintf("%s:%d", network.Localhost, nodeRPCPort),
+		WalletExtensionPort:     startPort,
+		NodeRPCWebsocketAddress: fmt.Sprintf("%s:%d", network.Localhost, nodeRPCPort),
 	}
 	walletExtensionAddr := fmt.Sprintf("%s:%d", network.Localhost, integration.StartPortWalletExtensionTest)
 
@@ -236,8 +236,8 @@ func TestCanCallAfterSubmittingViewingKey(t *testing.T) {
 
 	nodeRPCPort := integration.StartPortWalletExtensionTest + 1 + network.DefaultHostRPCHTTPOffset
 	walletExtensionConfig := walletextension.Config{
-		WalletExtensionPort: startPort,
-		NodeRPCAddress:      fmt.Sprintf("%s:%d", network.Localhost, nodeRPCPort),
+		WalletExtensionPort:     startPort,
+		NodeRPCWebsocketAddress: fmt.Sprintf("%s:%d", network.Localhost, nodeRPCPort),
 	}
 	walletExtensionAddr := fmt.Sprintf("%s:%d", network.Localhost, integration.StartPortWalletExtensionTest)
 
@@ -279,8 +279,8 @@ func TestCannotCallForAnotherAddressAfterSubmittingViewingKey(t *testing.T) {
 
 	nodeRPCPort := integration.StartPortWalletExtensionTest + 1 + network.DefaultHostRPCHTTPOffset
 	walletExtensionConfig := walletextension.Config{
-		WalletExtensionPort: startPort,
-		NodeRPCAddress:      fmt.Sprintf("%s:%d", network.Localhost, nodeRPCPort),
+		WalletExtensionPort:     startPort,
+		NodeRPCWebsocketAddress: fmt.Sprintf("%s:%d", network.Localhost, nodeRPCPort),
 	}
 	walletExtensionAddr := fmt.Sprintf("%s:%d", network.Localhost, integration.StartPortWalletExtensionTest)
 

--- a/tools/walletextension/main/cli.go
+++ b/tools/walletextension/main/cli.go
@@ -12,18 +12,18 @@ const (
 	walletExtensionPortDefault = 3000
 	walletExtensionPortUsage   = "The port on which to serve the wallet extension"
 
-	nodeRPCAddressName    = "nodeRPCAddress"
-	nodeRPCAddressDefault = "127.0.0.1:13000"
-	nodeRPCAddressUsage   = "The address on which to connect to the node via RPC"
+	nodeRPCWebsocketAddressName    = "nodeRPCWebsocketAddress"
+	nodeRPCWebsocketAddressDefault = "127.0.0.1:13000"
+	nodeRPCWebsocketAddressUsage   = "The address on which to connect to the node via RPC using websockets"
 )
 
 func parseCLIArgs() walletextension.Config {
 	walletExtensionPort := flag.Int(walletExtensionPortName, walletExtensionPortDefault, walletExtensionPortUsage)
-	nodeRPCAddress := flag.String(nodeRPCAddressName, nodeRPCAddressDefault, nodeRPCAddressUsage)
+	nodeRPCAddress := flag.String(nodeRPCWebsocketAddressName, nodeRPCWebsocketAddressDefault, nodeRPCWebsocketAddressUsage)
 	flag.Parse()
 
 	return walletextension.Config{
-		WalletExtensionPort: *walletExtensionPort,
-		NodeRPCAddress:      *nodeRPCAddress,
+		WalletExtensionPort:     *walletExtensionPort,
+		NodeRPCWebsocketAddress: *nodeRPCAddress,
 	}
 }


### PR DESCRIPTION
### Why is this change needed?

The wallet extension tests are disabled. This renables the first wallet extension test and gets it to pass.

As a trade-off, I've had to disable encryption of requests to the enclave for now. They will be reimplemented later.

### What changes were made as part of this PR:

Functional.

Reimplements first wallet extension test.

### What are the key areas to look at
