### PR TITLE
gh actions ignore docs folder

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -3,6 +3,8 @@ name: Build PR
 
 on:
   pull_request:
+    paths-ignore:
+      - 'docs/**'
     branches:
       - main
 

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,6 +1,8 @@
 name: golangci-lint
 on:
   push:
+    paths-ignore:
+      - 'docs/**'
     tags:
       - v*
     branches:


### PR DESCRIPTION
### Why is this change needed?

- excludes /docs from triggering GH Actions for CI

### What changes were made as part of this PR:

-gh actions
