### PR TITLE
Removes decryption of getBalance requests for now.

### DIFF
--- a/go/obscuronode/host/client_api_eth.go
+++ b/go/obscuronode/host/client_api_eth.go
@@ -32,6 +32,7 @@ func (api *EthereumAPI) BlockNumber() hexutil.Uint64 {
 
 // GetBalance returns the address's balance on the Obscuro network.
 // TODO - Establish what value we should return here (balance in a specific ERC-20 contract?).
+// TODO - Encrypt the response with a viewing key on the enclave side once we're returning a non-dummy value.
 func (api *EthereumAPI) GetBalance(context.Context, common.Address, rpc.BlockNumberOrHash) (*hexutil.Big, error) {
 	return (*hexutil.Big)(big.NewInt(0)), nil
 }

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -22,13 +22,12 @@ const (
 	pathSubmitViewingKey   = "/submitviewingkey/"
 	staticDir              = "./tools/walletextension/static"
 
-	reqJSONKeyMethod        = "method"
-	reqJSONMethodGetBalance = "eth_getBalance"
-	reqJSONMethodCall       = "eth_call"
-	respJSONKeyErr          = "error"
-	respJSONKeyMsg          = "message"
-	pathRoot                = "/"
-	httpCodeErr             = 500
+	reqJSONKeyMethod  = "method"
+	reqJSONMethodCall = "eth_call"
+	respJSONKeyErr    = "error"
+	respJSONKeyMsg    = "message"
+	pathRoot          = "/"
+	httpCodeErr       = 500
 
 	Localhost         = "127.0.0.1"
 	websocketProtocol = "ws://"
@@ -135,7 +134,7 @@ func (we *WalletExtension) handleHTTPEthJSON(resp http.ResponseWriter, req *http
 	}
 
 	// We decrypt the response if it's encrypted.
-	if method == reqJSONMethodGetBalance || method == reqJSONMethodCall {
+	if method == reqJSONMethodCall {
 		fmt.Printf("🔐 Decrypting %s response from Obscuro node with viewing key.\n", method)
 		nodeResp, err = we.viewingKeyPrivateEcies.Decrypt(nodeResp, nil, nil)
 		if err != nil {


### PR DESCRIPTION
### Why is this change needed?

For now, we are just returning a dummy response to `eth_getBalance` calls. It therefore doesn't make sense to encrypt the responses in the wallet extension.

### What changes were made as part of this PR:

- Removes encryption of `getBalance` responses
- Adds todo to reintroduce later

### What are the key areas to look at
