### PR TITLE
Fixing geth config + slowing down block production

### DIFF
--- a/.github/workflows/manual-deploy-l1network.yml
+++ b/.github/workflows/manual-deploy-l1network.yml
@@ -64,7 +64,7 @@ jobs:
           name: testnet-gethnetwork-app
           location: 'uksouth'
           restart-policy: 'Never'
-          command-line: /home/go-obscuro/integration/gethnetwork/main/main --numNodes=3 --startPort=8000 --websocketStartPort=9000 --prefundedAddrs=${{ secrets.GETHNETWORK_PREFUNDED_ADDR_WORKER }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_0 }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_1 }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_2 }}
+          command-line: /home/go-obscuro/integration/gethnetwork/main/main --blockTimeSecs 60 --numNodes=3 --startPort=8000 --websocketStartPort=9000 --prefundedAddrs=${{ secrets.GETHNETWORK_PREFUNDED_ADDR_WORKER }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_0 }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_1 }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_2 }}
           # Ports start at 9000 for Websockets and 8000 for Start port and 80025 for Http Port
           # Each node has Port + id
           ports: '8025 8026 8027 9000 9001 9002'

--- a/integration/gethnetwork/geth_network.go
+++ b/integration/gethnetwork/geth_network.go
@@ -60,6 +60,9 @@ const (
 	// snap (the default) mode does not work well for small, rapidly deployed private networks
 	syncModeFlag = "--syncmode=full"
 
+	// blockProductionIntervalFlag defines what is the block production period in seconds
+	blockProductionIntervalFlag = "--dev.period"
+
 	// We pre-allocate a wallet matching the private key used in the tests, plus an account per clique member.
 	genesisJSONTemplate = `{
 	  "config": {
@@ -114,6 +117,7 @@ type GethNetwork struct {
 	WebSocketPorts   []uint // Ports exposed by the geth nodes for
 	commStartPort    int
 	wsStartPort      int
+	blockTimeSecs    int
 }
 
 // NewGethNetwork returns an Ethereum network with numNodes nodes using the provided Geth binary and allows for prefunding addresses.
@@ -170,6 +174,7 @@ func NewGethNetwork(portStart int, websocketPortStart int, gethBinaryPath string
 		WebSocketPorts:   make([]uint, numNodes),
 		commStartPort:    portStart,
 		wsStartPort:      websocketPortStart,
+		blockTimeSecs:    blockTimeSecs,
 	}
 
 	// We create an account for each node.
@@ -347,6 +352,7 @@ func (network *GethNetwork) startMiner(dataDirPath string, idx int) {
 		network.passwordFilePath, mineFlag, rpcFeeCapFlag, syncModeFlag,
 		httpEnableFlag, httpPortFlag, strconv.Itoa(httpPort), httpEnableApis, allowedAPIs, allowCORSDomain, "*",
 		httpAddrFlag, "0.0.0.0", wsAddrFlag, "0.0.0.0", httpVhostsFlag, "*", gasLimitFlag,
+		blockProductionIntervalFlag, strconv.Itoa(network.blockTimeSecs),
 	}
 	cmd := exec.Command(network.gethBinaryPath, args...) // nolint
 

--- a/integration/gethnetwork/main/cli.go
+++ b/integration/gethnetwork/main/cli.go
@@ -37,7 +37,7 @@ func defaultHostConfig() gethConfig {
 		startPort:          12000,
 		websocketStartPort: 12100,
 		prefundedAddrs:     []string{},
-		blockTimeSecs:      6,
+		blockTimeSecs:      1,
 	}
 }
 

--- a/integration/gethnetwork/main/main.go
+++ b/integration/gethnetwork/main/main.go
@@ -17,7 +17,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	gethNetwork := gethnetwork.NewGethNetwork(config.startPort, config.websocketStartPort, gethBinaryPath, config.numNodes, 1, config.prefundedAddrs)
+	gethNetwork := gethnetwork.NewGethNetwork(config.startPort, config.websocketStartPort, gethBinaryPath, config.numNodes, config.blockTimeSecs, config.prefundedAddrs)
 	fmt.Println("Geth network started.")
 
 	handleInterrupt(gethNetwork)


### PR DESCRIPTION
### Why is this change needed?

- Keeps the testnet up for longer

### What changes were made as part of this PR:

- fixed geth arguments
- changed the deployment from 1 blk/sec to 1 blk/min
