### PR TITLE
store receipts and more rollup metadata to the db

### DIFF
--- a/go/obscuronode/enclave/core/rollup.go
+++ b/go/obscuronode/enclave/core/rollup.go
@@ -34,6 +34,9 @@ func (r *Rollup) Hash() obscurocommon.L2RootHash {
 	return v
 }
 
+func (r *Rollup) NumberU64() uint64 { return r.Header.Number.Uint64() }
+func (r *Rollup) Number() *big.Int  { return new(big.Int).Set(r.Header.Number) }
+
 func NewHeader(parent *common.Hash, height uint64, a common.Address) *nodecommon.Header {
 	parentHash := obscurocommon.GenesisHash
 	if parent != nil {

--- a/go/obscuronode/enclave/db/interfaces.go
+++ b/go/obscuronode/enclave/db/interfaces.go
@@ -48,8 +48,8 @@ type BlockStateStorage interface {
 	FetchBlockState(blockHash obscurocommon.L1RootHash) (*core.BlockState, bool)
 	// FetchHeadState returns the head rollup. Returns nil if nothing recorded yet
 	FetchHeadState() *core.BlockState
-	// SetBlockState save the rollup-block mapping
-	SetBlockState(blockHash obscurocommon.L1RootHash, state *core.BlockState, rollup *core.Rollup)
+	// SaveNewHead save the rollup-block mapping
+	SaveNewHead(state *core.BlockState, rollup *core.Rollup, receipts []*types.Receipt)
 	// CreateStateDB create a database that can be used to execute transactions
 	CreateStateDB(hash obscurocommon.L2RootHash) *state.StateDB
 	// GenesisStateDB create the original empty StateDB

--- a/go/obscuronode/enclave/db/storage.go
+++ b/go/obscuronode/enclave/db/storage.go
@@ -204,7 +204,6 @@ func (s *storageImpl) SaveNewHead(state *core.BlockState, rollup *core.Rollup, r
 
 	if state.FoundNewRollup {
 		obscurorawdb.WriteRollup(batch, rollup)
-		obscurorawdb.WriteCanonicalHash(batch, rollup.Hash(), rollup.NumberU64())
 		obscurorawdb.WriteHeadHeaderHash(batch, rollup.Hash())
 		obscurorawdb.WriteCanonicalHash(batch, rollup.Hash(), rollup.NumberU64())
 		obscurorawdb.WriteTxLookupEntriesByBlock(batch, rollup)

--- a/go/obscuronode/enclave/db/storage.go
+++ b/go/obscuronode/enclave/db/storage.go
@@ -199,16 +199,25 @@ func (s *storageImpl) FetchBlockState(hash obscurocommon.L1RootHash) (*core.Bloc
 	return nil, false
 }
 
-func (s *storageImpl) SetBlockState(hash obscurocommon.L1RootHash, state *core.BlockState, rollup *core.Rollup) {
-	if state.Block != hash {
-		log.Panic("failed sanity check: `state.Block.Hash() != hash`")
-	}
+func (s *storageImpl) SaveNewHead(state *core.BlockState, rollup *core.Rollup, receipts []*types.Receipt) {
+	batch := s.db.NewBatch()
 
 	if state.FoundNewRollup {
-		s.StoreRollup(rollup)
+		obscurorawdb.WriteRollup(batch, rollup)
+		obscurorawdb.WriteCanonicalHash(batch, rollup.Hash(), rollup.NumberU64())
+		obscurorawdb.WriteHeadHeaderHash(batch, rollup.Hash())
+		obscurorawdb.WriteCanonicalHash(batch, rollup.Hash(), rollup.NumberU64())
+		obscurorawdb.WriteTxLookupEntriesByBlock(batch, rollup)
+		obscurorawdb.WriteHeadRollupHash(batch, rollup.Hash())
+		obscurorawdb.WriteReceipts(batch, rollup.Hash(), rollup.NumberU64(), receipts)
 	}
-	obscurorawdb.WriteBlockState(s.db, state)
-	rawdb.WriteHeadHeaderHash(s.db, state.Block)
+
+	obscurorawdb.WriteBlockState(batch, state)
+	rawdb.WriteHeadHeaderHash(batch, state.Block)
+
+	if err := batch.Write(); err != nil {
+		log.Panic("could not save new head. Cause: %s", err)
+	}
 }
 
 func (s *storageImpl) CreateStateDB(hash obscurocommon.L2RootHash) *state.StateDB {

--- a/go/obscuronode/enclave/rawdb/README.md
+++ b/go/obscuronode/enclave/rawdb/README.md
@@ -1,2 +1,6 @@
-This package mirrors the geth "rawdb" package.
+This package dubplicates the geth "rawdb" package.
 It contains logic to wrap access to the key value store.
+The only changes are around the used prefixes, and the removal of the "ancients" which we don't use for now. 
+
+Note 1: We had to duplicate the geth code, since we're storing both rollup and block information, and so we need different convetions.
+Note 2: This needs to be reviewed, and maybe we can find a way to use the geth methods directly. (maybe by having two instances of the kv store, one for blocks and one for rollups)

--- a/go/obscuronode/enclave/rawdb/accessors_chain.go
+++ b/go/obscuronode/enclave/rawdb/accessors_chain.go
@@ -175,3 +175,56 @@ func ReadBlockState(kv ethdb.KeyValueReader, hash common.Hash) *core.BlockState 
 	}
 	return bs
 }
+
+// ReadCanonicalHash retrieves the hash assigned to a canonical block number.
+func ReadCanonicalHash(db ethdb.Reader, number uint64) common.Hash {
+	// Get it by hash from leveldb
+	data, _ := db.Get(headerHashKey(number))
+	return common.BytesToHash(data)
+}
+
+// WriteCanonicalHash stores the hash assigned to a canonical block number.
+func WriteCanonicalHash(db ethdb.KeyValueWriter, hash common.Hash, number uint64) {
+	if err := db.Put(headerHashKey(number), hash.Bytes()); err != nil {
+		log.Panic("Failed to store number to hash mapping. Cause: %s", err)
+	}
+}
+
+// DeleteCanonicalHash removes the number to hash canonical mapping.
+func DeleteCanonicalHash(db ethdb.KeyValueWriter, number uint64) {
+	if err := db.Delete(headerHashKey(number)); err != nil {
+		log.Panic("Failed to delete number to hash mapping. Cause: %s", err)
+	}
+}
+
+// ReadHeadRollupHash retrieves the hash of the current canonical head block.
+func ReadHeadRollupHash(db ethdb.KeyValueReader) common.Hash {
+	data, _ := db.Get(headRollupKey)
+	if len(data) == 0 {
+		return common.Hash{}
+	}
+	return common.BytesToHash(data)
+}
+
+// WriteHeadRollupHash stores the head block's hash.
+func WriteHeadRollupHash(db ethdb.KeyValueWriter, hash common.Hash) {
+	if err := db.Put(headRollupKey, hash.Bytes()); err != nil {
+		log.Panic("Failed to store last block's hash. Cause: %s", err)
+	}
+}
+
+// ReadHeadHeaderHash retrieves the hash of the current canonical head header.
+func ReadHeadHeaderHash(db ethdb.KeyValueReader) common.Hash {
+	data, _ := db.Get(headHeaderKey)
+	if len(data) == 0 {
+		return common.Hash{}
+	}
+	return common.BytesToHash(data)
+}
+
+// WriteHeadHeaderHash stores the hash of the current canonical head header.
+func WriteHeadHeaderHash(db ethdb.KeyValueWriter, hash common.Hash) {
+	if err := db.Put(headHeaderKey, hash.Bytes()); err != nil {
+		log.Panic("Failed to store last header's hash. Cause: %s", err)
+	}
+}

--- a/go/obscuronode/enclave/rawdb/accessors_indexes.go
+++ b/go/obscuronode/enclave/rawdb/accessors_indexes.go
@@ -80,7 +80,7 @@ func ReadTransaction(db ethdb.Reader, hash common.Hash) (*types.Transaction, com
 	}
 	transactions := ReadBody(db, blockHash, *blockNumber)
 	if transactions == nil {
-		log.Error("Transaction referenced missing %s = %s; %s = %s", "number", *blockNumber, "hash", blockHash)
+		log.Error("Transaction referenced missing %s = %d; %s = %s", "number", *blockNumber, "hash", blockHash)
 		return nil, common.Hash{}, 0, 0
 	}
 	for txIndex, tx := range transactions {
@@ -88,7 +88,7 @@ func ReadTransaction(db ethdb.Reader, hash common.Hash) (*types.Transaction, com
 			return tx, blockHash, *blockNumber, uint64(txIndex)
 		}
 	}
-	log.Error("Transaction not found %s = %s; %s = %s; %s = %s;", "number", *blockNumber, "hash", blockHash, "txhash", hash)
+	log.Error("Transaction not found %s = %d; %s = %s; %s = %s;", "number", *blockNumber, "hash", blockHash, "txhash", hash)
 	return nil, common.Hash{}, 0, 0
 }
 
@@ -111,7 +111,7 @@ func ReadReceipt(db ethdb.Reader, hash common.Hash, config *params.ChainConfig) 
 			return receipt, blockHash, *blockNumber, uint64(receiptIndex)
 		}
 	}
-	log.Error("Receipt not found %s = %s; %s = %s; %s = %s;", "number", *blockNumber, "hash", blockHash, "txhash", hash)
+	log.Error("Receipt not found %s = %d; %s = %s; %s = %s;", "number", *blockNumber, "hash", blockHash, "txhash", hash)
 	return nil, common.Hash{}, 0, 0
 }
 

--- a/go/obscuronode/enclave/rawdb/accessors_indexes.go
+++ b/go/obscuronode/enclave/rawdb/accessors_indexes.go
@@ -80,7 +80,7 @@ func ReadTransaction(db ethdb.Reader, hash common.Hash) (*types.Transaction, com
 	}
 	transactions := ReadBody(db, blockHash, *blockNumber)
 	if transactions == nil {
-		log.Error("Transaction referenced missing", "number", *blockNumber, "hash", blockHash)
+		log.Error("Transaction referenced missing %s = %s; %s = %s", "number", *blockNumber, "hash", blockHash)
 		return nil, common.Hash{}, 0, 0
 	}
 	for txIndex, tx := range transactions {
@@ -88,7 +88,7 @@ func ReadTransaction(db ethdb.Reader, hash common.Hash) (*types.Transaction, com
 			return tx, blockHash, *blockNumber, uint64(txIndex)
 		}
 	}
-	log.Error("Transaction not found", "number", *blockNumber, "hash", blockHash, "txhash", hash)
+	log.Error("Transaction not found %s = %s; %s = %s; %s = %s;", "number", *blockNumber, "hash", blockHash, "txhash", hash)
 	return nil, common.Hash{}, 0, 0
 }
 
