### PR TITLE
Moves wallet extension tests to own package.

### DIFF
--- a/integration/walletextension/wallet_extension_test.go
+++ b/integration/walletextension/wallet_extension_test.go
@@ -1,4 +1,4 @@
-package simulation
+package walletextension
 
 import (
 	"bytes"
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"github.com/obscuronet/obscuro-playground/integration/simulation"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -416,7 +417,7 @@ func createObscuroNetwork() (func(), error) {
 	wallet := wallets.Erc20ObsOwnerWallets[0]
 	contractBytes := common.Hex2Bytes(erc20contract.ContractByteCode)
 	deployContractTx := types.LegacyTx{
-		Nonce:    NextNonce(l2Clients[0], wallet),
+		Nonce:    simulation.NextNonce(l2Clients[0], wallet),
 		Gas:      1025_000_000,
 		GasPrice: common.Big0,
 		Data:     contractBytes,

--- a/integration/walletextension/wallet_extension_test.go
+++ b/integration/walletextension/wallet_extension_test.go
@@ -6,12 +6,13 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"github.com/obscuronet/obscuro-playground/integration/simulation"
 	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/obscuronet/obscuro-playground/integration/simulation"
 
 	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/viewingkeymanager"
 


### PR DESCRIPTION
### Why is this change needed?

The wallet extension integration tests were in the same folder as the sim tests due to a DB file overwriting issue. This is now fixed.

### What changes were made as part of this PR:

Refactoring.

- Moved file.

### What are the key areas to look at
