### PR TITLE
Further fixes to enable MetaMask and Remix

### DIFF
--- a/go/host/client_api_eth.go
+++ b/go/host/client_api_eth.go
@@ -46,21 +46,13 @@ func (api *EthereumAPI) GetBalance(_ context.Context, encryptedParams common.Enc
 // GetBlockByNumber returns the rollup with the given height as a block. No transactions are included.
 func (api *EthereumAPI) GetBlockByNumber(_ context.Context, number rpc.BlockNumber, _ bool) (map[string]interface{}, error) {
 	extRollup := api.host.EnclaveClient.GetRollupByHeight(uint64(number))
+	return extRollupToBlock(extRollup), nil
+}
 
-	block := map[string]interface{}{
-		"number":           (*hexutil.Big)(extRollup.Header.Number),
-		"hash":             extRollup.Header.Hash(),
-		"parenthash":       extRollup.Header.ParentHash,
-		"nonce":            extRollup.Header.Nonce,
-		"logsbloom":        extRollup.Header.Bloom,
-		"stateroot":        extRollup.Header.Root,
-		"receiptsroot":     extRollup.Header.ReceiptHash,
-		"miner":            extRollup.Header.Agg,
-		"extradata":        hexutil.Bytes(extRollup.Header.Extra),
-		"transactionsroot": extRollup.Header.TxHash,
-		"transactions":     extRollup.TxHashes,
-	}
-	return block, nil
+// GetBlockByHash returns the rollup with the given hash as a block. No transactions are included.
+func (api *EthereumAPI) GetBlockByHash(_ context.Context, hash gethcommon.Hash, _ bool) (map[string]interface{}, error) {
+	extRollup := api.host.EnclaveClient.GetRollup(hash)
+	return extRollupToBlock(extRollup), nil
 }
 
 // GasPrice is a placeholder for an RPC method required by MetaMask/Remix.
@@ -107,4 +99,21 @@ func (api *EthereumAPI) SendRawTransaction(_ context.Context, encryptedParams co
 func (api *EthereumAPI) GetTransactionCount(_ context.Context, address gethcommon.Address, _ rpc.BlockNumberOrHash) (*hexutil.Uint64, error) {
 	nonce := api.host.EnclaveClient.Nonce(address)
 	return (*hexutil.Uint64)(&nonce), nil
+}
+
+// Maps an external rollup to a block.
+func extRollupToBlock(extRollup *common.ExtRollup) map[string]interface{} {
+	return map[string]interface{}{
+		"number":           (*hexutil.Big)(extRollup.Header.Number),
+		"hash":             extRollup.Header.Hash(),
+		"parenthash":       extRollup.Header.ParentHash,
+		"nonce":            extRollup.Header.Nonce,
+		"logsbloom":        extRollup.Header.Bloom,
+		"stateroot":        extRollup.Header.Root,
+		"receiptsroot":     extRollup.Header.ReceiptHash,
+		"miner":            extRollup.Header.Agg,
+		"extradata":        hexutil.Bytes(extRollup.Header.Extra),
+		"transactionsroot": extRollup.Header.TxHash,
+		"transactions":     extRollup.TxHashes,
+	}
 }

--- a/integration/walletextension/wallet_extension_test.go
+++ b/integration/walletextension/wallet_extension_test.go
@@ -405,9 +405,10 @@ func TestCanSubmitTxAndGetTxReceiptAfterSubmittingViewingKey(t *testing.T) {
 	}
 	txReceiptJSON := makeEthJSONReqAsJSON(t, walletExtensionAddr, walletextension.ReqJSONMethodGetTxReceipt, []string{txHash})
 
-	expectedTxHashJSON := fmt.Sprintf("\"transactionHash\":\"%s\"", txHash)
-	if !strings.Contains(txReceiptJSON[walletextension.RespJSONKeyResult].(string), expectedTxHashJSON) {
-		t.Fatalf("Expected transaction receipt containing %s, got %s", "\"transactionHash\":\"0x03ec8936136e8a293d91309d8fcf095758015fb864aa64ecd9d77e3a4485b523\"", txReceiptJSON[walletextension.RespJSONKeyResult])
+	result := fmt.Sprintf("%s", txReceiptJSON[walletextension.RespJSONKeyResult])
+	expectedTxHashJSON := fmt.Sprintf("transactionHash:%s", txHash)
+	if !strings.Contains(result, expectedTxHashJSON) {
+		t.Fatalf("Expected transaction receipt containing %s, got %s", expectedTxHashJSON, result)
 	}
 }
 

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -395,7 +395,17 @@ func (we *WalletExtension) decryptResponseIfNeeded(method interface{}, respJSONM
 	if err != nil {
 		return nil, fmt.Errorf("could not decrypt enclave response with viewing key: %w", err)
 	}
-	respJSONMap[RespJSONKeyResult] = string(decryptedResult)
+	// todo - joel - cleanup. do for other result types - actually, it's only this one :)
+	if method == "eth_getTransactionReceipt" {
+		fields := map[string]interface{}{}
+		err := json.Unmarshal(decryptedResult, &fields)
+		if err != nil {
+			panic(err)
+		}
+		respJSONMap[RespJSONKeyResult] = fields
+	} else {
+		respJSONMap[RespJSONKeyResult] = string(decryptedResult)
+	}
 
 	return respJSONMap, nil
 }

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -395,17 +395,12 @@ func (we *WalletExtension) decryptResponseIfNeeded(method interface{}, respJSONM
 	if err != nil {
 		return nil, fmt.Errorf("could not decrypt enclave response with viewing key: %w", err)
 	}
-	// todo - joel - cleanup. do for other result types - actually, it's only this one :)
-	if method == "eth_getTransactionReceipt" {
-		fields := map[string]interface{}{}
-		err := json.Unmarshal(decryptedResult, &fields)
-		if err != nil {
-			panic(err)
-		}
-		respJSONMap[RespJSONKeyResult] = fields
-	} else {
-		respJSONMap[RespJSONKeyResult] = string(decryptedResult)
+
+	processedResult, err := processDecryptedResult(decryptedResult, method)
+	if err != nil {
+		return nil, fmt.Errorf("could not process decrypted enclave response: %s", err)
 	}
+	respJSONMap[RespJSONKeyResult] = processedResult
 
 	return respJSONMap, nil
 }
@@ -413,4 +408,19 @@ func (we *WalletExtension) decryptResponseIfNeeded(method interface{}, respJSONM
 // Indicates whether the RPC method's requests and responses should be encrypted.
 func isSensitive(method interface{}) bool {
 	return method == ReqJSONMethodGetBalance || method == ReqJSONMethodCall || method == ReqJSONMethodGetTxReceipt || method == ReqJSONMethodSendRawTx
+}
+
+// Converts the decrypted result to its correct JSON representation.
+func processDecryptedResult(decryptedResult []byte, method interface{}) (interface{}, error) {
+	// This method returns a JSON map, rather than a string.
+	if method == ReqJSONMethodGetTxReceipt {
+		fields := map[string]interface{}{}
+		err := json.Unmarshal(decryptedResult, &fields)
+		if err != nil {
+			return nil, err
+		}
+		return fields, nil
+	}
+
+	return string(decryptedResult), nil
 }

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -398,7 +398,7 @@ func (we *WalletExtension) decryptResponseIfNeeded(method interface{}, respJSONM
 
 	processedResult, err := processDecryptedResult(decryptedResult, method)
 	if err != nil {
-		return nil, fmt.Errorf("could not process decrypted enclave response: %s", err)
+		return nil, fmt.Errorf("could not process decrypted enclave response: %w", err)
 	}
 	respJSONMap[RespJSONKeyResult] = processedResult
 


### PR DESCRIPTION
### Why is this change needed?

Correctly formats the returned JSON for `eth_getTransactionReceipt`, so that MetaMask can detect a successful transaction.

Also adds the `eth_getBlockByHash` method that MetaMask needs.

### What changes were made as part of this PR:

Functional.

- As described above.

### What are the key areas to look at
