### PR TITLE
Testnet: Manual Github Action to deploy a geth network ( Third Part )

### DIFF
--- a/.github/workflows/manual-deploy-l1network.yml
+++ b/.github/workflows/manual-deploy-l1network.yml
@@ -17,7 +17,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  deploy:
+  build-and-deploy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -25,6 +25,7 @@ jobs:
       - name: Set up Docker
         uses: docker/setup-buildx-action@v1
 
+# to be used when our dockerhub account is fixed
 #      - name: Login to DockerHub
 #        uses: docker/login-action@v2
 #        with:
@@ -49,9 +50,6 @@ jobs:
           login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
-#    - run: |
-#        docker build . -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/sampleapp:${{ github.sha }}
-#        docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/sampleapp:${{ github.sha }}
       - run: |
           docker build -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/obscuro_testnet_l1network:latest -f testnet/gethnetwork.Dockerfile  .
           docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/obscuro_testnet_l1network:latest
@@ -60,12 +58,15 @@ jobs:
         uses: 'azure/aci-deploy@v1'
         with:
           resource-group: ${{ secrets.RESOURCE_GROUP }}
-          dns-name-label: ${{ secrets.RESOURCE_GROUP }}${{ github.run_number }}
+          dns-name-label: testnet-obscuro${{ github.run_number }}
           image: ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/obscuro_testnet_l1network:latest
           registry-login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
           registry-username: ${{ secrets.REGISTRY_USERNAME }}
           registry-password: ${{ secrets.REGISTRY_PASSWORD }}
           name: testnet-app
           location: 'uksouth'
+          ports: [8025 8026 8027 9001 9002 9003]
+          cpu: 2
+          memory: 4
 
 

--- a/.github/workflows/manual-deploy-l1network.yml
+++ b/.github/workflows/manual-deploy-l1network.yml
@@ -65,6 +65,7 @@ jobs:
           registry-password: ${{ secrets.REGISTRY_PASSWORD }}
           name: testnet-app
           location: 'uksouth'
+          restart-policy: 'Never'
           ports: '8025 8026 8027 9001 9002 9003'
           cpu: 2
           memory: 4

--- a/.github/workflows/manual-deploy-l1network.yml
+++ b/.github/workflows/manual-deploy-l1network.yml
@@ -65,13 +65,7 @@ jobs:
           registry-password: ${{ secrets.REGISTRY_PASSWORD }}
           name: testnet-app
           location: 'uksouth'
-          ports:
-            - 8025
-            - 8026
-            - 8027
-            - 9001
-            - 9002
-            - 9003
+          ports: '8025 8026 8027 9001 9002 9003'
           cpu: 2
           memory: 4
 

--- a/.github/workflows/manual-deploy-l1network.yml
+++ b/.github/workflows/manual-deploy-l1network.yml
@@ -65,7 +65,13 @@ jobs:
           registry-password: ${{ secrets.REGISTRY_PASSWORD }}
           name: testnet-app
           location: 'uksouth'
-          ports: [8025 8026 8027 9001 9002 9003]
+          ports:
+            - 8025
+            - 8026
+            - 8027
+            - 9001
+            - 9002
+            - 9003
           cpu: 2
           memory: 4
 

--- a/.github/workflows/manual-deploy-l1network.yml
+++ b/.github/workflows/manual-deploy-l1network.yml
@@ -53,7 +53,7 @@ jobs:
 #        docker build . -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/sampleapp:${{ github.sha }}
 #        docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/sampleapp:${{ github.sha }}
       - run: |
-          docker build . -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/obscuro_testnet_l1network:latest
+          docker build -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/obscuro_testnet_l1network:latest -f testnet/gethnetwork.Dockerfile  .
           docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/obscuro_testnet_l1network:latest
 
       - name: 'Deploy to Azure Container Instances'

--- a/.github/workflows/manual-deploy-l1network.yml
+++ b/.github/workflows/manual-deploy-l1network.yml
@@ -25,15 +25,47 @@ jobs:
       - name: Set up Docker
         uses: docker/setup-buildx-action@v1
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+#      - name: Login to DockerHub
+#        uses: docker/login-action@v2
+#        with:
+#          username: ${{ secrets.DOCKERHUB_USERNAME }}
+#          password: ${{ secrets.DOCKERHUB_TOKEN }}
+#
+#      - name: Build and push
+#        uses: docker/build-push-action@v3
+#        with:
+#          push: true
+#          tags: obscuronet/obscuro_testnet_l1network:latest
+#          file: ./testnet/gethnetwork.Dockerfile
 
-      - name: Build and push
-        uses: docker/build-push-action@v3
+      - name: 'Login via Azure CLI'
+        uses: azure/login@v1
         with:
