### PR TITLE
Surfaces errors during encoding and decoding of blocks.

### DIFF
--- a/go/common/l1_types.go
+++ b/go/common/l1_types.go
@@ -1,9 +1,8 @@
 package common
 
 import (
+	"fmt"
 	"math/big"
-
-	"github.com/obscuronet/obscuro-playground/go/common/log"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -19,12 +18,12 @@ var GenesisBlock = NewBlock(nil, common.HexToAddress("0x0"), []*types.Transactio
 // EncodedBlock the encoded version of an ExtBlock
 type EncodedBlock []byte
 
-func EncodeBlock(b *types.Block) EncodedBlock {
+func EncodeBlock(b *types.Block) (EncodedBlock, error) {
 	encoded, err := rlp.EncodeToBytes(b)
 	if err != nil {
-		log.Panic("could not encode block to bytes. Cause: %s", err)
+		return nil, fmt.Errorf("could not encode block to bytes. Cause: %w", err)
 	}
-	return encoded
+	return encoded, nil
 }
 
 func (eb EncodedBlock) Decode() (*types.Block, error) {
@@ -33,12 +32,12 @@ func (eb EncodedBlock) Decode() (*types.Block, error) {
 	return &bl, err
 }
 
-func (eb EncodedBlock) DecodeBlock() *types.Block {
+func (eb EncodedBlock) DecodeBlock() (*types.Block, error) {
 	b, err := eb.Decode()
 	if err != nil {
-		log.Panic("could not decode block from bytes. Cause: %s", err)
+		return nil, fmt.Errorf("could not decode block from bytes. Cause: %w", err)
 	}
-	return b
+	return b, nil
 }
 
 // NewBlock - todo - remove this ASAP

--- a/go/host/enclave_client.go
+++ b/go/host/enclave_client.go
@@ -161,7 +161,10 @@ func (c *EnclaveRPCClient) IngestBlocks(blocks []*types.Block) []common.BlockSub
 
 	encodedBlocks := make([][]byte, 0)
 	for _, block := range blocks {
-		encodedBlock := common.EncodeBlock(block)
+		encodedBlock, err := common.EncodeBlock(block)
+		if err != nil {
+			log.Panic(">   Agg%d: Failed to ingest blocks. Cause: %s", common.ShortAddress(c.config.ID), err)
+		}
 		encodedBlocks = append(encodedBlocks, encodedBlock)
 	}
 	response, err := c.protoClient.IngestBlocks(timeoutCtx, &generated.IngestBlocksRequest{EncodedBlocks: encodedBlocks})

--- a/integration/ethereummock/node.go
+++ b/integration/ethereummock/node.go
@@ -163,7 +163,15 @@ func (m *Node) Start() {
 				if !found {
 					panic("noo")
 				}
-				m.Network.BroadcastBlock(common.EncodeBlock(mb), common.EncodeBlock(p))
+				encodedBlock, err := common.EncodeBlock(mb)
+				if err != nil {
+					panic(fmt.Errorf("could not encode block. Cause: %w", err))
+				}
+				encodedParentBlock, err := common.EncodeBlock(p)
+				if err != nil {
+					panic(fmt.Errorf("could not encode parent block. Cause: %w", err))
+				}
+				m.Network.BroadcastBlock(encodedBlock, encodedParentBlock)
 			}
 		case <-m.headInCh:
 			m.headOutCh <- head
@@ -212,14 +220,22 @@ func (m *Node) setHead(b *types.Block) *types.Block {
 	// notify the clients
 	for _, c := range m.clients {
 		t := c
+		encodedBlock, err := common.EncodeBlock(b)
+		if err != nil {
+			panic(fmt.Errorf("could not encode block. Cause: %w", err))
+		}
 		if b.NumberU64() == common.L1GenesisHeight {
-			go t.MockedNewHead(common.EncodeBlock(b), nil)
+			go t.MockedNewHead(encodedBlock, nil)
 		} else {
 			p, f := m.Resolver.ParentBlock(b)
 			if !f {
 				panic("This should not happen")
 			}
-			go t.MockedNewHead(common.EncodeBlock(b), common.EncodeBlock(p))
+			encodedParentBlock, err := common.EncodeBlock(p)
+			if err != nil {
+				panic(fmt.Errorf("could not encode parent block. Cause: %w", err))
+			}
+			go t.MockedNewHead(encodedBlock, encodedParentBlock)
 		}
 	}
 	m.canonicalCh <- b
@@ -235,7 +251,11 @@ func (m *Node) setFork(blocks []*types.Block) *types.Block {
 
 	fork := make([]common.EncodedBlock, len(blocks))
 	for i, block := range blocks {
-		fork[i] = common.EncodeBlock(block)
+		encodedBlock, err := common.EncodeBlock(block)
+		if err != nil {
+			panic(fmt.Errorf("could not encode block. Cause: %w", err))
+		}
+		fork[i] = encodedBlock
 	}
 
 	// notify the clients
@@ -253,8 +273,16 @@ func (m *Node) P2PReceiveBlock(b common.EncodedBlock, p common.EncodedBlock) {
 	if atomic.LoadInt32(m.interrupt) == 1 {
 		return
 	}
-	m.p2pCh <- p.DecodeBlock()
-	m.p2pCh <- b.DecodeBlock()
+	decodedBlock, err := b.DecodeBlock()
+	if err != nil {
+		panic(fmt.Errorf("could not decode block. Cause: %w", err))
+	}
+	decodedParentBlock, err := p.DecodeBlock()
+	if err != nil {
+		panic(fmt.Errorf("could not decode parent block. Cause: %w", err))
+	}
+	m.p2pCh <- decodedParentBlock
+	m.p2pCh <- decodedBlock
 }
 
 // startMining - listens on the canonicalCh and schedule a go routine that produces a block after a PowTime and drop it


### PR DESCRIPTION
### Why is this change needed?

Encoding or decoding a block panics if there's an issue. This isn't always the correct behaviour. Often (e.g. when receiving blocks via RPC), it is better to handle the error (e.g. to prevent bad blocks from being sent over and crashing the node).

### What changes were made as part of this PR:

Functional.

- `EncodeBlock` now returns an error instead of panicking
- `DecodeBlock` now returns an error instead of panicking

### What are the key areas to look at
