### PR TITLE
Tudor/fix performance

### DIFF
--- a/go/common/types.go
+++ b/go/common/types.go
@@ -46,7 +46,7 @@ const (
 	L2GenesisHeight = uint64(0)
 	L1GenesisHeight = uint64(0)
 	// HeightCommittedBlocks is the number of blocks deep a transaction must be to be considered safe from reorganisations.
-	HeightCommittedBlocks = 20
+	HeightCommittedBlocks = 15
 )
 
 // Header is a public / plaintext struct that holds common properties of the Rollup

--- a/go/enclave/mempool/manager.go
+++ b/go/enclave/mempool/manager.go
@@ -76,6 +76,7 @@ func (db *mempoolManager) RemoveMempoolTxs(rollup *obscurocore.Rollup, resolver 
 func historicTxs(r *obscurocore.Rollup, resolver db.RollupResolver) map[gethcommon.Hash]gethcommon.Hash {
 	i := common.HeightCommittedBlocks
 	c := r
+	// todo - create method to return the canonical rollup from height N
 	for {
 		if i == 0 || c.Header.Number.Uint64() == common.L2GenesisHeight {
 			return obscurocore.ToMap(c.Transactions)
@@ -95,16 +96,21 @@ func (db *mempoolManager) CurrentTxs(head *obscurocore.Rollup, resolver db.Rollu
 // findTxsNotIncluded - given a list of transactions, it keeps only the ones that were not included in the block
 // todo - inefficient
 func findTxsNotIncluded(head *obscurocore.Rollup, txs []*common.L2Tx, s db.RollupResolver) []*common.L2Tx {
-	included := allIncludedTransactions(head, s)
+	// go back only HeightCommittedBlocks blocks to accumulate transactions to be diffed against the mempool
+	to := uint64(0)
+	if head.NumberU64() > common.HeightCommittedBlocks {
+		to = head.NumberU64() - common.HeightCommittedBlocks
+	}
+	included := allIncludedTransactions(head, s, to)
 	return removeExisting(txs, included)
 }
 
-func allIncludedTransactions(r *obscurocore.Rollup, s db.RollupResolver) map[gethcommon.Hash]*common.L2Tx {
-	if r.Header.Number.Uint64() == common.L2GenesisHeight {
+func allIncludedTransactions(r *obscurocore.Rollup, s db.RollupResolver, stopAtHeight uint64) map[gethcommon.Hash]*common.L2Tx {
+	if r.Header.Number.Uint64() == stopAtHeight {
 		return obscurocore.MakeMap(r.Transactions)
 	}
 	newMap := make(map[gethcommon.Hash]*common.L2Tx)
-	for k, v := range allIncludedTransactions(s.ParentRollup(r), s) {
+	for k, v := range allIncludedTransactions(s.ParentRollup(r), s, stopAtHeight) {
 		newMap[k] = v
 	}
 	for _, tx := range r.Transactions {

--- a/go/enclave/mempool/manager.go
+++ b/go/enclave/mempool/manager.go
@@ -97,11 +97,11 @@ func (db *mempoolManager) CurrentTxs(head *obscurocore.Rollup, resolver db.Rollu
 // todo - inefficient
 func findTxsNotIncluded(head *obscurocore.Rollup, txs []*common.L2Tx, s db.RollupResolver) []*common.L2Tx {
 	// go back only HeightCommittedBlocks blocks to accumulate transactions to be diffed against the mempool
-	to := uint64(0)
+	startAt := uint64(0)
 	if head.NumberU64() > common.HeightCommittedBlocks {
-		to = head.NumberU64() - common.HeightCommittedBlocks
+		startAt = head.NumberU64() - common.HeightCommittedBlocks
 	}
-	included := allIncludedTransactions(head, s, to)
+	included := allIncludedTransactions(head, s, startAt)
 	return removeExisting(txs, included)
 }
 

--- a/integration/simulation/simulation_in_mem_test.go
+++ b/integration/simulation/simulation_in_mem_test.go
@@ -26,7 +26,7 @@ func TestInMemoryMonteCarloSimulation(t *testing.T) {
 	simParams := params.SimParams{
 		NumberOfNodes:             numberOfNodes,
 		AvgBlockDuration:          50 * time.Millisecond,
-		SimulationTime:            25 * time.Second,
+		SimulationTime:            95 * time.Second,
 		L1EfficiencyThreshold:     0.2,
 		L2EfficiencyThreshold:     0.5,
 		L2ToL1EfficiencyThreshold: 0.5,

--- a/integration/simulation/simulation_in_mem_test.go
+++ b/integration/simulation/simulation_in_mem_test.go
@@ -26,7 +26,7 @@ func TestInMemoryMonteCarloSimulation(t *testing.T) {
 	simParams := params.SimParams{
 		NumberOfNodes:             numberOfNodes,
 		AvgBlockDuration:          50 * time.Millisecond,
-		SimulationTime:            95 * time.Second,
+		SimulationTime:            25 * time.Second,
 		L1EfficiencyThreshold:     0.2,
 		L2EfficiencyThreshold:     0.5,
 		L2ToL1EfficiencyThreshold: 0.5,


### PR DESCRIPTION
### Why is this change needed?

the testnet servers are dying after a couple of hours

### What changes were made as part of this PR:

Functional PR.

The method that was calculating which transactions to include in the current rollup, was recursively travelling the chain up to the genesis every time.
With the current change it will only go back 15 rollups.

Until we implement a proper mempool, this will keep performance crappy, but stable.


### What are the key areas to look at
- the mempool