### PR TITLE
Obscuroscan now allows decrypting of transaction blobs grabbed via the monitor.

### DIFF
--- a/go/obscuronode/enclave/core/transaction_blob_crypto.go
+++ b/go/obscuronode/enclave/core/transaction_blob_crypto.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	// TODO - This fixed nonce is insecure, and should be removed alongside the fixed rollup encryption key.
-	rollupCipherNonce = "000000000000"
+	RollupCipherNonce = "000000000000"
 	// RollupEncryptionKeyHex is the AES key used to encrypt and decrypt the transaction blob in rollups.
 	// TODO - Replace this fixed key with derived, rotating keys.
 	RollupEncryptionKeyHex = "bddbc0d46a0666ce57a466168d99c1830b0c65e052d77188f2cbfc3f6486588c"
@@ -51,11 +51,11 @@ func (t TransactionBlobCryptoImpl) Encrypt(transactions L2Txs) nodecommon.Encryp
 		log.Panic("could not encrypt L2 transaction. Cause: %s", err)
 	}
 
-	return t.transactionCipher.Seal(nil, []byte(rollupCipherNonce), encodedTxs, nil)
+	return t.transactionCipher.Seal(nil, []byte(RollupCipherNonce), encodedTxs, nil)
 }
 
 func (t TransactionBlobCryptoImpl) Decrypt(encryptedTxs nodecommon.EncryptedTransactions) L2Txs {
-	encodedTxs, err := t.transactionCipher.Open(nil, []byte(rollupCipherNonce), encryptedTxs, nil)
+	encodedTxs, err := t.transactionCipher.Open(nil, []byte(RollupCipherNonce), encryptedTxs, nil)
 	if err != nil {
 		log.Panic("could not decrypt encrypted L2 transactions. Cause: %s", err)
 	}

--- a/go/obscuronode/enclave/enclave.go
+++ b/go/obscuronode/enclave/enclave.go
@@ -45,7 +45,7 @@ import (
 const (
 	msgNoRollup  = "could not fetch rollup"
 	DummyBalance = "0x0"
-	// EnclavePrivateKeyHex is the private key used for sensitive communication with the enclave.
+	// enclavePrivateKeyHex is the private key used for sensitive communication with the enclave.
 	// TODO - Replace this fixed key with a derived key.
 	enclavePrivateKeyHex = "81acce9620f0adf1728cb8df7f6b8b8df857955eb9e8b7aed6ef8390c09fc207"
 

--- a/tools/obscuroscan/obscuroscan.go
+++ b/tools/obscuroscan/obscuroscan.go
@@ -159,6 +159,9 @@ func (o *Obscuroscan) decryptTxBlob(resp http.ResponseWriter, req *http.Request)
 // Decrypts the transaction blob and returns it as JSON.
 func decryptTxBlob(encryptedTxBytesBase64 []byte) ([]byte, error) {
 	encryptedTxBytes, err := base64.StdEncoding.DecodeString(string(encryptedTxBytesBase64))
+	if err != nil {
+		return nil, fmt.Errorf("could not decode encrypted transaction blob from Base64. Cause: %w", err)
+	}
 
 	key := common.Hex2Bytes(core.RollupEncryptionKeyHex)
 	block, err := aes.NewCipher(key)

--- a/tools/obscuroscan/obscuroscan.go
+++ b/tools/obscuroscan/obscuroscan.go
@@ -8,10 +8,11 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/ethereum/go-ethereum/rlp"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/core"
 	"net/http"
 	"strings"
+
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/core"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"

--- a/tools/obscuroscan/obscuroscan.go
+++ b/tools/obscuroscan/obscuroscan.go
@@ -3,8 +3,13 @@ package obscuroscan
 import (
 	"bytes"
 	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/core"
 	"net/http"
 	"strings"
 
@@ -22,11 +27,10 @@ import (
 const (
 	pathHeadBlock     = "/headblock/"
 	pathHeadRollup    = "/headrollup/"
-	pathDecryptRollup = "/decryptrollup/"
+	pathDecryptTxBlob = "/decrypttxblob/"
 	staticDir         = "./tools/obscuroscan/static"
 	pathRoot          = "/"
 	httpCodeErr       = 500
-	methodBytesLen    = 4
 )
 
 // Obscuroscan is a server that allows the monitoring of a running Obscuro network.
@@ -57,8 +61,8 @@ func (o *Obscuroscan) Serve(hostAndPort string) {
 	serveMux.HandleFunc(pathHeadBlock, o.getBlockHead)
 	// Handle requests for the head rollup.
 	serveMux.HandleFunc(pathHeadRollup, o.getHeadRollup)
-	// Handle requests to decrypt rollup.
-	serveMux.HandleFunc(pathDecryptRollup, o.decryptRollup)
+	// Handle requests to decrypt a transaction blob.
+	serveMux.HandleFunc(pathDecryptTxBlob, o.decryptTxBlob)
 	o.server = &http.Server{Addr: hostAndPort, Handler: serveMux}
 
 	err := o.server.ListenAndServe()
@@ -127,9 +131,9 @@ func (o *Obscuroscan) getHeadRollup(resp http.ResponseWriter, _ *http.Request) {
 	}
 }
 
-// Decrypts the provided rollup using the provided key.
-func (o *Obscuroscan) decryptRollup(resp http.ResponseWriter, req *http.Request) {
-	// TODO - Update logic here once rollups are encrypted. Currently, we just unpack the Ethereum transaction.
+// Decrypts the provided transaction blob using the provided key.
+// TODO - Use the passed-in key, rather than a hardcoded enclave key.
+func (o *Obscuroscan) decryptTxBlob(resp http.ResponseWriter, req *http.Request) {
 	body := req.Body
 	defer body.Close()
 	buffer := new(bytes.Buffer)
@@ -139,52 +143,46 @@ func (o *Obscuroscan) decryptRollup(resp http.ResponseWriter, req *http.Request)
 		return
 	}
 
-	jsonRollup, err := decryptRollup(buffer.Bytes(), o.contractABI)
+	jsonTxs, err := decryptTxBlob(buffer.Bytes())
 	if err != nil {
-		logAndSendErr(resp, fmt.Sprintf("could not decrypt rollup. Cause: %s", err))
+		logAndSendErr(resp, fmt.Sprintf("could not decrypt transaction blob. Cause: %s", err))
 		return
 	}
 
-	_, err = resp.Write(jsonRollup)
+	_, err = resp.Write(jsonTxs)
 	if err != nil {
-		logAndSendErr(resp, fmt.Sprintf("could not decrypt rollup. Cause: %s", err))
+		logAndSendErr(resp, fmt.Sprintf("could not write decrypted transactions to client. Cause: %s", err))
 		return
 	}
 }
 
-// Decrypts the rollup and returns it as JSON.
-func decryptRollup(encryptedRollupHex []byte, contractABI abi.ABI) ([]byte, error) {
-	encryptedRollupBytes := common.Hex2Bytes(string(encryptedRollupHex))
+// Decrypts the transaction blob and returns it as JSON.
+func decryptTxBlob(encryptedTxBytesBase64 []byte) ([]byte, error) {
+	encryptedTxBytes, err := base64.StdEncoding.DecodeString(string(encryptedTxBytesBase64))
 
-	method, err := contractABI.MethodById(encryptedRollupBytes[:methodBytesLen])
+	key := common.Hex2Bytes(core.RollupEncryptionKeyHex)
+	block, err := aes.NewCipher(key)
 	if err != nil {
-		return nil, fmt.Errorf("could not read ABI method for encrypted rollup. Cause: %w", err)
+		return nil, fmt.Errorf("could not initialise AES cipher for enclave rollup key. Cause: %w", err)
 	}
-	if method.Name != mgmtcontractlib.AddRollupMethod {
-		return nil, fmt.Errorf("encrypted rollup did not have correct ABI method name. Expected %s, got %s", mgmtcontractlib.AddRollupMethod, method.Name)
-	}
-
-	contractCallData := map[string]interface{}{}
-	if err = method.Inputs.UnpackIntoMap(contractCallData, encryptedRollupBytes[4:]); err != nil {
-		return nil, fmt.Errorf("encrypted rollup could not be unpacked using ABI. Cause: %w", err)
-	}
-	callData, found := contractCallData["rollupData"]
-	if !found {
-		return nil, fmt.Errorf("encrypted rollup did not contain call data for rollupData")
-	}
-	zippedRollup := mgmtcontractlib.Base64DecodeFromString(callData.(string))
-	encodedRollup, err := mgmtcontractlib.Decompress(zippedRollup)
+	transactionCipher, err := cipher.NewGCM(block)
 	if err != nil {
-		return nil, fmt.Errorf("decrypted rollup could not be decompressed. Cause: %w", err)
-	}
-	cleartextRollup, err := nodecommon.DecodeRollup(encodedRollup)
-	if err != nil {
-		return nil, fmt.Errorf("could not decode decompressed rollup. Cause: %w", err)
+		return nil, fmt.Errorf("could not initialise wrapper for AES cipher for enclave rollup key. Cause: %w", err)
 	}
 
-	jsonRollup, err := json.Marshal(cleartextRollup)
+	encodedTxs, err := transactionCipher.Open(nil, []byte(core.RollupCipherNonce), encryptedTxBytes, nil)
 	if err != nil {
-		return nil, fmt.Errorf("could not decrypt rollup: %w", err)
+		return nil, fmt.Errorf("could not decrypt encrypted L2 transactions. Cause: %w", err)
+	}
+
+	cleartextTxs := core.L2Txs{}
+	if err = rlp.DecodeBytes(encodedTxs, &cleartextTxs); err != nil {
+		return nil, fmt.Errorf("could not decode encoded L2 transactions. Cause: %w", err)
+	}
+
+	jsonRollup, err := json.Marshal(cleartextTxs)
+	if err != nil {
+		return nil, fmt.Errorf("could not decrypt transaction blob: %w", err)
 	}
 
 	return jsonRollup, nil

--- a/tools/obscuroscan/obscuroscan_test.go
+++ b/tools/obscuroscan/obscuroscan_test.go
@@ -1,82 +1,42 @@
 package obscuroscan
 
 import (
+	"encoding/base64"
 	"encoding/json"
-	"math/big"
-	"strings"
+	"github.com/obscuronet/obscuro-playground/integration/datagenerator"
 	"testing"
 
-	"github.com/ethereum/go-ethereum/accounts/abi"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/obscuronet/obscuro-playground/go/ethclient/mgmtcontractlib"
-	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
 	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/core"
 	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
 )
 
-const expectedNonce = 777
+func TestCanDecryptTxBlob(t *testing.T) {
+	txs := []*nodecommon.L2Tx{datagenerator.CreateL2Tx(), datagenerator.CreateL2Tx()}
 
-func TestCanDecryptRollup(t *testing.T) {
-	rollupJSON, err := decryptRollup(generateEncryptedRollupHex(), contractABI)
+	txsJSONBytes, err := decryptTxBlob(generateEncryptedTxBlob(txs))
 	if err != nil {
-		t.Fatalf("rollup decryption failed. Cause: %s", err)
-	}
-	var rollupJSONMap map[string]interface{}
-	err = json.Unmarshal(rollupJSON, &rollupJSONMap)
-	if err != nil {
-		t.Fatalf("rollup JSON unmarshalling failed. Cause: %s", err)
+		t.Fatalf("transaction blob decryption failed. Cause: %s", err)
 	}
 
-	// We use the nonce as an indicator of whether the entire rollup was successfully decrypted.
-	recoveredNonce := rollupJSONMap["Header"].(map[string]interface{})["Nonce"].(float64)
-	if recoveredNonce != expectedNonce {
-		t.Fatalf("rollup JSON did not contain correct nonce")
+	expectedTxsJSONBytes, err := json.Marshal(txs)
+	if err != nil {
+		t.Fatalf("marshalling transactions to JSON failed. Cause: %s", err)
+	}
+
+	if string(expectedTxsJSONBytes) != string(txsJSONBytes) {
+		t.Fatalf("expected %s, got %s", string(expectedTxsJSONBytes), string(txsJSONBytes))
 	}
 }
 
 func TestThrowsIfEncryptedRollupIsInvalid(t *testing.T) {
-	contractABI, err := abi.JSON(strings.NewReader(mgmtcontractlib.MgmtContractABI))
-	if err != nil {
-		panic(err)
-	}
-
-	_, err = decryptRollup([]byte("invalid_rollup"), contractABI)
+	_, err := decryptTxBlob([]byte("invalid_tx_blob"))
 	if err == nil {
-		t.Fatal("did not error on invalid rollup")
+		t.Fatal("did not error on invalid transaction blob")
 	}
 }
 
-// Generates an encrypted rollup in hex encoding.
-func generateEncryptedRollupHex() []byte {
-	rollup := core.NewRollup(
-		common.BigToHash(big.NewInt(0)),
-		nil,
-		obscurocommon.L2GenesisHeight,
-		common.HexToAddress("0x0"),
-		[]*nodecommon.L2Tx{},
-		[]nodecommon.Withdrawal{},
-		expectedNonce,
-		common.BigToHash(big.NewInt(0)),
-	)
-	rollupTx := &obscurocommon.L1RollupTx{
-		Rollup: nodecommon.EncodeRollup(rollup.ToExtRollup(core.NewTransactionBlobCryptoImpl()).ToRollup()),
-	}
-
-	mgmtContractAddress := common.BigToAddress(big.NewInt(0))
-	mgmtContractLib := mgmtcontractlib.NewMgmtContractLib(&mgmtContractAddress)
-	rollupTxData := mgmtContractLib.CreateRollup(rollupTx, 0)
-
-	prvKey, err := crypto.GenerateKey()
-	if err != nil {
-		panic(err)
-	}
-	signedRollupTx, err := types.SignNewTx(prvKey, types.NewEIP155Signer(big.NewInt(0)), rollupTxData)
-	if err != nil {
-		panic(err)
-	}
-
-	encryptedRollupHex := common.Bytes2Hex(signedRollupTx.Data())
-	return []byte(encryptedRollupHex)
+// Generates an encrypted transaction blob in Base64 encoding.
+func generateEncryptedTxBlob(txs []*nodecommon.L2Tx) []byte {
+	txBlob := core.NewTransactionBlobCryptoImpl().Encrypt(txs)
+	return []byte(base64.StdEncoding.EncodeToString(txBlob))
 }

--- a/tools/obscuroscan/obscuroscan_test.go
+++ b/tools/obscuroscan/obscuroscan_test.go
@@ -19,11 +19,6 @@ import (
 const expectedNonce = 777
 
 func TestCanDecryptRollup(t *testing.T) {
-	contractABI, err := abi.JSON(strings.NewReader(mgmtcontractlib.MgmtContractABI))
-	if err != nil {
-		panic(err)
-	}
-
 	rollupJSON, err := decryptRollup(generateEncryptedRollupHex(), contractABI)
 	if err != nil {
 		t.Fatalf("rollup decryption failed. Cause: %s", err)

--- a/tools/obscuroscan/obscuroscan_test.go
+++ b/tools/obscuroscan/obscuroscan_test.go
@@ -3,8 +3,9 @@ package obscuroscan
 import (
 	"encoding/base64"
 	"encoding/json"
-	"github.com/obscuronet/obscuro-playground/integration/datagenerator"
 	"testing"
+
+	"github.com/obscuronet/obscuro-playground/integration/datagenerator"
 
 	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/core"
 	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"

--- a/tools/obscuroscan/static/block_decoder.html
+++ b/tools/obscuroscan/static/block_decoder.html
@@ -10,24 +10,20 @@
 
 <body>
 
-<h2>Decrypt rollup transactions retrieved from the L1 (e.g. via Etherscan)</h2>
+<h2>Decrypt transaction blobs retrieved from the rollups</h2>
 
 <p>
-    Note that decrypting rollups is only possible on testnet, for which the rollup encryption key is long-lived and
-    well-known. On mainnet, enclaves will use rotating keys that are not known to anyone - or anything - other
-    than the Obscuro enclaves.
+    Note that decrypting transaction blobs is only possible on testnet, for which the rollup encryption key is
+    long-lived and well-known. On mainnet, rollups will use rotating keys that are not known to anyone - or anything -
+    other than the Obscuro enclaves.
 </p>
 
 <hr>
 
-<form id="form-decrypt-rollup">
+<form id="form-decrypt-tx-blob">
     <p>
-        <label>Enclave secret key:</label>
-        <textarea rows="5" cols="80"></textarea>
-    </p>
-    <p>
-        <label>Rollup to decrypt (encoded in hexadecimal):</label>
-        <textarea rows="10" cols="80" id="encryptedRollup"></textarea>
+        <label>Transaction blob to decrypt (encoded in Base64):</label>
+        <textarea rows="10" cols="80" id="encryptedTxBlob"></textarea>
     </p>
 
     <p>
@@ -36,8 +32,8 @@
 </form>
 
 <p>
-<div>Decrypted rollup:</div>
-<pre id="decryptedRollup">N/A</pre>
+<div>Decrypted transactions:</div>
+<pre id="decryptedTxs">N/A</pre>
 </p>
 
 </body>

--- a/tools/obscuroscan/static/block_decoder.js
+++ b/tools/obscuroscan/static/block_decoder.js
@@ -2,29 +2,29 @@
 
 const eventDomLoaded = "DOMContentLoaded";
 const typeSubmit = "submit"
-const idFormDecryptRollup = "form-decrypt-rollup"
-const idDecryptedRollup = "decryptedRollup";
-const idEncryptedRollup = "encryptedRollup";
-const pathDecryptRollup = "/decryptrollup/";
+const idFormDecryptTxBlob = "form-decrypt-tx-blob"
+const idDecryptedTxs = "decryptedTxs";
+const idEncryptedTxBlob = "encryptedTxBlob";
+const pathDecryptTxBlob = "/decrypttxblob/";
 const methodPost = "POST";
 
 const initialize = () => {
-    const decryptedRollupArea = document.getElementById(idDecryptedRollup);
+    const decryptedTxsArea = document.getElementById(idDecryptedTxs);
 
-    document.getElementById(idFormDecryptRollup).addEventListener(typeSubmit, async (event) => {
+    document.getElementById(idFormDecryptTxBlob).addEventListener(typeSubmit, async (event) => {
         event.preventDefault();
 
-        const encryptedRollup = document.getElementById(idEncryptedRollup).value
-        const decryptRollupResp = await fetch(pathDecryptRollup, {
+        const encryptedTxBlob = document.getElementById(idEncryptedTxBlob).value
+        const decryptTxBlobResp = await fetch(pathDecryptTxBlob, {
             method: methodPost,
-            body: encryptedRollup
+            body: encryptedTxBlob
         });
 
-        if (decryptRollupResp.ok) {
-            const json = JSON.parse(await decryptRollupResp.text())
-            decryptedRollupArea.innerText = JSON.stringify(json, null, "\t");
+        if (decryptTxBlobResp.ok) {
+            const json = JSON.parse(await decryptTxBlobResp.text())
+            decryptedTxsArea.innerText = JSON.stringify(json, null, "\t");
         } else {
-            decryptedRollupArea.innerText = "Failed to decrypt rollup. Cause: " + await decryptRollupResp.text()
+            decryptedTxsArea.innerText = "Failed to decrypt transaction blob. Cause: " + await decryptTxBlobResp.text()
         }
     })
 }

--- a/tools/obscuroscan/static/index.html
+++ b/tools/obscuroscan/static/index.html
@@ -18,7 +18,7 @@ Choose from one of the options below:
 </p>
 
 <p>
-    <a href="./block_decoder.html">Decrypt rollup transactions retrieved from the L1 (testnet only!)</a>
+    <a href="./block_decoder.html">Decrypt rollup transaction blobs (testnet only!)</a>
 </p>
 
 </body>


### PR DESCRIPTION
### Why is this change needed?

https://github.com/obscuronet/obscuro-internal/issues/508

The existing Obscuroscan design assumed that the entire rollup would be encrypted, rather than just the transactions.

Obscuroscan now decrypts encrypted tx blobs instead. These can be grabbed via the monitor page.

### What changes were made as part of this PR:

Functional.

- Updated Obscuroscan so that encrypted transaction blobs could be decrypted
- Removed the fake UI box where the enclave private key was supposed to be pasted, as not needed for now

### What are the key areas to look at