@@ -111,7 +111,7 @@ func ReadReceipt(db ethdb.Reader, hash common.Hash, config *params.ChainConfig) 
 			return receipt, blockHash, *blockNumber, uint64(receiptIndex)
 		}
 	}
-	log.Error("Receipt not found", "number", *blockNumber, "hash", blockHash, "txhash", hash)
+	log.Error("Receipt not found %s = %s; %s = %s; %s = %s;", "number", *blockNumber, "hash", blockHash, "txhash", hash)
 	return nil, common.Hash{}, 0, 0
 }
 
@@ -143,7 +143,10 @@ func DeleteBloombits(db ethdb.Database, bit uint, from uint64, to uint64) {
 		if len(it.Key()) != len(bloomBitsPrefix)+2+8+32 {
 			continue
 		}
-		db.Delete(it.Key())
+		err := db.Delete(it.Key())
+		if err != nil {
+			log.Panic("Failed to delete bloom bits. Cause: %s", err)
+		}
 	}
 	if it.Error() != nil {
 		log.Panic("Failed to delete bloom bits. Cause: %s", it.Error())

--- a/go/obscuronode/enclave/rawdb/accessors_indexes.go
+++ b/go/obscuronode/enclave/rawdb/accessors_indexes.go
@@ -1,0 +1,151 @@
+package rawdb
+
+import (
+	"bytes"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/obscuronet/obscuro-playground/go/log"
+	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/core"
+)
+
+// ReadTxLookupEntry retrieves the positional metadata associated with a transaction
+// hash to allow retrieving the transaction or receipt by hash.
+func ReadTxLookupEntry(db ethdb.Reader, hash common.Hash) *uint64 {
+	data, _ := db.Get(txLookupKey(hash))
+	if len(data) == 0 {
+		return nil
+	}
+	// Database v6 tx lookup just stores the block number
+	if len(data) < common.HashLength {
+		number := new(big.Int).SetBytes(data).Uint64()
+		return &number
+	}
+	panic("Should not be here")
+}
+
+// writeTxLookupEntry stores a positional metadata for a transaction,
+// enabling hash based transaction and receipt lookups.
+func writeTxLookupEntry(db ethdb.KeyValueWriter, hash common.Hash, numberBytes []byte) {
+	if err := db.Put(txLookupKey(hash), numberBytes); err != nil {
+		log.Panic("Failed to store transaction lookup entry. Cause: %s", err)
+	}
+}
+
+// WriteTxLookupEntries is identical to WriteTxLookupEntry, but it works on
+// a list of hashes
+func WriteTxLookupEntries(db ethdb.KeyValueWriter, number uint64, hashes []common.Hash) {
+	numberBytes := new(big.Int).SetUint64(number).Bytes()
+	for _, hash := range hashes {
+		writeTxLookupEntry(db, hash, numberBytes)
+	}
+}
+
+// WriteTxLookupEntriesByBlock stores a positional metadata for every transaction from
+// a block, enabling hash based transaction and receipt lookups.
+func WriteTxLookupEntriesByBlock(db ethdb.KeyValueWriter, rollup *core.Rollup) {
+	numberBytes := rollup.Number().Bytes()
+	for _, tx := range rollup.Transactions {
+		writeTxLookupEntry(db, tx.Hash(), numberBytes)
+	}
+}
+
+// DeleteTxLookupEntry removes all transaction data associated with a hash.
+func DeleteTxLookupEntry(db ethdb.KeyValueWriter, hash common.Hash) {
+	if err := db.Delete(txLookupKey(hash)); err != nil {
+		log.Panic("Failed to delete transaction lookup entry. Cause: %s", err)
+	}
+}
+
+// DeleteTxLookupEntries removes all transaction lookups for a given block.
+func DeleteTxLookupEntries(db ethdb.KeyValueWriter, hashes []common.Hash) {
+	for _, hash := range hashes {
+		DeleteTxLookupEntry(db, hash)
+	}
+}
+
+// ReadTransaction retrieves a specific transaction from the database, along with
+// its added positional metadata.
+func ReadTransaction(db ethdb.Reader, hash common.Hash) (*types.Transaction, common.Hash, uint64, uint64) {
+	blockNumber := ReadTxLookupEntry(db, hash)
+	if blockNumber == nil {
+		return nil, common.Hash{}, 0, 0
+	}
+	blockHash := ReadCanonicalHash(db, *blockNumber)
+	if blockHash == (common.Hash{}) {
+		return nil, common.Hash{}, 0, 0
+	}
+	transactions := ReadBody(db, blockHash, *blockNumber)
+	if transactions == nil {
+		log.Error("Transaction referenced missing", "number", *blockNumber, "hash", blockHash)
+		return nil, common.Hash{}, 0, 0
+	}
+	for txIndex, tx := range transactions {
+		if tx.Hash() == hash {
+			return tx, blockHash, *blockNumber, uint64(txIndex)
+		}
+	}
+	log.Error("Transaction not found", "number", *blockNumber, "hash", blockHash, "txhash", hash)
+	return nil, common.Hash{}, 0, 0
+}
+
+// ReadReceipt retrieves a specific transaction receipt from the database, along with
+// its added positional metadata.
+func ReadReceipt(db ethdb.Reader, hash common.Hash, config *params.ChainConfig) (*types.Receipt, common.Hash, uint64, uint64) {
+	// Retrieve the context of the receipt based on the transaction hash
+	blockNumber := ReadTxLookupEntry(db, hash)
+	if blockNumber == nil {
+		return nil, common.Hash{}, 0, 0
+	}
+	blockHash := ReadCanonicalHash(db, *blockNumber)
+	if blockHash == (common.Hash{}) {
+		return nil, common.Hash{}, 0, 0
+	}
+	// Read all the receipts from the block and return the one with the matching hash
+	receipts := ReadReceipts(db, blockHash, *blockNumber, config)
+	for receiptIndex, receipt := range receipts {
+		if receipt.TxHash == hash {
+			return receipt, blockHash, *blockNumber, uint64(receiptIndex)
+		}
+	}
+	log.Error("Receipt not found", "number", *blockNumber, "hash", blockHash, "txhash", hash)
+	return nil, common.Hash{}, 0, 0
+}
+
+// ReadBloomBits retrieves the compressed bloom bit vector belonging to the given
+// section and bit index from the.
+func ReadBloomBits(db ethdb.KeyValueReader, bit uint, section uint64, head common.Hash) ([]byte, error) {
+	return db.Get(bloomBitsKey(bit, section, head))
+}
+
+// WriteBloomBits stores the compressed bloom bits vector belonging to the given
+// section and bit index.
+func WriteBloomBits(db ethdb.KeyValueWriter, bit uint, section uint64, head common.Hash, bits []byte) {
+	if err := db.Put(bloomBitsKey(bit, section, head), bits); err != nil {
+		log.Panic("Failed to store bloom bits. Cause: %s", err)
+	}
+}
+
+// DeleteBloombits removes all compressed bloom bits vector belonging to the
+// given section range and bit index.
+func DeleteBloombits(db ethdb.Database, bit uint, from uint64, to uint64) {
+	start, end := bloomBitsKey(bit, from, common.Hash{}), bloomBitsKey(bit, to, common.Hash{})
+	it := db.NewIterator(nil, start)
+	defer it.Release()
+
+	for it.Next() {
+		if bytes.Compare(it.Key(), end) >= 0 {
+			break
+		}
+		if len(it.Key()) != len(bloomBitsPrefix)+2+8+32 {
+			continue
+		}
+		db.Delete(it.Key())
+	}
+	if it.Error() != nil {
+		log.Panic("Failed to delete bloom bits. Cause: %s", it.Error())
+	}
+}

--- a/go/obscuronode/enclave/rawdb/accessors_receipts.go
+++ b/go/obscuronode/enclave/rawdb/accessors_receipts.go
@@ -41,7 +41,7 @@ func ReadRawReceipts(db ethdb.Reader, hash common.Hash, number uint64) types.Rec
 	// Convert the receipts from their storage form to their internal representation
 	storageReceipts := []*types.ReceiptForStorage{}
 	if err := rlp.DecodeBytes(data, &storageReceipts); err != nil {
-		log.Error("Invalid receipt array RLP", "hash", hash, "err", err)
+		log.Error("Invalid receipt array RLP. %s = %s; %s = %s;", "hash", hash, "err", err)
 		return nil
 	}
 	receipts := make(types.Receipts, len(storageReceipts))
@@ -66,12 +66,12 @@ func ReadReceipts(db ethdb.Reader, hash common.Hash, number uint64, config *para
 	}
 	body := ReadBody(db, hash, number)
 	if body == nil {
-		log.Error("Missing body but have receipt", "hash", hash, "number", number)
+		log.Error("Missing body but have receipt.%s = %s; %s = %d;", "hash", hash, "number", number)
 		return nil
 	}
 
 	if err := receipts.DeriveFields(config, hash, number, types.Transactions(body)); err != nil {
-		log.Error("Failed to derive block receipts fields", "hash", hash, "number", number, "err", err)
+		log.Error("Failed to derive block receipts fields. %s = %s; %s = %d; %s = %s;", "hash", hash, "number", number, "err", err)
 		return nil
 	}
 	return receipts

--- a/go/obscuronode/enclave/rawdb/accessors_receipts.go
+++ b/go/obscuronode/enclave/rawdb/accessors_receipts.go
@@ -166,17 +166,17 @@ func ReadLogs(db ethdb.Reader, hash common.Hash, number uint64, config *params.C
 		if logs := readLegacyLogs(db, hash, number, config); logs != nil {
 			return logs
 		}
-		log.Error("Invalid receipt array RLP", "hash", hash, "err", err)
+		log.Error("Invalid receipt array RLP.%s = %s; %s = %s;", "hash", hash, "err", err)
 		return nil
 	}
 
 	body := ReadBody(db, hash, number)
 	if body == nil {
-		log.Error("Missing body but have receipt", "hash", hash, "number", number)
+		log.Error("Missing body but have receipt. %s = %s; %s = %d;", "hash", hash, "number", number)
 		return nil
 	}
 	if err := deriveLogFields(receipts, hash, number, types.Transactions(body)); err != nil {
-		log.Error("Failed to derive block receipts fields", "hash", hash, "number", number, "err", err)
+		log.Error("Failed to derive block receipts fields. %s = %s; %s = %d; %s = %s;", "hash", hash, "number", number, "err", err)
 		return nil
 	}
 	logs := make([][]*types.Log, len(receipts))

--- a/go/obscuronode/enclave/rawdb/accessors_receipts.go
+++ b/go/obscuronode/enclave/rawdb/accessors_receipts.go
@@ -1,0 +1,202 @@
+package rawdb
+
+import (
+	"errors"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/obscuronet/obscuro-playground/go/log"
+)
+
+// HasReceipts verifies the existence of all the transaction receipts belonging
+// to a block.
+func HasReceipts(db ethdb.Reader, hash common.Hash, number uint64) bool {
+	if has, err := db.Has(rollupReceiptsKey(number, hash)); !has || err != nil {
+		return false
+	}
+	return true
+}
+
+// ReadReceiptsRLP retrieves all the transaction receipts belonging to a block in RLP encoding.
+func ReadReceiptsRLP(db ethdb.Reader, hash common.Hash, number uint64) rlp.RawValue {
+	data, err := db.Get(rollupReceiptsKey(number, hash))
+	if err != nil {
+		log.Panic("Could not read receipts.Cause: %s", err)
+	}
+	return data
+}
+
+// ReadRawReceipts retrieves all the transaction receipts belonging to a block.
+// The receipt metadata fields are not guaranteed to be populated, so they
+// should not be used. Use ReadReceipts instead if the metadata is needed.
+func ReadRawReceipts(db ethdb.Reader, hash common.Hash, number uint64) types.Receipts {
+	// Retrieve the flattened receipt slice
+	data := ReadReceiptsRLP(db, hash, number)
+	if len(data) == 0 {
+		return nil
+	}
+	// Convert the receipts from their storage form to their internal representation
+	storageReceipts := []*types.ReceiptForStorage{}
+	if err := rlp.DecodeBytes(data, &storageReceipts); err != nil {
+		log.Error("Invalid receipt array RLP", "hash", hash, "err", err)
+		return nil
+	}
+	receipts := make(types.Receipts, len(storageReceipts))
+	for i, storageReceipt := range storageReceipts {
+		receipts[i] = (*types.Receipt)(storageReceipt)
+	}
+	return receipts
+}
+
+// ReadReceipts retrieves all the transaction receipts belonging to a block, including
+// its correspoinding metadata fields. If it is unable to populate these metadata
+// fields then nil is returned.
+//
+// The current implementation populates these metadata fields by reading the receipts'
+// corresponding block body, so if the block body is not found it will return nil even
+// if the receipt itself is stored.
+func ReadReceipts(db ethdb.Reader, hash common.Hash, number uint64, config *params.ChainConfig) types.Receipts {
+	// We're deriving many fields from the block body, retrieve beside the receipt
+	receipts := ReadRawReceipts(db, hash, number)
+	if receipts == nil {
+		return nil
+	}
+	body := ReadBody(db, hash, number)
+	if body == nil {
+		log.Error("Missing body but have receipt", "hash", hash, "number", number)
+		return nil
+	}
+
+	if err := receipts.DeriveFields(config, hash, number, types.Transactions(body)); err != nil {
+		log.Error("Failed to derive block receipts fields", "hash", hash, "number", number, "err", err)
+		return nil
+	}
+	return receipts
+}
+
+// WriteReceipts stores all the transaction receipts belonging to a block.
+func WriteReceipts(db ethdb.KeyValueWriter, hash common.Hash, number uint64, receipts types.Receipts) {
+	// Convert the receipts into their storage form and serialize them
+	storageReceipts := make([]*types.ReceiptForStorage, len(receipts))
+	for i, receipt := range receipts {
+		storageReceipts[i] = (*types.ReceiptForStorage)(receipt)
+	}
+	bytes, err := rlp.EncodeToBytes(storageReceipts)
+	if err != nil {
+		log.Panic("Failed to encode block receipts. Cause: %s", err)
+	}
+	// Store the flattened receipt slice
+	if err := db.Put(rollupReceiptsKey(number, hash), bytes); err != nil {
+		log.Panic("Failed to store block receipts. Cause: %s", err)
+	}
+}
+
+// DeleteReceipts removes all receipt data associated with a block hash.
+func DeleteReceipts(db ethdb.KeyValueWriter, hash common.Hash, number uint64) {
+	if err := db.Delete(rollupReceiptsKey(number, hash)); err != nil {
+		log.Panic("Failed to delete block receipts. Cause: %s", err)
+	}
+}
+
+// storedReceiptRLP is the storage encoding of a receipt.
+// Re-definition in core/types/receipt.go.
+type storedReceiptRLP struct {
+	PostStateOrStatus []byte
+	CumulativeGasUsed uint64
+	Logs              []*types.LogForStorage
+}
+
+// ReceiptLogs is a barebone version of ReceiptForStorage which only keeps
+// the list of logs. When decoding a stored receipt into this object we
+// avoid creating the bloom filter.
+type receiptLogs struct {
+	Logs []*types.Log
+}
+
+// DecodeRLP implements rlp.Decoder.
+func (r *receiptLogs) DecodeRLP(s *rlp.Stream) error {
+	var stored storedReceiptRLP
+	if err := s.Decode(&stored); err != nil {
+		return err
+	}
+	r.Logs = make([]*types.Log, len(stored.Logs))
+	for i, log := range stored.Logs {
+		r.Logs[i] = (*types.Log)(log)
+	}
+	return nil
+}
+
+// DeriveLogFields fills the logs in receiptLogs with information such as block number, txhash, etc.
+func deriveLogFields(receipts []*receiptLogs, hash common.Hash, number uint64, txs types.Transactions) error {
+	logIndex := uint(0)
+	if len(txs) != len(receipts) {
+		return errors.New("transaction and receipt count mismatch")
+	}
+	for i := 0; i < len(receipts); i++ {
+		txHash := txs[i].Hash()
+		// The derived log fields can simply be set from the block and transaction
+		for j := 0; j < len(receipts[i].Logs); j++ {
+			receipts[i].Logs[j].BlockNumber = number
+			receipts[i].Logs[j].BlockHash = hash
+			receipts[i].Logs[j].TxHash = txHash
+			receipts[i].Logs[j].TxIndex = uint(i)
+			receipts[i].Logs[j].Index = logIndex
+			logIndex++
+		}
+	}
+	return nil
+}
+
+// ReadLogs retrieves the logs for all transactions in a block. The log fields
+// are populated with metadata. In case the receipts or the block body
+// are not found, a nil is returned.
+func ReadLogs(db ethdb.Reader, hash common.Hash, number uint64, config *params.ChainConfig) [][]*types.Log {
+	// Retrieve the flattened receipt slice
+	data := ReadReceiptsRLP(db, hash, number)
+	if len(data) == 0 {
+		return nil
+	}
+	receipts := []*receiptLogs{}
+	if err := rlp.DecodeBytes(data, &receipts); err != nil {
+		// Receipts might be in the legacy format, try decoding that.
+		// TODO: to be removed after users migrated
+		if logs := readLegacyLogs(db, hash, number, config); logs != nil {
+			return logs
+		}
+		log.Error("Invalid receipt array RLP", "hash", hash, "err", err)
+		return nil
+	}
+
+	body := ReadBody(db, hash, number)
+	if body == nil {
+		log.Error("Missing body but have receipt", "hash", hash, "number", number)
+		return nil
+	}
+	if err := deriveLogFields(receipts, hash, number, types.Transactions(body)); err != nil {
+		log.Error("Failed to derive block receipts fields", "hash", hash, "number", number, "err", err)
+		return nil
+	}
+	logs := make([][]*types.Log, len(receipts))
+	for i, receipt := range receipts {
+		logs[i] = receipt.Logs
+	}
+	return logs
+}
+
+// readLegacyLogs is a temporary workaround for when trying to read logs
+// from a block which has its receipt stored in the legacy format. It'll
+// be removed after users have migrated their freezer databases.
+func readLegacyLogs(db ethdb.Reader, hash common.Hash, number uint64, config *params.ChainConfig) [][]*types.Log {
+	receipts := ReadReceipts(db, hash, number, config)
+	if receipts == nil {
+		return nil
+	}
+	logs := make([][]*types.Log, len(receipts))
+	for i, receipt := range receipts {
+		logs[i] = receipt.Logs
+	}
+	return logs
+}

--- a/go/obscuronode/enclave/rawdb/schema.go
+++ b/go/obscuronode/enclave/rawdb/schema.go
@@ -9,11 +9,16 @@ import (
 var (
 	sharedSecret             = []byte("SharedSecret")
 	genesisRollupHash        = []byte("GenesisRollupHash")
-	rollupHeaderPrefix       = []byte("oh")  // rollupHeaderPrefix + num (uint64 big endian) + hash -> header
-	rollupBodyPrefix         = []byte("or")  // rollupBodyPrefix + num (uint64 big endian) + hash -> rollup body
-	rollupHeaderNumberPrefix = []byte("oH")  // headerNumberPrefix + hash -> num (uint64 big endian)
-	blockStatePrefix         = []byte("obs") // headerNumberPrefix + hash -> num (uint64 big endian)
-
+	rollupHeaderPrefix       = []byte("oh")          // rollupHeaderPrefix + num (uint64 big endian) + hash -> header
+	headerHashSuffix         = []byte("on")          // headerPrefix + num (uint64 big endian) + headerHashSuffix -> hash
+	rollupBodyPrefix         = []byte("ob")          // rollupBodyPrefix + num (uint64 big endian) + hash -> rollup body
+	rollupHeaderNumberPrefix = []byte("oH")          // headerNumberPrefix + hash -> num (uint64 big endian)
+	blockStatePrefix         = []byte("obs")         // headerNumberPrefix + hash -> num (uint64 big endian)
+	rollupReceiptsPrefix     = []byte("or")          // rollupReceiptsPrefix + num (uint64 big endian) + hash -> block receipts
+	txLookupPrefix           = []byte("ol")          // txLookupPrefix + hash -> transaction/receipt lookup metadata
+	bloomBitsPrefix          = []byte("oB")          // bloomBitsPrefix + bit (uint16 big endian) + section (uint64 big endian) + hash -> bloom bits
+	headRollupKey            = []byte("oLastBlock")  // headRollupKey tracks the latest known full block's hash.
+	headHeaderKey            = []byte("oLastHeader") // headHeaderKey tracks the latest known header's hash.
 )
 
 // encodeRollupNumber encodes a rollup number as big endian uint64
@@ -45,4 +50,29 @@ func rollupBodyKey(number uint64, hash common.Hash) []byte {
 
 func blockStateKey(hash common.Hash) []byte {
 	return append(blockStatePrefix, hash.Bytes()...)
+}
+
+// rollupReceiptsKey = rollupReceiptsPrefix + num (uint64 big endian) + hash
+func rollupReceiptsKey(number uint64, hash common.Hash) []byte {
+	return append(append(rollupReceiptsPrefix, encodeRollupNumber(number)...), hash.Bytes()...)
+}
+
+// txLookupKey = txLookupPrefix + hash
+func txLookupKey(hash common.Hash) []byte {
+	return append(txLookupPrefix, hash.Bytes()...)
+}
+
+// bloomBitsKey = bloomBitsPrefix + bit (uint16 big endian) + section (uint64 big endian) + hash
+func bloomBitsKey(bit uint, section uint64, hash common.Hash) []byte {
+	key := append(append(bloomBitsPrefix, make([]byte, 10)...), hash.Bytes()...)
+
+	binary.BigEndian.PutUint16(key[1:], uint16(bit))
+	binary.BigEndian.PutUint64(key[3:], section)
+
+	return key
+}
+
+// headerHashKey = headerPrefix + num (uint64 big endian) + headerHashSuffix
+func headerHashKey(number uint64) []byte {
+	return append(append(rollupHeaderPrefix, encodeRollupNumber(number)...), headerHashSuffix...)
 }


### PR DESCRIPTION
### Why is this change needed?

We need to store tx receipts and other metadata, so that we can expose them via RPC to be used by wallets (in a subsequent PR).
In a previous PR, the Merkle root of the receipts was added to the rollup header.

### What changes were made as part of this PR:

- functional PR 
- a bunch of accessor methods were copy-pasted from geth and slightly modified
- pass in the "receipts" to the storage function that saves the rollup, and store more metadata

### What are the key areas to look at
- storage - "SaveNewHead"