### PR TITLE
Harmonises use of NextNonce in transaction injector.

### DIFF
--- a/integration/simulation/transaction_injector.go
+++ b/integration/simulation/transaction_injector.go
@@ -125,7 +125,7 @@ func (ti *TransactionInjector) Start() {
 			TokenContract: ti.wallets.Tokens[evm.BTC].L1ContractAddress,
 			Sender:        &addr,
 		}
-		tx := ti.erc20ContractLib.CreateDepositTx(txData, w.GetNonceAndIncrement())
+		tx := ti.erc20ContractLib.CreateDepositTx(txData, NextNonce(ti.l2Clients[0], w))
 		signedTx, err := w.SignTransaction(tx)
 		if err != nil {
 			panic(err)
@@ -240,7 +240,7 @@ func (ti *TransactionInjector) issueRandomDeposits() {
 			TokenContract: ti.wallets.Tokens[evm.BTC].L1ContractAddress,
 			Sender:        &addr,
 		}
-		tx := ti.erc20ContractLib.CreateDepositTx(txData, ethWallet.GetNonceAndIncrement())
+		tx := ti.erc20ContractLib.CreateDepositTx(txData, NextNonce(ti.l2Clients[0], ethWallet))
 		signedTx, err := ethWallet.SignTransaction(tx)
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
### Why is this change needed?

Small PR. Makes sure `NextNonce` is used everything in `transaction_injector.go`, for consistency.

### What changes were made as part of this PR:

Refactoring.

### What are the key areas to look at
