### PR TITLE
Do not panic when encoding/decoding

### DIFF
--- a/go/common/encoding.go
+++ b/go/common/encoding.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rlp"
-	"github.com/obscuronet/obscuro-playground/go/common/log"
 )
 
 // EncodedBlock the encoded version of an ExtBlock
@@ -27,12 +26,8 @@ func (eb EncodedBlock) DecodeBlock() (*types.Block, error) {
 	return &b, nil
 }
 
-func EncodeRollup(r *EncryptedRollup) EncodedRollup {
-	encoded, err := rlp.EncodeToBytes(r)
-	if err != nil {
-		log.Panic("could not encode rollup. Cause: %s", err)
-	}
-	return encoded
+func EncodeRollup(r *EncryptedRollup) (EncodedRollup, error) {
+	return rlp.EncodeToBytes(r)
 }
 
 func DecodeRollup(encoded EncodedRollup) (*EncryptedRollup, error) {
@@ -41,12 +36,8 @@ func DecodeRollup(encoded EncodedRollup) (*EncryptedRollup, error) {
 	return r, err
 }
 
-func EncodeAttestation(att *AttestationReport) EncodedAttestationReport {
-	encoded, err := rlp.EncodeToBytes(att)
-	if err != nil {
-		panic(err)
-	}
-	return encoded
+func EncodeAttestation(att *AttestationReport) (EncodedAttestationReport, error) {
+	return rlp.EncodeToBytes(att)
 }
 
 func DecodeAttestation(encoded EncodedAttestationReport) (*AttestationReport, error) {

--- a/go/common/encoding.go
+++ b/go/common/encoding.go
@@ -1,9 +1,31 @@
 package common
 
 import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/obscuronet/obscuro-playground/go/common/log"
 )
+
+// EncodedBlock the encoded version of an ExtBlock
+type EncodedBlock []byte
+
+func EncodeBlock(b *types.Block) (EncodedBlock, error) {
+	encoded, err := rlp.EncodeToBytes(b)
+	if err != nil {
+		return nil, fmt.Errorf("could not encode block to bytes. Cause: %w", err)
+	}
+	return encoded, nil
+}
+
+func (eb EncodedBlock) DecodeBlock() (*types.Block, error) {
+	b := types.Block{}
+	if err := rlp.DecodeBytes(eb, &b); err != nil {
+		return nil, fmt.Errorf("could not decode block from bytes. Cause: %w", err)
+	}
+	return &b, nil
+}
 
 func EncodeRollup(r *EncryptedRollup) EncodedRollup {
 	encoded, err := rlp.EncodeToBytes(r)
@@ -19,15 +41,6 @@ func DecodeRollup(encoded EncodedRollup) (*EncryptedRollup, error) {
 	err := rlp.DecodeBytes(encoded, r)
 
 	return r, err
-}
-
-func DecodeRollupOrPanic(rollup EncodedRollup) *EncryptedRollup {
-	r, err := DecodeRollup(rollup)
-	if err != nil {
-		log.Panic("could not decode rollup. Cause: %s", err)
-	}
-
-	return r
 }
 
 func EncodeAttestation(att *AttestationReport) EncodedAttestationReport {

--- a/go/common/encoding.go
+++ b/go/common/encoding.go
@@ -32,14 +32,12 @@ func EncodeRollup(r *EncryptedRollup) EncodedRollup {
 	if err != nil {
 		log.Panic("could not encode rollup. Cause: %s", err)
 	}
-
 	return encoded
 }
 
 func DecodeRollup(encoded EncodedRollup) (*EncryptedRollup, error) {
 	r := new(EncryptedRollup)
 	err := rlp.DecodeBytes(encoded, r)
-
 	return r, err
 }
 
@@ -48,13 +46,11 @@ func EncodeAttestation(att *AttestationReport) EncodedAttestationReport {
 	if err != nil {
 		panic(err)
 	}
-
 	return encoded
 }
 
 func DecodeAttestation(encoded EncodedAttestationReport) (*AttestationReport, error) {
 	att := new(AttestationReport)
 	err := rlp.DecodeBytes(encoded, att)
-
 	return att, err
 }

--- a/go/common/l1_types.go
+++ b/go/common/l1_types.go
@@ -1,12 +1,10 @@
 package common
 
 import (
-	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/trie"
 )
 
@@ -14,31 +12,6 @@ var GenesisHash = common.HexToHash("00000000000000000000000000000000000000000000
 
 // GenesisBlock - this is a hack that has to be removed ASAP.
 var GenesisBlock = NewBlock(nil, common.HexToAddress("0x0"), []*types.Transaction{})
-
-// EncodedBlock the encoded version of an ExtBlock
-type EncodedBlock []byte
-
-func EncodeBlock(b *types.Block) (EncodedBlock, error) {
-	encoded, err := rlp.EncodeToBytes(b)
-	if err != nil {
-		return nil, fmt.Errorf("could not encode block to bytes. Cause: %w", err)
-	}
-	return encoded, nil
-}
-
-func (eb EncodedBlock) Decode() (*types.Block, error) {
-	bl := types.Block{}
-	err := rlp.DecodeBytes(eb, &bl)
-	return &bl, err
-}
-
-func (eb EncodedBlock) DecodeBlock() (*types.Block, error) {
-	b, err := eb.Decode()
-	if err != nil {
-		return nil, fmt.Errorf("could not decode block from bytes. Cause: %w", err)
-	}
-	return b, nil
-}
 
 // NewBlock - todo - remove this ASAP
 func NewBlock(parent *types.Block, nodeID common.Address, txs []*types.Transaction) *types.Block {

--- a/go/common/utils.go
+++ b/go/common/utils.go
@@ -18,6 +18,8 @@ type (
 	ScheduledFunc func()
 )
 
+// TODO -  Move the three methods below into a testutils folder. They are not safe for use in non-test code, due to panics.
+
 func RndBtw(min uint64, max uint64) uint64 {
 	if min >= max {
 		panic(fmt.Sprintf("RndBtw requires min (%d) to be greater than max (%d)", min, max))

--- a/go/enclave/bridge/bridge.go
+++ b/go/enclave/bridge/bridge.go
@@ -154,7 +154,10 @@ func (bridge *Bridge) ExtractRollups(b *types.Block, blockResolver db.BlockResol
 		}
 
 		if rolTx, ok := t.(*ethadapter.L1RollupTx); ok {
-			r := common.DecodeRollupOrPanic(rolTx.Rollup)
+			r, err := common.DecodeRollup(rolTx.Rollup)
+			if err != nil {
+				log.Panic("could not decode rollup. Cause: %s", err)
+			}
 
 			// Ignore rollups created with proofs from different L1 blocks
 			// In case of L1 reorgs, rollups may end published on a fork

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -127,9 +127,13 @@ func (a *Node) Start() {
 			log.Panic(">   Agg%d: genesis node has ID %s, but its enclave produced an attestation using ID %s", a.shortID, a.ID.Hex(), attestation.Owner.Hex())
 		}
 
+		encodedAttestation, err := common.EncodeAttestation(attestation)
+		if err != nil {
+			log.Panic("could not encode attestation Cause: %s", err)
+		}
 		l1tx := &ethadapter.L1InitializeSecretTx{
 			AggregatorID:  &a.ID,
-			Attestation:   common.EncodeAttestation(attestation),
+			Attestation:   encodedAttestation,
 			InitialSecret: a.EnclaveClient.GenerateSecret(),
 			HostAddress:   a.config.P2PAddress,
 		}
@@ -386,7 +390,11 @@ func (a *Node) processBlocks(blocks []common.EncodedBlock, interrupt *int32) err
 
 	// Nodes can start before the genesis was published, and it makes no sense to enter the protocol.
 	if result.ProducedRollup.Header != nil {
-		err := a.P2p.BroadcastRollup(common.EncodeRollup(result.ProducedRollup.ToRollup()))
+		encodedRollup, err := common.EncodeRollup(result.ProducedRollup.ToRollup())
+		if err != nil {
+			return fmt.Errorf("could not encode rollup. Cause: %w", err)
+		}
+		err = a.P2p.BroadcastRollup(encodedRollup)
 		if err != nil {
 			return fmt.Errorf("could not broadcast rollup. Cause: %w", err)
 		}
@@ -449,8 +457,12 @@ func (a *Node) handleRoundWinner(result common.BlockSubmissionResponse) func() {
 				winnerRollup.Header.Number,
 			)
 
+			encodedRollup, err := common.EncodeRollup(winnerRollup.ToRollup())
+			if err != nil {
+				log.Panic("could not encode rollup. Cause: %s", err)
+			}
 			tx := &ethadapter.L1RollupTx{
-				Rollup: common.EncodeRollup(winnerRollup.ToRollup()),
+				Rollup: encodedRollup,
 			}
 
 			// That handler can get called multiple times for the same height. And it will return the same winner rollup.
@@ -478,15 +490,19 @@ func (a *Node) storeBlockProcessingResult(result common.BlockSubmissionResponse)
 
 // Called only by the first enclave to bootstrap the network
 func (a *Node) initialiseProtocol(block *types.Block) common.L2RootHash {
-	// Create the genesis rollup and submit it to the MC
+	// Create the genesis rollup and submit it to the management contract
 	genesisResponse := a.EnclaveClient.ProduceGenesis(block.Hash())
 	common.LogWithID(
 		a.shortID,
 		"Initialising network. Genesis rollup r_%d.",
 		common.ShortHash(genesisResponse.ProducedRollup.Header.Hash()),
 	)
+	encodedRollup, err := common.EncodeRollup(genesisResponse.ProducedRollup.ToRollup())
+	if err != nil {
+		log.Panic("could not encode rollup. Cause: %s", err)
+	}
 	l1tx := &ethadapter.L1RollupTx{
-		Rollup: common.EncodeRollup(genesisResponse.ProducedRollup.ToRollup()),
+		Rollup: encodedRollup,
 	}
 
 	a.broadcastL1Tx(a.mgmtContractLib.CreateRollup(l1tx, a.ethWallet.GetNonceAndIncrement()))
@@ -514,7 +530,10 @@ func (a *Node) requestSecret() {
 	if att.Owner != a.ID {
 		log.Panic(">   Agg%d: node has ID %s, but its enclave produced an attestation using ID %s", a.shortID, a.ID.Hex(), att.Owner.Hex())
 	}
-	encodedAttestation := common.EncodeAttestation(att)
+	encodedAttestation, err := common.EncodeAttestation(att)
+	if err != nil {
+		log.Panic("could not encode attestation. Cause: %s", err)
+	}
 	l1tx := &ethadapter.L1RequestSecretTx{
 		Attestation: encodedAttestation,
 	}

--- a/integration/ethereummock/mock_l1_network.go
+++ b/integration/ethereummock/mock_l1_network.go
@@ -39,7 +39,7 @@ func NewMockEthNetwork(avgBlockDuration time.Duration, avgLatency time.Duration,
 
 // BroadcastBlock broadcast a block to the l1 nodes
 func (n *MockEthNetwork) BroadcastBlock(b common.EncodedBlock, p common.EncodedBlock) {
-	bl, _ := b.Decode()
+	bl, _ := b.DecodeBlock()
 	for _, m := range n.AllNodes {
 		if m.ID != n.CurrentNode.ID {
 			t := m
@@ -85,7 +85,10 @@ func printBlock(b *types.Block, m Node) string {
 
 		switch l1Tx := t.(type) {
 		case *ethadapter.L1RollupTx:
-			r := common.DecodeRollupOrPanic(l1Tx.Rollup)
+			r, err := common.DecodeRollup(l1Tx.Rollup)
+			if err != nil {
+				log.Panic("failed to decode rollup")
+			}
 			txs = append(txs, fmt.Sprintf("r_%d(nonce=%d)", common.ShortHash(r.Hash()), tx.Nonce()))
 
 		case *ethadapter.L1DepositTx:

--- a/integration/simulation/output_stats.go
+++ b/integration/simulation/output_stats.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/obscuronet/obscuro-playground/go/common/log"
+
 	"github.com/obscuronet/obscuro-playground/go/ethadapter"
 
 	"github.com/obscuronet/obscuro-playground/go/common"
@@ -64,7 +66,10 @@ func (o *OutputStats) countBlockChain() {
 
 			switch l1Tx := t.(type) {
 			case *ethadapter.L1RollupTx:
-				r := common.DecodeRollupOrPanic(l1Tx.Rollup)
+				r, err := common.DecodeRollup(l1Tx.Rollup)
+				if err != nil {
+					log.Panic("could not decode rollup. Cause: %s", err)
+				}
 				if l1Node.IsBlockAncestor(headBlock, r.Header.L1Proof) {
 					o.l2RollupCountInL1Blocks++
 					o.l2RollupTxCountInL1Blocks += len(r.Transactions)

--- a/integration/simulation/validate_chain.go
+++ b/integration/simulation/validate_chain.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/obscuronet/obscuro-playground/go/common/log"
+
 	"github.com/obscuronet/obscuro-playground/go/enclave/bridge"
 
 	"github.com/obscuronet/obscuro-playground/go/rpcclientlib"
@@ -157,7 +159,10 @@ func ExtractDataFromEthereumChain(startBlock *types.Block, endBlock *types.Block
 				deposits = append(deposits, tx.Hash())
 				totalDeposited += l1tx.Amount
 			case *ethadapter.L1RollupTx:
-				r := common.DecodeRollupOrPanic(l1tx.Rollup)
+				r, err := common.DecodeRollup(l1tx.Rollup)
+				if err != nil {
+					log.Panic("could not decode rollup. Cause: %s", err)
+				}
 				rollups = append(rollups, r.Hash())
 				if node.IsBlockAncestor(block, r.Header.L1Proof) {
 					// only count the rollup if it is published in the right branch

--- a/integration/smartcontract/debug_mgmt_contract_lib.go
+++ b/integration/smartcontract/debug_mgmt_contract_lib.go
@@ -37,8 +37,12 @@ func newDebugMgmtContractLib(address gethcommon.Address, client *ethereumclient.
 
 // AwaitedIssueRollup speeds ups the issuance of rollup, await of tx to be minted and makes sure the values are correctly stored
 func (d *debugMgmtContractLib) AwaitedIssueRollup(rollup common.EncryptedRollup, client ethadapter.EthClient, w *debugWallet) error {
+	encodedRollup, err := common.EncodeRollup(&rollup)
+	if err != nil {
+		return err
+	}
 	txData := d.CreateRollup(
-		&ethadapter.L1RollupTx{Rollup: common.EncodeRollup(&rollup)},
+		&ethadapter.L1RollupTx{Rollup: encodedRollup},
 		w.GetNonceAndIncrement(),
 	)
 

--- a/integration/smartcontract/smartcontracts_test.go
+++ b/integration/smartcontract/smartcontracts_test.go
@@ -105,8 +105,12 @@ func TestManagementContract(t *testing.T) {
 // nonAttestedNodesCannotCreateRollup issues a rollup from a node that did not receive the secret network key
 func nonAttestedNodesCannotCreateRollup(t *testing.T, mgmtContractLib *debugMgmtContractLib, w *debugWallet, client ethadapter.EthClient) {
 	rollup := datagenerator.RandomRollup()
+	encodedRollup, err := common.EncodeRollup(&rollup)
+	if err != nil {
+		t.Error(err)
+	}
 	txData := mgmtContractLib.CreateRollup(
-		&ethadapter.L1RollupTx{Rollup: common.EncodeRollup(&rollup)},
+		&ethadapter.L1RollupTx{Rollup: encodedRollup},
 		w.GetNonceAndIncrement(),
 	)
 
@@ -640,8 +644,12 @@ func detectSimpleFork(t *testing.T, mgmtContractLib *debugMgmtContractLib, w *de
 
 	t.Logf("LAST Issued Rollup: %s parent: %s", r.Hash(), r.Header.ParentHash)
 
+	encodedRollup, err := common.EncodeRollup(&r)
+	if err != nil {
+		t.Error(err)
+	}
 	txData = mgmtContractLib.CreateRollup(
-		&ethadapter.L1RollupTx{Rollup: common.EncodeRollup(&r)},
+		&ethadapter.L1RollupTx{Rollup: encodedRollup},
 		w.GetNonceAndIncrement(),
 	)
 


### PR DESCRIPTION
### Why is this change needed?

In many cases, we panic when encoding or decoding a rollup or attestation. This is dangerous. The decision on whether to panic should be made further down the stack.

### What changes were made as part of this PR:

Functional.

- Removes implicit panics when encoding/decoding rollups/attestations
- Combines `Decode` and `DecodeBlock` methods - only one is needed
- Moves block encoding/decoding into the `encoding.go` file for consistency

### What are the key areas to look at
