### PR TITLE
Enclave SQL: Fix binary length bug and column naming

### DIFF
--- a/go/obscuronode/enclave/sql/sql.go
+++ b/go/obscuronode/enclave/sql/sql.go
@@ -9,10 +9,10 @@ import (
 )
 
 const (
-	getQry    = `select kv.value from kv where kv.key = ?;`
-	putQry    = `insert or replace into kv values(?, ?);`
-	delQry    = `delete from kv where kv.key = ?;`
-	searchQry = `select * from kv where substring(kv.key, 1, ?) = ? and kv.key >= ? order by kv.key asc`
+	getQry    = `select keyvalue.val from keyvalue where keyvalue.ky = ?;`
+	putQry    = `insert or replace into keyvalue values(?, ?);`
+	delQry    = `delete from keyvalue where keyvalue.ky = ?;`
+	searchQry = `select * from keyvalue where substring(keyvalue.ky, 1, ?) = ? and keyvalue.ky >= ? order by keyvalue.ky asc`
 )
 
 // sqlEthDatabase implements ethdb.Database

--- a/go/obscuronode/enclave/sql/sqlite.go
+++ b/go/obscuronode/enclave/sql/sqlite.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	tempDirName = "obscuro-persistence"
-	createQry   = `create table if not exists kv (key binary(32) primary key, value blob); delete from kv;`
+	createQry   = `create table if not exists keyvalue (ky varbinary(64) primary key, val blob); delete from keyvalue;`
 )
 
 // CreateTemporarySQLiteDB if dbPath is empty will use a random throwaway temp file,


### PR DESCRIPTION
### Why is this change needed?

- there is a bug with the 32-byte fixed length binary column that we weren't hitting. Some of the keys that geth uses are 41-bytes long and sqlite just truncates the key on insert and select, the truncated hashes always happened to match in testing

- MariaDB (underlying Edgeless DB (edb)) doesn't allow `key` to be used as a column name because it's a keyword

### What changes were made as part of this PR:

- renamed SQL columns/table to avoid the protected keyword
- Changed the key column to be varbinary of up to 64-bytes to fix the bug and avoid having to pad the 32-byte keys 

### What are the key areas to look at
- happy with the col length fix?
- any suggestions to improve the table/col names?
