### PR TITLE
Set useInMemory=false on enclave docker-compose wiring

### DIFF
--- a/go/config/enclave_config.go
+++ b/go/config/enclave_config.go
@@ -49,7 +49,7 @@ func DefaultEnclaveConfig() EnclaveConfig {
 		Address:                   "127.0.0.1:11000",
 		L1ChainID:                 1337,
 		ObscuroChainID:            777,
-		WillAttest:                false,
+		WillAttest:                false, // todo: attestation should be on by default before production release
 		ValidateL1Blocks:          false,
 		GenesisJSON:               nil,
 		SpeculativeExecution:      false,
@@ -57,7 +57,7 @@ func DefaultEnclaveConfig() EnclaveConfig {
 		ERC20ContractAddresses:    []*common.Address{},
 		WriteToLogs:               false,
 		LogPath:                   "enclave_logs.txt",
-		UseInMemoryDB:             true,
+		UseInMemoryDB:             true, // todo: persistence should be on by default before production release
 		ViewingKeysEnabled:        true,
 		EdgelessDBHost:            "",
 	}

--- a/testnet/docker-compose.yml
+++ b/testnet/docker-compose.yml
@@ -39,6 +39,7 @@ services:
                  "ego", "run", "/home/obscuro/go-obscuro/go/enclave/main/main",
                  "--hostID=$HOSTID",
                  "--address=:11000",
+                 "--useInMemoryDB=false",
                  "--managementContractAddress=$MGMTCONTRACTADDR",
                  "--erc20ContractAddresses=$ERC20CONTRACTADDR,$ERC20CONTRACTADDR",
                  "--viewingKeysEnabled=false",


### PR DESCRIPTION
### Why is this change needed?

- we don't want to use in-memory db for long running nodes (memory leak)

### What changes were made as part of this PR:

- set useInMemory flag to calse
- add todos to make persistence and attestation the default
