### PR TITLE
Renables encryption of viewing keys on wallet extension side.

### DIFF
--- a/go/obscuronode/enclave/enclave.go
+++ b/go/obscuronode/enclave/enclave.go
@@ -618,7 +618,11 @@ func (e *enclaveImpl) ShareSecret(att *obscurocommon.AttestationReport) (obscuro
 	return e.encryptSecret(att.PubKey, secret)
 }
 
-func (e *enclaveImpl) AddViewingKey(viewingKeyBytes []byte, signature []byte) error {
+func (e *enclaveImpl) AddViewingKey(encryptedViewingKeyBytes []byte, signature []byte) error {
+	viewingKeyBytes, err := ecies.ImportECDSA(e.privateKey).Decrypt(encryptedViewingKeyBytes, nil, nil)
+	if err != nil {
+		return fmt.Errorf("could not decrypt viewing key. Cause: %w", err)
+	}
 	return e.viewingKeyManager.AddViewingKey(viewingKeyBytes, signature)
 }
 

--- a/go/obscuronode/nodecommon/enclave.go
+++ b/go/obscuronode/nodecommon/enclave.go
@@ -67,7 +67,7 @@ type Enclave interface {
 	// GetRollup returns the rollup with the given hash
 	GetRollup(rollupHash obscurocommon.L2RootHash) *ExtRollup
 
-	// AddViewingKey - Verifies and saves viewing keys.
+	// AddViewingKey - Decrypts, verifies and saves viewing keys.
 	// Viewing keys are asymmetric keys generated inside the wallet extension, and then signed by the wallet (e.g.
 	// MetaMask) in which the user holds the signing keys.
 	// The keys are then are sent to the enclave via RPC and processed using this method.
@@ -76,7 +76,7 @@ type Enclave interface {
 	// public key from the signature. By hashing the public key, we can then determine the address of the account.
 	// At the end, we save the viewing key (which is a public key) against the account, and use it to encrypt any
 	// "eth_call" and "eth_getBalance" requests that have that address as a "from" field.
-	AddViewingKey(viewingKeyBytes []byte, signature []byte) error
+	AddViewingKey(encryptedViewingKeyBytes []byte, signature []byte) error
 
 	// GetBalance returns the balance of the address on the Obscuro network, encrypted with the viewing key for the address.
 	// TODO - Handle multiple viewing keys, and thus multiple return values.

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -223,6 +223,10 @@ func (we *WalletExtension) handleSubmitViewingKey(resp http.ResponseWriter, req 
 
 	// We encrypt the viewing key bytes.
 	encryptedViewingKeyBytes, err := ecies.Encrypt(rand.Reader, we.enclavePublicKey, we.viewingPublicKeyBytes, nil, nil)
+	if err != nil {
+		logAndSendErr(resp, fmt.Sprintf("could not encrypt viewing key with enclave public key: %s", err))
+		return
+	}
 
 	var rpcErr error
 	err = we.hostClient.Call(&rpcErr, obscuroclient.RPCAddViewingKey, encryptedViewingKeyBytes, signature)

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -119,7 +119,7 @@ func (we *WalletExtension) handleHTTPEthJSON(resp http.ResponseWriter, req *http
 	method := reqJSONMap[reqJSONKeyMethod]
 	fmt.Printf("Received request from wallet: %s\n", body)
 
-	// We encrypt the JSON with the enclave's public key.
+	//// We encrypt the JSON with the enclave's public key.
 	//fmt.Println("🔒 Encrypting request from wallet with enclave public key.")
 	//eciesPublicKey := ecies.ImportECDSAPublic(we.enclavePublicKey)
 	//encryptedBody, err := ecies.Encrypt(rand.Reader, eciesPublicKey, body, nil, nil)


### PR DESCRIPTION
### Why is this change needed?

To prevent MitM attacks, viewing keys should be encrypted before they are sent to the enclave.

### What changes were made as part of this PR:

Functional.

- Encrypts the viewing key on the wallet side
- Decrypts the viewing key on the enclave side

### What are the key areas to look at
