### PR TITLE
Fix state calculation logic

### DIFF
--- a/go/enclave/core/rollup.go
+++ b/go/enclave/core/rollup.go
@@ -4,10 +4,8 @@ import (
 	"math/big"
 	"sync/atomic"
 
-	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/trie"
-
 	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/obscuronet/obscuro-playground/go/common"
 )
 
@@ -48,28 +46,18 @@ func NewHeader(parent *gethcommon.Hash, height uint64, a gethcommon.Address) *co
 	}
 }
 
-func NewRollupFromHeader(header *common.Header, blkHash gethcommon.Hash, txs []*common.L2Tx, nonce common.Nonce, state common.StateRoot) Rollup {
+func EmptyRollup(agg gethcommon.Address, parent *common.Header, blkHash gethcommon.Hash, nonce common.Nonce) *Rollup {
 	h := common.Header{
-		Agg:        header.Agg,
-		ParentHash: header.ParentHash,
+		Agg:        agg,
+		ParentHash: parent.Hash(),
 		L1Proof:    blkHash,
 		Nonce:      nonce,
-		Root:       state,
-		Number:     header.Number,
+		Number:     big.NewInt(int64(parent.Number.Uint64() + 1)),
 	}
-	transactions := make([]*common.L2Tx, len(txs))
-	copy(transactions, txs)
 	r := Rollup{
-		Header:       &h,
-		Transactions: transactions,
+		Header: &h,
 	}
-	if len(txs) == 0 {
-		h.TxHash = types.EmptyRootHash
-	} else {
-		h.TxHash = types.DeriveSha(types.Transactions(txs), trie.NewStackTrie(nil))
-	}
-
-	return r
+	return &r
 }
 
 // NewRollup - produces a new rollup. only used for genesis. todo - review

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -309,7 +309,6 @@ func (rc *RollupChain) validateRollup(rollup *obscurocore.Rollup, rootHash gethc
 	h := rollup.Header
 	if !bytes.Equal(rootHash.Bytes(), h.Root.Bytes()) {
 		dump := stateDB.Dump(&state.DumpConfig{})
-		// dump := ""
 		log.Info("Calculated a different state. This should not happen as there are no malicious actors yet. Rollup: r_%d, \nGot: %s\nExp: %s\nHeight:%d\nTxs:%v\nState: %s.\nDeposits: %+v",
 			common.ShortHash(rollup.Hash()), rootHash, h.Root, h.Number, obscurocore.PrintTxs(rollup.Transactions), dump, depositReceipts)
 		return false
@@ -543,8 +542,8 @@ func (rc *RollupChain) produceRollup(b *types.Block, bs *obscurocore.BlockState)
 		r.Header.TxHash = types.DeriveSha(types.Transactions(successfulTxs), trie.NewStackTrie(nil))
 	}
 
-	dump := newRollupState.Dump(&state.DumpConfig{})
-	log.Info("Create rollup. State: %s", dump)
+	// dump := newRollupState.Dump(&state.DumpConfig{})
+	// log.Info("Create rollup. State: %s", dump)
 
 	return r
 }


### PR DESCRIPTION
### Why is this change needed?

The logic to process the transactions in a rollup was implemented slightly different in the rollup checking function and in the rollup producing function.
This might have been the cause of the elusive bug where the calculated state of a rollup doesn't match the root hash from the header.

### What changes were made as part of this PR:

Refactoring.

Make the `process` function a bit more generic and use it in both the checkRollup and produceRollup

### What are the key areas to look at
- produceRollup