### PR TITLE
Fixes signer for tx receipts.

### DIFF
--- a/go/enclave/db/storage.go
+++ b/go/enclave/db/storage.go
@@ -269,7 +269,7 @@ func (s *storageImpl) GetSender(txHash gethcommon.Hash) (gethcommon.Address, err
 	if tx == nil {
 		return gethcommon.Address{}, fmt.Errorf("could not retrieve transaction in eth_getTransactionReceipt")
 	}
-	msg, err := tx.AsMessage(types.NewEIP155Signer(tx.ChainId()), nil)
+	msg, err := tx.AsMessage(types.NewLondonSigner(tx.ChainId()), nil)
 	if err != nil {
 		return gethcommon.Address{}, fmt.Errorf("could not convert transaction to message to retrieve sender address in eth_getTransactionReceipt request. Cause: %w", err)
 	}


### PR DESCRIPTION
### Why is this change needed?

Previously, the incorrect signer type was used to get the sender for tx receipts, preventing tx receipts from being retrieved.

### What changes were made as part of this PR:

Functional.

- Switches to correct signer type

### What are the key areas to look at
