### PR TITLE
Use random L2 client for transfers in sim, not always the first

### DIFF
--- a/integration/simulation/transaction_injector.go
+++ b/integration/simulation/transaction_injector.go
@@ -209,7 +209,7 @@ func (ti *TransactionInjector) issueRandomTransfers() {
 		for len(ti.wallets.SimObsWallets) > 1 && fromWallet.Address().Hex() == toWallet.Address().Hex() {
 			toWallet = ti.rndObsWallet()
 		}
-		tx := ti.newObscuroTransferTx(fromWallet, toWallet.Address(), common.RndBtw(1, 500), ti.l2Clients[0])
+		tx := ti.newObscuroTransferTx(fromWallet, toWallet.Address(), common.RndBtw(1, 500), ti.rndL2NodeClient())
 		signedTx, err := fromWallet.SignTransaction(tx)
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
### Why is this change needed?

We always use the first L2 client for transfers in the simulation. This might hide issues.

### What changes were made as part of this PR:

Functional.

- Uses random L2 client for transfers in the simulation

### What are the key areas to look at
