### PR TITLE
Checks whether HTTP request to add viewing key failed.

### DIFF
--- a/integration/walletextension/wallet_extension_test.go
+++ b/integration/walletextension/wallet_extension_test.go
@@ -443,6 +443,9 @@ func generateAndSubmitViewingKey(t *testing.T, walletExtensionAddr string, accou
 	}
 	submitViewingKeyBody := bytes.NewBuffer(submitViewingKeyBodyBytes)
 	resp, err := http.Post(httpProtocol+walletExtensionAddr+walletextension.PathSubmitViewingKey, "application/json", submitViewingKeyBody) //nolint:noctx
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		t.Fatalf("request to add viewing key failed with following status: %s", resp.Status)
+	}
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
### Why is this change needed?

In the wallet extension tests, if the request to add a viewing key returns successfully but with a non-200 error code, this is treated as a success. We should fail the test instead. Otherwise, we get confusing errors later on.

### What changes were made as part of this PR:

Functional.

- Catch broader set of failures to add viewing key

### What are the key areas to look at
