### PR TITLE
Smoketest checks L2 transactions

### DIFF
--- a/integration/simulation/utils.go
+++ b/integration/simulation/utils.go
@@ -104,14 +104,6 @@ func getTransaction(client rpcclientlib.Client, txHash gethcommon.Hash) *common.
 	if err != nil {
 		panic(fmt.Errorf("simulation failed due to failed %s RPC call. Cause: %w", rpcclientlib.RPCGetTransaction, err))
 	}
-
-	// We check that there is a valid receipt for each transaction, as a sanity-check.
-	txReceiptJSONMap := getTransactionReceipt(client, txHash)
-	// Per Geth's rules, a receipt is valid if: status == 1 OR root.len == 32.
-	if len(txReceiptJSONMap[jsonKeyRoot].(string)) == 0 && txReceiptJSONMap[jsonKeyStatus] == receiptStatusFailure {
-		panic(fmt.Errorf("simulation failed because transaction receipt was not created for transaction %s", txHash.Hex()))
-	}
-
 	return l2Tx
 }
 

--- a/integration/simulation/validate_chain.go
+++ b/integration/simulation/validate_chain.go
@@ -17,10 +17,14 @@ import (
 	"github.com/obscuronet/obscuro-playground/go/common"
 )
 
-// The threshold number of transactions below which we consider the simulation to have failed. We generally expect far
-// more than this, but this is a sanity check to ensure the simulation doesn't stop after a single transaction of each
-// type, for example.
-const txThreshold = 5
+const (
+	// The threshold number of transactions below which we consider the simulation to have failed. We generally expect far
+	// more than this, but this is a sanity check to ensure the simulation doesn't stop after a single transaction of each
+	// type, for example.
+	txThreshold = 5
+	// The maximum number of blocks an Obscuro node can fall behind
+	maxBlockDelay = 5
+)
 
 // After a simulation has run, check as much as possible that the outputs of the simulation are expected.
 // For example, all injected transactions were processed correctly, the height of the rollup chain is a function of the total
@@ -166,9 +170,6 @@ func ExtractDataFromEthereumChain(startBlock *types.Block, endBlock *types.Block
 	return deposits, rollups, totalDeposited, len(blockchain)
 }
 
