### PR TITLE
Wallet extension prints warning if MetaMask is not enabled.

### DIFF
--- a/tools/walletextension/static/javascript.js
+++ b/tools/walletextension/static/javascript.js
@@ -18,6 +18,11 @@ const initialize = () => {
     const statusArea = document.getElementById(idStatus);
 
     generateViewingKeyButton.addEventListener(eventClick, async () => {
+        if (typeof ethereum === "undefined") {
+            statusArea.innerText = "`ethereum` object is not available. Please install and enable MetaMask."
+            return
+        }
+
         const viewingKeyResp = await fetch(pathGenerateViewingKey);
         if (!viewingKeyResp.ok) {
             statusArea.innerText = "Failed to generate viewing key."

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -73,8 +73,6 @@ const (
 //go:embed static
 var staticFiles embed.FS
 
-// TODO - Display error in browser if Metamask is not enabled (i.e. `ethereum` object is not available in-browser).
-
 // WalletExtension is a server that handles the management of viewing keys and the forwarding of Ethereum JSON-RPC requests.
 type WalletExtension struct {
 	enclavePublicKey *ecies.PublicKey // The public key used to encrypt requests for the enclave.


### PR DESCRIPTION
### Why is this change needed?

Previously, if MetaMask was not installed, the wallet extension would simply not respond to attempts to generate a viewing key.

### What changes were made as part of this PR:

Functional.

- Attempting to generate a viewing key without MetaMask enabled prints an error, telling the user to install and enable MetaMask.

### What are the key areas to look at
