### PR TITLE
Add logging for wallet ext simulations

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -48,4 +48,5 @@ jobs:
           path: |
             integration/.build/simulations/sim-log-*.txt
             integration/.build/noderunner/noderunner-*.txt
+            integration/.build/wallet_extension/wal-ext-*.txt
         if: always() # Ensures the artifacts are created even if the tests fail.

--- a/integration/walletextension/wallet_extension_test.go
+++ b/integration/walletextension/wallet_extension_test.go
@@ -545,6 +545,7 @@ func createObscuroNetwork() (func(), *ecdsa.PrivateKey, error) {
 }
 
 func setupWalletTestLog(testName string) {
+	// todo: creating an individual file for every test is very heavy-handed, come up with a better solution?
 	logutil.SetupTestLog(&logutil.TestLogCfg{
 		LogDir:      testLogs,
 		TestType:    "wal-ext",

--- a/integration/walletextension/wallet_extension_test.go
+++ b/integration/walletextension/wallet_extension_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"github.com/obscuronet/obscuro-playground/go/common/log/logutil"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -40,6 +41,7 @@ import (
 )
 
 const (
+	testLogs     = "../.build/wallet_extension/"
 	l2ChainIDHex = "0x309"
 
 	reqJSONMethodChainID = "eth_chainId"
@@ -68,6 +70,7 @@ var (
 )
 
 func TestCanMakeNonSensitiveRequestWithoutSubmittingViewingKey(t *testing.T) {
+	setupWalletTestLog("req-no-viewing-key")
 	stopHandle, _, err := createObscuroNetwork()
 	defer stopHandle()
 	if err != nil {
@@ -87,6 +90,7 @@ func TestCanMakeNonSensitiveRequestWithoutSubmittingViewingKey(t *testing.T) {
 }
 
 func TestCannotGetBalanceWithoutSubmittingViewingKey(t *testing.T) {
+	setupWalletTestLog("bal-no-viewing-key")
 	stopHandle, _, err := createObscuroNetwork()
 	defer stopHandle()
 	if err != nil {
@@ -107,6 +111,7 @@ func TestCannotGetBalanceWithoutSubmittingViewingKey(t *testing.T) {
 }
 
 func TestCanGetOwnBalanceAfterSubmittingViewingKey(t *testing.T) {
+	setupWalletTestLog("bal-with-viewing-key")
 	stopHandle, _, err := createObscuroNetwork()
 	defer stopHandle()
 	if err != nil {
@@ -135,6 +140,7 @@ func TestCanGetOwnBalanceAfterSubmittingViewingKey(t *testing.T) {
 }
 
 func TestCannotGetAnothersBalanceAfterSubmittingViewingKey(t *testing.T) {
+	setupWalletTestLog("others-bal-with-viewing-key")
 	stopHandle, _, err := createObscuroNetwork()
 	defer stopHandle()
 	if err != nil {
@@ -162,6 +168,7 @@ func TestCannotGetAnothersBalanceAfterSubmittingViewingKey(t *testing.T) {
 }
 
 func TestCannotCallWithoutSubmittingViewingKey(t *testing.T) {
+	setupWalletTestLog("tx-no-viewing-key")
 	stopHandle, _, err := createObscuroNetwork()
 	defer stopHandle()
 	if err != nil {
@@ -199,6 +206,7 @@ func TestCannotCallWithoutSubmittingViewingKey(t *testing.T) {
 }
 
 func TestCanCallAfterSubmittingViewingKey(t *testing.T) {
+	setupWalletTestLog("tx-with-viewing-key")
 	stopHandle, _, err := createObscuroNetwork()
 	defer stopHandle()
 	if err != nil {
@@ -237,6 +245,7 @@ func TestCanCallAfterSubmittingViewingKey(t *testing.T) {
 }
 
 func TestCannotCallForAnotherAddressAfterSubmittingViewingKey(t *testing.T) {
+	setupWalletTestLog("others-tx-with-viewing-key")
 	stopHandle, _, err := createObscuroNetwork()
 	defer stopHandle()
 	if err != nil {
@@ -275,6 +284,7 @@ func TestCannotCallForAnotherAddressAfterSubmittingViewingKey(t *testing.T) {
 }
 
 func TestCannotGetTxReceiptWithoutSubmittingViewingKey(t *testing.T) {
+	setupWalletTestLog("tx-rcpt-no-viewing-key")
 	stopHandle, _, err := createObscuroNetwork()
 	defer stopHandle()
 	if err != nil {
@@ -298,6 +308,7 @@ func TestCannotGetTxReceiptWithoutSubmittingViewingKey(t *testing.T) {
 }
 
 func TestCanGetTxReceiptAfterSubmittingViewingKey(t *testing.T) {
+	setupWalletTestLog("tx-rcpt-with-viewing-key")
 	stopHandle, erc20PrivateKey, err := createObscuroNetwork()
 	defer stopHandle()
 	if err != nil {
@@ -324,6 +335,7 @@ func TestCanGetTxReceiptAfterSubmittingViewingKey(t *testing.T) {
 }
 
 func TestCannotGetTxReceiptSubmittedFromAnotherAddressAfterSubmittingViewingKey(t *testing.T) {
+	setupWalletTestLog("others-tx-rcpt-with-viewing-key")
 	stopHandle, _, err := createObscuroNetwork()
 	defer stopHandle()
 	if err != nil {
@@ -529,4 +541,12 @@ func createObscuroNetwork() (func(), *ecdsa.PrivateKey, error) {
 	}
 
 	return obscuroNetwork.TearDown, wallets.Tokens[bridge.BTC].L2Owner.PrivateKey(), nil
+}
+
+func setupWalletTestLog(testName string) {
+	logutil.SetupTestLog(&logutil.TestLogCfg{
+		LogDir:      testLogs,
+		TestType:    "wal-ext",
+		TestSubtype: testName,
+	})
 }

--- a/integration/walletextension/wallet_extension_test.go
+++ b/integration/walletextension/wallet_extension_test.go
@@ -6,12 +6,13 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"github.com/obscuronet/obscuro-playground/go/common/log/logutil"
 	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/obscuronet/obscuro-playground/go/common/log/logutil"
 
 	"github.com/obscuronet/obscuro-playground/go/enclave/rollupchain"
 


### PR DESCRIPTION
### Why is this change needed?

- hard to debug wallet ext tests when the nodes in the network are a black box

### What changes were made as part of this PR:

- add log file per test
- add the config for github to include those files in the downloadable bundle

### What are the key areas to look at
- my main concern is that this might be a bit heavy handed, it spams out a lot of these files. But we can always rethink it once things have settled down I suppose...