### PR TITLE
Add config for sqlite db path

### DIFF
--- a/go/config/enclave_config.go
+++ b/go/config/enclave_config.go
@@ -39,6 +39,9 @@ type EnclaveConfig struct {
 	ViewingKeysEnabled bool
 	// host address for the edgeless DB instance (can be empty if using InMemory DB or if attestation is disabled)
 	EdgelessDBHost string
+	// filepath for the sqlite DB persistence file (can be empty if a throwaway file in /tmp/ is acceptable or
+	//	if using InMemory DB or if attestation is enabled)
+	SqliteDBPath string
 }
 
 // DefaultEnclaveConfig returns an EnclaveConfig with default values.
@@ -60,5 +63,6 @@ func DefaultEnclaveConfig() EnclaveConfig {
 		UseInMemoryDB:             true, // todo: persistence should be on by default before production release
 		ViewingKeysEnabled:        true,
 		EdgelessDBHost:            "",
+		SqliteDBPath:              "",
 	}
 }

--- a/go/enclave/db/db.go
+++ b/go/enclave/db/db.go
@@ -26,7 +26,7 @@ func CreateDBFromConfig(nodeID uint64, cfg config.EnclaveConfig) (ethdb.Database
 		common.LogWithID(nodeID, "Attestation is disabled, using a basic sqlite DB for persistence")
 		// todo: for now we pass in an empty dbPath which will provide a throwaway temp file,
 		// 		when we want to test persistence after node restart we should change this path to be config driven
-		return sql.CreateTemporarySQLiteDB("")
+		return sql.CreateTemporarySQLiteDB(cfg.SqliteDBPath)
 	}
 
 	// persistent and with attestation means connecting to edgeless DB in a trusted enclave from a secure enclave
@@ -44,6 +44,12 @@ func validateDBConf(cfg config.EnclaveConfig) error {
 	}
 	if !cfg.UseInMemoryDB && cfg.WillAttest && cfg.EdgelessDBHost == "" {
 		return fmt.Errorf("useInMemoryDB=false, willAttest=true so expected an EdgelessDB host but none was provided")
+	}
+	if cfg.SqliteDBPath != "" && cfg.UseInMemoryDB {
+		return fmt.Errorf("useInMemoryDB=true so sqlite database will not be used and no path is needed, but sqliteDBPath=%s", cfg.SqliteDBPath)
+	}
+	if cfg.SqliteDBPath != "" && cfg.WillAttest {
+		return fmt.Errorf("willAttest=true so sqlite database will not be used and no path is needed, but sqliteDBPath=%s", cfg.SqliteDBPath)
 	}
 	return nil
 }

--- a/go/enclave/enclaverunner/cli.go
+++ b/go/enclave/enclaverunner/cli.go
@@ -50,6 +50,7 @@ func ParseConfig() config.EnclaveConfig {
 	useInMemoryDB := flag.Bool(useInMemoryDBName, cfg.UseInMemoryDB, useInMemoryDBUsage)
 	viewingKeysEnabled := flag.Bool(ViewingKeysEnabledName, cfg.ViewingKeysEnabled, ViewingKeysEnabledUsage)
 	edgelessDBHost := flag.String(edgelessDBHostName, cfg.EdgelessDBHost, edgelessDBHostUsage)
+	sqliteDBPath := flag.String(sqliteDBPathName, cfg.SqliteDBPath, sqliteDBPathUsage)
 
 	flag.Parse()
 
@@ -84,6 +85,7 @@ func ParseConfig() config.EnclaveConfig {
 	cfg.UseInMemoryDB = *useInMemoryDB
 	cfg.ViewingKeysEnabled = *viewingKeysEnabled
 	cfg.EdgelessDBHost = *edgelessDBHost
+	cfg.SqliteDBPath = *sqliteDBPath
 
 	return cfg
 }

--- a/go/enclave/enclaverunner/cli_flags.go
+++ b/go/enclave/enclaverunner/cli_flags.go
@@ -49,4 +49,7 @@ const (
 
 	edgelessDBHostName  = "edgelessDBHost"
 	edgelessDBHostUsage = "host address for the edgeless DB instance (can be empty if useInMemoryDB is true or if not using attestation"
+
+	sqliteDBPathName  = "sqliteDBPath"
+	sqliteDBPathUsage = "filepath for the sqlite DB persistence file (can be empty if a throwaway file in /tmp/ is acceptable or if using InMemory DB or if using attestation/EdgelessDB)"
 )

--- a/testnet/docker-compose.yml
+++ b/testnet/docker-compose.yml
@@ -40,6 +40,7 @@ services:
                  "--hostID=$HOSTID",
                  "--address=:11000",
                  "--useInMemoryDB=false",
+                 "--sqliteDBPath=/data/sqlite.db",
                  "--managementContractAddress=$MGMTCONTRACTADDR",
                  "--erc20ContractAddresses=$ERC20CONTRACTADDR,$ERC20CONTRACTADDR",
                  "--viewingKeysEnabled=false",


### PR DESCRIPTION
### Why is this change needed?

- ego doesn't let you write to arbitrary file path without mounting them. Out testnet is using ego on docker
- there's a /data folder available but we didn't have the ability to configure where the sqlite file goes

### What changes were made as part of this PR:

- Wire through a sqliteDBPath config flag
- add /data/sqlite.db as the default file for the testnet

### What are the key areas to look at
Comparing the sqliteDBPath flag to the edgelessDBPath flag etc. to make sure it follows the same usage pattern as it is analogous