### PR TITLE
Correct enclave flags. Use 127.0.0.1 instead of localhost.

### DIFF
--- a/tools/azuredeployer/networkdeployer/run.sh
+++ b/tools/azuredeployer/networkdeployer/run.sh
@@ -14,12 +14,15 @@ PUB_KEY_TWO_ADDR="0x2B5AD5c4795c026514f8317c7a215E218DcCD6cF"
 # additional pre-funded address in the Geth network.
 PUB_KEY_THREE_ADDR="0x6813Eb9362372EEF6200f3b1dbC3f819671cBA69"
 
+# TODO - Use real bridge ERC20 contract addresses.
+BRIDGE_ERC20_PLACEHOLDER="bad,bad"
+
 go-obscuro/integration/gethnetwork/main/geth --numNodes=2 --startPort=12000 --websocketStartPort=12100 --prefundedAddrs=$PUB_KEY_ONE_ADDR,$PUB_KEY_TWO_ADDR,$PUB_KEY_THREE_ADDR > ./run_logs.txt 2>&1 &
 MGMT_CONTRACT_ADDR=$(go-obscuro/tools/networkmanager/main/networkmanager --l1NodePort=12100 --privateKeys=$PRIV_KEY_ONE deployMgmtContract)
 ERC20_CONTRACT_ADDR=$(go-obscuro/tools/networkmanager/main/networkmanager --l1NodePort=12100 --privateKeys=$PRIV_KEY_ONE deployERC20Contract)
 
-sudo docker run -e OE_SIMULATION=0 --privileged -v /dev/sgx:/dev/sgx -p 127.0.0.1:11000:11000/tcp obscuro_enclave --hostID 1 --address :11000 --willAttest=true > ./run_logs.txt 2>&1 &
-sudo docker run -e OE_SIMULATION=0 --privileged -v /dev/sgx:/dev/sgx -p 127.0.0.1:11001:11000/tcp obscuro_enclave --hostID 2 --address :11000 --willAttest=true > ./run_logs.txt 2>&1 &
+sudo docker run -e OE_SIMULATION=0 --privileged -v /dev/sgx:/dev/sgx -p 127.0.0.1:11000:11000/tcp obscuro_enclave --hostID 1 --address :11000 --willAttest=true --erc20ContractAddresses=$BRIDGE_ERC20_PLACEHOLDER > ./run_logs.txt 2>&1 &
+sudo docker run -e OE_SIMULATION=0 --privileged -v /dev/sgx:/dev/sgx -p 127.0.0.1:11001:11000/tcp obscuro_enclave --hostID 2 --address :11000 --willAttest=true --erc20ContractAddresses=$BRIDGE_ERC20_PLACEHOLDER > ./run_logs.txt 2>&1 &
 go-obscuro/go/obscuronode/host/main/host --id=1 --isGenesis=true --p2pAddress=localhost:10000 --enclaveRPCAddress=localhost:11000 --clientRPCHost=0.0.0.0 --clientRPCPortHttp=13000 --l1NodePort=12100 --privateKey=$PRIV_KEY_ONE > ./run_logs.txt 2>&1 &
 go-obscuro/go/obscuronode/host/main/host --id=2 --isGenesis=false --p2pAddress=localhost:10001 --enclaveRPCAddress=localhost:11001 --clientRPCHost=localhost --clientRPCPortHttp=13001 --l1NodePort=12101 --privateKey=$PRIV_KEY_TWO > ./run_logs.txt 2>&1 &
 cd go-obscuro

--- a/tools/obscuroscan/main/cli.go
+++ b/tools/obscuroscan/main/cli.go
@@ -25,8 +25,8 @@ type obscuroscanConfig struct {
 func defaultObscuroClientConfig() obscuroscanConfig {
 	return obscuroscanConfig{
 		nodeID:        "",
-		rpcServerAddr: "localhost:13000",
-		address:       "localhost:3000",
+		rpcServerAddr: "127.0.0.1:13000",
+		address:       "127.0.0.1:3000",
 	}
 }
 


### PR DESCRIPTION
### Why is this change needed?

Network deployer script could not start enclaves correctly.

Obscuroscan used `localhost` in defaults, which could break things.

### What changes were made as part of this PR:

Functional.

- Fixed script
- Fixed use of localhost

### What are the key areas to look at
