### PR TITLE
Retrieves network peers from L1

### DIFF
--- a/go/ethclient/interface.go
+++ b/go/ethclient/interface.go
@@ -3,6 +3,8 @@ package ethclient
 import (
 	"math/big"
 
+	"github.com/ethereum/go-ethereum"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -24,6 +26,8 @@ type EthClient interface {
 	IsBlockAncestor(block *types.Block, proof obscurocommon.L1RootHash) bool // returns if the node considers a block the ancestor
 	RPCBlockchainFeed() []*types.Block                                       // returns all blocks from genesis to head
 	BlockListener() chan *types.Header                                       // subscribes to new blocks and returns a listener with the blocks heads
+
+	CallContract(msg ethereum.CallMsg) ([]byte, error) // Runs the provided call message on the latest block.
 
 	Stop() // tries to cleanly stop the client and release any resources
 

--- a/go/ethclient/l1_client.go
+++ b/go/ethclient/l1_client.go
@@ -6,6 +6,8 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/ethereum/go-ethereum"
+
 	"github.com/obscuronet/obscuro-playground/go/obscuronode/config"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -156,6 +158,10 @@ func (e *gethRPCClient) BlockByNumber(n *big.Int) (*types.Block, error) {
 
 func (e *gethRPCClient) BlockByHash(hash common.Hash) (*types.Block, error) {
 	return e.client.BlockByHash(context.Background(), hash)
+}
+
+func (e *gethRPCClient) CallContract(msg ethereum.CallMsg) ([]byte, error) {
+	return e.client.CallContract(context.Background(), msg, nil)
 }
 
 func (e *gethRPCClient) EthClient() *ethclient.Client {

--- a/go/obscuronode/config/host_config.go
+++ b/go/obscuronode/config/host_config.go
@@ -38,8 +38,6 @@ type HostConfig struct {
 	EnclaveRPCTimeout time.Duration
 	// Our network for P2P communication with peer Obscuro nodes
 	P2PAddress string
-	// The addresses of all the Obscuro nodes on the network
-	AllP2PAddresses []string
 	// The host of the connected L1 node
 	L1NodeHost string
 	// The websocket port of the connected L1 node
@@ -71,7 +69,6 @@ func DefaultHostConfig() HostConfig {
 		EnclaveRPCAddress:      "127.0.0.1:11000",
 		EnclaveRPCTimeout:      time.Duration(defaultRPCTimeoutSecs) * time.Second,
 		P2PAddress:             "127.0.0.1:10000",
-		AllP2PAddresses:        []string{},
 		L1NodeHost:             "127.0.0.1",
 		L1NodeWebsocketPort:    8546,
 		L1ConnectionTimeout:    time.Duration(defaultL1ConnectionTimeoutSecs) * time.Second,

--- a/go/obscuronode/host/host.go
+++ b/go/obscuronode/host/host.go
@@ -338,7 +338,7 @@ func (a *Node) processBlocks(blocks []obscurocommon.EncodedBlock, interrupt *int
 	for _, block := range blocks {
 		// For the genesis block the parent is nil
 		if block != nil {
-			a.handleBlock(block)
+			a.processBlock(block)
 
 			// submit each block to the enclave for ingestion plus validation
 			result = a.EnclaveClient.SubmitBlock(*block.DecodeBlock())
@@ -360,8 +360,8 @@ func (a *Node) processBlocks(blocks []obscurocommon.EncodedBlock, interrupt *int
 	}
 }
 
-// Looks at each transaction in the block, and kicks off special handling based on the transaction if needed.
-func (a *Node) handleBlock(block obscurocommon.EncodedBlock) {
+// Looks at each transaction in the block, and kicks off special handling for the transaction if needed.
+func (a *Node) processBlock(block obscurocommon.EncodedBlock) {
 	b := block.DecodeBlock()
 	for _, tx := range b.Transactions() {
 		t := a.mgmtContractLib.DecodeTx(tx)

--- a/go/obscuronode/host/host.go
+++ b/go/obscuronode/host/host.go
@@ -1,12 +1,10 @@
 package host
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"math/big"
-	"strings"
 	"sync/atomic"
 	"time"
 
@@ -536,7 +534,7 @@ func (a *Node) processSharedSecretResponse(_ *obscurocommon.L1RespondSecretTx) e
 	if err != nil {
 		return err
 	}
-	response, err := a.ethClient.EthClient().CallContract(context.Background(), msg, nil)
+	response, err := a.ethClient.CallContract(msg)
 	if err != nil {
 		return err
 	}
@@ -565,9 +563,6 @@ func (a *Node) processSharedSecretResponse(_ *obscurocommon.L1RespondSecretTx) e
 
 	// We update our list of peer addresses.
 	a.config.AllP2PAddresses = noDupsHostAddresses
-
-	// todo - joel - delete this
-	println("hey jjj what's up?", strings.Join(a.config.AllP2PAddresses, ", "))
 
 	return nil
 }

--- a/go/obscuronode/host/hostrunner/cli.go
+++ b/go/obscuronode/host/hostrunner/cli.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math/big"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/naoina/toml"
@@ -27,7 +26,6 @@ type HostConfigToml struct {
 	EnclaveRPCAddress       string
 	EnclaveRPCTimeoutSecs   int
 	P2PAddress              string
-	PeerP2PAddresses        []string
 	L1NodeHost              string
 	L1NodePort              uint
 	L1ConnectionTimeoutSecs int
@@ -53,7 +51,6 @@ func ParseConfig() config.HostConfig {
 	enclaveRPCAddress := flag.String(enclaveRPCAddressName, defaultConfig.EnclaveRPCAddress, enclaveRPCAddressUsage)
 	enclaveRPCTimeoutSecs := flag.Uint64(enclaveRPCTimeoutSecsName, uint64(defaultConfig.EnclaveRPCTimeout.Seconds()), enclaveRPCTimeoutSecsUsage)
 	p2pAddress := flag.String(p2pAddressName, defaultConfig.P2PAddress, p2pAddressUsage)
-	allP2PAddresses := flag.String(peerP2PAddressesName, "", peerP2PAddrsUsage)
 	l1NodeHost := flag.String(l1NodeHostName, defaultConfig.L1NodeHost, l1NodeHostUsage)
 	l1NodePort := flag.Uint64(l1NodePortName, uint64(defaultConfig.L1NodeWebsocketPort), l1NodePortUsage)
 	l1ConnectionTimeoutSecs := flag.Uint64(l1ConnectionTimeoutSecsName, uint64(defaultConfig.L1ConnectionTimeout.Seconds()), l1ConnectionTimeoutSecsUsage)
@@ -68,12 +65,6 @@ func ParseConfig() config.HostConfig {
 		return fileBasedConfig(*configPath)
 	}
 
-	parsedP2PAddrs := strings.Split(*allP2PAddresses, ",")
-	if *allP2PAddresses == "" {
-		// We handle the special case of an empty list.
-		parsedP2PAddrs = []string{}
-	}
-
 	defaultConfig.ID = common.HexToAddress(*nodeID)
 	defaultConfig.IsGenesis = *isGenesis
 	defaultConfig.GossipRoundDuration = time.Duration(*gossipRoundNanos)
@@ -86,7 +77,6 @@ func ParseConfig() config.HostConfig {
 	defaultConfig.EnclaveRPCAddress = *enclaveRPCAddress
 	defaultConfig.EnclaveRPCTimeout = time.Duration(*clientRPCTimeoutSecs) * time.Second
 	defaultConfig.P2PAddress = *p2pAddress
-	defaultConfig.AllP2PAddresses = parsedP2PAddrs
 	defaultConfig.L1NodeHost = *l1NodeHost
 	defaultConfig.L1NodeWebsocketPort = uint(*l1NodePort)
 	defaultConfig.L1ConnectionTimeout = time.Duration(*l1ConnectionTimeoutSecs) * time.Second
@@ -124,7 +114,6 @@ func fileBasedConfig(configPath string) config.HostConfig {
 		EnclaveRPCAddress:      tomlConfig.EnclaveRPCAddress,
 		EnclaveRPCTimeout:      time.Duration(tomlConfig.EnclaveRPCTimeoutSecs) * time.Second,
 		P2PAddress:             tomlConfig.P2PAddress,
-		AllP2PAddresses:        tomlConfig.PeerP2PAddresses,
 		L1NodeHost:             tomlConfig.L1NodeHost,
 		L1NodeWebsocketPort:    tomlConfig.L1NodePort,
 		L1ConnectionTimeout:    time.Duration(tomlConfig.L1ConnectionTimeoutSecs) * time.Second,

--- a/go/obscuronode/host/hostrunner/cli_flags.go
+++ b/go/obscuronode/host/hostrunner/cli_flags.go
@@ -35,9 +35,6 @@ const (
 	p2pAddressName  = "p2pAddress"
 	p2pAddressUsage = "The P2P address for our node"
 
-	peerP2PAddressesName = "peerP2PAddresses"
-	peerP2PAddrsUsage    = "The P2P addresses of our peer nodes as a comma-separated list"
-
 	l1NodeHostName  = "l1NodeHost"
 	l1NodeHostUsage = "The host on which to connect to the Ethereum client"
 

--- a/go/obscuronode/host/hostrunner/test.toml
+++ b/go/obscuronode/host/hostrunner/test.toml
@@ -8,7 +8,6 @@ clientRPCTimeoutSecs = 10
 enclaveRPCAddress = "127.0.0.1:11000"
 enclaveRPCTimeoutSecs = 10
 p2pAddress = "127.0.0.1:10000"
-peerP2PAddresses = []
 l1NodeHost = "127.0.0.1"
 l1NodePort = 8546
 l1ConnectionTimeoutSecs = 15

--- a/go/obscuronode/host/interfaces.go
+++ b/go/obscuronode/host/interfaces.go
@@ -17,6 +17,7 @@ type P2PCallback interface {
 type P2P interface {
 	StartListening(callback P2PCallback)
 	StopListening() error
+	UpdatePeerList([]string)
 	BroadcastRollup(r obscurocommon.EncodedRollup)
 	BroadcastTx(tx nodecommon.EncryptedTx)
 }

--- a/go/obscuronode/host/p2p/p2p.go
+++ b/go/obscuronode/host/p2p/p2p.go
@@ -34,19 +34,10 @@ type Message struct {
 }
 
 // NewSocketP2PLayer - returns the Socket implementation of the P2P
-// allAddresses is a list of all the transaction P2P addresses on the network, possibly including ourAddress.
 func NewSocketP2PLayer(config config.HostConfig) host.P2P {
-	// We filter out our P2P address if it's contained in the list of all P2P addresses.
-	var peerAddresses []string // TODO - Retrieve host P2P addresses dynamically from management contract.
-	for _, address := range config.AllP2PAddresses {
-		if address != config.P2PAddress {
-			peerAddresses = append(peerAddresses, address)
-		}
-	}
-
 	return &p2pImpl{
 		ourAddress:    config.P2PAddress,
-		peerAddresses: peerAddresses,
+		peerAddresses: []string{},
 		nodeID:        obscurocommon.ShortAddress(config.ID),
 	}
 }

--- a/integration/ethereummock/mgmt_contract_lib.go
+++ b/integration/ethereummock/mgmt_contract_lib.go
@@ -50,11 +50,11 @@ func (m *mockContractLib) CreateInitializeSecret(tx *obscurocommon.L1InitializeS
 }
 
 func (m *mockContractLib) GetHostAddresses() (ethereum.CallMsg, error) {
-	panic("not implemented")
+	return ethereum.CallMsg{}, nil
 }
 
 func (m *mockContractLib) DecodeCallResponse([]byte) ([][]string, error) {
-	panic("not implemented")
+	return [][]string{{""}}, nil
 }
 
 func decodeTx(tx *types.Transaction) obscurocommon.L1Transaction {

--- a/integration/ethereummock/node.go
+++ b/integration/ethereummock/node.go
@@ -353,6 +353,10 @@ func (m *Node) BlocksBetween(blockA *types.Block, blockB *types.Block) []*types.
 	return result
 }
 
+func (m *Node) CallContract(ethereum.CallMsg) ([]byte, error) {
+	return nil, nil
+}
+
 func (m *Node) EthClient() *ethclient_ethereum.Client {
 	return nil
 }

--- a/integration/simulation/network/azureenclave.go
+++ b/integration/simulation/network/azureenclave.go
@@ -41,7 +41,7 @@ func NewNetworkWithAzureEnclaves(enclaveIps []string, wallets *params.SimWallets
 	}
 }
 
-func (n *networkWithAzureEnclaves) Create(params *params.SimParams, stats *stats.Stats) ([]ethclient.EthClient, []obscuroclient.Client, []string, error) {
+func (n *networkWithAzureEnclaves) Create(params *params.SimParams, stats *stats.Stats) ([]ethclient.EthClient, []obscuroclient.Client, error) {
 	params.MgmtContractAddr, params.Erc20Address, n.gethClients, n.gethNetwork = SetUpGethNetwork(
 		n.wallets,
 		params.StartPort,
@@ -68,10 +68,10 @@ func (n *networkWithAzureEnclaves) Create(params *params.SimParams, stats *stats
 		n.enclaveAddresses[i] = fmt.Sprintf("%s:%d", Localhost, params.StartPort+DefaultEnclaveOffset+i)
 	}
 
-	obscuroClients, nodeP2pAddrs := startStandaloneObscuroNodes(params, stats, n.gethClients, n.enclaveAddresses)
+	obscuroClients := startStandaloneObscuroNodes(params, stats, n.gethClients, n.enclaveAddresses)
 	n.obscuroClients = obscuroClients
 
-	return n.gethClients, n.obscuroClients, nodeP2pAddrs, nil
+	return n.gethClients, n.obscuroClients, nil
 }
 
 func (n *networkWithAzureEnclaves) TearDown() {

--- a/integration/simulation/network/dockerenclave.go
+++ b/integration/simulation/network/dockerenclave.go
@@ -55,10 +55,10 @@ func NewBasicNetworkOfNodesWithDockerEnclave(wallets *params.SimWallets) Network
 
 // Create initializes Obscuro nodes with their own Dockerised enclave servers that communicate with peers via sockets, wires them up, and populates the network objects
 // TODO - Use individual Docker containers for the Obscuro nodes and Ethereum nodes.
-func (n *basicNetworkOfNodesWithDockerEnclave) Create(params *params.SimParams, stats *stats.Stats) ([]ethclient.EthClient, []obscuroclient.Client, []string, error) {
+func (n *basicNetworkOfNodesWithDockerEnclave) Create(params *params.SimParams, stats *stats.Stats) ([]ethclient.EthClient, []obscuroclient.Client, error) {
 	// We create Docker client, and finish early if docker or the enclave image are not available.
 	if err := n.setupAndCheckDocker(); err != nil {
-		return nil, nil, nil, err
+		return nil, nil, err
 	}
 
 	// We start a geth network with all necessary contracts deployed.
@@ -80,10 +80,10 @@ func (n *basicNetworkOfNodesWithDockerEnclave) Create(params *params.SimParams, 
 	}
 
 	// Start the standalone obscuro nodes connected to the enclaves and to the geth nodes
-	obscuroClients, nodeP2pAddrs := startStandaloneObscuroNodes(params, stats, n.gethClients, n.enclaveAddresses)
+	obscuroClients := startStandaloneObscuroNodes(params, stats, n.gethClients, n.enclaveAddresses)
 	n.obscuroClients = obscuroClients
 
-	return n.gethClients, obscuroClients, nodeP2pAddrs, nil
+	return n.gethClients, obscuroClients, nil
 }
 
 func (n *basicNetworkOfNodesWithDockerEnclave) TearDown() {

--- a/integration/simulation/network/geth_network.go
+++ b/integration/simulation/network/geth_network.go
@@ -26,7 +26,7 @@ func NewNetworkInMemoryGeth(wallets *params.SimWallets) Network {
 }
 
 // Create inits and starts the nodes, wires them up, and populates the network objects
-func (n *networkInMemGeth) Create(params *params.SimParams, stats *stats.Stats) ([]ethclient.EthClient, []obscuroclient.Client, []string, error) {
+func (n *networkInMemGeth) Create(params *params.SimParams, stats *stats.Stats) ([]ethclient.EthClient, []obscuroclient.Client, error) {
 	// kickoff the network with the prefunded wallet addresses
 	params.MgmtContractAddr, params.Erc20Address, n.gethClients, n.gethNetwork = SetUpGethNetwork(
 		n.wallets,
@@ -41,7 +41,7 @@ func (n *networkInMemGeth) Create(params *params.SimParams, stats *stats.Stats) 
 	// Start the obscuro nodes and return the handles
 	n.obscuroClients = startInMemoryObscuroNodes(params, stats, n.gethNetwork.GenesisJSON, n.gethClients)
 
-	return n.gethClients, n.obscuroClients, nil, nil
+	return n.gethClients, n.obscuroClients, nil
 }
 
 func (n *networkInMemGeth) TearDown() {

--- a/integration/simulation/network/inmemory.go
+++ b/integration/simulation/network/inmemory.go
@@ -27,7 +27,7 @@ func NewBasicNetworkOfInMemoryNodes() Network {
 }
 
 // Create inits and starts the nodes, wires them up, and populates the network objects
-func (n *basicNetworkOfInMemoryNodes) Create(params *params.SimParams, stats *stats.Stats) ([]ethclient.EthClient, []obscuroclient.Client, []string, error) {
+func (n *basicNetworkOfInMemoryNodes) Create(params *params.SimParams, stats *stats.Stats) ([]ethclient.EthClient, []obscuroclient.Client, error) {
 	l1Clients := make([]ethclient.EthClient, params.NumberOfNodes)
 	n.ethNodes = make([]*ethereum_mock.Node, params.NumberOfNodes)
 	obscuroNodes := make([]*host.Node, params.NumberOfNodes)
@@ -89,7 +89,7 @@ func (n *basicNetworkOfInMemoryNodes) Create(params *params.SimParams, stats *st
 		time.Sleep(params.AvgBlockDuration / 3)
 	}
 
-	return l1Clients, n.obscuroClients, nil, nil
+	return l1Clients, n.obscuroClients, nil
 }
 
 func (n *basicNetworkOfInMemoryNodes) TearDown() {

--- a/integration/simulation/network/network.go
+++ b/integration/simulation/network/network.go
@@ -14,9 +14,9 @@ import (
 // - Once we implement a few more versions: for example using Geth, or using enclaves running in azure, etc, we'll revisit and create better abstractions.
 // TODO Decompose the network so we can pick and choose different types of l1 and obscuro nodes
 type Network interface {
-	// Create - returns the started Ethereum nodes, the started Obscuro node clients, and the Obscuro nodes' P2P addresses.
+	// Create - returns the started Ethereum nodes and the started Obscuro node clients.
 	// Responsible with spinning up all resources required for the test
 	// Return an error in case it cannot start for an expected reason. Otherwise it panics.
-	Create(params *params.SimParams, stats *stats.Stats) ([]ethclient.EthClient, []obscuroclient.Client, []string, error)
+	Create(params *params.SimParams, stats *stats.Stats) ([]ethclient.EthClient, []obscuroclient.Client, error)
 	TearDown()
 }

--- a/integration/simulation/network/network_utils.go
+++ b/integration/simulation/network/network_utils.go
@@ -104,7 +104,6 @@ func createSocketObscuroNode(
 	avgGossipPeriod time.Duration,
 	stats *stats.Stats,
 	p2pAddr string,
-	peerAddrs []string,
 	enclaveAddr string,
 	clientRPCHost string,
 	clientRPCPortHTTP uint64,
@@ -126,7 +125,6 @@ func createSocketObscuroNode(
 		EnclaveRPCTimeout:      ClientRPCTimeoutSecs * time.Second,
 		EnclaveRPCAddress:      enclaveAddr,
 		P2PAddress:             p2pAddr,
-		AllP2PAddresses:        peerAddrs,
 		ChainID:                config.DefaultHostConfig().ChainID,
 	}
 

--- a/integration/simulation/network/obscuro_node_utils.go
+++ b/integration/simulation/network/obscuro_node_utils.go
@@ -63,17 +63,10 @@ func startInMemoryObscuroNodes(params *params.SimParams, stats *stats.Stats, gen
 	return obscuroClients
 }
 
-func startStandaloneObscuroNodes(params *params.SimParams, stats *stats.Stats, gethClients []ethclient.EthClient, enclaveAddresses []string) ([]obscuroclient.Client, []string) {
+func startStandaloneObscuroNodes(params *params.SimParams, stats *stats.Stats, gethClients []ethclient.EthClient, enclaveAddresses []string) []obscuroclient.Client {
 	// handle to the obscuro clients
 	obscuroClients := make([]obscuroclient.Client, params.NumberOfNodes)
-
 	obscuroNodes := make([]*host.Node, params.NumberOfNodes)
-	nodeP2pAddrs := make([]string, params.NumberOfNodes)
-
-	for i := 0; i < params.NumberOfNodes; i++ {
-		// We assign a P2P address to each node on the network according to the convention.
-		nodeP2pAddrs[i] = fmt.Sprintf("%s:%d", Localhost, params.StartPort+DefaultHostP2pOffset+i)
-	}
 
 	for i := 0; i < params.NumberOfNodes; i++ {
 		isGenesis := i == 0
@@ -88,8 +81,7 @@ func startStandaloneObscuroNodes(params *params.SimParams, stats *stats.Stats, g
 			isGenesis,
 			params.AvgGossipPeriod,
 			stats,
-			nodeP2pAddrs[i],
-			nodeP2pAddrs,
+			fmt.Sprintf("%s:%d", Localhost, params.StartPort+DefaultHostP2pOffset+i),
 			enclaveAddresses[i],
 			Localhost,
 			uint64(nodeRPCPortHTTP),
@@ -123,7 +115,7 @@ func startStandaloneObscuroNodes(params *params.SimParams, stats *stats.Stats, g
 		}
 	}
 
-	return obscuroClients, nodeP2pAddrs
+	return obscuroClients
 }
 
 func startRemoteEnclaveServers(startAt int, params *params.SimParams, stats *stats.Stats) {

--- a/integration/simulation/network/socket.go
+++ b/integration/simulation/network/socket.go
@@ -33,7 +33,7 @@ func NewNetworkOfSocketNodes(wallets *params.SimWallets) Network {
 	}
 }
 
-func (n *networkOfSocketNodes) Create(params *params.SimParams, stats *stats.Stats) ([]ethclient.EthClient, []obscuroclient.Client, []string, error) {
+func (n *networkOfSocketNodes) Create(params *params.SimParams, stats *stats.Stats) ([]ethclient.EthClient, []obscuroclient.Client, error) {
 	// kickoff the network with the prefunded wallet addresses
 	params.MgmtContractAddr, params.Erc20Address, n.gethClients, n.gethNetwork = SetUpGethNetwork(
 		n.wallets,
@@ -53,10 +53,10 @@ func (n *networkOfSocketNodes) Create(params *params.SimParams, stats *stats.Sta
 		n.enclaveAddresses[i] = fmt.Sprintf("%s:%d", Localhost, params.StartPort+DefaultEnclaveOffset+i)
 	}
 
-	obscuroClients, nodeP2pAddrs := startStandaloneObscuroNodes(params, stats, n.gethClients, n.enclaveAddresses)
+	obscuroClients := startStandaloneObscuroNodes(params, stats, n.gethClients, n.enclaveAddresses)
 	n.obscuroClients = obscuroClients
 
-	return n.gethClients, n.obscuroClients, nodeP2pAddrs, nil
+	return n.gethClients, n.obscuroClients, nil
 }
 
 func (n *networkOfSocketNodes) TearDown() {

--- a/integration/simulation/p2p/mock_l2_network.go
+++ b/integration/simulation/p2p/mock_l2_network.go
@@ -42,6 +42,10 @@ func (netw *MockP2P) StopListening() error {
 	return nil
 }
 
+func (netw *MockP2P) UpdatePeerList([]string) {
+	// Do nothing.
+}
+
 // BroadcastRollup Broadcasts the rollup to all L2 peers
 func (netw *MockP2P) BroadcastRollup(r obscurocommon.EncodedRollup) {
 	if atomic.LoadInt32(netw.listenerInterrupt) == 1 {

--- a/integration/simulation/simulation.go
+++ b/integration/simulation/simulation.go
@@ -22,7 +22,6 @@ const initialBalance = 5000
 type Simulation struct {
 	EthClients       []ethclient.EthClient  // the list of mock ethereum clients
 	ObscuroClients   []obscuroclient.Client // the list of Obscuro host clients
-	ObscuroP2PAddrs  []string               // the P2P addresses of the Obscuro nodes
 	AvgBlockDuration uint64
 	TxInjector       *TransactionInjector
 	SimulationTime   time.Duration

--- a/integration/simulation/simulation_tester.go
+++ b/integration/simulation/simulation_tester.go
@@ -29,7 +29,7 @@ func testSimulation(t *testing.T, netw network.Network, params *params.SimParams
 	stats := stats2.NewStats(params.NumberOfNodes) // todo - temporary object used to collect metrics. Needs to be replaced with something better
 
 	defer netw.TearDown()
-	ethClients, obscuroClients, p2pAddrs, err := netw.Create(params, stats)
+	ethClients, obscuroClients, err := netw.Create(params, stats)
 	// Return early if the network was not created
 	if err != nil {
 		fmt.Printf("Could not run test: %s\n", err)
@@ -51,7 +51,6 @@ func testSimulation(t *testing.T, netw network.Network, params *params.SimParams
 	simulation := Simulation{
 		EthClients:       ethClients,
 		ObscuroClients:   obscuroClients,
-		ObscuroP2PAddrs:  p2pAddrs,
 		AvgBlockDuration: uint64(params.AvgBlockDuration),
 		TxInjector:       txInjector,
 		SimulationTime:   params.SimulationTime,

--- a/integration/walletextension/wallet_extension_test.go
+++ b/integration/walletextension/wallet_extension_test.go
@@ -489,7 +489,7 @@ func createObscuroNetwork() (func(), *ecdsa.PrivateKey, error) {
 	simStats := stats.NewStats(simParams.NumberOfNodes)
 
 	obscuroNetwork := network.NewNetworkOfSocketNodes(wallets)
-	_, l2Clients, _, err := obscuroNetwork.Create(&simParams, simStats)
+	_, l2Clients, err := obscuroNetwork.Create(&simParams, simStats)
 	if err != nil {
 		return obscuroNetwork.TearDown, nil, err
 	}

--- a/tools/azuredeployer/networkdeployer/run.sh
+++ b/tools/azuredeployer/networkdeployer/run.sh
@@ -20,7 +20,7 @@ ERC20_CONTRACT_ADDR=$(go-obscuro/tools/networkmanager/main/networkmanager --l1No
 
 sudo docker run -e OE_SIMULATION=0 --privileged -v /dev/sgx:/dev/sgx -p 127.0.0.1:11000:11000/tcp obscuro_enclave --hostID 1 --address :11000 --willAttest=true > ./run_logs.txt 2>&1 &
 sudo docker run -e OE_SIMULATION=0 --privileged -v /dev/sgx:/dev/sgx -p 127.0.0.1:11001:11000/tcp obscuro_enclave --hostID 2 --address :11000 --willAttest=true > ./run_logs.txt 2>&1 &
-go-obscuro/go/obscuronode/host/main/host --id=1 --isGenesis=true --p2pAddress=localhost:10000 --peerP2PAddresses=localhost:10001 --enclaveRPCAddress=localhost:11000 --clientRPCHost=0.0.0.0 --clientRPCPortHttp=13000 --l1NodePort=12100 --privateKey=$PRIV_KEY_ONE > ./run_logs.txt 2>&1 &
-go-obscuro/go/obscuronode/host/main/host --id=2 --isGenesis=false --p2pAddress=localhost:10001 --peerP2PAddresses=localhost:10000 --enclaveRPCAddress=localhost:11001 --clientRPCHost=localhost --clientRPCPortHttp=13001 --l1NodePort=12101 --privateKey=$PRIV_KEY_TWO > ./run_logs.txt 2>&1 &
+go-obscuro/go/obscuronode/host/main/host --id=1 --isGenesis=true --p2pAddress=localhost:10000 --enclaveRPCAddress=localhost:11000 --clientRPCHost=0.0.0.0 --clientRPCPortHttp=13000 --l1NodePort=12100 --privateKey=$PRIV_KEY_ONE > ./run_logs.txt 2>&1 &
+go-obscuro/go/obscuronode/host/main/host --id=2 --isGenesis=false --p2pAddress=localhost:10001 --enclaveRPCAddress=localhost:11001 --clientRPCHost=localhost --clientRPCPortHttp=13001 --l1NodePort=12101 --privateKey=$PRIV_KEY_TWO > ./run_logs.txt 2>&1 &
 cd go-obscuro
 sudo ./tools/obscuroscan/main/obscuroscan --rpcServerAddress=127.0.0.1:13000 --address=0.0.0.0:80 > ../run_logs.txt 2>&1 &


### PR DESCRIPTION
### Why is this change needed?

The list of network peers is now stored in the L1 contract, but our P2P layer was still using the hardcoded list.

### What changes were made as part of this PR:

Functional.

- Monitors for incoming respond-secret-request L1 transactions
- Updates the P2P layer's peer addresses based on the contents of the L1 contract
- Deletes the peer-addresses config option
- Deletes the peer-addresses variables that are passed around in the sims and are no longer used

### What are the key areas to look at
