### PR TITLE
Simplify DB setup in enclave

### DIFF
--- a/go/obscuronode/enclave/db/interfaces.go
+++ b/go/obscuronode/enclave/db/interfaces.go
@@ -3,7 +3,6 @@ package db
 import (
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
 	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/core"
 )
@@ -71,8 +70,3 @@ type Storage interface {
 	SharedSecretStorage
 	BlockStateStorage
 }
-
-// EthDBConnector is an abstraction for constructing/validating/connecting-to an eth-compatible key-value store.
-// The DB might be a simple in-memory map, a SQL DB for testing or a trusted enclave-based EdgelessDB instance.
-// Implementation should handle validation/attestation in the case of a secure DB
-type EthDBConnector func(nodeID uint64) (ethdb.Database, error)


### PR DESCRIPTION
Small PR to make the edgeless DB connection PR simpler. 

### Why is this change needed?

- Edgeless DB will need various config (like the host address of the edgeless DB) and this abstraction I tried to guess at when I first wrote this is making that harder and not adding value.

### What changes were made as part of this PR:

- removes the db connector abstraction that was unhelpful and allows ethdb construction with the whole config object.

### What are the key areas to look at
- Enclave DB connection setup