-          push: true
-          tags: obscuronet/obscuro_testnet_l1network:latest
-          file: ./testnet/gethnetwork.Dockerfile
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: 'Build and push image'
+        uses: azure/docker-login@v1
+        with:
+          login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+#    - run: |
+#        docker build . -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/sampleapp:${{ github.sha }}
+#        docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/sampleapp:${{ github.sha }}
+      - run: |
+          docker build . -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/obscuro_testnet_l1network:latest
+          docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/obscuro_testnet_l1network:latest
+
+      - name: 'Deploy to Azure Container Instances'
+        uses: 'azure/aci-deploy@v1'
+        with:
+          resource-group: ${{ secrets.RESOURCE_GROUP }}
+          dns-name-label: ${{ secrets.RESOURCE_GROUP }}${{ github.run_number }}
+          image: ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/obscuro_testnet_l1network:latest
+          registry-login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
+          registry-username: ${{ secrets.REGISTRY_USERNAME }}
+          registry-password: ${{ secrets.REGISTRY_PASSWORD }}
+          name: testnet-app
+          location: 'uksouth'
+
+

--- a/integration/gethnetwork/geth_network.go
+++ b/integration/gethnetwork/geth_network.go
@@ -43,7 +43,7 @@ const (
 	portFlag           = "--port"
 	httpEnableFlag     = "--http"
 	httpPortFlag       = "--http.port"
-	httpIPFlag         = "--http.addr"
+	httpAddrFlag       = "--http.addr"
 	httpEnableApis     = "--http.api"
 	allowedAPIs        = "personal,eth,net,web3,debug"
 	allowCORSDomain    = "--http.corsdomain"
@@ -52,6 +52,7 @@ const (
 	unlockInsecureFlag = "--allow-insecure-unlock"
 	websocketFlag      = "--ws" // Enables websocket connections to the node.
 	wsPortFlag         = "--ws.port"
+	wsAddrFlag         = "--ws.addr"
 	gasLimitFlag       = "--miner.gaslimit=2000000000" // Ensures the miners don't gradually reduce the block gas limit.
 
 	// syncModeFlag defines the node block sync approach
@@ -344,7 +345,7 @@ func (network *GethNetwork) startMiner(dataDirPath string, idx int) {
 		strconv.Itoa(port), unlockInsecureFlag, unlockFlag, network.addresses[idx], passwordFlag,
 		network.passwordFilePath, mineFlag, rpcFeeCapFlag, syncModeFlag,
 		httpEnableFlag, httpPortFlag, strconv.Itoa(httpPort), httpEnableApis, allowedAPIs, allowCORSDomain, "*",
-		httpIPFlag, "0.0.0.0", gasLimitFlag,
+		httpAddrFlag, "*", wsAddrFlag, "*", gasLimitFlag,
 	}
 	cmd := exec.Command(network.gethBinaryPath, args...) // nolint
 

--- a/integration/gethnetwork/geth_network.go
+++ b/integration/gethnetwork/geth_network.go
@@ -44,6 +44,7 @@ const (
 	httpEnableFlag     = "--http"
 	httpPortFlag       = "--http.port"
 	httpAddrFlag       = "--http.addr"
+	httpVhostsFlag     = "--http.vhosts"
 	httpEnableApis     = "--http.api"
 	allowedAPIs        = "personal,eth,net,web3,debug"
 	allowCORSDomain    = "--http.corsdomain"
@@ -345,7 +346,7 @@ func (network *GethNetwork) startMiner(dataDirPath string, idx int) {
 		strconv.Itoa(port), unlockInsecureFlag, unlockFlag, network.addresses[idx], passwordFlag,
 		network.passwordFilePath, mineFlag, rpcFeeCapFlag, syncModeFlag,
 		httpEnableFlag, httpPortFlag, strconv.Itoa(httpPort), httpEnableApis, allowedAPIs, allowCORSDomain, "*",
-		httpAddrFlag, "*", wsAddrFlag, "*", gasLimitFlag,
+		httpAddrFlag, "0.0.0.0", wsAddrFlag, "0.0.0.0", httpVhostsFlag, "*", gasLimitFlag,
 	}
 	cmd := exec.Command(network.gethBinaryPath, args...) // nolint
 


### PR DESCRIPTION
### Why is this change needed?

- [Ticket](https://github.com/obscuronet/obscuro-internal/issues/543)
- Manually deploys an l1 network to the testnet machines in azure ( First part )
- This change will add a manual action that allows to trigger the functionality

### What changes were made as part of this PR:

- Adds a docker file that can run a geth network
- Adds a Github manual action that can start a network
- Pushes the image to azure container registry 
- Functional

### What are the key areas to look at
- Github action files
- Dockerfile on the testnet folder ( the folder might be removed if it has few files)