### PR TITLE
Set from field if missing in eth_call requests

### DIFF
--- a/go/enclave/db/storage.go
+++ b/go/enclave/db/storage.go
@@ -273,10 +273,10 @@ func (s *storageImpl) GetTransaction(txHash gethcommon.Hash) (*types.Transaction
 func (s *storageImpl) GetSender(txHash gethcommon.Hash) (gethcommon.Address, error) {
 	tx, _, _, _, err := s.GetTransaction(txHash) //nolint:dogsled
 	if err != nil {
-		return gethcommon.Address{}, fmt.Errorf("could not retrieve transaction in eth_getTransactionReceipt request. Cause: %w", err)
+		return gethcommon.Address{}, fmt.Errorf("could not retrieve transaction with hash %s. Cause: %w", txHash.Hex(), err)
 	}
 	if tx == nil {
-		return gethcommon.Address{}, fmt.Errorf("could not retrieve transaction in eth_getTransactionReceipt")
+		return gethcommon.Address{}, fmt.Errorf("could not retrieve transaction with hash %s", txHash.Hex())
 	}
 	msg, err := tx.AsMessage(types.NewLondonSigner(tx.ChainId()), nil)
 	if err != nil {

--- a/integration/walletextension/wallet_extension_test.go
+++ b/integration/walletextension/wallet_extension_test.go
@@ -247,7 +247,7 @@ func TestCanCallAfterSubmittingViewingKey(t *testing.T) {
 }
 
 func TestCanCallWithoutSettingFromField(t *testing.T) {
-	setupWalletTestLog("tx-with-viewing-key")
+	setupWalletTestLog("tx-no-from-field")
 
 	walletExtension := walletextension.NewWalletExtension(walletExtensionConfig)
 	defer walletExtension.Shutdown()

--- a/tools/walletextension/main/main.go
+++ b/tools/walletextension/main/main.go
@@ -14,8 +14,7 @@ func main() {
 	walletExtensionAddr := fmt.Sprintf("%s:%d", walletextension.Localhost, config.WalletExtensionPort)
 	go walletExtension.Serve(walletExtensionAddr)
 	fmt.Printf("Wallet extension started.\n💡 Visit %s/viewingkeys/ to generate an ephemeral viewing key. "+
-		"Without a viewing key, you will not be able to decrypt the enclave's secure responses to your "+
-		"eth_getBalance and eth_call requests.\n", walletExtensionAddr)
+		"Without a viewing key, you will not be able to decrypt the enclave's secure responses to sensitive requests.\n", walletExtensionAddr)
 
 	select {}
 }

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/ethereum/go-ethereum/accounts"
 	"io/fs"
 	"io/ioutil"
 	"net/http"
@@ -33,6 +34,7 @@ const (
 
 	reqJSONKeyMethod          = "method"
 	reqJSONKeyParams          = "params"
+	reqJSONKeyFrom            = "from"
 	ReqJSONMethodGetBalance   = "eth_getBalance"
 	ReqJSONMethodCall         = "eth_call"
 	ReqJSONMethodGetTxReceipt = "eth_getTransactionReceipt"
@@ -56,6 +58,14 @@ const (
 	// EnclavePublicKeyHex is the public key of the enclave.
 	// TODO - Retrieve this key from the management contract instead.
 	enclavePublicKeyHex = "034d3b7e63a8bcd532ee3d1d6ecad9d67fca7821981a044551f0f0cbec74d0bc5e"
+
+	// ViewingKeySignedMsgPrefix is the prefix added when signing the viewing key in MetaMask using the personal_sign
+	// API. Why is this needed? MetaMask has a security feature whereby if you ask it to sign something that looks like
+	// a transaction using the personal_sign API, it modifies the data being signed. The goal is to prevent hackers
+	// from asking a visitor to their website to personal_sign something that is actually a malicious transaction (e.g.
+	// theft of funds). By adding a prefix, the viewing key bytes no longer looks like a transaction hash, and thus get
+	// signed as-is.
+	ViewingKeySignedMsgPrefix = "vk"
 )
 
 //go:embed static
@@ -70,9 +80,10 @@ type WalletExtension struct {
 	hostClient       rpcclientlib.Client
 	// TODO - Support multiple viewing keys. This will require the enclave to attach metadata on encrypted results
 	//  to indicate which viewing key they were encrypted with.
-	viewingPublicKeyBytes  []byte
-	viewingPrivateKeyEcies *ecies.PrivateKey
-	server                 *http.Server
+	viewingPublicKeyAddress common.Address
+	viewingPublicKeyBytes   []byte
+	viewingPrivateKeyEcies  *ecies.PrivateKey
+	server                  *http.Server
 }
 
 func NewWalletExtension(config Config) *WalletExtension {
@@ -152,6 +163,12 @@ func (we *WalletExtension) handleHTTPEthJSON(resp http.ResponseWriter, req *http
 	method := reqJSONMap[reqJSONKeyMethod]
 	fmt.Printf("Received %s request from wallet: %s\n", method, body)
 
+	reqJSONMap, err = we.ensureCallsHaveFromField(method, reqJSONMap)
+	if err != nil {
+		logAndSendErr(resp, err.Error())
+		return
+	}
+
 	// We encrypt the request's params with the enclave's public key if it's a sensitive request.
 	maybeEncryptedBody, err := we.encryptParamsIfNeeded(body, method, reqJSONMap)
 	if err != nil {
@@ -203,6 +220,39 @@ func (we *WalletExtension) handleHTTPEthJSON(resp http.ResponseWriter, req *http
 	}
 }
 
+// If an `eth_call` request doesn't have a `from` field, we won't be able to encrypt the response. In that case, we use
+// the viewing key address as the `from` field to allow encryption and decryption.
+func (we *WalletExtension) ensureCallsHaveFromField(method interface{}, reqJSONMap map[string]interface{}) (map[string]interface{}, error) {
+	if method != ReqJSONMethodCall {
+		// We only modify `eth_call` requests.
+		return reqJSONMap, nil
+	}
+
+	params, ok := reqJSONMap[reqJSONKeyParams].([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("params for %s request were malformed", method)
+	}
+	txCallParams, ok := params[0].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("params for %s request were malformed", method)
+	}
+
+	if txCallParams[reqJSONKeyFrom] != nil {
+		// We only modify `eth_call` requests where the `from` field is not set.
+		return reqJSONMap, nil
+	}
+
+	if we.viewingPublicKeyAddress == (common.Address{}) {
+		return nil, fmt.Errorf("could not add `from` field to `eth_call` request as no viewing key has been generated")
+	}
+
+	txCallParams[reqJSONKeyFrom] = we.viewingPublicKeyAddress.Hex()
+	params[0] = txCallParams
+	reqJSONMap[reqJSONKeyParams] = params
+
+	return reqJSONMap, nil
+}
+
 // Generates a new viewing key.
 func (we *WalletExtension) handleGenerateViewingKey(resp http.ResponseWriter, _ *http.Request) {
 	viewingKeyPrivate, err := crypto.GenerateKey()
@@ -238,13 +288,22 @@ func (we *WalletExtension) handleSubmitViewingKey(resp http.ResponseWriter, req 
 		return
 	}
 
-	// We have to drop the leading "0x", and transform the V from 27/28 to 0/1.
+	// We drop the leading "0x", and transform the V from 27/28 to 0/1.
 	signature, err := hex.DecodeString(reqJSONMap["signature"][2:])
 	if err != nil {
 		logAndSendErr(resp, fmt.Sprintf("could not decode signature from client to hex: %s", err))
 		return
 	}
 	signature[64] -= 27
+
+	// We recover the public key address.
+	msgToSign := ViewingKeySignedMsgPrefix + hex.EncodeToString(we.viewingPublicKeyBytes)
+	recoveredPublicKey, err := crypto.SigToPub(accounts.TextHash([]byte(msgToSign)), signature)
+	if err != nil {
+		logAndSendErr(resp, fmt.Sprintf("could not recover public key from signature: %s", err))
+		return
+	}
+	we.viewingPublicKeyAddress = crypto.PubkeyToAddress(*recoveredPublicKey)
 
 	// We encrypt the viewing key bytes.
 	encryptedViewingKeyBytes, err := ecies.Encrypt(rand.Reader, we.enclavePublicKey, we.viewingPublicKeyBytes, nil, nil)

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -8,11 +8,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/ethereum/go-ethereum/accounts"
 	"io/fs"
 	"io/ioutil"
 	"net/http"
 	"strings"
+
+	"github.com/ethereum/go-ethereum/accounts"
 
 	"github.com/ethereum/go-ethereum/common"
 

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -383,6 +383,10 @@ func (we *WalletExtension) decryptResponseIfNeeded(method interface{}, respJSONM
 		return respJSONMap, nil
 	}
 
+	if we.viewingPrivateKeyEcies == nil {
+		return nil, fmt.Errorf("could not decrypt enclave response as no viewing key has been created")
+	}
+
 	fmt.Printf("🔐 Decrypting %s response from Obscuro node with viewing key.\n", method)
 	encryptedResult := common.Hex2Bytes(respJSONMap[RespJSONKeyResult].(string))
 	decryptedResult, err := we.viewingPrivateKeyEcies.Decrypt(encryptedResult, nil, nil)

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -81,9 +81,10 @@ type WalletExtension struct {
 	hostClient       rpcclientlib.Client
 	// TODO - Support multiple viewing keys. This will require the enclave to attach metadata on encrypted results
 	//  to indicate which viewing key they were encrypted with.
+	viewingPublicKeyBytes  []byte
+	viewingPrivateKeyEcies *ecies.PrivateKey
+	// The address associated with the last viewing key submitted. Used to set missing `from` fields in `eth_call` requests.
 	viewingPublicKeyAddress common.Address
-	viewingPublicKeyBytes   []byte
-	viewingPrivateKeyEcies  *ecies.PrivateKey
 	server                  *http.Server
 }
 


### PR DESCRIPTION
### Why is this change needed?

The `from` field in `eth_call` requests is optional. If it's missing, we have nothing to encrypt the response with, and we cannot send it in plaintext. So we set the `from` field to the viewing key address if it's missing.

### What changes were made as part of this PR:

Functional.

- Set `from` field in `eth_call` requests iff missing

### What are the key areas to look at
