### PR TITLE
Use pointers to transactions

### DIFF
--- a/go/ethclient/erc20contractlib/obscuro_ERC20_contract_ABI.go
+++ b/go/ethclient/erc20contractlib/obscuro_ERC20_contract_ABI.go
@@ -29,7 +29,7 @@ const (
 	ToField           = "to"
 )
 
-func DecodeTransferTx(t types.Transaction) (bool, *common.Address, *big.Int) {
+func DecodeTransferTx(t *types.Transaction) (bool, *common.Address, *big.Int) {
 	method, err := obscuroERC20ContractABIJSON.MethodById(t.Data()[:methodBytesLen])
 	if err != nil {
 		log.Info("Could not decode tx %d, Err: %s", obscurocommon.ShortHash(t.Hash()), err)

--- a/go/obscuronode/enclave/core/crypto.go
+++ b/go/obscuronode/enclave/core/crypto.go
@@ -21,11 +21,11 @@ func EncryptTx(tx *nodecommon.L2Tx) nodecommon.EncryptedTx {
 
 // DecryptTx reverses the encryption performed by EncryptTx.
 // TODO - Perform real decryption here, and not just RLP decoding.
-func DecryptTx(tx nodecommon.EncryptedTx) nodecommon.L2Tx {
+func DecryptTx(tx nodecommon.EncryptedTx) *nodecommon.L2Tx {
 	t := nodecommon.L2Tx{}
 	if err := rlp.DecodeBytes(tx, &t); err != nil {
 		log.Panic("could not decrypt encrypted L2 transaction. Cause: %s", err)
 	}
 
-	return t
+	return &t
 }

--- a/go/obscuronode/enclave/core/rollup.go
+++ b/go/obscuronode/enclave/core/rollup.go
@@ -56,9 +56,7 @@ func NewRollupFromHeader(header *nodecommon.Header, blkHash common.Hash, txs []*
 		Number:     header.Number,
 	}
 	transactions := make([]*nodecommon.L2Tx, len(txs))
-	for i, tx := range txs {
-		transactions[i] = tx
-	}
+	copy(transactions, txs)
 	r := Rollup{
 		Header:       &h,
 		Transactions: transactions,

--- a/go/obscuronode/enclave/core/rollup.go
+++ b/go/obscuronode/enclave/core/rollup.go
@@ -55,9 +55,9 @@ func NewRollupFromHeader(header *nodecommon.Header, blkHash common.Hash, txs []*
 		Root:       state,
 		Number:     header.Number,
 	}
-	transactions := make([]nodecommon.L2Tx, len(txs))
+	transactions := make([]*nodecommon.L2Tx, len(txs))
 	for i, tx := range txs {
-		transactions[i] = *tx
+		transactions[i] = tx
 	}
 	r := Rollup{
 		Header:       &h,
@@ -73,7 +73,7 @@ func NewRollupFromHeader(header *nodecommon.Header, blkHash common.Hash, txs []*
 }
 
 // NewRollup - produces a new rollup. only used for genesis. todo - review
-func NewRollup(blkHash common.Hash, parent *Rollup, height uint64, a common.Address, txs []nodecommon.L2Tx, withdrawals []nodecommon.Withdrawal, nonce obscurocommon.Nonce, state nodecommon.StateRoot) Rollup {
+func NewRollup(blkHash common.Hash, parent *Rollup, height uint64, a common.Address, txs []*nodecommon.L2Tx, withdrawals []nodecommon.Withdrawal, nonce obscurocommon.Nonce, state nodecommon.StateRoot) Rollup {
 	parentHash := obscurocommon.GenesisHash
 	if parent != nil {
 		parentHash = parent.Hash()

--- a/go/obscuronode/enclave/core/types.go
+++ b/go/obscuronode/enclave/core/types.go
@@ -6,7 +6,7 @@ import (
 )
 
 // L2Txs Todo - is this type useful?
-type L2Txs []nodecommon.L2Tx
+type L2Txs []*nodecommon.L2Tx
 
 // BlockState - Represents the state after an L1 Block was processed.
 type BlockState struct {

--- a/go/obscuronode/enclave/evm/evm_facade.go
+++ b/go/obscuronode/enclave/evm/evm_facade.go
@@ -20,7 +20,7 @@ import (
 // ExecuteTransactions
 // header - the header of the rollup where this transaction will be included
 // fromTxIndex - for the receipts and events, the evm needs to know for each transaction the order in which it was executed in the block.
-func ExecuteTransactions(txs []nodecommon.L2Tx, s *state.StateDB, header *nodecommon.Header, rollupResolver db.RollupResolver, chainID int64, fromTxIndex int) []*types.Receipt {
+func ExecuteTransactions(txs []*nodecommon.L2Tx, s *state.StateDB, header *nodecommon.Header, rollupResolver db.RollupResolver, chainID int64, fromTxIndex int) []*types.Receipt {
 	chain, cc, vmCfg, gp := initParams(rollupResolver, chainID)
 	zero := uint64(0)
 	usedGas := &zero
@@ -42,12 +42,12 @@ func ExecuteTransactions(txs []nodecommon.L2Tx, s *state.StateDB, header *nodeco
 	return receipts
 }
 
-func executeTransaction(s *state.StateDB, cc *params.ChainConfig, chain *ObscuroChainContext, gp *core2.GasPool, header *nodecommon.Header, t nodecommon.L2Tx, usedGas *uint64, vmCfg vm.Config, tCount int) (*types.Receipt, error) {
+func executeTransaction(s *state.StateDB, cc *params.ChainConfig, chain *ObscuroChainContext, gp *core2.GasPool, header *nodecommon.Header, t *nodecommon.L2Tx, usedGas *uint64, vmCfg vm.Config, tCount int) (*types.Receipt, error) {
 	s.Prepare(t.Hash(), tCount)
 
 	snap := s.Snapshot()
 	// todo - Author?
-	receipt, err := core2.ApplyTransaction(cc, chain, nil, gp, s, convertToEthHeader(header), &t, usedGas, vmCfg)
+	receipt, err := core2.ApplyTransaction(cc, chain, nil, gp, s, convertToEthHeader(header), t, usedGas, vmCfg)
 	if err == nil {
 		return receipt, nil
 	}

--- a/go/obscuronode/enclave/mempool/interface.go
+++ b/go/obscuronode/enclave/mempool/interface.go
@@ -7,9 +7,9 @@ import (
 
 type Manager interface {
 	// FetchMempoolTxs returns all L2 transactions in the mempool
-	FetchMempoolTxs() []nodecommon.L2Tx
+	FetchMempoolTxs() []*nodecommon.L2Tx
 	// AddMempoolTx adds an L2 transaction to the mempool
-	AddMempoolTx(tx nodecommon.L2Tx)
+	AddMempoolTx(tx *nodecommon.L2Tx)
 	// RemoveMempoolTxs removes any L2 transactions whose hash is keyed in the map from the mempool
 	RemoveMempoolTxs(toRemove map[common.Hash]common.Hash)
 }

--- a/go/obscuronode/enclave/mempool/manager.go
+++ b/go/obscuronode/enclave/mempool/manager.go
@@ -9,28 +9,28 @@ import (
 
 type mempoolManager struct {
 	mpMutex sync.RWMutex // Controls access to `mempool`
-	mempool map[common.Hash]nodecommon.L2Tx
+	mempool map[common.Hash]*nodecommon.L2Tx
 }
 
 func New() Manager {
 	return &mempoolManager{
-		mempool: make(map[common.Hash]nodecommon.L2Tx),
+		mempool: make(map[common.Hash]*nodecommon.L2Tx),
 		mpMutex: sync.RWMutex{},
 	}
 }
 
-func (db *mempoolManager) AddMempoolTx(tx nodecommon.L2Tx) {
+func (db *mempoolManager) AddMempoolTx(tx *nodecommon.L2Tx) {
 	db.mpMutex.Lock()
 	defer db.mpMutex.Unlock()
 
 	db.mempool[tx.Hash()] = tx
 }
 
-func (db *mempoolManager) FetchMempoolTxs() []nodecommon.L2Tx {
+func (db *mempoolManager) FetchMempoolTxs() []*nodecommon.L2Tx {
 	db.mpMutex.RLock()
 	defer db.mpMutex.RUnlock()
 
-	mpCopy := make([]nodecommon.L2Tx, 0)
+	mpCopy := make([]*nodecommon.L2Tx, 0)
 	for _, tx := range db.mempool {
 		mpCopy = append(mpCopy, tx)
 	}
@@ -41,7 +41,7 @@ func (db *mempoolManager) RemoveMempoolTxs(toRemove map[common.Hash]common.Hash)
 	db.mpMutex.Lock()
 	defer db.mpMutex.Unlock()
 
-	r := make(map[common.Hash]nodecommon.L2Tx)
+	r := make(map[common.Hash]*nodecommon.L2Tx)
 	for id, t := range db.mempool {
 		_, f := toRemove[id]
 		if !f {

--- a/go/obscuronode/enclave/utils.go
+++ b/go/obscuronode/enclave/utils.go
@@ -15,16 +15,16 @@ import (
 
 // findTxsNotIncluded - given a list of transactions, it keeps only the ones that were not included in the block
 // todo - inefficient
-func findTxsNotIncluded(head *core.Rollup, txs []nodecommon.L2Tx, s db.RollupResolver) []nodecommon.L2Tx {
+func findTxsNotIncluded(head *core.Rollup, txs []*nodecommon.L2Tx, s db.RollupResolver) []*nodecommon.L2Tx {
 	included := allIncludedTransactions(head, s)
 	return removeExisting(txs, included)
 }
 
-func allIncludedTransactions(r *core.Rollup, s db.RollupResolver) map[common.Hash]nodecommon.L2Tx {
+func allIncludedTransactions(r *core.Rollup, s db.RollupResolver) map[common.Hash]*nodecommon.L2Tx {
 	if r.Header.Number.Uint64() == obscurocommon.L2GenesisHeight {
 		return makeMap(r.Transactions)
 	}
-	newMap := make(map[common.Hash]nodecommon.L2Tx)
+	newMap := make(map[common.Hash]*nodecommon.L2Tx)
 	for k, v := range allIncludedTransactions(s.ParentRollup(r), s) {
 		newMap[k] = v
 	}
@@ -34,7 +34,7 @@ func allIncludedTransactions(r *core.Rollup, s db.RollupResolver) map[common.Has
 	return newMap
 }
 
-func removeExisting(base []nodecommon.L2Tx, toRemove map[common.Hash]nodecommon.L2Tx) (r []nodecommon.L2Tx) {
+func removeExisting(base []*nodecommon.L2Tx, toRemove map[common.Hash]*nodecommon.L2Tx) (r []*nodecommon.L2Tx) {
 	for _, t := range base {
 		_, f := toRemove[t.Hash()]
 		if !f {
@@ -57,15 +57,15 @@ func historicTxs(r *core.Rollup, s db.Storage) map[common.Hash]common.Hash {
 	}
 }
 
-func makeMap(txs []nodecommon.L2Tx) map[common.Hash]nodecommon.L2Tx {
-	m := make(map[common.Hash]nodecommon.L2Tx)
+func makeMap(txs []*nodecommon.L2Tx) map[common.Hash]*nodecommon.L2Tx {
+	m := make(map[common.Hash]*nodecommon.L2Tx)
 	for _, tx := range txs {
 		m[tx.Hash()] = tx
 	}
 	return m
 }
 
-func toMap(txs []nodecommon.L2Tx) map[common.Hash]common.Hash {
+func toMap(txs []*nodecommon.L2Tx) map[common.Hash]common.Hash {
 	m := make(map[common.Hash]common.Hash)
 	for _, tx := range txs {
 		m[tx.Hash()] = tx.Hash()
@@ -73,14 +73,14 @@ func toMap(txs []nodecommon.L2Tx) map[common.Hash]common.Hash {
 	return m
 }
 
-func printTxs(txs []nodecommon.L2Tx) (txsString []string) {
+func printTxs(txs []*nodecommon.L2Tx) (txsString []string) {
 	for _, t := range txs {
 		txsString = printTx(t, txsString)
 	}
 	return txsString
 }
 
-func printTx(t nodecommon.L2Tx, txsString []string) []string {
+func printTx(t *nodecommon.L2Tx, txsString []string) []string {
 	txsString = append(txsString, fmt.Sprintf("%d,", obscurocommon.ShortHash(t.Hash())))
 	return txsString
 }

--- a/integration/simulation/transaction_injector.go
+++ b/integration/simulation/transaction_injector.go
@@ -199,7 +199,7 @@ func (ti *TransactionInjector) issueRandomTransfers() {
 			continue
 		}
 
-		go ti.counter.trackTransferL2Tx(*signedTx)
+		go ti.counter.trackTransferL2Tx(signedTx)
 	}
 }
 
@@ -250,7 +250,7 @@ func (ti *TransactionInjector) issueRandomWithdrawals() {
 		}
 
 		ti.stats.Withdrawal(v)
-		go ti.counter.trackWithdrawalL2Tx(*signedTx)
+		go ti.counter.trackWithdrawalL2Tx(signedTx)
 	}
 }
 

--- a/integration/simulation/transaction_injector_counter.go
+++ b/integration/simulation/transaction_injector_counter.go
@@ -23,8 +23,8 @@ func newCounter() *txInjectorCounter {
 		l1TransactionsLock:       sync.RWMutex{},
 		l1Transactions:           []obscurocommon.L1Transaction{},
 		l2TransactionsLock:       sync.RWMutex{},
-		transferL2Transactions:   []nodecommon.L2Tx{},
-		withdrawalL2Transactions: []nodecommon.L2Tx{},
+		transferL2Transactions:   []*nodecommon.L2Tx{},
+		withdrawalL2Transactions: []*nodecommon.L2Tx{},
 	}
 }
 
@@ -35,13 +35,13 @@ func (m *txInjectorCounter) trackL1Tx(tx obscurocommon.L1Transaction) {
 	m.l1Transactions = append(m.l1Transactions, tx)
 }
 
-func (m *txInjectorCounter) trackWithdrawalL2Tx(tx nodecommon.L2Tx) {
+func (m *txInjectorCounter) trackWithdrawalL2Tx(tx *nodecommon.L2Tx) {
 	m.l2TransactionsLock.Lock()
 	defer m.l2TransactionsLock.Unlock()
 	m.withdrawalL2Transactions = append(m.withdrawalL2Transactions, tx)
 }
 
-func (m *txInjectorCounter) trackTransferL2Tx(tx nodecommon.L2Tx) {
+func (m *txInjectorCounter) trackTransferL2Tx(tx *nodecommon.L2Tx) {
 	m.l2TransactionsLock.Lock()
 	defer m.l2TransactionsLock.Unlock()
 	m.transferL2Transactions = append(m.transferL2Transactions, tx)

--- a/tools/obscuroscan/obscuroscan_test.go
+++ b/tools/obscuroscan/obscuroscan_test.go
@@ -60,7 +60,7 @@ func generateEncryptedRollupHex() []byte {
 		nil,
 		obscurocommon.L2GenesisHeight,
 		common.HexToAddress("0x0"),
-		[]nodecommon.L2Tx{},
+		[]*nodecommon.L2Tx{},
 		[]nodecommon.Withdrawal{},
 		expectedNonce,
 		common.BigToHash(big.NewInt(0)),


### PR DESCRIPTION
### Why is this change needed?

To align with geth, and be able to call geth functions, we have to use pointers to transactions.

### What changes were made as part of this PR:

- refactoring PR 
- use pointers

### What are the key areas to look at
- core/types.go - L2Txs