### PR TITLE
Adds hardcoded enclave public and private keys.

### DIFF
--- a/go/obscuronode/enclave/core/crypto.go
+++ b/go/obscuronode/enclave/core/crypto.go
@@ -6,6 +6,12 @@ import (
 	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
 )
 
+const (
+	// EnclavePrivateKeyHex is the private key of the enclave.
+	// TODO - Replace this fixed key with a derived key.
+	EnclavePrivateKeyHex = "81acce9620f0adf1728cb8df7f6b8b8df857955eb9e8b7aed6ef8390c09fc207"
+)
+
 // todo - this should become an elaborate data structure
 type SharedEnclaveSecret []byte
 

--- a/go/obscuronode/enclave/core/main/main.go
+++ b/go/obscuronode/enclave/core/main/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+func main() {
+	privateKey, _ := crypto.GenerateKey()
+	hex := common.Bytes2Hex(crypto.FromECDSA(privateKey))
+	println(hex)
+
+	hex2 := common.Bytes2Hex(crypto.CompressPubkey(&privateKey.PublicKey))
+	println(hex2)
+}

--- a/go/obscuronode/enclave/core/transaction_blob_crypto.go
+++ b/go/obscuronode/enclave/core/transaction_blob_crypto.go
@@ -11,8 +11,8 @@ import (
 	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
 )
 
-// TODO - This fixed nonce is insecure, and should be removed alongside the fixed rollup encryption key.
 const (
+	// TODO - This fixed nonce is insecure, and should be removed alongside the fixed rollup encryption key.
 	rollupCipherNonce = "000000000000"
 	// RollupEncryptionKeyHex is the AES key used to encrypt and decrypt the transaction blob in rollups.
 	// TODO - Replace this fixed key with derived, rotating keys.

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -38,6 +38,10 @@ const (
 
 	Localhost         = "127.0.0.1"
 	websocketProtocol = "ws://"
+
+	// EnclavePublicKeyHex is the public key of the enclave.
+	// TODO - Retrieve this key from the management contract instead.
+	EnclavePublicKeyHex = "034d3b7e63a8bcd532ee3d1d6ecad9d67fca7821981a044551f0f0cbec74d0bc5e"
 )
 
 // TODO - Display error in browser if Metamask is not enabled (i.e. `ethereum` object is not available in-browser).


### PR DESCRIPTION
### Why is this change needed?

Needed to encrypt the submission of viewing keys and sensitive requests from the wallet extension and the enclave

### What changes were made as part of this PR:

Functional.

- Adds a hardcoded private key to the enclave
- Adds the hardcoded public key for the enclave to the wallet extension

### What are the key areas to look at
