### PR TITLE
Moves test utils out of common, and into test-specific common.

### DIFF
--- a/go/common/utils.go
+++ b/go/common/utils.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"fmt"
 	"math"
 	"math/big"
 	"math/rand"
@@ -17,24 +16,6 @@ type (
 	Latency       func() time.Duration
 	ScheduledFunc func()
 )
-
-func RndBtw(min uint64, max uint64) uint64 {
-	if min >= max {
-		panic(fmt.Sprintf("RndBtw requires min (%d) to be greater than max (%d)", min, max))
-	}
-	return uint64(rand.Int63n(int64(max-min))) + min //nolint:gosec
-}
-
-func RndBtwTime(min time.Duration, max time.Duration) time.Duration {
-	if min <= 0 || max <= 0 {
-		panic("invalid durations")
-	}
-	return time.Duration(RndBtw(uint64(min.Nanoseconds()), uint64(max.Nanoseconds()))) * time.Nanosecond
-}
-
-func SleepRndBtw(min time.Duration, max time.Duration) {
-	time.Sleep(RndBtwTime(min, max))
-}
 
 // ScheduleInterrupt runs the function after the delay and can be interrupted
 func ScheduleInterrupt(delay time.Duration, interrupt *int32, fun ScheduledFunc) {

--- a/integration/common/utils.go
+++ b/integration/common/utils.go
@@ -1,0 +1,21 @@
+package common
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+)
+
+func RndBtw(min uint64, max uint64) uint64 {
+	if min >= max {
+		panic(fmt.Sprintf("RndBtw requires min (%d) to be greater than max (%d)", min, max))
+	}
+	return uint64(rand.Int63n(int64(max-min))) + min //nolint:gosec
+}
+
+func RndBtwTime(min time.Duration, max time.Duration) time.Duration {
+	if min <= 0 || max <= 0 {
+		panic("invalid durations")
+	}
+	return time.Duration(RndBtw(uint64(min.Nanoseconds()), uint64(max.Nanoseconds()))) * time.Nanosecond
+}

--- a/integration/ethereummock/mock_l1_network.go
+++ b/integration/ethereummock/mock_l1_network.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	testcommon "github.com/obscuronet/obscuro-playground/integration/common"
+
 	"github.com/obscuronet/obscuro-playground/go/common/log"
 
 	"github.com/obscuronet/obscuro-playground/go/ethadapter"
@@ -67,7 +69,7 @@ func (n *MockEthNetwork) BroadcastTx(tx *types.Transaction) {
 
 // delay returns an expected delay on the l1 network
 func (n *MockEthNetwork) delay() time.Duration {
-	return common.RndBtwTime(n.avgLatency/10, 2*n.avgLatency)
+	return testcommon.RndBtwTime(n.avgLatency/10, 2*n.avgLatency)
 }
 
 func printBlock(b *types.Block, m Node) string {

--- a/integration/simulation/network/network_utils.go
+++ b/integration/simulation/network/network_utils.go
@@ -5,7 +5,7 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/obscuronet/obscuro-playground/go/common"
+	testcommon "github.com/obscuronet/obscuro-playground/integration/common"
 
 	"github.com/obscuronet/obscuro-playground/integration/simulation/params"
 
@@ -163,7 +163,7 @@ func defaultMockEthNodeCfg(nrNodes int, avgBlockDuration time.Duration) ethereum
 			// while everyone else will have higher values.
 			// Over a large number of rounds, the actual average block duration will be around the desired value, while the number of miners who get very close numbers will be limited.
 			span := math.Max(2, float64(nrNodes)) // We handle the special cases of zero or one nodes.
-			return common.RndBtwTime(avgBlockDuration/time.Duration(span), avgBlockDuration*time.Duration(span))
+			return testcommon.RndBtwTime(avgBlockDuration/time.Duration(span), avgBlockDuration*time.Duration(span))
 		},
 	}
 }

--- a/integration/simulation/p2p/mock_l2_network.go
+++ b/integration/simulation/p2p/mock_l2_network.go
@@ -5,6 +5,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	testcommon "github.com/obscuronet/obscuro-playground/integration/common"
+
 	"github.com/obscuronet/obscuro-playground/go/host"
 
 	"github.com/obscuronet/obscuro-playground/go/common"
