### PR TITLE
Testnet: Manual Github Action to deploy a geth network ( Second Part )

### DIFF
--- a/.github/workflows/manual-deploy-l1network.yml
+++ b/.github/workflows/manual-deploy-l1network.yml
@@ -36,4 +36,4 @@ jobs:
         with:
           push: true
           tags: obscuronet/obscuro_testnet_l1network:latest
-          file: {context}/testnet/gethnetwork.Dockerfile
+          file: ./testnet/gethnetwork.Dockerfile

--- a/.github/workflows/manual-deploy-l1network.yml
+++ b/.github/workflows/manual-deploy-l1network.yml
@@ -1,4 +1,3 @@
-name: Manual Deploy L1 network
 # Deploys a L1 network on Azure for Testnet
 # Builds the l1 network image, kills any running container, pushes the image to dockerhub and starts the l1 network on azure
 #
@@ -12,6 +11,7 @@ name: Manual Deploy L1 network
 #  geth1.testnet.obscu.ro
 #  geth2.testnet.obscu.ro
 
+name: Manual Deploy L1 network
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
### Why is this change needed?

- [Ticket](https://github.com/obscuronet/obscuro-internal/issues/543)
- Manually deploys an l1 network to the testnet machines in azure ( First part )
- This change will add a manual action that allows to trigger the functionality

### What changes were made as part of this PR:

- Adds a docker file that can run a geth network
- Adds a Github manual action that can start a network
- Pushes the image to dockerhub 
- Functional

### What are the key areas to look at
- Github action files
- Dockerfile on the testnet folder ( the folder might be removed if it has few files)