### PR TITLE
Drops down to a single node in the wallet extension tests. Second node is not needed.

### DIFF
--- a/integration/walletextension/wallet_extension_test.go
+++ b/integration/walletextension/wallet_extension_test.go
@@ -475,9 +475,10 @@ func signViewingKey(t *testing.T, privateKey *ecdsa.PrivateKey, viewingKey []byt
 
 // Creates a single-node Obscuro network for testing, and deploys an ERC20 contract to it.
 func createObscuroNetwork() (func(), *ecdsa.PrivateKey, error) {
-	wallets := params.NewSimWallets(1, 2, 1, integration.EthereumChainID, integration.ObscuroChainID)
+	numberOfNodes := 1
+	wallets := params.NewSimWallets(1, numberOfNodes, 1, integration.EthereumChainID, integration.ObscuroChainID)
 	simParams := params.SimParams{
-		NumberOfNodes:      2,
+		NumberOfNodes:      numberOfNodes,
 		AvgBlockDuration:   1 * time.Second,
 		AvgGossipPeriod:    1 * time.Second / 3,
 		MgmtContractLib:    ethereummock.NewMgmtContractLibMock(),


### PR DESCRIPTION
### Why is this change needed?

It makes the test faster to run, and gives the sim less space for mistakes.

### What changes were made as part of this PR:

Functional.

- Creates a single node network in the wallet tests, rather than a two-node network

### What are the key areas to look at