@@ -79,5 +81,5 @@ func (netw *MockP2P) BroadcastTx(tx common.EncryptedTx) error {
 
 // delay returns an expected delay on the l2
 func (netw *MockP2P) delay() time.Duration {
-	return common.RndBtwTime(netw.avgLatency/10, 2*netw.avgLatency)
+	return testcommon.RndBtwTime(netw.avgLatency/10, 2*netw.avgLatency)
 }

--- a/integration/simulation/transaction_injector.go
+++ b/integration/simulation/transaction_injector.go
@@ -9,6 +9,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	testcommon "github.com/obscuronet/obscuro-playground/integration/common"
+
 	"github.com/obscuronet/obscuro-playground/go/common/log"
 
 	"github.com/obscuronet/obscuro-playground/go/enclave/bridge"
@@ -209,7 +211,7 @@ func (ti *TransactionInjector) issueRandomTransfers() {
 		for len(ti.wallets.SimObsWallets) > 1 && fromWallet.Address().Hex() == toWallet.Address().Hex() {
 			toWallet = ti.rndObsWallet()
 		}
-		tx := ti.newObscuroTransferTx(fromWallet, toWallet.Address(), common.RndBtw(1, 500), ti.l2Clients[0])
+		tx := ti.newObscuroTransferTx(fromWallet, toWallet.Address(), testcommon.RndBtw(1, 500), ti.l2Clients[0])
 		signedTx, err := fromWallet.SignTransaction(tx)
 		if err != nil {
 			panic(err)
@@ -231,14 +233,14 @@ func (ti *TransactionInjector) issueRandomTransfers() {
 		}
 
 		go ti.Counter.trackTransferL2Tx(signedTx)
-		common.SleepRndBtw(ti.avgBlockDuration/4, ti.avgBlockDuration)
+		SleepRndBtw(ti.avgBlockDuration/4, ti.avgBlockDuration)
 	}
 }
 
 // issueRandomDeposits creates and issues a number of transactions proportional to the simulation time, such that they can be processed
 func (ti *TransactionInjector) issueRandomDeposits() {
 	for txCounter := 0; ti.shouldKeepIssuing(txCounter); txCounter++ {
-		v := common.RndBtw(1, 100)
+		v := testcommon.RndBtw(1, 100)
 		ethWallet := ti.rndEthWallet()
 		addr := ethWallet.Address()
 		txData := &ethadapter.L1DepositTx{
@@ -264,14 +266,14 @@ func (ti *TransactionInjector) issueRandomDeposits() {
 
 		ti.stats.Deposit(v)
 		go ti.Counter.trackL1Tx(txData)
-		common.SleepRndBtw(ti.avgBlockDuration, ti.avgBlockDuration*2)
+		SleepRndBtw(ti.avgBlockDuration, ti.avgBlockDuration*2)
 	}
 }
 
 // issueRandomWithdrawals creates and issues a number of transactions proportional to the simulation time, such that they can be processed
 func (ti *TransactionInjector) issueRandomWithdrawals() {
 	for txCounter := 0; ti.shouldKeepIssuing(txCounter); txCounter++ {
-		v := common.RndBtw(1, 100)
+		v := testcommon.RndBtw(1, 100)
 		obsWallet := ti.rndObsWallet()
 		tx := ti.newObscuroWithdrawalTx(obsWallet, v, ti.rndL2NodeClient())
 		signedTx, err := obsWallet.SignTransaction(tx)
@@ -293,7 +295,7 @@ func (ti *TransactionInjector) issueRandomWithdrawals() {
 
 		ti.stats.Withdrawal(v)
 		go ti.Counter.trackWithdrawalL2Tx(signedTx)
-		common.SleepRndBtw(ti.avgBlockDuration, ti.avgBlockDuration*2)
+		SleepRndBtw(ti.avgBlockDuration, ti.avgBlockDuration*2)
 	}
 }
 
@@ -307,7 +309,7 @@ func (ti *TransactionInjector) issueInvalidL2Txs() {
 		for len(ti.wallets.SimObsWallets) > 1 && fromWallet.Address().Hex() == toWallet.Address().Hex() {
 			toWallet = ti.rndObsWallet()
 		}
-		tx := ti.newCustomObscuroWithdrawalTx(common.RndBtw(1, 100))
+		tx := ti.newCustomObscuroWithdrawalTx(testcommon.RndBtw(1, 100))
 
 		signedTx := ti.createInvalidSignage(tx, fromWallet)
 		encryptedTx := encryptTx(signedTx, ti.enclavePublicKey)
@@ -316,7 +318,7 @@ func (ti *TransactionInjector) issueInvalidL2Txs() {
 		if err != nil {
 			log.Info("Failed to issue withdrawal via RPC. Cause: %s", err)
 		}
-		time.Sleep(common.RndBtwTime(ti.avgBlockDuration/4, ti.avgBlockDuration))
+		time.Sleep(testcommon.RndBtwTime(ti.avgBlockDuration/4, ti.avgBlockDuration))
 	}
 }
 

--- a/integration/simulation/utils.go
+++ b/integration/simulation/utils.go
@@ -4,6 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
+	"time"
+
+	testcommon "github.com/obscuronet/obscuro-playground/integration/common"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -200,4 +203,8 @@ func findRollupDups(list []common.L2RootHash) map[common.L2RootHash]int {
 		}
 	}
 	return dups
+}
+
+func SleepRndBtw(min time.Duration, max time.Duration) {
+	time.Sleep(testcommon.RndBtwTime(min, max))
 }


### PR DESCRIPTION
### Why is this change needed?

Some test utilities ended up in the `go/common/` package, where they were at risk of being used by non-test code. In this particular instance, the issue was that the functions panicked, but in general we should try to segregate our test vs production code.

### What changes were made as part of this PR:

Functional.

- Creates new `common` package inside `integration`
- Moves certain test utils to that package

### What are the key areas to look at
