### PR TITLE
Move test log setup to util for reuse

### DIFF
--- a/go/common/log/logutil/README.md
+++ b/go/common/log/logutil/README.md
@@ -1,0 +1,1 @@
+This package contains utils related to logging.

--- a/go/common/log/logutil/logutil.go
+++ b/go/common/log/logutil/logutil.go
@@ -1,0 +1,30 @@
+package logutil
+
+import (
+	"fmt"
+	"github.com/obscuronet/obscuro-playground/go/common/log"
+	"os"
+	"time"
+)
+
+type TestLogCfg struct {
+	LogDir      string // directory for the log file
+	TestType    string // type of test (comes before timestamp in filename so sorted file list will block these together)
+	TestSubtype string // test subtype (comes after timestamp in filename so sorted file list will show latest of different subtypes together)
+}
+
+// SetupTestLog will direct logs to a timestamped log file with a standard naming pattern, useful for simulations etc.
+func SetupTestLog(cfg *TestLogCfg) *os.File {
+	// create a folder specific for the test
+	err := os.MkdirAll(cfg.LogDir, 0o700)
+	if err != nil {
+		panic(err)
+	}
+	timeFormatted := time.Now().Format("2006-01-02_15-04-05")
+	f, err := os.CreateTemp(cfg.LogDir, fmt.Sprintf("%s-%s-%s-*.txt", cfg.TestType, timeFormatted, cfg.TestSubtype))
+	if err != nil {
+		panic(err)
+	}
+	log.OutputToFile(f)
+	return f
+}

