### PR TITLE
Setup /data folder for enclave secure persistence

### DIFF
--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -20,3 +20,10 @@ non-simulation mode instead, run:
 Stop and remove all Obscuro docker containers:
 
     docker rm $(docker stop $(docker ps -a -q --filter ancestor=obscuro_enclave --format="{{.ID}}"))
+
+## Data directory
+The ego docker images setup a home directory in `/home/obscuro/` and within that `go-obscuro/` contains the code 
+while `data/` is used for persistence by the enclave.
+
+That `/home/obscuro/data` directory is mounted inside the enclave as `/data`, any files written to it by the enclave process
+should be sealed using the private enclave key, so it will be unreadable to anyone that accesses the container.

--- a/dockerfiles/enclave.Dockerfile
+++ b/dockerfiles/enclave.Dockerfile
@@ -1,8 +1,14 @@
 FROM ghcr.io/edgelesssys/ego-dev:latest
 
-RUN git clone https://github.com/obscuronet/obscuro-playground
-RUN cd obscuro-playground/go/obscuronode/enclave/main && ego-go build && ego sign main
+# on the container:
+#   /home/obscuro/data       contains working files for the enclave
+#   /home/obscuro/go-obscuro contains the src
+RUN mkdir /home/obscuro
+RUN mkdir /home/obscuro/data
+WORKDIR /home/obscuro
+
+RUN git clone https://github.com/obscuronet/go-obscuro
+RUN cd go-obscuro/go/obscuronode/enclave/main && ego-go build && ego sign main
 
 ENV OE_SIMULATION=1
-ENTRYPOINT ["ego", "run", "obscuro-playground/go/obscuronode/enclave/main/main"]
-EXPOSE 11000
+ENTRYPOINT ["ego", "run", "/home/obscuro/go-obscuro/go/obscuronode/enclave/main/main"]

--- a/dockerfiles/enclave_local_build.Dockerfile
+++ b/dockerfiles/enclave_local_build.Dockerfile
@@ -1,10 +1,16 @@
 FROM ghcr.io/edgelesssys/ego-dev:latest
 
+# on the container:
+#   /home/obscuro/data       contains working files for the enclave
+#   /home/obscuro/go-obscuro contains the src
+RUN mkdir /home/obscuro
+RUN mkdir /home/obscuro/data
+RUN mkdir /home/obscuro/go-obscuro
+
 # build the enclave from the current branch
-RUN mkdir /home/obscuro-playground
-COPY . /home/obscuro-playground
-RUN cd /home/obscuro-playground/go/obscuronode/enclave/main && ego-go build && ego sign main
+COPY . /home/obscuro/go-obscuro
+RUN cd /home/obscuro/go-obscuro/go/obscuronode/enclave/main && ego-go build && ego sign main
 
 ENV OE_SIMULATION=1
-ENTRYPOINT ["ego", "run", "/home/obscuro-playground/go/obscuronode/enclave/main/main"]
+ENTRYPOINT ["ego", "run", "/home/obscuro/go-obscuro/go/obscuronode/enclave/main/main"]
 EXPOSE 11000

--- a/dockerfiles/plain_go_enclave_local.Dockerfile
+++ b/dockerfiles/plain_go_enclave_local.Dockerfile
@@ -1,9 +1,18 @@
 FROM golang:1.17-alpine
 
+# on the container:
+#   /data                    contains working files for the enclave
+#   /home/obscuro/go-obscuro contains the src
+#
+# Note: on ego it maps /home/obscuro/data to /data inside the enclave,
+#   using /data here should allow us to preserve /data folder in paths inside enclave)
+RUN mkdir /data
+RUN mkdir /home/obscuro
+RUN mkdir /home/obscuro/go-obscuro
+
 # build the enclave from the current branch
-RUN mkdir /home/obscuro-playground
-COPY . /home/obscuro-playground
-WORKDIR /home/obscuro-playground/go/obscuronode/enclave/main
+COPY . /home/obscuro/go-obscuro
+WORKDIR /home/obscuro/go-obscuro/go/obscuronode/enclave/main
 RUN apk add build-base
 ENV CGO_ENABLED=1
 # Download all the dependencies

--- a/dockerfiles/plain_go_enclave_local.Dockerfile
+++ b/dockerfiles/plain_go_enclave_local.Dockerfile
@@ -4,8 +4,8 @@ FROM golang:1.17-alpine
 #   /data                    contains working files for the enclave
 #   /home/obscuro/go-obscuro contains the src
 #
-# Note: on ego it maps /home/obscuro/data to /data inside the enclave,
-#   using /data here should allow us to preserve /data folder in paths inside enclave)
+# Note: ego uses a virtual file system mount to map data directory to /data inside the enclave,
+#   for this non-ego build I'm using /data as the data dir to preserve /data folder in paths inside enclave
 RUN mkdir /data
 RUN mkdir /home/obscuro
 RUN mkdir /home/obscuro/go-obscuro

--- a/go/obscuronode/enclave/main/enclave.json
+++ b/go/obscuronode/enclave/main/enclave.json
@@ -5,5 +5,13 @@
   "heapSize": 1024,
   "executableHeap": true,
   "productID": 1,
-  "securityVersion": 1
+  "securityVersion": 1,
+  "mounts": [
+    {
+      "source": "/home/obscuro/data",
+      "target": "/data",
+      "type": "hostfs",
+      "readOnly": false
+    }
+  ]
 }


### PR DESCRIPTION
### Why is this change needed?

- The enclave needs to be able to persist certificates for connection to Edgeless DB
- Anything the enclave persists should be sealed using its built-in private keys
- We may wish to persist other things here going forwards to make enclave restart smoother (e.g. the sealed and encrypted secret)

### What changes were made as part of this PR:

- change dockerfiles to create directories `/home/obscuro/go-obscuro` for the code and `/home/obscuro/data` for the data
- change enclave.json to add a file mount, make `/home/obscuro/data` available inside the enclave as `/data` (as per https://docs.edgeless.systems/ego/#/reference/config?id=mounts)

### What are the key areas to look at
- The config change
- The dockerfile changes:
-- I have tested the enclave_local_build on the SGX server as part of my edb branch testing
-- I'll watch the build for this PR closely, it will build and test the enclave.Dockerfile
-- I haven't tested the plain_go dockerfile, I think it's probably just used ad-hoc for specific issue testing?