### PR TITLE
fix tx decoding bug

### DIFF
--- a/go/ethadapter/erc20contractlib/obscuro_ERC20_contract_ABI.go
+++ b/go/ethadapter/erc20contractlib/obscuro_ERC20_contract_ABI.go
@@ -31,6 +31,9 @@ const (
 )
 
 func DecodeTransferTx(t *types.Transaction) (bool, *gethcommon.Address, *big.Int) {
+	if len(t.Data()) < methodBytesLen {
+		return false, nil, nil
+	}
 	method, err := obscuroERC20ContractABIJSON.MethodById(t.Data()[:methodBytesLen])
 	if err != nil {
 		log.Info("Could not decode tx %d, Err: %s", common.ShortHash(t.Hash()), err)


### PR DESCRIPTION
### Why is this change needed?

to fix a bug:
```anic: runtime error: slice bounds out of range [:4] with capacity 0


goroutine 368 [running]:

github.com/obscuronet/obscuro-playground/go/ethadapter/erc20contractlib.DecodeTransferTx(0x7f9d14101320)

/home/obscuro/go-obscuro/go/ethadapter/erc20contractlib/obscuro_ERC20_contract_ABI.go:34 +0x365

github.com/obscuronet/obscuro-playground/go/enclave/bridge.(*Bridge).RollupPostProcessingWithdrawals(0x7f9d1416e380, 0x7f9d14704690, 0x7f9d14183380, 0xcacc86480d1e346f?)

/home/obscuro/go-obscuro/go/enclave/bridge/bridge.go:260 +0xdd

github.com/obscuronet/obscuro-playground/go/enclave/rollupchain.(*RollupChain).produceRollup(0x7f9d143e2a20, 0x7f9d1459cb40?, 0x7f9d141f12c0)

/home/obscuro/go-obscuro/go/enclave/rollupchain/rollup_chain.go:539 +0xa85

github.com/obscuronet/obscuro-playground/go/enclave/rollupchain.(*RollupChain).SubmitBlock(_, {0x7f9d141138c0, {0x7f9cffb0fcf8, 0x0, 0x0}, {0x7f9d1437f320, 0x1, 0x4}, {{0x0, 0x0}}, ...})

/home/obscuro/go-obscuro/go/enclave/rollupchain/rollup_chain.go:447 +0x389

```

### What changes were made as part of this PR:

Functional PR.
Add check that the tx.data can be parsed.

### What are the key areas to look at