--- a/go/common/log/logutil/logutil.go
+++ b/go/common/log/logutil/logutil.go
@@ -2,9 +2,10 @@ package logutil
 
 import (
 	"fmt"
-	"github.com/obscuronet/obscuro-playground/go/common/log"
 	"os"
 	"time"
+
+	"github.com/obscuronet/obscuro-playground/go/common/log"
 )
 
 type TestLogCfg struct {

--- a/integration/noderunner/noderunner_test.go
+++ b/integration/noderunner/noderunner_test.go
@@ -3,12 +3,11 @@ package noderunner
 import (
 	"encoding/hex"
 	"fmt"
+	"github.com/obscuronet/obscuro-playground/go/common/log/logutil"
 	"net"
 	"os"
 	"testing"
 	"time"
-
-	"github.com/obscuronet/obscuro-playground/go/common/log"
 
 	"github.com/obscuronet/obscuro-playground/go/config"
 
@@ -126,16 +125,9 @@ func tcpConnectionAvailable(addr string) bool {
 }
 
 func setupTestLog() *os.File {
-	// create a folder specific for the test
-	err := os.MkdirAll(testLogs, 0o700)
-	if err != nil {
-		panic(err)
-	}
-	timeFormatted := time.Now().Format("2006-01-02_15-04-05")
-	f, err := os.CreateTemp(testLogs, fmt.Sprintf("noderunner-%s-*.txt", timeFormatted))
-	if err != nil {
-		panic(err)
-	}
-	log.OutputToFile(f)
-	return f
+	return logutil.SetupTestLog(&logutil.TestLogCfg{
+		LogDir:      testLogs,
+		TestType:    "noderunner",
+		TestSubtype: "test",
+	})
 }

--- a/integration/noderunner/noderunner_test.go
+++ b/integration/noderunner/noderunner_test.go
@@ -3,11 +3,12 @@ package noderunner
 import (
 	"encoding/hex"
 	"fmt"
-	"github.com/obscuronet/obscuro-playground/go/common/log/logutil"
 	"net"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/obscuronet/obscuro-playground/go/common/log/logutil"
 
 	"github.com/obscuronet/obscuro-playground/go/config"
 

--- a/integration/noderunner/noderunner_test.go
+++ b/integration/noderunner/noderunner_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"net"
-	"os"
 	"testing"
 	"time"
 
@@ -35,7 +34,11 @@ const (
 
 // A smoke test to check that we can stand up a standalone Obscuro host and enclave.
 func TestCanStartStandaloneObscuroHostAndEnclave(t *testing.T) {
-	setupTestLog()
+	logutil.SetupTestLog(&logutil.TestLogCfg{
+		LogDir:      testLogs,
+		TestType:    "noderunner",
+		TestSubtype: "test",
+	})
 
 	startPort := integration.StartPortNodeRunnerTest
 	enclaveAddr := fmt.Sprintf("%s:%d", localhost, startPort)
@@ -123,12 +126,4 @@ func tcpConnectionAvailable(addr string) bool {
 	_ = conn.Close()
 	// we don't worry about failure while closing, it connected successfully so let test proceed
 	return true
-}
-
-func setupTestLog() *os.File {
-	return logutil.SetupTestLog(&logutil.TestLogCfg{
-		LogDir:      testLogs,
-		TestType:    "noderunner",
-		TestSubtype: "test",
-	})
 }

--- a/integration/simulation/simulation_azure_enclaves_test.go
+++ b/integration/simulation/simulation_azure_enclaves_test.go
@@ -30,7 +30,7 @@ func TestAzureEnclaveNodesMonteCarloSimulation(t *testing.T) {
 	if os.Getenv(azureTestEnv) == "" {
 		t.Skipf("set the variable to run this test: `%s=true`", azureTestEnv)
 	}
-	setupTestLog("azure-enclave")
+	setupSimTestLog("azure-enclave")
 
 	numberOfNodes := 1
 	numberOfSimWallets := 5

--- a/integration/simulation/simulation_docker_test.go
+++ b/integration/simulation/simulation_docker_test.go
@@ -14,7 +14,7 @@ import (
 // All nodes live in the same process, the enclaves run in individual Docker containers, and the Ethereum nodes are mocked out.
 // $> docker rm $(docker stop $(docker ps -a -q --filter ancestor=obscuro_enclave --format="{{.ID}}") will stop and remove all images
 func TestDockerNodesMonteCarloSimulation(t *testing.T) {
-	setupTestLog("docker")
+	setupSimTestLog("docker")
 
 	numberOfNodes := 5
 	numberOfSimWallets := 5

--- a/integration/simulation/simulation_full_network_test.go
+++ b/integration/simulation/simulation_full_network_test.go
@@ -15,7 +15,7 @@ import (
 // The L2 nodes communicate with each other via sockets, and with their enclave servers via RPC.
 // All nodes and enclaves live in the same process. The L1 network is a private geth network using Clique (PoA).
 func TestFullNetworkMonteCarloSimulation(t *testing.T) {
-	setupTestLog("full-network")
+	setupSimTestLog("full-network")
 
 	numberOfNodes := 5
 	numberOfSimWallets := 5

--- a/integration/simulation/simulation_geth_in_mem_test.go
+++ b/integration/simulation/simulation_geth_in_mem_test.go
@@ -12,7 +12,7 @@ import (
 
 // TestGethSimulation runs the simulation against a private geth network using Clique (PoA)
 func TestGethSimulation(t *testing.T) {
-	setupTestLog("geth-in-mem")
+	setupSimTestLog("geth-in-mem")
 
 	numberOfNodes := 5
 	numberOfSimWallets := 5

--- a/integration/simulation/simulation_in_mem_test.go
+++ b/integration/simulation/simulation_in_mem_test.go
@@ -17,7 +17,7 @@ import (
 // Everything else is reported to this value. This number has to be adjusted in conjunction with the number of nodes. If it's too low,
 // the CPU usage will be very high during the simulation which might result in inconclusive results.
 func TestInMemoryMonteCarloSimulation(t *testing.T) {
-	setupTestLog("in-mem")
+	setupSimTestLog("in-mem")
 
 	numberOfNodes := 7
 	numberOfSimWallets := 10

--- a/integration/simulation/utils.go
+++ b/integration/simulation/utils.go
@@ -3,15 +3,14 @@ package simulation
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/obscuronet/obscuro-playground/go/common/log/logutil"
-	"github.com/obscuronet/obscuro-playground/go/enclave/rollupchain"
 	"math/big"
-	"os"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/obscuronet/obscuro-playground/go/common"
+	"github.com/obscuronet/obscuro-playground/go/common/log/logutil"
+	"github.com/obscuronet/obscuro-playground/go/enclave/rollupchain"
 	"github.com/obscuronet/obscuro-playground/go/ethadapter/erc20contractlib"
 	"github.com/obscuronet/obscuro-playground/go/rpcclientlib"
 )
@@ -23,8 +22,8 @@ const (
 	receiptStatusFailure = "0x0"
 )
 
-func setupTestLog(simType string) *os.File {
-	return logutil.SetupTestLog(&logutil.TestLogCfg{
+func setupTestLog(simType string) {
+	logutil.SetupTestLog(&logutil.TestLogCfg{
 		LogDir:      testLogs,
 		TestType:    "sim-log",
 		TestSubtype: simType,

--- a/integration/simulation/utils.go
+++ b/integration/simulation/utils.go
@@ -3,13 +3,10 @@ package simulation
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/obscuronet/obscuro-playground/go/common/log/logutil"
+	"github.com/obscuronet/obscuro-playground/go/enclave/rollupchain"
 	"math/big"
 	"os"
-	"time"
-
-	"github.com/obscuronet/obscuro-playground/go/common/log"
-
-	"github.com/obscuronet/obscuro-playground/go/enclave/rollupchain"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -27,18 +24,11 @@ const (
 )
 
 func setupTestLog(simType string) *os.File {
-	// create a folder specific for the test
-	err := os.MkdirAll(testLogs, 0o700)
-	if err != nil {
-		panic(err)
-	}
-	timeFormatted := time.Now().Format("2006-01-02_15-04-05")
-	f, err := os.CreateTemp(testLogs, fmt.Sprintf("sim-log-%s-%s-*.txt", timeFormatted, simType))
-	if err != nil {
-		panic(err)
-	}
-	log.OutputToFile(f)
-	return f
+	return logutil.SetupTestLog(&logutil.TestLogCfg{
+		LogDir:      testLogs,
+		TestType:    "sim-log",
+		TestSubtype: simType,
+	})
 }
 
 func minMax(arr []uint64) (min uint64, max uint64) {

--- a/integration/simulation/utils.go
+++ b/integration/simulation/utils.go
@@ -22,7 +22,7 @@ const (
 	receiptStatusFailure = "0x0"
 )
 
-func setupTestLog(simType string) {
+func setupSimTestLog(simType string) {
 	logutil.SetupTestLog(&logutil.TestLogCfg{
 		LogDir:      testLogs,
 		TestType:    "sim-log",


### PR DESCRIPTION
### Why is this change needed?

- minor refactor because test log setup is duplicated and I was about to duplicate it again (for wallet extension)

### What changes were made as part of this PR:

- refactor test logging to a logutil

### What are the key areas to look at
- happy with naming, generic-ness etc? I went for logutil rather than log because it'll be annoying to have SetupTestLog start showing up as an option when you're looking for log.Info