-// MaxBlockDelay the maximum an Obscuro node can fall behind
-const MaxBlockDelay = 5
-
 func checkBlockchainOfObscuroNode(
 	t *testing.T,
 	nodeClient rpcclientlib.Client,
@@ -192,7 +193,7 @@ func checkBlockchainOfObscuroNode(
 	// We cast to int64 to avoid an overflow when l1Height is greater than maxEthereumHeight (due to additional blocks
 	// produced since maxEthereumHeight was calculated from querying all L1 nodes - the simulation is still running, so
 	// new blocks might have been added in the meantime).
-	if int64(maxEthereumHeight)-l1Height > MaxBlockDelay {
+	if int64(maxEthereumHeight)-l1Height > maxBlockDelay {
 		t.Errorf("Node %d: Obscuro node fell behind by %d blocks.", nodeAddr, maxEthereumHeight-uint64(l1Height))
 	}
 
@@ -224,26 +225,14 @@ func checkBlockchainOfObscuroNode(
 		t.Errorf("Node %d: L2 to L1 Efficiency is %f. Expected:%f", nodeAddr, efficiency, s.Params.L2ToL1EfficiencyThreshold)
 	}
 
-	// check that all expected transactions were included.
-	transfers, withdrawals := s.TxInjector.Counter.GetL2Transactions()
-	notFoundTransfers := 0
-	for _, tx := range transfers {
-		if l2tx := getTransaction(nodeClient, tx.Hash()); l2tx == nil {
-			notFoundTransfers++
-		}
-	}
+	notFoundTransfers, notFoundWithdrawals := FindNotIncludedL2Txs(nodeClient, s.TxInjector)
 	if notFoundTransfers > 0 {
-		t.Errorf("Node %d: %d out of %d Transfer Txs not found in the enclave", nodeAddr, notFoundTransfers, len(transfers))
-	}
-
-	notFoundWithdrawals := 0
-	for _, tx := range withdrawals {
-		if l2tx := getTransaction(nodeClient, tx.Hash()); l2tx == nil {
-			notFoundWithdrawals++
-		}
+		t.Errorf("Node %d: %d out of %d Transfer Txs not found in the enclave",
+			nodeAddr, notFoundTransfers, len(s.TxInjector.Counter.TransferL2Transactions))
 	}
 	if notFoundWithdrawals > 0 {
-		t.Errorf("Node %d: %d out of %d Withdrawal Txs not found in the enclave", nodeAddr, notFoundWithdrawals, len(withdrawals))
+		t.Errorf("Node %d: %d out of %d Withdrawal Txs not found in the enclave",
+			nodeAddr, notFoundWithdrawals, len(s.TxInjector.Counter.WithdrawalL2Transactions))
 	}
 
 	totalSuccessfullyWithdrawn, numberOfWithdrawalRequests := extractWithdrawals(t, nodeClient, nodeAddr)
@@ -286,6 +275,26 @@ func checkBlockchainOfObscuroNode(
 	// (execute deposits and transactions and compare to the state in the rollup)
 
 	heights[nodeIdx] = l2Height.Uint64()
+}
+
+// FindNotIncludedL2Txs returns the number of transfers and withdrawals that were injected but are not present in the L2 blockchain.
+func FindNotIncludedL2Txs(l2Client rpcclientlib.Client, txInjector *TransactionInjector) (int, int) {
+	transfers, withdrawals := txInjector.Counter.GetL2Transactions()
+	notFoundTransfers := 0
+	for _, tx := range transfers {
+		if l2tx := getTransaction(l2Client, tx.Hash()); l2tx == nil {
+			notFoundTransfers++
+		}
+	}
+
+	notFoundWithdrawals := 0
+	for _, tx := range withdrawals {
+		if l2tx := getTransaction(l2Client, tx.Hash()); l2tx == nil {
+			notFoundWithdrawals++
+		}
+	}
+
+	return notFoundTransfers, notFoundWithdrawals
 }
 
 func extractWithdrawals(t *testing.T, nodeClient rpcclientlib.Client, nodeAddr uint64) (totalSuccessfullyWithdrawn uint64, numberOfWithdrawalRequests int) {

--- a/tools/networkmanager/README.md
+++ b/tools/networkmanager/README.md
@@ -1,10 +1,11 @@
 # Network manager
 
-A tool that performs various functions for the management of an Obscuro network.
+A tool that performs various functions for the management of an Obscuro network:
 
-* Deploys the management contract to the L1, and returns its deployed address
-* Deploys the ERC20 contract to the L1, and returns its deployed address
-* Injects transactions (deposits from the L1 to the L2, transfers on the L2, and withdrawals back to the L1)
+* **Contract deployer**: Deploys the management contract and ERC20 contracts to the L1, and returns their deployed addresses
+* **Transaction injector**: Injects transactions across the L1 and L2 networks (deposits from the L1 to the L2, 
+  transfers on the L2, and withdrawals back to the L1), then reports on whether the injected transactions were 
+  successfully incorporated into the blockchain
 
 ## Usage
 

--- a/tools/networkmanager/inject_txs.go
+++ b/tools/networkmanager/inject_txs.go
@@ -41,9 +41,10 @@ func InjectTransactions(cfg Config, args []string) {
 	simStats := stats.NewStats(0)
 	mgmtContractLib := mgmtcontractlib.NewMgmtContractLib(&cfg.mgmtContractAddress)
 	erc20ContractLib := erc20contractlib.NewERC20ContractLib(&cfg.mgmtContractAddress, &cfg.erc20ContractAddress)
+	avgBlockDuration := time.Second
 
 	txInjector := simulation.NewTransactionInjector(
-		time.Second,
+		avgBlockDuration,
 		simStats,
 		[]ethadapter.EthClient{l1Client},
 		createWallets(cfg, l1Client, l2Client),
@@ -56,13 +57,14 @@ func InjectTransactions(cfg Config, args []string) {
 
 	println("Injecting transactions into network...")
 	txInjector.Start()
+	time.Sleep(5 * avgBlockDuration) // We sleep to allow transactions to propagate.
 
 	println(fmt.Sprintf("Stopped injecting transactions into network.\n"+
-		"Injected %d L1 transactions, %d L2 transfer transactions, and %d L2 withdrawal transactions.",
+		"Attempted to inject %d L1 transactions, %d L2 transfer transactions, and %d L2 withdrawal transactions.",
 		len(txInjector.Counter.L1Transactions), len(txInjector.Counter.TransferL2Transactions), len(txInjector.Counter.WithdrawalL2Transactions),
 	))
 
-	checkDepositsSuccessful(l1Client, simStats, erc20ContractLib, mgmtContractLib, startBlock)
+	checkDepositsSuccessful(txInjector, l1Client, simStats, erc20ContractLib, mgmtContractLib, startBlock)
 	checkL2TxsSuccessful(l2Client, txInjector)
 
 	os.Exit(0)
@@ -119,7 +121,7 @@ func parseNumOfTxs(args []string) int {
 	return numOfTxs
 }
 
-func checkDepositsSuccessful(l1Client ethadapter.EthClient, stats *stats.Stats, erc20ContractLib erc20contractlib.ERC20ContractLib, mgmtContractLib mgmtcontractlib.MgmtContractLib, startBlock *types.Block) {
+func checkDepositsSuccessful(txInjector *simulation.TransactionInjector, l1Client ethadapter.EthClient, stats *stats.Stats, erc20ContractLib erc20contractlib.ERC20ContractLib, mgmtContractLib mgmtcontractlib.MgmtContractLib, startBlock *types.Block) {
 	currentBlock := l1Client.FetchHeadBlock()
 	dummySim := simulation.Simulation{
 		Stats: stats,
@@ -128,27 +130,30 @@ func checkDepositsSuccessful(l1Client ethadapter.EthClient, stats *stats.Stats, 
 			MgmtContractLib:  mgmtContractLib,
 		},
 	}
-	_, _, totalDeposited, _ := simulation.ExtractDataFromEthereumChain(startBlock, currentBlock, l1Client, &dummySim) // nolint:dogsled
+	deposits, _, _, _ := simulation.ExtractDataFromEthereumChain(startBlock, currentBlock, l1Client, &dummySim) // nolint:dogsled
 
-	// todo - joel - simpler to do a straight count here
-	if totalDeposited != stats.TotalDepositedAmount {
-		println(fmt.Sprintf("Mismatch between deposit transactions injected and deposit transactions found on L1.\n"+
-			"Expected deposits of %d, found deposits of %d.", stats.TotalDepositedAmount, totalDeposited))
+	if len(deposits) != len(txInjector.Counter.L1Transactions) {
+		println(fmt.Sprintf("Injected %d deposits into the L1 but %d were missing.",
+			len(deposits), len(txInjector.Counter.L1Transactions)))
+	} else {
+		println(fmt.Sprintf("Successfully injected %d deposits into the L1.", len(deposits)))
 	}
-
-	println("Deposit transactions injected successfully found on L1.")
 }
 
 func checkL2TxsSuccessful(l2Client rpcclientlib.Client, txInjector *simulation.TransactionInjector) {
+	injectedTransfers := len(txInjector.Counter.TransferL2Transactions)
+	injectedWithdrawals := len(txInjector.Counter.WithdrawalL2Transactions)
 	notFoundTransfers, notFoundWithdrawals := simulation.FindNotIncludedL2Txs(l2Client, txInjector)
 
 	if notFoundTransfers != 0 {
-		println(fmt.Sprintf("Injected %d transfers but %d were missing on the L2.",
-			len(txInjector.Counter.TransferL2Transactions), notFoundTransfers))
+		println(fmt.Sprintf("Injected %d transfers into the L2 but %d were missing.", injectedTransfers, notFoundTransfers))
+	} else {
+		println(fmt.Sprintf("Successfully injected %d transfers into the L1.", injectedTransfers))
 	}
 
-	if notFoundTransfers != 0 {
-		println(fmt.Sprintf("Injected %d withdrawals but %d were missing on the L2.",
-			len(txInjector.Counter.WithdrawalL2Transactions), notFoundWithdrawals))
+	if notFoundWithdrawals != 0 {
+		println(fmt.Sprintf("Injected %d withdrawals into the L2 but %d were missing.", injectedWithdrawals, notFoundWithdrawals))
+	} else {
+		println(fmt.Sprintf("Successfully injected %d withdrawals into the L1.", injectedWithdrawals))
 	}
 }


### PR DESCRIPTION
### Why is this change needed?

Currently, the smoketest only checks L1 transactions. It should check L2 transactions as well.

### What changes were made as part of this PR:

Functional.

- Checks success of L2 transactions

### What are the key areas to look at
