### PR TITLE
Fix sqlite file clashes in tests

### DIFF
--- a/go/obscuronode/enclave/enclave.go
+++ b/go/obscuronode/enclave/enclave.go
@@ -805,7 +805,8 @@ func getDB(nodeID uint64, cfg config.EnclaveConfig) (ethdb.Database, error) {
 	if !cfg.WillAttest {
 		// persistent but not secure in an enclave, we'll connect to a throwaway sqlite DB and test out persistence/sql implementations
 		nodecommon.LogWithID(nodeID, "Attestation is disabled, using a basic sqlite DB for persistence")
-		// todo: for now we pass in an empty dbPath, when we want to test persistence after node restart we should change this to be config driven
+		// todo: for now we pass in an empty dbPath which will provide a throwaway temp file,
+		// 		when we want to test persistence after node restart we should change this path to be config driven
 		return sql.CreateTemporarySQLiteDB("")
 	}
 

--- a/go/obscuronode/enclave/enclave.go
+++ b/go/obscuronode/enclave/enclave.go
@@ -805,7 +805,8 @@ func getDB(nodeID uint64, cfg config.EnclaveConfig) (ethdb.Database, error) {
 	if !cfg.WillAttest {
 		// persistent but not secure in an enclave, we'll connect to a throwaway sqlite DB and test out persistence/sql implementations
 		nodecommon.LogWithID(nodeID, "Attestation is disabled, using a basic sqlite DB for persistence")
-		return sql.CreateTemporarySQLiteDB(nodeID)
+		// todo: for now we pass in an empty dbPath, when we want to test persistence after node restart we should change this to be config driven
+		return sql.CreateTemporarySQLiteDB("")
 	}
 
 	// persistent and with attestation means connecting to edgeless DB in a trusted enclave from a secure enclave

--- a/go/obscuronode/enclave/sql/sqlite.go
+++ b/go/obscuronode/enclave/sql/sqlite.go
@@ -31,7 +31,7 @@ func CreateTemporarySQLiteDB(dbPath string) (ethdb.Database, error) {
 	}
 	// determine if a db file already exists, we don't want to overwrite it
 	_, err := os.Stat(dbPath)
-	existingDB := err == nil
+	existingDB := err == nil //nolint:ifshort
 
 	db, err := sql.Open("sqlite3", dbPath)
 	if err != nil {

--- a/go/obscuronode/enclave/sql/sqlite.go
+++ b/go/obscuronode/enclave/sql/sqlite.go
@@ -30,15 +30,17 @@ func CreateTemporarySQLiteDB(dbPath string) (ethdb.Database, error) {
 	}
 	// determine if a db file already exists, we don't want to overwrite it
 	_, err := os.Stat(dbPath)
-	existingDB := err == nil // err is nil if it exists
+	newOrExisting := "new"
+	if err == nil {
+		// err is nil if it exists
+		newOrExisting = "existing"
+	}
 
 	db, err := sql.Open("sqlite3", dbPath)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't open sqlite db - %w", err)
 	}
-	newOrExisting := "existing"
-	if !existingDB {
-		newOrExisting = "new"
+	if newOrExisting == "new" {
 		// db wasn't there already so we should set it up (create kv store table)
 		if _, err := db.Exec(createQry); err != nil {
 			return nil, fmt.Errorf("failed to create sqlite db table - %w", err)

--- a/go/obscuronode/enclave/sql/sqlite.go
+++ b/go/obscuronode/enclave/sql/sqlite.go
@@ -3,43 +3,66 @@ package sql
 import (
 	"database/sql"
 	"fmt"
+	"math/rand"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/ethereum/go-ethereum/ethdb"
 	_ "github.com/mattn/go-sqlite3" // this imports the sqlite driver to make the sql.Open() connection work
 )
 
 const (
-	tempDirName = "temp-obscuro-persistence"
+	tempDirName = "obscuro-persistence"
 	createQry   = `create table if not exists kv (key binary(32) primary key, value blob); delete from kv;`
 )
 
-func CreateTemporarySQLiteDB(nodeID uint64) (ethdb.Database, error) {
-	dbFile, err := getTempDBFile(nodeID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create temp sqlite DB file - %w", err)
+// CreateTemporarySQLiteDB takes a filepath which can be empty but allows for tests that care about persistence between restarts
+func CreateTemporarySQLiteDB(dbPath string) (ethdb.Database, error) {
+	if dbPath == "" {
+		tempPath, err := getTempDBFile()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create temp sqlite DB file - %w", err)
+		}
+		dbPath = tempPath
 	}
-	db, err := sql.Open("sqlite3", dbFile)
+	// determine if a db file already exists, we don't want to overwrite it
+	_, err := os.Stat(dbPath)
+	dbExists := err != nil
+
+	db, err := sql.Open("sqlite3", dbPath)
 	if err != nil {
-		return nil, fmt.Errorf("couldn't create temp sqlite db - %w", err)
+		return nil, fmt.Errorf("couldn't open sqlite db - %w", err)
 	}
 
-	if _, err := db.Exec(createQry); err != nil {
-		return nil, fmt.Errorf("failed to create sqlite db table - %w", err)
+	if !dbExists {
+		// db wasn't there already so we should set it up (create kv store table)
+		if _, err := db.Exec(createQry); err != nil {
+			return nil, fmt.Errorf("failed to create sqlite db table - %w", err)
+		}
 	}
 	return CreateSQLEthDatabase(db)
 }
 
-func getTempDBFile(nodeID uint64) (string, error) {
-	tempDir := filepath.Join("/tmp", tempDirName)
+func getTempDBFile() (string, error) {
+	tempDir := filepath.Join("/tmp", tempDirName, randomStr(5))
 	err := os.MkdirAll(tempDir, os.ModePerm)
 	if err != nil {
 		return "", fmt.Errorf("failed to create sqlite temp dir - %w", err)
 	}
 	// by using nodeIDs we ensure we overwrite old DBs when starting new tests
-	tempFile := filepath.Join(tempDir, fmt.Sprintf("enclave-%v.db", nodeID))
-	// delete old db if it exists
-	_ = os.Remove(tempFile)
+	tempFile := filepath.Join(tempDir, "enclave.db")
 	return tempFile, nil
+}
+
+// Generates a random string n characters long.
+func randomStr(n int) string {
+	randGen := rand.New(rand.NewSource(time.Now().UnixNano())) //nolint:gosec
+
+	letters := []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+	suffix := make([]rune, n)
+	for i := range suffix {
+		suffix[i] = letters[randGen.Intn(len(letters))]
+	}
+	return string(suffix)
 }


### PR DESCRIPTION
### Why is this change needed?

- Joel spotted odd test failures that are likely caused by sqlite DB files being overwritten by parallel tests
- In future we will need to be able to pass in a path to the db so that we can test persistence and recovery for an enclave

### What changes were made as part of this PR:

- use random path instead of the node ID
- add possibility for configurable DB and make sure we wouldn't overwrite an existing DB

### What are the key areas to look at
- the creation of a temp DB in sqlite.go