### PR TITLE
Fixes serving of static files.

### DIFF
--- a/tools/obscuroscan/obscuroscan.go
+++ b/tools/obscuroscan/obscuroscan.go
@@ -8,6 +8,7 @@ import (
 	"embed"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/fs"
 	"net/http"
@@ -81,7 +82,7 @@ func (o *Obscuroscan) Serve(hostAndPort string) {
 	o.server = &http.Server{Addr: hostAndPort, Handler: serveMux}
 
 	err = o.server.ListenAndServe()
-	if err != http.ErrServerClosed {
+	if !errors.Is(err, http.ErrServerClosed) {
 		panic(err)
 	}
 }

--- a/tools/obscuroscan/obscuroscan.go
+++ b/tools/obscuroscan/obscuroscan.go
@@ -72,7 +72,7 @@ func (o *Obscuroscan) Serve(hostAndPort string) {
 	// Handle requests to decrypt a transaction blob.
 	serveMux.HandleFunc(pathDecryptTxBlob, o.decryptTxBlob)
 
-	// Serves the web interface.
+	// Serves the web assets for the user interface.
 	noPrefixStaticFiles, err := fs.Sub(staticFiles, staticDir)
 	if err != nil {
 		panic(fmt.Sprintf("could not serve static files. Cause: %s", err))

--- a/tools/walletextension/README.md
+++ b/tools/walletextension/README.md
@@ -78,6 +78,6 @@ following commands from the `tools/walletextension/main` folder:
 ```
 env GOOS=darwin GOARCH=amd64 go build -o ../bin/wallet_extension_macos_amd64 .
 env GOOS=darwin GOARCH=arm64 go build -o ../bin/wallet_extension_macos_arm64 .
-env GOOS=windows GOARCH=amd64 go build -o ../bin/wallet_extension_win_amd64 .
+env GOOS=windows GOARCH=amd64 go build -o ../bin/wallet_extension_win_amd64.exe .
 env GOOS=linux GOARCH=amd64 go build -o ../bin/wallet_extension_linux_amd64 .
 ```

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -3,14 +3,13 @@ package walletextension
 import (
 	"context"
 	"crypto/rand"
+	"embed"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"io/ioutil"
 	"net/http"
-	"path"
-	"path/filepath"
-	"runtime"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -57,11 +56,8 @@ const (
 	enclavePublicKeyHex = "034d3b7e63a8bcd532ee3d1d6ecad9d67fca7821981a044551f0f0cbec74d0bc5e"
 )
 
-var (
-	// Ensures can find static files when calling from different packages/directories.
-	_, callFile, _, _ = runtime.Caller(0)
-	basepath          = filepath.Dir(callFile)
-)
+//go:embed static
+var staticFiles embed.FS
 
 // TODO - Display error in browser if Metamask is not enabled (i.e. `ethereum` object is not available in-browser).
 
@@ -93,16 +89,23 @@ func NewWalletExtension(config Config) *WalletExtension {
 // Serve listens for and serves Ethereum JSON-RPC requests and viewing-key generation requests.
 func (we *WalletExtension) Serve(hostAndPort string) {
 	serveMux := http.NewServeMux()
+
 	// Handles Ethereum JSON-RPC requests received over HTTP.
 	serveMux.HandleFunc(pathRoot, we.handleHTTPEthJSON)
 	serveMux.HandleFunc(PathReady, we.handleReady)
-	// Handles the management of viewing keys.
-	serveMux.Handle(pathViewingKeys, http.StripPrefix(pathViewingKeys, http.FileServer(http.Dir(path.Join(basepath, staticDir)))))
 	serveMux.HandleFunc(PathGenerateViewingKey, we.handleGenerateViewingKey)
 	serveMux.HandleFunc(PathSubmitViewingKey, we.handleSubmitViewingKey)
+
+	// Handles the management of viewing keys.
+	noPrefixStaticFiles, err := fs.Sub(staticFiles, staticDir)
+	if err != nil {
+		panic(fmt.Sprintf("could not serve static files. Cause: %s", err))
+	}
+	serveMux.Handle(pathViewingKeys, http.StripPrefix(pathViewingKeys, http.FileServer(http.FS(noPrefixStaticFiles))))
+
 	we.server = &http.Server{Addr: hostAndPort, Handler: serveMux}
 
-	err := we.server.ListenAndServe()
+	err = we.server.ListenAndServe()
 	if err != http.ErrServerClosed {
 		panic(err)
 	}

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -97,7 +97,7 @@ func (we *WalletExtension) Serve(hostAndPort string) {
 	serveMux.HandleFunc(PathGenerateViewingKey, we.handleGenerateViewingKey)
 	serveMux.HandleFunc(PathSubmitViewingKey, we.handleSubmitViewingKey)
 
-	// Handles the management of viewing keys.
+	// Serves the web assets for the management of viewing keys.
 	noPrefixStaticFiles, err := fs.Sub(staticFiles, staticDir)
 	if err != nil {
 		panic(fmt.Sprintf("could not serve static files. Cause: %s", err))

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -6,6 +6,7 @@ import (
 	"embed"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/fs"
 	"io/ioutil"
@@ -106,7 +107,7 @@ func (we *WalletExtension) Serve(hostAndPort string) {
 	we.server = &http.Server{Addr: hostAndPort, Handler: serveMux}
 
 	err = we.server.ListenAndServe()
-	if err != http.ErrServerClosed {
+	if !errors.Is(err, http.ErrServerClosed) {
 		panic(err)
 	}
 }


### PR DESCRIPTION
### Why is this change needed?

Serving of static files was previously broken. The Go binary would simply point to the location of the static files on disk, outside the binary. This worked fine when compiling the binary yourself, since it pointed to your files. But if the binary was moved to another machine, the files couldn't be found.

### What changes were made as part of this PR:

Functional.

- Embeds static files
- Adds `.exe` to Windows binary in readme instructions

### What are the key areas to look at
