### PR TITLE
Uses EncryptedResponse for GetBalance. Shifts ExecContract to Eth standard.

### DIFF
--- a/go/obscuronode/enclave/enclave.go
+++ b/go/obscuronode/enclave/enclave.go
@@ -646,7 +646,7 @@ func (e *enclaveImpl) AddViewingKey(viewingKeyBytes []byte, signature []byte) er
 	return nil
 }
 
-func (e *enclaveImpl) GetBalance(address common.Address) ([]byte, error) {
+func (e *enclaveImpl) GetBalance(address common.Address) (nodecommon.EncryptedResponse, error) {
 	// TODO - Calculate balance correctly, rather than returning this dummy value.
 	balance := DummyBalance // The Ethereum API is to return the balance in hex.
 

--- a/go/obscuronode/host/client_api_eth.go
+++ b/go/obscuronode/host/client_api_eth.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"math/big"
 
+	"github.com/ethereum/go-ethereum/core/types"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
-// EthereumAPI implements a subset of the Ethereum JSON RPC operations.
+// EthereumAPI implements a subset of the Ethereum JSON RPC operations. All the method signatures are copied from the
+// corresponding Geth implementations.
 type EthereumAPI struct {
 	host *Node
 }
@@ -30,7 +33,8 @@ func (api *EthereumAPI) BlockNumber() hexutil.Uint64 {
 	return hexutil.Uint64(api.host.nodeDB.GetCurrentRollupHead().Number)
 }
 
-// GetBalance returns the address's balance on the Obscuro network, encrypted with the viewing key for the address.
+// GetBalance returns the address's balance on the Obscuro network, encrypted with the viewing key for the address and
+// encoded as hex.
 func (api *EthereumAPI) GetBalance(_ context.Context, address common.Address, _ rpc.BlockNumberOrHash) (string, error) {
 	encryptedBalance, err := api.host.EnclaveClient.GetBalance(address)
 	if err != nil {
@@ -48,3 +52,42 @@ func (api *EthereumAPI) GetBlockByNumber(context.Context, rpc.BlockNumber, bool)
 func (api *EthereumAPI) GasPrice(context.Context) (*hexutil.Big, error) {
 	return (*hexutil.Big)(big.NewInt(0)), nil
 }
+
+// Call returns the result of executing the smart contract as a user, encrypted with the viewing key for the address
+// and encoded as hex.
+// `data` is generally generated from the ABI of a smart contract.
+func (api *EthereumAPI) Call(_ context.Context, args TransactionArgs, _ rpc.BlockNumberOrHash, _ *StateOverride) (string, error) {
+	encryptedResponse, err := api.host.EnclaveClient.ExecuteOffChainTransaction(*args.From, *args.To, *args.Data)
+	return common.Bytes2Hex(encryptedResponse), err
+}
+
+// TransactionArgs is a copy of the same class in Geth's `internal/ethapi` package.
+type TransactionArgs struct {
+	From                 *common.Address `json:"from"`
+	To                   *common.Address `json:"to"`
+	Gas                  *hexutil.Uint64 `json:"gas"`
+	GasPrice             *hexutil.Big    `json:"gasPrice"`
+	MaxFeePerGas         *hexutil.Big    `json:"maxFeePerGas"`
+	MaxPriorityFeePerGas *hexutil.Big    `json:"maxPriorityFeePerGas"`
+	Value                *hexutil.Big    `json:"value"`
+	Nonce                *hexutil.Uint64 `json:"nonce"`
+
+	Data  *hexutil.Bytes `json:"data"`
+	Input *hexutil.Bytes `json:"input"`
+
+	// Introduced by AccessListTxType transaction.
+	AccessList *types.AccessList `json:"accessList,omitempty"`
+	ChainID    *hexutil.Big      `json:"chainId,omitempty"`
+}
+
+// OverrideAccount is a copy of the same class in Geth's `internal/ethapi` package.
+type OverrideAccount struct {
+	Nonce     *hexutil.Uint64              `json:"nonce"`
+	Code      *hexutil.Bytes               `json:"code"`
+	Balance   **hexutil.Big                `json:"balance"`
+	State     *map[common.Hash]common.Hash `json:"state"`
+	StateDiff *map[common.Hash]common.Hash `json:"stateDiff"`
+}
+
+// StateOverride is a copy of the same class in Geth's `internal/ethapi` package.
+type StateOverride map[common.Address]OverrideAccount

--- a/go/obscuronode/host/client_api_obscuro.go
+++ b/go/obscuronode/host/client_api_obscuro.go
@@ -66,8 +66,3 @@ func (api *ObscuroAPI) AddViewingKey(viewingKeyBytes []byte, signature []byte) e
 func (api *ObscuroAPI) StopHost() {
 	go api.host.Stop()
 }
-
-type OffChainResponse struct {
-	Response nodecommon.EncryptedResponse
-	Error    error
-}

--- a/go/obscuronode/host/client_api_obscuro.go
+++ b/go/obscuronode/host/client_api_obscuro.go
@@ -52,16 +52,6 @@ func (api *ObscuroAPI) GetTransaction(hash common.Hash) *nodecommon.L2Tx {
 	return api.host.EnclaveClient.GetTransaction(hash)
 }
 
-// ExecContract returns the result of executing the smart contract as a user.
-// `data` is generally generated from the ABI of a smart contract.
-func (api *ObscuroAPI) ExecContract(from common.Address, contractAddress common.Address, data []byte) OffChainResponse {
-	r, err := api.host.EnclaveClient.ExecuteOffChainTransaction(from, contractAddress, data)
-	return OffChainResponse{
-		Response: r,
-		Error:    err,
-	}
-}
-
 // Nonce returns the nonce of the wallet with the given address.
 func (api *ObscuroAPI) Nonce(address common.Address) uint64 {
 	return api.host.EnclaveClient.Nonce(address)

--- a/go/obscuronode/host/enclave_client.go
+++ b/go/obscuronode/host/enclave_client.go
@@ -333,7 +333,7 @@ func (c *EnclaveRPCClient) AddViewingKey(viewingKeyBytes []byte, signature []byt
 	return nil
 }
 
-func (c *EnclaveRPCClient) GetBalance(address common.Address) ([]byte, error) {
+func (c *EnclaveRPCClient) GetBalance(address common.Address) (nodecommon.EncryptedResponse, error) {
 	timeoutCtx, cancel := context.WithTimeout(context.Background(), c.config.EnclaveRPCTimeout)
 	defer cancel()
 

--- a/go/obscuronode/host/in_mem_obscuro_client.go
+++ b/go/obscuronode/host/in_mem_obscuro_client.go
@@ -84,31 +84,27 @@ func (c *inMemObscuroClient) Call(result interface{}, method string, args ...int
 		*result.(**nodecommon.L2Tx) = c.obscuroAPI.GetTransaction(hash)
 
 	case obscuroclient.RPCCall:
-		if len(args) != 4 {
-			return fmt.Errorf("expected 4 args to %s, got %d", obscuroclient.RPCCall, len(args))
+		if len(args) != 3 {
+			return fmt.Errorf("expected 3 args to %s, got %d", obscuroclient.RPCCall, len(args))
 		}
-		callContext, ok := args[0].(context.Context)
-		if !ok {
-			return fmt.Errorf("arg 0 to %s was not of expected type context.Context", obscuroclient.RPCCall)
-		}
-		txArgs, ok := args[1].(TransactionArgs)
+		txArgs, ok := args[0].(TransactionArgs)
 		if !ok {
 			return fmt.Errorf("arg 1 to %s was not of expected type host.TransactionArgs", obscuroclient.RPCCall)
 		}
-		blockNumberOrHash, ok := args[2].(rpc.BlockNumberOrHash)
+		blockNumberOrHash, ok := args[1].(rpc.BlockNumberOrHash)
 		if !ok {
 			return fmt.Errorf("arg 2 to %s was not of expected type rpc.BlockNumberOrHash", obscuroclient.RPCCall)
 		}
-		stateOverride, ok := args[3].(*StateOverride)
+		stateOverride, ok := args[2].(*StateOverride)
 		if !ok {
 			return fmt.Errorf("arg 3 to %s was not of expected type *host.StateOverride", obscuroclient.RPCCall)
 		}
 
-		encryptedResponse, err := c.ethAPI.Call(callContext, txArgs, blockNumberOrHash, stateOverride)
-		*result.(*OffChainResponse) = OffChainResponse{
-			Response: common.Hex2Bytes(encryptedResponse),
-			Error:    err,
+		encryptedResponse, err := c.ethAPI.Call(context.Background(), txArgs, blockNumberOrHash, stateOverride)
+		if err != nil {
+			return fmt.Errorf("off-chain call failed. Cause: %w", err)
 		}
+		*result.(*string) = encryptedResponse
 
 	case obscuroclient.RPCNonce:
 		if len(args) != 1 {

--- a/go/obscuronode/host/in_mem_obscuro_client.go
+++ b/go/obscuronode/host/in_mem_obscuro_client.go
@@ -84,21 +84,21 @@ func (c *inMemObscuroClient) Call(result interface{}, method string, args ...int
 
 		*result.(**nodecommon.L2Tx) = c.obscuroAPI.GetTransaction(hash)
 
-	case obscuroclient.RPCExecContract:
+	case obscuroclient.RPCCall:
 		if len(args) != 3 {
-			return fmt.Errorf("expected 3 arg to %s, got %d", obscuroclient.RPCExecContract, len(args))
+			return fmt.Errorf("expected 3 arg to %s, got %d", obscuroclient.RPCCall, len(args))
 		}
 		fromAddress, ok := args[0].(common.Address)
 		if !ok {
-			return fmt.Errorf("arg 0 to %s was not of expected type common.Address", obscuroclient.RPCExecContract)
+			return fmt.Errorf("arg 0 to %s was not of expected type common.Address", obscuroclient.RPCCall)
 		}
 		contractAddress, ok := args[1].(common.Address)
 		if !ok {
-			return fmt.Errorf("arg 1 to %s was not of expected type common.Address", obscuroclient.RPCExecContract)
+			return fmt.Errorf("arg 1 to %s was not of expected type common.Address", obscuroclient.RPCCall)
 		}
 		data, ok := args[2].([]byte)
 		if !ok {
-			return fmt.Errorf("arg 2 to %s was not of expected type []byte", obscuroclient.RPCExecContract)
+			return fmt.Errorf("arg 2 to %s was not of expected type []byte", obscuroclient.RPCCall)
 		}
 
 		convertedData := (hexutil.Bytes)(data)

--- a/go/obscuronode/host/in_mem_obscuro_client.go
+++ b/go/obscuronode/host/in_mem_obscuro_client.go
@@ -101,7 +101,7 @@ func (c *inMemObscuroClient) Call(result interface{}, method string, args ...int
 		}
 		stateOverride, ok := args[3].(*StateOverride)
 		if !ok {
-			return fmt.Errorf("arg 3 to %s was not of expected type host.StateOverride", obscuroclient.RPCCall)
+			return fmt.Errorf("arg 3 to %s was not of expected type *host.StateOverride", obscuroclient.RPCCall)
 		}
 
 		encryptedResponse, err := c.ethAPI.Call(callContext, txArgs, blockNumberOrHash, stateOverride)

--- a/go/obscuronode/nodecommon/enclave.go
+++ b/go/obscuronode/nodecommon/enclave.go
@@ -80,7 +80,7 @@ type Enclave interface {
 
 	// GetBalance returns the balance of the address on the Obscuro network, encrypted with the viewing key for the address.
 	// TODO - Handle multiple viewing keys, and thus multiple return values.
-	GetBalance(address common.Address) ([]byte, error)
+	GetBalance(address common.Address) (EncryptedResponse, error)
 
 	// StopClient stops the enclave client if one exists
 	StopClient() error

--- a/go/obscuronode/nodecommon/types.go
+++ b/go/obscuronode/nodecommon/types.go
@@ -18,7 +18,7 @@ type (
 	L2Tx                  = types.Transaction
 	EncryptedTx           []byte // A single transaction encrypted using the enclave's public key
 	EncryptedTransactions []byte // A blob of encrypted transactions, as they're stored in the rollup.
-	EncryptedResponse     []byte // The response of a off-chain call. Encrypted with the viewing key of the user.
+	EncryptedResponse     []byte // The response of an off-chain call or getBalance request. Encrypted with the viewing key of the user.
 )
 
 // Header is a public / plaintext struct that holds common properties of the Rollup

--- a/go/obscuronode/obscuroclient/obscuro_client.go
+++ b/go/obscuronode/obscuroclient/obscuro_client.go
@@ -17,10 +17,10 @@ const (
 	RPCGetRollupHeader          = "obscuro_getRollupHeader"
 	RPCGetRollup                = "obscuro_getRollup"
 	RPCGetTransaction           = "obscuro_getTransaction"
-	RPCExecContract             = "obscuro_execContract"
 	RPCNonce                    = "obscuro_nonce"
 	RPCAddViewingKey            = "obscuro_addViewingKey"
 	RPCStopHost                 = "obscuro_stopHost"
+	RPCCall                     = "eth_call"
 )
 
 // Client is used by client applications to interact with the Obscuro node.

--- a/integration/simulation/utils.go
+++ b/integration/simulation/utils.go
@@ -1,7 +1,6 @@
 package simulation
 
 import (
-	"context"
 	"fmt"
 	"math/big"
 	"os"
@@ -118,15 +117,12 @@ func balance(client obscuroclient.Client, address common.Address) uint64 {
 	convertedData := (hexutil.Bytes)(balanceData)
 	txArgs := host.TransactionArgs{From: &address, To: &evm.Erc20ContractAddress, Data: &convertedData}
 
-	var result host.OffChainResponse
-	err := client.Call(&result, method, context.Background(), txArgs, rpc.BlockNumberOrHash{}, &host.StateOverride{})
+	var encryptedResponse string
+	err := client.Call(&encryptedResponse, method, txArgs, rpc.BlockNumberOrHash{}, &host.StateOverride{})
 	if err != nil {
 		panic(fmt.Errorf("simulation failed due to failed %s RPC call. Cause: %w", method, err))
 	}
-	if result.Error != nil {
-		panic(fmt.Errorf("simulation failed due to failed %s RPC call. Cause: %w", method, result.Error))
-	}
 	r := new(big.Int)
-	r = r.SetBytes(core.DecryptResponse(result.Response))
+	r = r.SetBytes(core.DecryptResponse(common.Hex2Bytes(encryptedResponse)))
 	return r.Uint64()
 }

--- a/integration/simulation/utils.go
+++ b/integration/simulation/utils.go
@@ -119,7 +119,7 @@ func balance(client obscuroclient.Client, address common.Address) uint64 {
 	txArgs := host.TransactionArgs{From: &address, To: &evm.Erc20ContractAddress, Data: &convertedData}
 
 	var result host.OffChainResponse
-	err := client.Call(&result, method, context.Background(), txArgs, rpc.BlockNumberOrHash{}, nil)
+	err := client.Call(&result, method, context.Background(), txArgs, rpc.BlockNumberOrHash{}, &host.StateOverride{})
 	if err != nil {
 		panic(fmt.Errorf("simulation failed due to failed %s RPC call. Cause: %w", method, err))
 	}

--- a/integration/simulation/utils.go
+++ b/integration/simulation/utils.go
@@ -1,10 +1,14 @@
 package simulation
 
 import (
+	"context"
 	"fmt"
 	"math/big"
 	"os"
 	"time"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/obscuronet/obscuro-playground/go/obscuronode/host"
 
@@ -111,9 +115,11 @@ func getTransaction(client obscuroclient.Client, hash common.Hash) *nodecommon.L
 func balance(client obscuroclient.Client, address common.Address) uint64 {
 	method := obscuroclient.RPCCall
 	balanceData := erc20contractlib.CreateBalanceOfData(address)
+	convertedData := (hexutil.Bytes)(balanceData)
+	txArgs := host.TransactionArgs{From: &address, To: &evm.Erc20ContractAddress, Data: &convertedData}
 
 	var result host.OffChainResponse
-	err := client.Call(&result, method, address, evm.Erc20ContractAddress, balanceData)
+	err := client.Call(&result, method, context.Background(), txArgs, rpc.BlockNumberOrHash{}, nil)
 	if err != nil {
 		panic(fmt.Errorf("simulation failed due to failed %s RPC call. Cause: %w", method, err))
 	}

--- a/integration/simulation/utils.go
+++ b/integration/simulation/utils.go
@@ -109,7 +109,7 @@ func getTransaction(client obscuroclient.Client, hash common.Hash) *nodecommon.L
 
 // Uses the client to retrieve the balance of the wallet with the given address.
 func balance(client obscuroclient.Client, address common.Address) uint64 {
-	method := obscuroclient.RPCExecContract
+	method := obscuroclient.RPCCall
 	balanceData := erc20contractlib.CreateBalanceOfData(address)
 
 	var result host.OffChainResponse


### PR DESCRIPTION
### Why is this change needed?

Allows calls to be made against Obscuro nodes (via the wallet extension) without app-side changes.

### What changes were made as part of this PR:

- Refactoring?
- Replaces `ObscuroAPI.ExecContract` with `EthereumAPI.Call`, the standard Eth API
- Changes GetBalance to use `EncryptedResponse` type

### What are the key areas to look at
