### PR TITLE
initialise the wallets with custom chain ids

### DIFF
--- a/integration/simulation/params/wallet_utils.go
+++ b/integration/simulation/params/wallet_utils.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/evm"
 	"github.com/obscuronet/obscuro-playground/go/obscuronode/wallet"
-	"github.com/obscuronet/obscuro-playground/integration"
 	"github.com/obscuronet/obscuro-playground/integration/datagenerator"
 )
 
@@ -20,11 +19,11 @@ type SimWallets struct {
 	Erc20ObsOwnerWallets []wallet.Wallet // and the owners of the respective wrapped versions on Obscuro
 }
 
-func NewSimWallets(nrSimWallets int, nNodes int, nrErc20s int) *SimWallets {
+func NewSimWallets(nrSimWallets int, nNodes int, nrErc20s int, ethereumChainID int64, obscuroChainID int64) *SimWallets {
 	// create the ethereum wallets to be used by the nodes
 	nodeWallets := make([]wallet.Wallet, nNodes)
 	for i := 0; i < nNodes; i++ {
-		nodeWallets[i] = datagenerator.RandomWallet(integration.EthereumChainID)
+		nodeWallets[i] = datagenerator.RandomWallet(ethereumChainID)
 	}
 
 	// create the wallets to be used by the simulated users
@@ -32,12 +31,12 @@ func NewSimWallets(nrSimWallets int, nNodes int, nrErc20s int) *SimWallets {
 	simEthWallets := make([]wallet.Wallet, nrSimWallets)
 	simObsWallets := make([]wallet.Wallet, nrSimWallets)
 	for i := 0; i < nrSimWallets; i++ {
-		simEthWallets[i] = datagenerator.RandomWallet(integration.EthereumChainID)
-		simObsWallets[i] = wallet.NewInMemoryWalletFromPK(big.NewInt(integration.ObscuroChainID), simEthWallets[i].PrivateKey())
+		simEthWallets[i] = datagenerator.RandomWallet(ethereumChainID)
+		simObsWallets[i] = wallet.NewInMemoryWalletFromPK(big.NewInt(obscuroChainID), simEthWallets[i].PrivateKey())
 	}
 
 	// create the wallet to deploy the Management contract
-	mcOwnerWallet := datagenerator.RandomWallet(integration.EthereumChainID)
+	mcOwnerWallet := datagenerator.RandomWallet(ethereumChainID)
 
 	// create the ethereum wallets to be used to deploy ERC20 contracts
 	// and their counterparts in the Obscuro world for the wrapped versions
@@ -46,12 +45,12 @@ func NewSimWallets(nrSimWallets int, nNodes int, nrErc20s int) *SimWallets {
 	}
 	erc20EthWallets := make([]wallet.Wallet, nrErc20s)
 	erc20ObsWallets := make([]wallet.Wallet, nrErc20s)
-	erc20EthWallets[0] = datagenerator.RandomWallet(integration.EthereumChainID)
+	erc20EthWallets[0] = datagenerator.RandomWallet(ethereumChainID)
 
 	// this cannot be random for now, because there is hardcoded logic in the obscuro core
 	// to generate synthetic "transfer" transactions on the wrapped erc20 for each erc20 deposit on ethereum
 	// and these transactions need to be signed
-	erc20ObsWallets[0] = wallet.NewInMemoryWalletFromPK(big.NewInt(integration.ObscuroChainID), evm.Erc20OwnerKey)
+	erc20ObsWallets[0] = wallet.NewInMemoryWalletFromPK(big.NewInt(obscuroChainID), evm.Erc20OwnerKey)
 
 	return &SimWallets{
 		MCOwnerWallet:        mcOwnerWallet,

--- a/integration/simulation/simulation_azure_enclaves_test.go
+++ b/integration/simulation/simulation_azure_enclaves_test.go
@@ -35,7 +35,7 @@ func TestAzureEnclaveNodesMonteCarloSimulation(t *testing.T) {
 	numberOfNodes := 5
 	numberOfSimWallets := 5
 
-	wallets := params.NewSimWallets(numberOfSimWallets, numberOfNodes, 1)
+	wallets := params.NewSimWallets(numberOfSimWallets, numberOfNodes, 1, integration.EthereumChainID, integration.ObscuroChainID)
 
 	simParams := params.SimParams{
 		NumberOfNodes:             numberOfNodes,

--- a/integration/simulation/simulation_docker_test.go
+++ b/integration/simulation/simulation_docker_test.go
@@ -18,7 +18,7 @@ func TestDockerNodesMonteCarloSimulation(t *testing.T) {
 
 	numberOfNodes := 5
 	numberOfSimWallets := 5
-	wallets := params.NewSimWallets(numberOfSimWallets, numberOfNodes, 1)
+	wallets := params.NewSimWallets(numberOfSimWallets, numberOfNodes, 1, integration.EthereumChainID, integration.ObscuroChainID)
 
 	simParams := params.SimParams{
 		NumberOfNodes:         numberOfNodes,

--- a/integration/simulation/simulation_full_network_test.go
+++ b/integration/simulation/simulation_full_network_test.go
@@ -20,7 +20,7 @@ func TestFullNetworkMonteCarloSimulation(t *testing.T) {
 	numberOfNodes := 5
 	numberOfSimWallets := 5
 
-	wallets := params.NewSimWallets(numberOfSimWallets, numberOfNodes, 1)
+	wallets := params.NewSimWallets(numberOfSimWallets, numberOfNodes, 1, integration.EthereumChainID, integration.ObscuroChainID)
 
 	simParams := &params.SimParams{
 		NumberOfNodes:         numberOfNodes,

--- a/integration/simulation/simulation_geth_in_mem_test.go
+++ b/integration/simulation/simulation_geth_in_mem_test.go
@@ -17,7 +17,7 @@ func TestGethSimulation(t *testing.T) {
 	numberOfNodes := 5
 	numberOfSimWallets := 5
 
-	wallets := params.NewSimWallets(numberOfSimWallets, numberOfNodes, 1)
+	wallets := params.NewSimWallets(numberOfSimWallets, numberOfNodes, 1, integration.EthereumChainID, integration.ObscuroChainID)
 
 	simParams := &params.SimParams{
 		NumberOfNodes:         numberOfNodes,

--- a/integration/simulation/simulation_in_mem_test.go
+++ b/integration/simulation/simulation_in_mem_test.go
@@ -21,7 +21,7 @@ func TestInMemoryMonteCarloSimulation(t *testing.T) {
 
 	numberOfNodes := 7
 	numberOfSimWallets := 10
-	wallets := params.NewSimWallets(numberOfSimWallets, numberOfNodes, 1)
+	wallets := params.NewSimWallets(numberOfSimWallets, numberOfNodes, 1, integration.EthereumChainID, integration.ObscuroChainID)
 
 	simParams := params.SimParams{
 		NumberOfNodes:             numberOfNodes,

--- a/integration/walletextension/wallet_extension_test.go
+++ b/integration/walletextension/wallet_extension_test.go
@@ -471,7 +471,7 @@ func deployERC20Contract(t *testing.T, walletExtensionAddr string, signingKey *e
 
 // Creates a single-node Obscuro network for testing.
 func createObscuroNetwork(startPort int) (func(), error) {
-	wallets := params.NewSimWallets(1, 1, 1)
+	wallets := params.NewSimWallets(1, 1, 1, integration.EthereumChainID, integration.ObscuroChainID)
 
 	simParams := params.SimParams{
 		NumberOfNodes:    1,


### PR DESCRIPTION
### Why is this change needed?

to be able to reuse the SimWalleets outside the integration tests

### What changes were made as part of this PR:

- refactoring PR

### What are the key areas to look at
- the SimWallets