### PR TITLE
Add viewing key encryption/decryption to rpc client lib

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,9 +11,9 @@ require (
 	github.com/docker/go-connections v0.4.0
 	github.com/edgelesssys/ego v0.5.0
 	github.com/ethereum/go-ethereum v1.10.16
+	github.com/go-kit/kit v0.10.0
 	github.com/go-sql-driver/mysql v1.4.1
 	github.com/google/uuid v1.3.0
-	github.com/gorilla/websocket v1.4.2
 	github.com/mattn/go-sqlite3 v1.14.13
 	github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416
 	github.com/rs/zerolog v1.26.1
@@ -49,13 +49,14 @@ require (
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/edsrzf/mmap-go v1.0.0 // indirect
 	github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5 // indirect
-	github.com/go-kit/kit v0.10.0 // indirect
+	github.com/go-logfmt/logfmt v0.5.0 // indirect
 	github.com/go-ole/go-ole v1.2.1 // indirect
 	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.4.1 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
+	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/hashicorp/go-bexpr v0.1.10 // indirect
 	github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d // indirect
 	github.com/holiman/bloomfilter/v2 v2.0.3 // indirect

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -252,7 +252,7 @@ func (e *enclaveImpl) SubmitRollup(rollup common.ExtRollup) {
 }
 
 func (e *enclaveImpl) SubmitTx(tx common.EncryptedTx) (common.EncryptedResponseSendRawTx, error) {
-	decryptedTx, err := e.rpcEncryptionManager.DecryptTx(tx)
+	decryptedTx, err := e.rpcEncryptionManager.ExtractTxFromBinary(tx)
 	if err != nil {
 		log.Info(fmt.Sprintf("could not decrypt transaction. Cause: %s", err))
 		return nil, fmt.Errorf("could not decrypt transaction. Cause: %w", err)

--- a/go/enclave/rpcencryptionmanager/rpc_encryption_manager.go
+++ b/go/enclave/rpcencryptionmanager/rpc_encryption_manager.go
@@ -128,15 +128,17 @@ func (rpc *RPCEncryptionManager) EncryptTxReceiptWithViewingKey(address gethcomm
 	return rpc.EncryptWithViewingKey(address, txReceiptBytes)
 }
 
-// DecryptTx decrypts an L2 transaction encrypted with the enclave's public key.
-func (rpc *RPCEncryptionManager) DecryptTx(encryptedTx common.EncryptedTx) (*common.L2Tx, error) {
-	txBinaryListJSON, err := rpc.decryptWithEnclavePrivateKey(encryptedTx)
-	if err != nil {
-		return nil, fmt.Errorf("could not decrypt transaction with enclave private key. Cause: %w", err)
+func (rpc *RPCEncryptionManager) ExtractTxFromBinary(encodedTx []byte) (*common.L2Tx, error) {
+	var err error
+	if rpc.viewingKeysEnabled {
+		encodedTx, err = rpc.decryptWithEnclavePrivateKey(encodedTx)
+		if err != nil {
+			return nil, fmt.Errorf("could not decrypt transaction with enclave private key. Cause: %w", err)
+		}
 	}
 
 	// We need to extract the transaction hex from the JSON list encoding. We remove the leading `"[0x`, and the trailing `]"`.
-	txBinary := txBinaryListJSON[4 : len(txBinaryListJSON)-2]
+	txBinary := encodedTx[4 : len(encodedTx)-2]
 	txBytes := gethcommon.Hex2Bytes(string(txBinary))
 
 	tx := &common.L2Tx{}

--- a/go/rpcclientlib/README.md
+++ b/go/rpcclientlib/README.md
@@ -1,1 +1,17 @@
 This package contains library code to allow client applications to connect to Obscuro nodes via RPC.
+
+### Viewing keys
+
+Viewing keys are generated inside the wallet extension (or other users of the obscuro rpc client), and then signed by the wallet (e.g. MetaMask)
+to which the keys relate.
+The keys are then are sent to the enclave via RPC and processed by:
+- checking the validity of the signature over the viewing key
+- finding the account to which this viewing key corresponds
+
+We can do that by retrieving the signing public key from the signature.
+By hashing the public key, we can then determine the address of the account.
+- finally the enclave will save the viewing key (which is a public key) against the account, and use it to encrypt any
+sensitive requests (e.g. "eth_call" and "eth_getBalance") permitted to be viewed by that account
+
+Client requests to the enclave are encrypted by the client with the enclave's public key and the response will be encrypted
+with the relevant viewing key (pre-added using the method above) so only the intended recipient can read it.

--- a/go/rpcclientlib/obscuro_client.go
+++ b/go/rpcclientlib/obscuro_client.go
@@ -1,6 +1,13 @@
 package rpcclientlib
 
 import (
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/crypto/ecies"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/obscuronet/obscuro-playground/go/common/log"
 )
@@ -8,7 +15,8 @@ import (
 type RPCMethod uint8
 
 const (
-	http = "http://"
+	http           = "http://"
+	reqJSONKeyFrom = "from"
 
 	RPCGetID                = "obscuro_getID"
 	RPCGetCurrentBlockHead  = "obscuro_getCurrentBlockHead"
@@ -19,10 +27,19 @@ const (
 	RPCAddViewingKey        = "obscuro_addViewingKey"
 	RPCStopHost             = "obscuro_stopHost"
 	RPCCall                 = "eth_call"
+	RPCChainID              = "eth_chainId"
+	RPCGetBalance           = "eth_getBalance"
+	RPCGetTransactionByHash = "eth_getTransactionByHash"
+	RPCGetTxCount           = "eth_getTransactionCount"
 	RPCGetTxReceipt         = "eth_getTransactionReceipt"
 	RPCSendRawTransaction   = "eth_sendRawTransaction"
-	RPCGetTransactionByHash = "eth_getTransactionByHash"
+
+	// todo: this is a convenience for testnet testing and will eventually be retrieved from the L1
+	enclavePublicKeyHex = "034d3b7e63a8bcd532ee3d1d6ecad9d67fca7821981a044551f0f0cbec74d0bc5e"
 )
+
+// for these methods, the RPC method's requests and responses should be encrypted
+var sensitiveMethods = []string{RPCCall, RPCGetBalance, RPCGetTxReceipt, RPCSendRawTransaction, RPCGetTransactionByHash}
 
 // Client is used by client applications to interact with the Obscuro node.
 type Client interface {
@@ -30,28 +47,228 @@ type Client interface {
 	Call(result interface{}, method string, args ...interface{}) error
 	// Stop closes the client.
 	Stop()
+
+	// SetViewingKey sets the current viewing key on the client to be used for all sensitive request decryption
+	SetViewingKey(viewingKey *ecies.PrivateKey, pubKeyBytes []byte)
+
+	// RegisterViewingKey takes a signature for the public key, it verifies the signed public key matches the currently set private viewing key
+	//	and then submits it to the enclave
+	RegisterViewingKey(signerAddr common.Address, signature []byte) error
 }
 
-// A Client implementation that wraps rpc.Client to make calls.
-type clientImpl struct {
-	rpcClient *rpc.Client
+// RPCClient is a Client implementation that wraps rpc.Client to make calls.
+type networkClient struct {
+	rpcClient        *rpc.Client
+	enclavePublicKey *ecies.PublicKey
+	// todo: add support for multiple keys on the same client?
+	viewingPrivKey *ecies.PrivateKey // private viewing key to use for decrypting sensitive requests
+	viewingPubKey  []byte            // public viewing key, submitted to the enclave
+	viewingKeyAddr common.Address    // address that generated the public key
 }
 
 func NewClient(address string) Client {
+	// todo: this is a convenience for testnet but needs to replaced by a parameter and/or retrieved from the target host
+	enclPubECDSA, err := crypto.DecompressPubkey(common.Hex2Bytes(enclavePublicKeyHex))
+	if err != nil {
+		panic(err)
+	}
+	enclavePublicKey := ecies.ImportECDSAPublic(enclPubECDSA)
+
 	rpcClient, err := rpc.Dial(http + address)
 	if err != nil {
 		log.Panic("could not create RPC client on %s. Cause: %s", http+address, err)
 	}
 
-	return &clientImpl{
-		rpcClient: rpcClient,
+	return &networkClient{
+		rpcClient:        rpcClient,
+		enclavePublicKey: enclavePublicKey,
 	}
 }
 
-func (c *clientImpl) Call(result interface{}, method string, args ...interface{}) error {
-	return c.rpcClient.Call(&result, method, args...)
+// Call handles JSON rpc requests - if the method is sensitive it will encrypt the args before sending the request and
+//	then decrypts the response before returning.
+// The result must be a pointer so that package json can unmarshal into it. You can also pass nil, in which case the result is ignored.
+func (c *networkClient) Call(result interface{}, method string, args ...interface{}) error {
+	if !isSensitive(method) {
+		// for non-sensitive methods or when viewing keys are disabled we just delegate directly to the geth RPC client
+		return c.rpcClient.Call(&result, method, args...)
+	}
+
+	// we setup a generic rawResult to receive the response (then we can decrypt it as necessary into the requested result type)
+	var rawResult interface{}
+	if result == nil {
+		// we set result receiver to nil if caller set nil since no return needs to be set
+		rawResult = nil
+	}
+
+	var err error
+	if method == RPCCall {
+		// RPCCall is a sensitive method that requires a viewing key lookup but the 'from' field is not mandatory in geth
+		//	and is often not included from metamask etc. So we ensure it is populated here.
+		args, err = c.ensureCallParamsHaveFromAddress(method, args)
+		if err != nil {
+			return err
+		}
+	}
+
+	// encode the params into a json blob and encrypt them
+	var encryptedParams []byte
+	encryptedParams, err = c.encryptArgs(args...)
+	if err != nil {
+		return fmt.Errorf("failed to encrypt args for rpc call - %w", err)
+	}
+	err = c.rpcClient.Call(&rawResult, method, encryptedParams)
+	if err != nil {
+		return fmt.Errorf("rpc call failed - %w", err)
+	}
+
+	// if caller not interested in response, we're done
+	if result == nil {
+		return nil
+	}
+
+	// method is sensitive, so we decrypt it before unmarshalling the result
+	decrypted, err := c.decryptResponse(rawResult)
+	if err != nil {
+		return fmt.Errorf("failed to decrypt args for rpc call - %w", err)
+	}
+
+	// process the decrypted result to get the desired type and set it on the result pointer
+	err = c.setResult(decrypted, result)
+	if err != nil {
+		return fmt.Errorf("failed to extract result from RPC response: %w", err)
+	}
+
+	return nil
 }
 
-func (c *clientImpl) Stop() {
+func (c *networkClient) encryptArgs(args ...interface{}) ([]byte, error) {
+	if len(args) == 0 {
+		return nil, nil
+	}
+
+	paramsJSON, err := json.Marshal(args)
+	if err != nil {
+		return nil, fmt.Errorf("could not json encode request params: %w", err)
+	}
+
+	return c.encryptParamBytes(paramsJSON)
+}
+
+func (c *networkClient) encryptParamBytes(params []byte) ([]byte, error) {
+	encryptedParams, err := ecies.Encrypt(rand.Reader, c.enclavePublicKey, params, nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("could not encrypt request params with enclave public key: %w", err)
+	}
+	return encryptedParams, nil
+}
+
+func (c *networkClient) decryptResponse(resultBlob interface{}) ([]byte, error) {
+	if c.viewingPrivKey == nil {
+		// todo: remove this non-decryption part when we make viewing key encryption mandatory across all tests
+		// extract result from the data as-is, in case we can't decrypt/process it below
+		unencrypted, ok := resultBlob.([]byte) // if viewing key was nil we try and extract result from the data as-is
+		if !ok {
+			decStr, ok := resultBlob.(string)
+			if ok {
+				unencrypted = []byte(decStr)
+			}
+		}
+		// todo: remove this when we no longer support disabling viewing keys for testing
+		return unencrypted, nil
+	}
+	encryptedResult := common.Hex2Bytes(resultBlob.(string))
+	decryptedResult, err := c.viewingPrivKey.Decrypt(encryptedResult, nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("could not decrypt enclave response with viewing key: %w", err)
+	}
+
+	return decryptedResult, nil
+}
+
+// setResult tries to cast/unmarshal data into the result pointer, based on its type
+func (c *networkClient) setResult(data []byte, result interface{}) error {
+	switch result := result.(type) {
+	case *string:
+		*result = string(data)
+		return nil
+
+	case *interface{}:
+		err := json.Unmarshal(data, result)
+		if err != nil {
+			// if unmarshal failed with generic return we can try to send it back as a string
+			*result = string(data)
+		}
+		return nil
+
+	default:
+		// for any other type we attempt to json unmarshal it
+		return json.Unmarshal(data, result)
+	}
+}
+
+func (c *networkClient) Stop() {
 	c.rpcClient.Close()
+}
+
+func (c *networkClient) SetViewingKey(viewingKey *ecies.PrivateKey, viewingPubKeyBytes []byte) {
+	c.viewingPrivKey = viewingKey
+	c.viewingPubKey = viewingPubKeyBytes
+}
+
+func (c *networkClient) RegisterViewingKey(signerAddr common.Address, signature []byte) error {
+	c.viewingKeyAddr = signerAddr
+
+	// We encrypt the viewing key bytes
+	encryptedViewingKeyBytes, err := ecies.Encrypt(rand.Reader, c.enclavePublicKey, c.viewingPubKey, nil, nil)
+	if err != nil {
+		return fmt.Errorf("could not encrypt viewing key with enclave public key: %w", err)
+	}
+
+	var rpcErr error
+	err = c.Call(&rpcErr, RPCAddViewingKey, encryptedViewingKeyBytes, signature)
+	if err != nil {
+		return fmt.Errorf("could not add viewing key: %w", err)
+	}
+	return nil
+}
+
+// enclave requires a from address to be set for the viewing key encryption but sources like metamask often don't set it
+func (c *networkClient) ensureCallParamsHaveFromAddress(method string, args []interface{}) ([]interface{}, error) {
+	if len(args) == 0 {
+		return nil, fmt.Errorf("expected %s params to have a 'from' field but no params found", RPCCall)
+	}
+
+	callParams, ok := args[0].(map[string]interface{})
+	if !ok {
+		callParamsJSON, ok := args[0].([]byte)
+		if !ok {
+			return nil, fmt.Errorf("expected %s first param to be a map or json encoded bytes but was %t", method, args[0])
+		}
+
+		err := json.Unmarshal(callParamsJSON, &callParams)
+		if err != nil {
+			return nil, fmt.Errorf("expected %s first param to be a map or json encoded bytes, failed to decode: %w", method, err)
+		}
+	}
+
+	if callParams[reqJSONKeyFrom] != nil {
+		// We only modify `eth_call` requests where the `from` field is not set.
+		return args, nil
+	}
+	callParams[reqJSONKeyFrom] = c.viewingKeyAddr
+
+	args[0] = callParams
+
+	return args, nil
+}
+
+// isSensitive indicates whether the RPC method's requests and responses should be encrypted.
+func isSensitive(method interface{}) bool {
+	for _, m := range sensitiveMethods {
+		if m == method {
+			return true
+		}
+	}
+	return false
 }

--- a/integration/simulation/utils.go
+++ b/integration/simulation/utils.go
@@ -82,7 +82,7 @@ func getRollupHeader(client rpcclientlib.Client, hash gethcommon.Hash) *common.H
 	method := rpcclientlib.RPCGetRollupHeader
 
 	var result *common.Header
-	err := client.Call(&result, method, hash)
+	err := client.Call(&result, method, hash.Hex())
 	if err != nil {
 		panic(fmt.Errorf("simulation failed due to failed %s RPC call. Cause: %w", method, err))
 	}
@@ -92,13 +92,8 @@ func getRollupHeader(client rpcclientlib.Client, hash gethcommon.Hash) *common.H
 
 // Uses the client to retrieve the transaction with the matching hash.
 func getTransaction(client rpcclientlib.Client, txHash gethcommon.Hash) map[string]interface{} {
-	paramsJSON, err := json.Marshal([]string{txHash.Hex()})
-	if err != nil {
-		panic(fmt.Errorf("simulation failed because could not marshal JSON param to %s RPC call. Cause: %w", rpcclientlib.RPCGetTransactionByHash, err))
-	}
-
 	var encryptedResponse string
-	err = client.Call(&encryptedResponse, rpcclientlib.RPCGetTransactionByHash, paramsJSON)
+	err := client.Call(&encryptedResponse, rpcclientlib.RPCGetTransactionByHash, txHash.Hex())
 	if err != nil {
 		panic(fmt.Errorf("simulation failed due to failed %s RPC call. Cause: %w", rpcclientlib.RPCGetTransactionByHash, err))
 	}
@@ -114,13 +109,8 @@ func getTransaction(client rpcclientlib.Client, txHash gethcommon.Hash) map[stri
 
 // Returns the transaction receipt for the given transaction hash.
 func getTransactionReceipt(client rpcclientlib.Client, txHash gethcommon.Hash) map[string]interface{} {
-	paramsJSON, err := json.Marshal([]string{txHash.Hex()})
-	if err != nil {
-		panic(fmt.Errorf("simulation failed because could not marshall JSON param to %s RPC call. Cause: %w", rpcclientlib.RPCGetTxReceipt, err))
-	}
-
 	var encryptedResponse string
-	err = client.Call(&encryptedResponse, rpcclientlib.RPCGetTxReceipt, paramsJSON)
+	err := client.Call(&encryptedResponse, rpcclientlib.RPCGetTxReceipt, txHash.Hex())
 	if err != nil {
 		panic(fmt.Errorf("simulation failed due to failed %s RPC call. Cause: %w", rpcclientlib.RPCGetTxReceipt, err))
 	}
@@ -145,13 +135,9 @@ func balance(client rpcclientlib.Client, address gethcommon.Address, l2ContractA
 		rollupchain.CallFieldTo:   l2ContractAddress.Hex(),
 		rollupchain.CallFieldData: convertedData,
 	}
-	jsonParams, err := json.Marshal([]interface{}{params})
-	if err != nil {
-		panic(fmt.Errorf("simulation failed because could not marshall JSON param to %s RPC call. Cause: %w", method, err))
-	}
 
 	var encryptedResponse string
-	err = client.Call(&encryptedResponse, method, jsonParams)
+	err := client.Call(&encryptedResponse, method, params)
 	if err != nil {
 		panic(fmt.Errorf("simulation failed due to failed %s RPC call. Cause: %w", method, err))
 	}

--- a/integration/walletextension/wallet_extension_test.go
+++ b/integration/walletextension/wallet_extension_test.go
@@ -660,7 +660,7 @@ func createObscuroNetwork(t *testing.T) (func(), error) {
 		if counter > 20 {
 			t.Fatalf("could not get receipt for Obscuro ERC20 deployment transaction after 20 seconds")
 		}
-		txReceiptResp := makeEthJSONReq(t, walletExtensionAddr, walletextension.ReqJSONMethodGetTxReceipt, []string{txHash})
+		txReceiptResp := makeEthJSONReq(t, walletExtensionAddr, rpcclientlib.RPCGetTxReceipt, []string{txHash})
 		isTxOnChain := !strings.Contains(string(txReceiptResp), "could not retrieve transaction with hash")
 		if isTxOnChain {
 			break

--- a/tools/obscuroscan/main/cli.go
+++ b/tools/obscuroscan/main/cli.go
@@ -25,7 +25,7 @@ type obscuroscanConfig struct {
 func defaultObscuroClientConfig() obscuroscanConfig {
 	return obscuroscanConfig{
 		nodeID:        "",
-		rpcServerAddr: "127.0.0.1:13000",
+		rpcServerAddr: "testnet.obscu.ro:13000",
 		address:       "127.0.0.1:3000",
 	}
 }

--- a/tools/walletextension/main/main.go
+++ b/tools/walletextension/main/main.go
@@ -6,12 +6,16 @@ import (
 	"github.com/obscuronet/obscuro-playground/tools/walletextension"
 )
 
+const (
+	localhost = "127.0.0.1"
+)
+
 func main() {
 	config := parseCLIArgs()
 	walletExtension := walletextension.NewWalletExtension(config)
 	defer walletExtension.Shutdown()
 
-	walletExtensionAddr := fmt.Sprintf("%s:%d", walletextension.Localhost, config.WalletExtensionPort)
+	walletExtensionAddr := fmt.Sprintf("%s:%d", localhost, config.WalletExtensionPort)
 	go walletExtension.Serve(walletExtensionAddr)
 	fmt.Printf("Wallet extension started.\n💡 Visit %s/viewingkeys/ to generate an ephemeral viewing key. "+
 		"Without a viewing key, you will not be able to decrypt the enclave's secure responses to sensitive requests.\n", walletExtensionAddr)

--- a/tools/walletextension/static/javascript.js
+++ b/tools/walletextension/static/javascript.js
@@ -49,7 +49,7 @@ const initialize = () => {
             return
         }
 
-        const signedViewingKeyJson = {"signature": signature}
+        const signedViewingKeyJson = {"address": account, "signature": signature}
         const submitViewingKeyResp = await fetch(
             pathSubmitViewingKey, {
                 method: methodPost,

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -7,11 +7,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/obscuronet/obscuro-playground/go/common/log"
 	"io/fs"
 	"io/ioutil"
 	"net/http"
 	"os"
+
+	"github.com/obscuronet/obscuro-playground/go/common/log"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/go-kit/kit/transport/http/jsonrpc"

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -2,27 +2,20 @@ package walletextension
 
 import (
 	"context"
-	"crypto/rand"
 	"embed"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/obscuronet/obscuro-playground/go/common/log"
 	"io/fs"
 	"io/ioutil"
 	"net/http"
 	"os"
-	"strings"
-
-	"github.com/obscuronet/obscuro-playground/go/common/log"
-
-	"github.com/ethereum/go-ethereum/accounts"
 
 	"github.com/ethereum/go-ethereum/common"
-
+	"github.com/go-kit/kit/transport/http/jsonrpc"
 	"github.com/obscuronet/obscuro-playground/go/rpcclientlib"
-
-	"github.com/gorilla/websocket"
 
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/crypto/ecies"
@@ -36,18 +29,13 @@ const (
 	PathSubmitViewingKey   = "/submitviewingkey/"
 	staticDir              = "static"
 
-	reqJSONKeyMethod          = "method"
-	reqJSONKeyParams          = "params"
-	reqJSONKeyFrom            = "from"
-	ReqJSONMethodGetBalance   = "eth_getBalance"
-	ReqJSONMethodCall         = "eth_call"
-	ReqJSONMethodGetTxReceipt = "eth_getTransactionReceipt"
-	ReqJSONMethodSendRawTx    = "eth_sendRawTransaction"
-	ReqJSONMethodGetTxByHash  = "eth_getTransactionByHash"
-	respJSONKeyErr            = "error"
-	respJSONKeyMsg            = "message"
-	RespJSONKeyResult         = "result"
-	httpCodeErr               = 500
+	reqJSONKeyID      = "id"
+	reqJSONKeyMethod  = "method"
+	reqJSONKeyParams  = "params"
+	resJSONKeyID      = "id"
+	resJSONKeyRPCVer  = "jsonrpc"
+	RespJSONKeyResult = "result"
+	httpCodeErr       = 500
 
 	// CORS-related constants.
 	corsAllowOrigin  = "Access-Control-Allow-Origin"
@@ -57,20 +45,9 @@ const (
 	corsAllowHeaders = "Access-Control-Allow-Headers"
 	corsHeaders      = "Accept, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization"
 
-	Localhost         = "127.0.0.1"
-	websocketProtocol = "ws://"
-
 	// EnclavePublicKeyHex is the public key of the enclave.
 	// TODO - Retrieve this key from the management contract instead.
 	enclavePublicKeyHex = "034d3b7e63a8bcd532ee3d1d6ecad9d67fca7821981a044551f0f0cbec74d0bc5e"
-
-	// ViewingKeySignedMsgPrefix is the prefix added when signing the viewing key in MetaMask using the personal_sign
-	// API. Why is this needed? MetaMask has a security feature whereby if you ask it to sign something that looks like
-	// a transaction using the personal_sign API, it modifies the data being signed. The goal is to prevent hackers
-	// from asking a visitor to their website to personal_sign something that is actually a malicious transaction (e.g.
-	// theft of funds). By adding a prefix, the viewing key bytes no longer looks like a transaction hash, and thus get
-	// signed as-is.
-	ViewingKeySignedMsgPrefix = "vk"
 )
 
 //go:embed static
@@ -81,26 +58,26 @@ type WalletExtension struct {
 	enclavePublicKey *ecies.PublicKey // The public key used to encrypt requests for the enclave.
 	hostAddr         string           // The address on which the Obscuro host can be reached.
 	hostClient       rpcclientlib.Client
+	server           *http.Server
+}
 
-	// TODO - Support multiple viewing keys. This will require the enclave to attach metadata on encrypted results
-	//  to indicate which viewing key they were encrypted with.
-	viewingPublicKeyBytes  []byte
-	viewingPrivateKeyEcies *ecies.PrivateKey
-	// The address associated with the last viewing key submitted. Used to set missing `from` fields in `eth_call` requests.
-	viewingPublicKeyAddress common.Address
-	server                  *http.Server
+type rpcRequest struct {
+	id     interface{} // can be string or int
+	method string
+	params []interface{}
 }
 
 func NewWalletExtension(config Config) *WalletExtension {
-	enclavePublicKey, err := crypto.DecompressPubkey(common.Hex2Bytes(enclavePublicKeyHex))
+	enclPubECDSA, err := crypto.DecompressPubkey(common.Hex2Bytes(enclavePublicKeyHex))
 	if err != nil {
 		panic(err)
 	}
+	enclavePublicKey := ecies.ImportECDSAPublic(enclPubECDSA)
 
 	setLogs(config.LogPath)
 
 	return &WalletExtension{
-		enclavePublicKey: ecies.ImportECDSAPublic(enclavePublicKey),
+		enclavePublicKey: enclavePublicKey,
 		hostAddr:         config.NodeRPCWebsocketAddress,
 		hostClient:       rpcclientlib.NewClient(config.NodeRPCHTTPAddress),
 	}
@@ -171,105 +148,71 @@ func (we *WalletExtension) handleHTTPEthJSON(resp http.ResponseWriter, req *http
 		return
 	}
 
-	// We unmarshall the JSON request.
-	var reqJSONMap map[string]interface{}
-	err = json.Unmarshal(body, &reqJSONMap)
-	if err != nil {
-		logAndSendErr(resp, fmt.Sprintf("could not unmarshall JSON-RPC request body to JSON: %s. "+
-			"If you're trying to generate a viewing key, visit %s", err, pathViewingKeys))
-		return
-	}
-	method := reqJSONMap[reqJSONKeyMethod]
-	log.Info("Received %s request from wallet: %s", method, body)
-
-	reqJSONMap, err = we.ensureCallsHaveFromField(method, reqJSONMap)
+	rpcReq, err := parseRequest(body)
 	if err != nil {
 		logAndSendErr(resp, err.Error())
 		return
 	}
 
-	// We encrypt the request's params with the enclave's public key if it's a sensitive request.
-	maybeEncryptedBody, err := we.encryptParamsIfNeeded(body, method, reqJSONMap)
+	var rpcResp interface{}
+	err = we.hostClient.Call(&rpcResp, rpcReq.method, rpcReq.params...)
 	if err != nil {
-		logAndSendErr(resp, fmt.Sprintf("could not encrypt request parameters: %s", err))
+		logAndSendErr(resp, fmt.Sprintf("rpc request failed: %s", err))
 		return
 	}
 
-	// We forward the request on to the Obscuro node.
-	nodeResp, err := forwardMsgOverWebsocket(websocketProtocol+we.hostAddr, maybeEncryptedBody)
-	if err != nil {
-		logAndSendErr(resp, fmt.Sprintf("received error response when forwarding request to node at %s: %s", we.hostAddr, err))
-		return
-	}
+	respMap := make(map[string]interface{})
+	respMap[resJSONKeyID] = rpcReq.id
+	respMap[resJSONKeyRPCVer] = jsonrpc.Version
+	respMap[RespJSONKeyResult] = rpcResp
 
-	// We unmarshall the JSON response.
-	var respJSONMap map[string]interface{}
-	err = json.Unmarshal(nodeResp, &respJSONMap)
+	rpcRespToSend, err := json.Marshal(respMap)
 	if err != nil {
-		logAndSendErr(resp, fmt.Sprintf("could not unmarshall enclave response to JSON: %s", err))
-		return
+		logAndSendErr(resp, fmt.Sprintf("failed to remarshal RPC response to return to caller: %s", err))
 	}
-
-	// We report any errors from the request.
-	if respJSONMap[respJSONKeyErr] != nil {
-		logAndSendErr(resp, respJSONMap[respJSONKeyErr].(map[string]interface{})[respJSONKeyMsg].(string))
-		return
-	}
-
-	// We decrypt the result field if it's encrypted.
-	maybeDecryptedRespJSONMap, err := we.decryptResponseIfNeeded(method, respJSONMap)
-	if err != nil {
-		logAndSendErr(resp, fmt.Sprintf("could not decrypt response: %s", err))
-		return
-	}
-
-	// We marshal the response to present to the client.
-	clientResponse, err := json.Marshal(maybeDecryptedRespJSONMap)
-	if err != nil {
-		logAndSendErr(resp, fmt.Sprintf("could not marshal JSON response to present to the client: %s", err))
-		return
-	}
-	log.Info("Received %s response from Obscuro node: %s", method, strings.TrimSpace(string(clientResponse)))
+	log.Info("Forwarding %s response from Obscuro node: %s", rpcReq.method, rpcRespToSend)
 
 	// We write the response to the client.
-	_, err = resp.Write(clientResponse)
+	_, err = resp.Write(rpcRespToSend)
 	if err != nil {
 		logAndSendErr(resp, fmt.Sprintf("could not write JSON-RPC response: %s", err))
 		return
 	}
 }
 
-// If an `eth_call` request doesn't have a `from` field, we won't be able to encrypt the response. In that case, we use
-// the viewing key address as the `from` field to allow encryption and decryption.
-func (we *WalletExtension) ensureCallsHaveFromField(method interface{}, reqJSONMap map[string]interface{}) (map[string]interface{}, error) {
-	if method != ReqJSONMethodCall {
-		// We only modify `eth_call` requests.
-		return reqJSONMap, nil
+func parseRequest(body []byte) (*rpcRequest, error) {
+	// We unmarshall the JSON request
+	var reqJSONMap map[string]json.RawMessage
+	err := json.Unmarshal(body, &reqJSONMap)
+	if err != nil {
+		return nil, fmt.Errorf("could not unmarshal JSON-RPC request body to JSON: %s. "+
+			"If you're trying to generate a viewing key, visit %s", err, pathViewingKeys)
 	}
 
-	params, ok := reqJSONMap[reqJSONKeyParams].([]interface{})
-	if !ok {
-		return nil, fmt.Errorf("params for %s request were malformed", method)
+	var reqID interface{}
+	err = json.Unmarshal(reqJSONMap[reqJSONKeyID], &reqID)
+	if err != nil {
+		return nil, fmt.Errorf("could not unmarshal id from JSON-RPC request body: %w", err)
 	}
-	txCallParams, ok := params[0].(map[string]interface{})
-	if !ok {
-		return nil, fmt.Errorf("params for %s request were malformed", method)
+	var method string
+	err = json.Unmarshal(reqJSONMap[reqJSONKeyMethod], &method)
+	if err != nil {
+		return nil, fmt.Errorf("could not unmarshal method string from JSON-RPC request body: %w", err)
+	}
+	log.Info("Received %s request from wallet: %s", method, body)
+
+	// we extract the params into a JSON list
+	var params []interface{}
+	err = json.Unmarshal(reqJSONMap[reqJSONKeyParams], &params)
+	if err != nil {
+		return nil, fmt.Errorf("could not unmarshal params list from JSON-RPC request body: %w", err)
 	}
 
-	if txCallParams[reqJSONKeyFrom] != nil {
-		// We only modify `eth_call` requests where the `from` field is not set.
-		return reqJSONMap, nil
-	}
-
-	if we.viewingPublicKeyAddress == (common.Address{}) {
-		return nil, fmt.Errorf("could not add `from` field to `eth_call` request as no viewing key has been generated")
-	}
-
-	txCallParams[reqJSONKeyFrom] = we.viewingPublicKeyAddress.Hex()
-	params[0] = txCallParams
-	reqJSONMap[reqJSONKeyParams] = params
-
-	return reqJSONMap, nil
+	return &rpcRequest{
+		id:     reqID,
+		method: method,
+		params: params,
+	}, nil
 }
 
 // Generates a new viewing key.
@@ -279,8 +222,9 @@ func (we *WalletExtension) handleGenerateViewingKey(resp http.ResponseWriter, _ 
 		logAndSendErr(resp, fmt.Sprintf("could not generate new keypair: %s", err))
 		return
 	}
-	we.viewingPublicKeyBytes = crypto.CompressPubkey(&viewingKeyPrivate.PublicKey)
-	we.viewingPrivateKeyEcies = ecies.ImportECDSA(viewingKeyPrivate)
+	viewingPublicKeyBytes := crypto.CompressPubkey(&viewingKeyPrivate.PublicKey)
+	viewingPrivateKeyEcies := ecies.ImportECDSA(viewingKeyPrivate)
+	we.hostClient.SetViewingKey(viewingPrivateKeyEcies, viewingPublicKeyBytes)
 
 	// We return the hex of the viewing key's public key for MetaMask to sign over.
 	viewingKeyBytes := crypto.CompressPubkey(&viewingKeyPrivate.PublicKey)
@@ -303,7 +247,7 @@ func (we *WalletExtension) handleSubmitViewingKey(resp http.ResponseWriter, req 
 	var reqJSONMap map[string]string
 	err = json.Unmarshal(body, &reqJSONMap)
 	if err != nil {
-		logAndSendErr(resp, fmt.Sprintf("could not unmarshall viewing key and signature from client to JSON: %s", err))
+		logAndSendErr(resp, fmt.Sprintf("could not unmarshal viewing key and signature from client to JSON: %s", err))
 		return
 	}
 
@@ -313,28 +257,14 @@ func (we *WalletExtension) handleSubmitViewingKey(resp http.ResponseWriter, req 
 		logAndSendErr(resp, fmt.Sprintf("could not decode signature from client to hex: %s", err))
 		return
 	}
+	// This same change is made in geth internals, for legacy reasons to be able to recover the address:
+	//	https://github.com/ethereum/go-ethereum/blob/55599ee95d4151a2502465e0afc7c47bd1acba77/internal/ethapi/api.go#L452-L459
 	signature[64] -= 27
 
-	// We recover the public key address.
-	msgToSign := ViewingKeySignedMsgPrefix + hex.EncodeToString(we.viewingPublicKeyBytes)
-	recoveredPublicKey, err := crypto.SigToPub(accounts.TextHash([]byte(msgToSign)), signature)
+	// We return the hex of the viewing key's public key for MetaMask to sign over.
+	err = we.hostClient.RegisterViewingKey(common.HexToAddress(reqJSONMap["address"]), signature)
 	if err != nil {
-		logAndSendErr(resp, fmt.Sprintf("could not recover public key from signature: %s", err))
-		return
-	}
-	we.viewingPublicKeyAddress = crypto.PubkeyToAddress(*recoveredPublicKey)
-
-	// We encrypt the viewing key bytes.
-	encryptedViewingKeyBytes, err := ecies.Encrypt(rand.Reader, we.enclavePublicKey, we.viewingPublicKeyBytes, nil, nil)
-	if err != nil {
-		logAndSendErr(resp, fmt.Sprintf("could not encrypt viewing key with enclave public key: %s", err))
-		return
-	}
-
-	var rpcErr error
-	err = we.hostClient.Call(&rpcErr, rpcclientlib.RPCAddViewingKey, encryptedViewingKeyBytes, signature)
-	if err != nil {
-		logAndSendErr(resp, fmt.Sprintf("could not add viewing key: %s", err))
+		logAndSendErr(resp, fmt.Sprintf("RPC request to register viewing key failed: %s", err))
 		return
 	}
 }
@@ -352,96 +282,4 @@ type Config struct {
 	NodeRPCHTTPAddress      string
 	NodeRPCWebsocketAddress string
 	LogPath                 string
-}
-
-func forwardMsgOverWebsocket(url string, msg []byte) ([]byte, error) {
-	connection, resp, err := websocket.DefaultDialer.Dial(url, nil)
-	if err != nil {
-		return nil, err
-	}
-	defer connection.Close()
-	defer resp.Body.Close()
-
-	err = connection.WriteMessage(websocket.TextMessage, msg)
-	if err != nil {
-		return nil, err
-	}
-
-	_, message, err := connection.ReadMessage()
-	if err != nil {
-		return nil, err
-	}
-	return message, nil
-}
-
-// Encrypts the request's params with the enclave public key if the request is sensitive.
-func (we *WalletExtension) encryptParamsIfNeeded(body []byte, method interface{}, reqJSONMap map[string]interface{}) ([]byte, error) {
-	if !isSensitive(method) {
-		return body, nil
-	}
-
-	params := reqJSONMap[reqJSONKeyParams]
-	paramsJSON, err := json.Marshal(params)
-	if err != nil {
-		return nil, fmt.Errorf("could not marshal request params to JSON for encryption: %w", err)
-	}
-	encryptedParams, err := ecies.Encrypt(rand.Reader, we.enclavePublicKey, paramsJSON, nil, nil)
-	if err != nil {
-		return nil, fmt.Errorf("could not encrypt request params with enclave public key: %w", err)
-	}
-	reqJSONMap[reqJSONKeyParams] = []interface{}{encryptedParams}
-	body, err = json.Marshal(reqJSONMap)
-	if err != nil {
-		return nil, fmt.Errorf("could not marshal request with encrypted params to JSON: %w", err)
-	}
-
-	return body, nil
-}
-
-func (we *WalletExtension) decryptResponseIfNeeded(method interface{}, respJSONMap map[string]interface{}) (map[string]interface{}, error) {
-	if !isSensitive(method) {
-		return respJSONMap, nil
-	}
-
-	if we.viewingPrivateKeyEcies == nil {
-		return nil, fmt.Errorf("could not decrypt enclave response as no viewing key has been created")
-	}
-
-	encryptedResult := common.Hex2Bytes(respJSONMap[RespJSONKeyResult].(string))
-	decryptedResult, err := we.viewingPrivateKeyEcies.Decrypt(encryptedResult, nil, nil)
-	if err != nil {
-		return nil, fmt.Errorf("could not decrypt enclave response with viewing key: %w", err)
-	}
-
-	processedResult, err := processDecryptedResult(decryptedResult, method)
-	if err != nil {
-		return nil, fmt.Errorf("could not process decrypted enclave response: %w", err)
-	}
-	respJSONMap[RespJSONKeyResult] = processedResult
-
-	return respJSONMap, nil
-}
-
-// Indicates whether the RPC method's requests and responses should be encrypted.
-func isSensitive(method interface{}) bool {
-	return method == ReqJSONMethodGetBalance ||
-		method == ReqJSONMethodCall ||
-		method == ReqJSONMethodGetTxReceipt ||
-		method == ReqJSONMethodSendRawTx ||
-		method == ReqJSONMethodGetTxByHash
-}
-
-// Converts the decrypted result to its correct JSON representation.
-func processDecryptedResult(decryptedResult []byte, method interface{}) (interface{}, error) {
-	// This method returns a JSON map, rather than a string.
-	if method == ReqJSONMethodGetTxReceipt || method == ReqJSONMethodGetTxByHash {
-		fields := map[string]interface{}{}
-		err := json.Unmarshal(decryptedResult, &fields)
-		if err != nil {
-			return nil, err
-		}
-		return fields, nil
-	}
-
-	return string(decryptedResult), nil
 }


### PR DESCRIPTION
### Why is this change needed?

- We want to re-use the viewing key encryption/decryption for tests and scripts
- Communicating to the obscuro node is done a bit differently in many places, adding the enc/dec into the rpc client should give us a single codepath to worry about

### What changes were made as part of this PR:

- move the `isSensitive(method)` function and the encrypt/decrypt if necessary out from wallet extensions to be part of rpc client lib
- change wallet extension to use rpc client lib
- fix simulation tests (transaction injector) to use rpc client in a way that is consistent

### What are the key areas to look at
- `obscuro_client.go` in the rpcclientlib, the wallet_extension changes and the transaction injector changes
- there will be follow-ups to:
    * make viewing key enc/dec mandatory (means updating lots of test code and removing the viewing key disabled flag/codepaths from enclave code)
    * refactor to make sure encryption and transport encoding details don't leak into the logic implementations in the enclave/rollup_chain
    * make more methods sensitive/encrypted (i.e. the getNonce)