### PR TITLE
Use `LogWithID` and similar everywhere

### DIFF
--- a/go/common/logging.go
+++ b/go/common/logging.go
@@ -9,29 +9,29 @@ import (
 // LogWithID logs a message at INFO level with the aggregator's identity prepended.
 func LogWithID(nodeID uint64, msg string, args ...interface{}) {
 	formattedMsg := fmt.Sprintf(msg, args...)
-	log.Info(fmt.Sprintf(">   Agg%d: %s", nodeID, formattedMsg))
+	log.Info(">   Agg%d: %s", nodeID, formattedMsg)
 }
 
 // WarnWithID logs a message at WARN level with the aggregator's identity prepended.
 func WarnWithID(nodeID uint64, msg string, args ...interface{}) {
 	formattedMsg := fmt.Sprintf(msg, args...)
-	log.Warn(fmt.Sprintf(">   Agg%d: %s", nodeID, formattedMsg))
+	log.Warn(">   Agg%d: %s", nodeID, formattedMsg)
 }
 
 // TraceWithID logs a message at TRACE level with the aggregator's identity prepended.
 func TraceWithID(nodeID uint64, msg string, args ...interface{}) {
 	formattedMsg := fmt.Sprintf(msg, args...)
-	log.Trace(fmt.Sprintf(">   Agg%d: %s", nodeID, formattedMsg))
+	log.Trace(">   Agg%d: %s", nodeID, formattedMsg)
 }
 
 // ErrorWithID logs a message at ERROR level with the aggregator's identity prepended.
 func ErrorWithID(nodeID uint64, msg string, args ...interface{}) {
 	formattedMsg := fmt.Sprintf(msg, args...)
-	log.Error(fmt.Sprintf(">   Agg%d: %s", nodeID, formattedMsg))
+	log.Error(">   Agg%d: %s", nodeID, formattedMsg)
 }
 
 // PanicWithID logs a message at PANIC level with the aggregator's identity prepended.
 func PanicWithID(nodeID uint64, msg string, args ...interface{}) {
 	formattedMsg := fmt.Sprintf(msg, args...)
-	log.Panic(fmt.Sprintf(">   Agg%d: %s", nodeID, formattedMsg))
+	log.Panic(">   Agg%d: %s", nodeID, formattedMsg)
 }

--- a/go/common/logging.go
+++ b/go/common/logging.go
@@ -18,6 +18,12 @@ func WarnWithID(nodeID uint64, msg string, args ...interface{}) {
 	log.Warn(fmt.Sprintf(">   Agg%d: %s", nodeID, formattedMsg))
 }
 
+// TraceWithID logs a message at TRACE level with the aggregator's identity prepended.
+func TraceWithID(nodeID uint64, msg string, args ...interface{}) {
+	formattedMsg := fmt.Sprintf(msg, args...)
+	log.Trace(fmt.Sprintf(">   Agg%d: %s", nodeID, formattedMsg))
+}
+
 // ErrorWithID logs a message at ERROR level with the aggregator's identity prepended.
 func ErrorWithID(nodeID uint64, msg string, args ...interface{}) {
 	formattedMsg := fmt.Sprintf(msg, args...)

--- a/go/common/logging.go
+++ b/go/common/logging.go
@@ -29,3 +29,9 @@ func ErrorWithID(nodeID uint64, msg string, args ...interface{}) {
 	formattedMsg := fmt.Sprintf(msg, args...)
 	log.Error(fmt.Sprintf(">   Agg%d: %s", nodeID, formattedMsg))
 }
+
+// PanicWithID logs a message at PANIC level with the aggregator's identity prepended.
+func PanicWithID(nodeID uint64, msg string, args ...interface{}) {
+	formattedMsg := fmt.Sprintf(msg, args...)
+	log.Panic(fmt.Sprintf(">   Agg%d: %s", nodeID, formattedMsg))
+}

--- a/go/common/logging.go
+++ b/go/common/logging.go
@@ -6,32 +6,34 @@ import (
 	"github.com/obscuronet/obscuro-playground/go/common/log"
 )
 
+const logPattern = ">   Agg%d: %s"
+
 // LogWithID logs a message at INFO level with the aggregator's identity prepended.
 func LogWithID(nodeID uint64, msg string, args ...interface{}) {
 	formattedMsg := fmt.Sprintf(msg, args...)
-	log.Info(">   Agg%d: %s", nodeID, formattedMsg)
+	log.Info(logPattern, nodeID, formattedMsg)
 }
 
 // WarnWithID logs a message at WARN level with the aggregator's identity prepended.
 func WarnWithID(nodeID uint64, msg string, args ...interface{}) {
 	formattedMsg := fmt.Sprintf(msg, args...)
-	log.Warn(">   Agg%d: %s", nodeID, formattedMsg)
+	log.Warn(logPattern, nodeID, formattedMsg)
 }
 
 // TraceWithID logs a message at TRACE level with the aggregator's identity prepended.
 func TraceWithID(nodeID uint64, msg string, args ...interface{}) {
 	formattedMsg := fmt.Sprintf(msg, args...)
-	log.Trace(">   Agg%d: %s", nodeID, formattedMsg)
+	log.Trace(logPattern, nodeID, formattedMsg)
 }
 
 // ErrorWithID logs a message at ERROR level with the aggregator's identity prepended.
 func ErrorWithID(nodeID uint64, msg string, args ...interface{}) {
 	formattedMsg := fmt.Sprintf(msg, args...)
-	log.Error(">   Agg%d: %s", nodeID, formattedMsg)
+	log.Error(logPattern, nodeID, formattedMsg)
 }
 
 // PanicWithID logs a message at PANIC level with the aggregator's identity prepended.
 func PanicWithID(nodeID uint64, msg string, args ...interface{}) {
 	formattedMsg := fmt.Sprintf(msg, args...)
-	log.Panic(">   Agg%d: %s", nodeID, formattedMsg)
+	log.Panic(logPattern, nodeID, formattedMsg)
 }

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -418,7 +418,7 @@ func (e *enclaveImpl) InitEnclave(s common.EncryptedSharedEnclaveSecret) error {
 		return err
 	}
 	e.storage.StoreSecret(*secret)
-	log.Trace(">   Agg%d: Secret decrypted and stored. Secret: %v", e.nodeShortID, secret)
+	common.TraceWithID(e.nodeShortID, "Secret decrypted and stored. Secret: %v", secret)
 	return nil
 }
 

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -521,8 +521,7 @@ func (e *enclaveImpl) start(block types.Block) {
 			env.header = obscurocore.NewHeader(&hash, winnerRollup.Header.Number.Uint64()+1, e.config.HostID)
 			env.headRollup = winnerRollup
 			env.state = e.storage.CreateStateDB(winnerRollup.Hash())
-			log.Trace(fmt.Sprintf(">   Agg%d: Create new speculative env  r_%d(%d).",
-				e.nodeShortID,
+			common.TraceWithID(e.nodeShortID, "Create new speculative env  r_%d(%d).",
 				obscurocommon.ShortHash(winnerRollup.Header.Hash()),
 				winnerRollup.Header.Number,
 			))

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -216,11 +216,10 @@ func (rc *RollupChain) updateState(b *types.Block) *obscurocore.BlockState {
 	}
 
 	bs, head, receipts := rc.calculateBlockState(b, parentState, rollups)
-	log.Trace(fmt.Sprintf(">   Agg%d: Calc block state b_%d: Found: %t - r_%d, ",
-		rc.nodeID,
+	common.TraceWithID(rc.nodeID, "Calc block state b_%d: Found: %t - r_%d, ",
 		common.ShortHash(b.Hash()),
 		bs.FoundNewRollup,
-		common.ShortHash(bs.HeadRollup)))
+		common.ShortHash(bs.HeadRollup))
 
 	rc.storage.SaveNewHead(bs, head, receipts)
 
@@ -282,7 +281,7 @@ func (rc *RollupChain) processState(rollup *obscurocore.Rollup, txs obscurocore.
 		if f {
 			successfulTransactions = append(successfulTransactions, tx)
 		} else {
-			log.Info(">   Agg%d: Excluding transaction %d", common.ShortAddress(rc.hostID), common.ShortHash(tx.Hash()))
+			common.LogWithID(common.ShortAddress(rc.hostID), "Excluding transaction %d", common.ShortHash(tx.Hash()))
 		}
 	}
 

--- a/go/host/enclave_client.go
+++ b/go/host/enclave_client.go
@@ -29,15 +29,18 @@ type EnclaveRPCClient struct {
 	protoClient generated.EnclaveProtoClient
 	connection  *grpc.ClientConn
 	config      config.HostConfig
+	nodeShortID uint64
 }
 
 // TODO - Avoid panicking and return errors instead where appropriate.
 
 func NewEnclaveRPCClient(config config.HostConfig) *EnclaveRPCClient {
+	nodeShortID := common.ShortAddress(config.ID)
+
 	opts := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
 	connection, err := grpc.Dial(config.EnclaveRPCAddress, opts...)
 	if err != nil {
-		log.Panic(">   Agg%d: Failed to connect to enclave RPC service. Cause: %s", common.ShortAddress(config.ID), err)
+		common.PanicWithID(nodeShortID, "Failed to connect to enclave RPC service. Cause: %s", err)
 	}
 
 	// We wait for the RPC connection to be ready.
@@ -54,10 +57,15 @@ func NewEnclaveRPCClient(config config.HostConfig) *EnclaveRPCClient {
 	}
 
 	if currentState != connectivity.Ready {
-		log.Panic(">   Agg%d: RPC connection failed to establish. Current state is %s", common.ShortAddress(config.ID), currentState)
+		common.PanicWithID(nodeShortID, "RPC connection failed to establish. Current state is %s", currentState)
 	}
 
-	return &EnclaveRPCClient{generated.NewEnclaveProtoClient(connection), connection, config}
+	return &EnclaveRPCClient{
+		generated.NewEnclaveProtoClient(connection),
+		connection,
+		config,
+		nodeShortID,
+	}
 }
 
 func (c *EnclaveRPCClient) StopClient() error {
@@ -88,7 +96,7 @@ func (c *EnclaveRPCClient) Attestation() *common.AttestationReport {
 
 	response, err := c.protoClient.Attestation(timeoutCtx, &generated.AttestationRequest{})
 	if err != nil {
-		log.Panic(">   Agg%d: Failed to retrieve attestation. Cause: %s", common.ShortAddress(c.config.ID), err)
+		common.PanicWithID(c.nodeShortID, "Failed to retrieve attestation. Cause: %s", err)
 	}
 	return rpc.FromAttestationReportMsg(response.AttestationReportMsg)
 }
@@ -99,7 +107,7 @@ func (c *EnclaveRPCClient) GenerateSecret() common.EncryptedSharedEnclaveSecret 
 
 	response, err := c.protoClient.GenerateSecret(timeoutCtx, &generated.GenerateSecretRequest{})
 	if err != nil {
-		log.Panic(">   Agg%d: Failed to generate secret. Cause: %s", common.ShortAddress(c.config.ID), err)
+		common.PanicWithID(c.nodeShortID, "Failed to generate secret. Cause: %s", err)
 	}
 	return response.EncryptedSharedEnclaveSecret
 }
@@ -140,7 +148,7 @@ func (c *EnclaveRPCClient) IsInitialised() bool {
 
 	response, err := c.protoClient.IsInitialised(timeoutCtx, &generated.IsInitialisedRequest{})
 	if err != nil {
-		log.Panic(">   Agg%d: Failed to establish enclave initialisation status. Cause: %s", common.ShortAddress(c.config.ID), err)
+		common.PanicWithID(c.nodeShortID, "Failed to establish enclave initialisation status. Cause: %s", err)
 	}
 	return response.IsInitialised
 }
@@ -150,7 +158,7 @@ func (c *EnclaveRPCClient) ProduceGenesis(blkHash gethcommon.Hash) common.BlockS
 	defer cancel()
 	response, err := c.protoClient.ProduceGenesis(timeoutCtx, &generated.ProduceGenesisRequest{BlockHash: blkHash.Bytes()})
 	if err != nil {
-		log.Panic(">   Agg%d: Failed to produce genesis. Cause: %s", common.ShortAddress(c.config.ID), err)
+		common.PanicWithID(c.nodeShortID, "Failed to produce genesis. Cause: %s", err)
 	}
 	return rpc.FromBlockSubmissionResponseMsg(response.BlockSubmissionResponse)
 }
@@ -166,7 +174,7 @@ func (c *EnclaveRPCClient) IngestBlocks(blocks []*types.Block) []common.BlockSub
 	}
 	response, err := c.protoClient.IngestBlocks(timeoutCtx, &generated.IngestBlocksRequest{EncodedBlocks: encodedBlocks})
 	if err != nil {
-		log.Panic(">   Agg%d: Failed to ingest blocks. Cause: %s", common.ShortAddress(c.config.ID), err)
+		common.PanicWithID(c.nodeShortID, "Failed to ingest blocks. Cause: %s", err)
 	}
 	responses := response.GetBlockSubmissionResponses()
 	result := make([]common.BlockSubmissionResponse, len(responses))
@@ -182,11 +190,11 @@ func (c *EnclaveRPCClient) Start(block types.Block) {
 
 	var buffer bytes.Buffer
 	if err := block.EncodeRLP(&buffer); err != nil {
-		log.Panic(">   Agg%d: Failed to encode block. Cause: %s", common.ShortAddress(c.config.ID), err)
+		common.PanicWithID(c.nodeShortID, "Failed to encode block. Cause: %s", err)
 	}
 	_, err := c.protoClient.Start(timeoutCtx, &generated.StartRequest{EncodedBlock: buffer.Bytes()})
 	if err != nil {
-		log.Panic(">   Agg%d: Failed to start enclave. Cause: %s", common.ShortAddress(c.config.ID), err)
+		common.PanicWithID(c.nodeShortID, "Failed to start enclave. Cause: %s", err)
 	}
 }
 
@@ -196,13 +204,13 @@ func (c *EnclaveRPCClient) SubmitBlock(block types.Block) common.BlockSubmission
 
 	var buffer bytes.Buffer
 	if err := block.EncodeRLP(&buffer); err != nil {
-		log.Panic(">   Agg%d: Failed to encode block. Cause: %s", common.ShortAddress(c.config.ID), err)
+		common.PanicWithID(c.nodeShortID, "Failed to encode block. Cause: %s", err)
 	}
 
 	processTime := time.Now()
 	response, err := c.protoClient.SubmitBlock(timeoutCtx, &generated.SubmitBlockRequest{EncodedBlock: buffer.Bytes()})
 	if err != nil {
-		log.Panic(">   Agg%d: Failed to submit block. Cause: %s", common.ShortAddress(c.config.ID), err)
+		common.PanicWithID(c.nodeShortID, "Failed to submit block. Cause: %s", err)
 	}
 	log.Debug("Block %s processed by the enclave over RPC in %s", block.Hash().Hex(), time.Since(processTime))
 	return rpc.FromBlockSubmissionResponseMsg(response.BlockSubmissionResponse)
@@ -215,7 +223,7 @@ func (c *EnclaveRPCClient) SubmitRollup(rollup common.ExtRollup) {
 	extRollupMsg := rpc.ToExtRollupMsg(&rollup)
 	_, err := c.protoClient.SubmitRollup(timeoutCtx, &generated.SubmitRollupRequest{ExtRollup: &extRollupMsg})
 	if err != nil {
-		log.Panic(">   Agg%d: Failed to submit rollup. Cause: %s", common.ShortAddress(c.config.ID), err)
+		common.PanicWithID(c.nodeShortID, "Failed to submit rollup. Cause: %s", err)
 	}
 }
 
@@ -252,7 +260,7 @@ func (c *EnclaveRPCClient) Nonce(address gethcommon.Address) uint64 {
 
 	response, err := c.protoClient.Nonce(timeoutCtx, &generated.NonceRequest{Address: address.Bytes()})
 	if err != nil {
-		log.Panic(">   Agg%d: Failed to retrieve nonce: %s", common.ShortAddress(c.config.ID), err)
+		common.PanicWithID(c.nodeShortID, "Failed to retrieve nonce: %s", err)
 	}
 	return response.Nonce
 }
@@ -263,7 +271,7 @@ func (c *EnclaveRPCClient) RoundWinner(parent common.L2RootHash) (common.ExtRoll
 
 	response, err := c.protoClient.RoundWinner(timeoutCtx, &generated.RoundWinnerRequest{Parent: parent.Bytes()})
 	if err != nil {
-		log.Panic(">   Agg%d: Failed to determine round winner. Cause: %s", common.ShortAddress(c.config.ID), err)
+		common.PanicWithID(c.nodeShortID, "Failed to determine round winner. Cause: %s", err)
 	}
 
 	if response.Winner {
@@ -311,7 +319,7 @@ func (c *EnclaveRPCClient) GetRollup(rollupHash common.L2RootHash) *common.ExtRo
 
 	response, err := c.protoClient.GetRollup(timeoutCtx, &generated.GetRollupRequest{RollupHash: rollupHash.Bytes()})
 	if err != nil {
-		log.Panic(">   Agg%d: Failed to retrieve rollup. Cause: %s", common.ShortAddress(c.config.ID), err)
+		common.PanicWithID(c.nodeShortID, "Failed to retrieve rollup. Cause: %s", err)
 	}
 
 	if !response.Known {
@@ -328,7 +336,7 @@ func (c *EnclaveRPCClient) GetRollupByHeight(rollupHeight int64) *common.ExtRoll
 
 	response, err := c.protoClient.GetRollupByHeight(timeoutCtx, &generated.GetRollupByHeightRequest{RollupHeight: rollupHeight})
 	if err != nil {
-		log.Panic(">   Agg%d: Failed to retrieve rollup with height %d. Cause: %s", common.ShortAddress(c.config.ID), rollupHeight, err)
+		common.PanicWithID(c.nodeShortID, "Failed to retrieve rollup with height %d. Cause: %s", rollupHeight, err)
 	}
 
 	if !response.Known {

--- a/go/host/enclave_client.go
+++ b/go/host/enclave_client.go
@@ -171,7 +171,7 @@ func (c *EnclaveRPCClient) IngestBlocks(blocks []*types.Block) []common.BlockSub
 	for _, block := range blocks {
 		encodedBlock, err := common.EncodeBlock(block)
 		if err != nil {
-			log.Panic(">   Agg%d: Failed to ingest blocks. Cause: %s", common.ShortAddress(c.config.ID), err)
+			common.PanicWithID(c.nodeShortID, "Failed to ingest blocks. Cause: %s", err)
 		}
 		encodedBlocks = append(encodedBlocks, encodedBlock)
 	}

--- a/go/host/enclave_client.go
+++ b/go/host/enclave_client.go
@@ -252,7 +252,7 @@ func (c *EnclaveRPCClient) Nonce(address gethcommon.Address) uint64 {
 
 	response, err := c.protoClient.Nonce(timeoutCtx, &generated.NonceRequest{Address: address.Bytes()})
 	if err != nil {
-		panic(fmt.Errorf(">   Agg%d: Failed to retrieve nonce: %w", common.ShortAddress(c.config.ID), err))
+		log.Panic(">   Agg%d: Failed to retrieve nonce: %s", common.ShortAddress(c.config.ID), err)
 	}
 	return response.Nonce
 }

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -183,7 +183,7 @@ func (a *Node) SubmitAndBroadcastTx(encryptedParams common.EncryptedParamsSendRa
 	encryptedTx := common.EncryptedTx(encryptedParams)
 	encryptedResponse, err := a.EnclaveClient.SubmitTx(encryptedTx)
 	if err != nil {
-		log.Info(fmt.Sprintf(">   Agg%d: Could not submit transaction: %s", a.shortID, err))
+		common.LogWithID(a.shortID, "Could not submit transaction: %s", err)
 		return nil, err
 	}
 
@@ -320,11 +320,10 @@ func (a *Node) startProcessing() {
 
 		case r := <-a.rollupsP2PCh:
 			rol, err := common.DecodeRollup(r)
-			log.Trace(fmt.Sprintf(">   Agg%d: Received rollup: r_%d from A%d",
-				a.shortID,
+			common.TraceWithID(a.shortID, "Received rollup: r_%d from A%d",
 				common.ShortHash(rol.Hash()),
 				common.ShortAddress(rol.Header.Agg),
-			))
+			)
 			if err != nil {
 				common.WarnWithID(a.shortID, "Could not check enclave initialisation. Cause: %v", err)
 			}

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -124,7 +124,7 @@ func (a *Node) Start() {
 		// Create the shared secret and submit it to the management contract for storage
 		attestation := a.EnclaveClient.Attestation()
 		if attestation.Owner != a.ID {
-			log.Panic(">   Agg%d: genesis node has ID %s, but its enclave produced an attestation using ID %s", a.shortID, a.ID.Hex(), attestation.Owner.Hex())
+			common.PanicWithID(a.shortID, "genesis node has ID %s, but its enclave produced an attestation using ID %s", a.ID.Hex(), attestation.Owner.Hex())
 		}
 
 		l1tx := &ethadapter.L1InitializeSecretTx{
@@ -505,7 +505,7 @@ func (a *Node) requestSecret() {
 	common.LogWithID(a.shortID, "Requesting secret.")
 	att := a.EnclaveClient.Attestation()
 	if att.Owner != a.ID {
-		log.Panic(">   Agg%d: node has ID %s, but its enclave produced an attestation using ID %s", a.shortID, a.ID.Hex(), att.Owner.Hex())
+		common.PanicWithID(a.shortID, "node has ID %s, but its enclave produced an attestation using ID %s", a.ID.Hex(), att.Owner.Hex())
 	}
 	encodedAttestation := common.EncodeAttestation(att)
 	l1tx := &ethadapter.L1RequestSecretTx{


### PR DESCRIPTION
### Why is this change needed?

We have introduced `LogWithID` and similar methods to automate prefixing a node's ID to a log message. But we used it inconsistently, in part because we didn't have similar methods for `log.Panic` and `log.Trace`.

### What changes were made as part of this PR:

Functional.

- Introduces `TraceWithID` and `LogWithID` everywhere
- Uses the logging methods everywhere they apply
- Creates a `nodeShortID` field on the enclave client to avoid endless recalculation of the node's short ID

### What are the key areas to look at
