### PR TITLE
Extend viewing key manager to handle decryption of sensitive RPC requests

### DIFF
--- a/go/obscuronode/enclave/enclave.go
+++ b/go/obscuronode/enclave/enclave.go
@@ -10,14 +10,14 @@ import (
 	"math/big"
 	"sync"
 
+	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/rpcencryptionmanager"
+
 	"github.com/ethereum/go-ethereum/common/hexutil"
 
 	"github.com/ethereum/go-ethereum/trie"
 
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/crypto/ecies"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/viewingkeymanager"
-
 	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/sql"
 
 	"github.com/ethereum/go-ethereum/core/rawdb"
@@ -62,14 +62,14 @@ type StatsCollector interface {
 }
 
 type enclaveImpl struct {
-	config            config.EnclaveConfig
-	nodeShortID       uint64
-	storage           db.Storage
-	blockResolver     db.BlockResolver
-	mempool           mempool.Manager
-	statsCollector    StatsCollector
-	l1Blockchain      *core.BlockChain
-	viewingKeyManager viewingkeymanager.ViewingKeyManager
+	config               config.EnclaveConfig
+	nodeShortID          uint64
+	storage              db.Storage
+	blockResolver        db.BlockResolver
+	mempool              mempool.Manager
+	statsCollector       StatsCollector
+	l1Blockchain         *core.BlockChain
+	rpcEncryptionManager rpcencryptionmanager.RPCEncryptionManager
 
 	txCh                 chan *nodecommon.L2Tx
 	roundWinnerCh        chan *obscurocore.Rollup
@@ -135,7 +135,7 @@ func NewEnclave(
 		mempool:               mempool.New(),
 		statsCollector:        collector,
 		l1Blockchain:          l1Blockchain,
-		viewingKeyManager:     viewingkeymanager.NewViewingKeyManager(config.ViewingKeysEnabled),
+		rpcEncryptionManager:  rpcencryptionmanager.NewRPCEncryptionManager(config.ViewingKeysEnabled, ecies.ImportECDSA(privKey)),
 		txCh:                  make(chan *nodecommon.L2Tx),
 		roundWinnerCh:         make(chan *obscurocore.Rollup),
 		exitCh:                make(chan bool),
@@ -411,18 +411,13 @@ func (e *enclaveImpl) notifySpeculative(winnerRollup *obscurocore.Rollup) {
 }
 
 func (e *enclaveImpl) ExecuteOffChainTransaction(encryptedParams nodecommon.EncryptedParams) (nodecommon.EncryptedResponse, error) {
-	// TODO - Encapsulate the config-based skipping of encryption in the viewing key manager.
-	paramBytes := encryptedParams
-	if e.config.ViewingKeysEnabled {
-		var err error
-		paramBytes, err = ecies.ImportECDSA(e.privateKey).Decrypt(encryptedParams, nil, nil)
-		if err != nil {
-			return nil, fmt.Errorf("could not decrypt params in Call request. Cause: %w", err)
-		}
+	paramBytes, err := e.rpcEncryptionManager.DecryptWithEnclaveKey(encryptedParams)
+	if err != nil {
+		return nil, fmt.Errorf("could not decrypt params in Call request. Cause: %w", err)
 	}
 
 	var paramsJSONMap []interface{}
-	err := json.Unmarshal(paramBytes, &paramsJSONMap)
+	err = json.Unmarshal(paramBytes, &paramsJSONMap)
 	if err != nil {
 		return nil, fmt.Errorf("could not parse JSON params in Call request. Cause: %w", err)
 	}
@@ -467,7 +462,7 @@ func (e *enclaveImpl) ExecuteOffChainTransaction(encryptedParams nodecommon.Encr
 		return nil, result.Err
 	}
 
-	encryptedResult, err := e.viewingKeyManager.EncryptWithViewingKey(from, result.ReturnData)
+	encryptedResult, err := e.rpcEncryptionManager.EncryptWithViewingKey(from, result.ReturnData)
 	if err != nil {
 		return nil, fmt.Errorf("enclave could not respond securely to eth_call request. Cause: %w", err)
 	}
@@ -680,22 +675,17 @@ func (e *enclaveImpl) AddViewingKey(encryptedViewingKeyBytes []byte, signature [
 	if err != nil {
 		return fmt.Errorf("could not decrypt viewing key when adding it to enclave. Cause: %w", err)
 	}
-	return e.viewingKeyManager.AddViewingKey(viewingKeyBytes, signature)
+	return e.rpcEncryptionManager.AddViewingKey(viewingKeyBytes, signature)
 }
 
 func (e *enclaveImpl) GetBalance(encryptedParams nodecommon.EncryptedParams) (nodecommon.EncryptedResponse, error) {
-	// TODO - Encapsulate the config-based skipping of encryption in the viewing key manager.
-	paramBytes := encryptedParams
-	if e.config.ViewingKeysEnabled {
-		var err error
-		paramBytes, err = ecies.ImportECDSA(e.privateKey).Decrypt(encryptedParams, nil, nil)
-		if err != nil {
-			return nil, fmt.Errorf("could not decrypt params in GetBalance request. Cause: %w", err)
-		}
+	paramBytes, err := e.rpcEncryptionManager.DecryptWithEnclaveKey(encryptedParams)
+	if err != nil {
+		return nil, fmt.Errorf("could not decrypt params in GetBalance request. Cause: %w", err)
 	}
 
 	var paramsJSONMap []string
-	err := json.Unmarshal(paramBytes, &paramsJSONMap)
+	err = json.Unmarshal(paramBytes, &paramsJSONMap)
 	if err != nil {
 		return nil, fmt.Errorf("could not parse JSON params in GetBalance request. Cause: %w", err)
 	}
@@ -704,7 +694,7 @@ func (e *enclaveImpl) GetBalance(encryptedParams nodecommon.EncryptedParams) (no
 	// TODO - Calculate balance correctly, rather than returning this dummy value.
 	balance := DummyBalance // The Ethereum API is to return the balance in hex.
 
-	encryptedBalance, err := e.viewingKeyManager.EncryptWithViewingKey(address, []byte(balance))
+	encryptedBalance, err := e.rpcEncryptionManager.EncryptWithViewingKey(address, []byte(balance))
 	if err != nil {
 		return nil, fmt.Errorf("enclave could not respond securely to eth_getBalance request. Cause: %w", err)
 	}

--- a/integration/simulation/wallet_extension_test.go
+++ b/integration/simulation/wallet_extension_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/viewingkeymanager"
+	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/rpcencryptionmanager"
 
 	"github.com/obscuronet/obscuro-playground/go/ethclient/erc20contractlib"
 	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/core"
@@ -223,8 +223,8 @@ func TestCanCallAfterSubmittingViewingKey(t *testing.T) {
 	}
 	callJSON := makeEthJSONReqAsJSON(t, walletExtensionAddr, walletextension.ReqJSONMethodCall, []interface{}{reqParams, "latest"})
 
-	if callJSON[walletextension.RespJSONKeyResult] != string(viewingkeymanager.PlaceholderResult) {
-		t.Fatalf("Expected call result of %s, got %s", viewingkeymanager.PlaceholderResult, callJSON[walletextension.RespJSONKeyResult])
+	if callJSON[walletextension.RespJSONKeyResult] != string(rpcencryptionmanager.PlaceholderResult) {
+		t.Fatalf("Expected call result of %s, got %s", rpcencryptionmanager.PlaceholderResult, callJSON[walletextension.RespJSONKeyResult])
 	}
 }
 
@@ -377,7 +377,7 @@ func generateViewingKey(t *testing.T, walletExtensionAddr string) []byte {
 
 // Signs a viewing key.
 func signViewingKey(t *testing.T, privateKey *ecdsa.PrivateKey, viewingKey []byte) []byte {
-	msgToSign := viewingkeymanager.ViewingKeySignedMsgPrefix + string(viewingKey)
+	msgToSign := rpcencryptionmanager.ViewingKeySignedMsgPrefix + string(viewingKey)
 	signature, err := crypto.Sign(accounts.TextHash([]byte(msgToSign)), privateKey)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
### Why is this change needed?

Encapsulates the decryption of sensitive RPC requests to reduce the amount of logic in enclave.go.

### What changes were made as part of this PR:

Refactoring.

### What are the key areas to look at
