### PR TITLE
Adds dummies for eth RPC methods required by Remix. Fixes network version

### DIFF
--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -33,7 +33,8 @@ const (
 	CallFieldTo   = "to"
 	CallFieldFrom = "from"
 	CallFieldData = "data"
-	DummyBalance  = "0x0"
+
+	DummyBalance = "0xD3C21BCECCEDA1000000" // 1,000,000,000,000,000,000,000,000 in hex.
 )
 
 // RollupChain represents the canonical chain, and manages the state.

--- a/go/host/client_api_eth.go
+++ b/go/host/client_api_eth.go
@@ -43,7 +43,7 @@ func (api *EthereumAPI) GetBalance(_ context.Context, encryptedParams common.Enc
 	return gethcommon.Bytes2Hex(encryptedBalance), nil
 }
 
-// GetBlockByNumber is a placeholder for an RPC method required by MetaMask.
+// GetBlockByNumber is a placeholder for an RPC method required by MetaMask/Remix.
 func (api *EthereumAPI) GetBlockByNumber(context.Context, rpc.BlockNumber, bool) (map[string]interface{}, error) {
 	result := map[string]interface{}{
 		// TODO - Return non-dummy values.
@@ -53,7 +53,7 @@ func (api *EthereumAPI) GetBlockByNumber(context.Context, rpc.BlockNumber, bool)
 	return result, nil
 }
 
-// GasPrice is a placeholder for an RPC method required by MetaMask.
+// GasPrice is a placeholder for an RPC method required by MetaMask/Remix.
 func (api *EthereumAPI) GasPrice(context.Context) (*hexutil.Big, error) {
 	return (*hexutil.Big)(big.NewInt(0)), nil
 }
@@ -78,8 +78,15 @@ func (api *EthereumAPI) GetTransactionReceipt(_ context.Context, encryptedParams
 	return gethcommon.Bytes2Hex(encryptedResponse), nil
 }
 
-// EstimateGas is a placeholder for an RPC method required by Remix.
+// EstimateGas is a placeholder for an RPC method required by MetaMask/Remix.
 func (api *EthereumAPI) EstimateGas(_ context.Context, _ interface{}, _ *rpc.BlockNumberOrHash) (hexutil.Uint64, error) {
 	// TODO - Return a non-dummy gas estimate.
 	return 0, nil
+}
+
+// GetTransactionCount is a placeholder for an RPC method required by MetaMask/Remix.
+func (api *EthereumAPI) GetTransactionCount(_ context.Context, _ gethcommon.Address, _ rpc.BlockNumberOrHash) (*hexutil.Uint64, error) {
+	// TODO - Return a non-dummy count.
+	count := uint64(0)
+	return (*hexutil.Uint64)(&count), nil
 }

--- a/go/host/client_api_eth.go
+++ b/go/host/client_api_eth.go
@@ -2,6 +2,7 @@ package host
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 
 	"github.com/obscuronet/obscuro-playground/go/common"
@@ -45,7 +46,12 @@ func (api *EthereumAPI) GetBalance(_ context.Context, encryptedParams common.Enc
 
 // GetBlockByNumber is a placeholder for an RPC method required by MetaMask.
 func (api *EthereumAPI) GetBlockByNumber(context.Context, rpc.BlockNumber, bool) (map[string]interface{}, error) {
-	return nil, nil //nolint:nilnil
+	result := map[string]interface{}{
+		// TODO - Return non-dummy values.
+		"baseFeePerGas": (*hexutil.Big)(big.NewInt(0)),
+		"number":        (*hexutil.Big)(big.NewInt(0)),
+	}
+	return result, nil
 }
 
 // GasPrice is a placeholder for an RPC method required by MetaMask.
@@ -77,4 +83,10 @@ func (api *EthereumAPI) GetTransactionReceipt(_ context.Context, encryptedParams
 func (api *EthereumAPI) EstimateGas(_ context.Context, _ interface{}, _ *rpc.BlockNumberOrHash) (hexutil.Uint64, error) {
 	// TODO - Return a non-dummy gas estimate.
 	return 0, nil
+}
+
+// Version is a placeholder for an RPC method required by Remix.
+func (api *EthereumAPI) Version() string {
+	// TODO - Return a non-dummy version.
+	return fmt.Sprintf("%d", 0)
 }

--- a/go/host/client_api_eth.go
+++ b/go/host/client_api_eth.go
@@ -2,7 +2,6 @@ package host
 
 import (
 	"context"
-	"fmt"
 	"math/big"
 
 	"github.com/obscuronet/obscuro-playground/go/common"
@@ -83,10 +82,4 @@ func (api *EthereumAPI) GetTransactionReceipt(_ context.Context, encryptedParams
 func (api *EthereumAPI) EstimateGas(_ context.Context, _ interface{}, _ *rpc.BlockNumberOrHash) (hexutil.Uint64, error) {
 	// TODO - Return a non-dummy gas estimate.
 	return 0, nil
-}
-
-// Version is a placeholder for an RPC method required by Remix.
-func (api *EthereumAPI) Version() string {
-	// TODO - Return a non-dummy version.
-	return fmt.Sprintf("%d", 0)
 }

--- a/go/host/client_api_eth.go
+++ b/go/host/client_api_eth.go
@@ -72,3 +72,9 @@ func (api *EthereumAPI) GetTransactionReceipt(_ context.Context, encryptedParams
 	}
 	return gethcommon.Bytes2Hex(encryptedResponse), nil
 }
+
+// EstimateGas is a placeholder for an RPC method required by Remix.
+func (api *EthereumAPI) EstimateGas(_ context.Context, _ interface{}, _ *rpc.BlockNumberOrHash) (hexutil.Uint64, error) {
+	// TODO - Return a non-dummy gas estimate.
+	return 0, nil
+}

--- a/go/host/client_api_eth.go
+++ b/go/host/client_api_eth.go
@@ -83,10 +83,3 @@ func (api *EthereumAPI) EstimateGas(_ context.Context, _ interface{}, _ *rpc.Blo
 	// TODO - Return a non-dummy gas estimate.
 	return 0, nil
 }
-
-// GetTransactionCount is a placeholder for an RPC method required by MetaMask/Remix.
-func (api *EthereumAPI) GetTransactionCount(_ context.Context, _ gethcommon.Address, _ rpc.BlockNumberOrHash) (*hexutil.Uint64, error) {
-	// TODO - Return a non-dummy count.
-	count := uint64(0)
-	return (*hexutil.Uint64)(&count), nil
-}

--- a/go/host/client_api_net.go
+++ b/go/host/client_api_net.go
@@ -2,8 +2,6 @@ package host
 
 import "fmt"
 
-const obscuroNetworkVersion = 1
-
 // NetworkAPI implements a subset of the Ethereum network JSON RPC operations.
 type NetworkAPI struct {
 	host *Node

--- a/go/host/client_api_net.go
+++ b/go/host/client_api_net.go
@@ -5,13 +5,17 @@ import "fmt"
 const obscuroNetworkVersion = 1
 
 // NetworkAPI implements a subset of the Ethereum network JSON RPC operations.
-type NetworkAPI struct{}
+type NetworkAPI struct {
+	host *Node
+}
 
-func NewNetworkAPI() *NetworkAPI {
-	return &NetworkAPI{}
+func NewNetworkAPI(host *Node) *NetworkAPI {
+	return &NetworkAPI{
+		host: host,
+	}
 }
 
 // Version returns the protocol version of the Obscuro network.
 func (api *NetworkAPI) Version() string {
-	return fmt.Sprintf("%d", obscuroNetworkVersion)
+	return fmt.Sprintf("%d", api.host.config.ObscuroChainID)
 }

--- a/go/host/rpc_server.go
+++ b/go/host/rpc_server.go
@@ -54,7 +54,7 @@ func NewRPCServer(config config.HostConfig, host *Node) RPCServer {
 		{
 			Namespace: apiNamespaceNetwork,
 			Version:   apiVersion1,
-			Service:   NewNetworkAPI(),
+			Service:   NewNetworkAPI(host),
 			Public:    true,
 		},
 	}


### PR DESCRIPTION
### Why is this change needed?

Fixes various issues related to contract deployment via Remix.

### What changes were made as part of this PR:

Functional.

- Introduces additional RPC methods expected by Remix/MetaMask
- Fixes bug whereby we returned wrong network ID

### What are the key areas to look at
