### PR TITLE
Moves SetUpTestLog to test common package.

### DIFF
--- a/go/common/log/logutil/README.md
+++ b/go/common/log/logutil/README.md
@@ -1,1 +1,0 @@
-This package contains utils related to logging.

--- a/integration/common/log/log.go
+++ b/integration/common/log/log.go
@@ -1,4 +1,4 @@
-package logutil
+package log
 
 import (
 	"fmt"

--- a/integration/noderunner/noderunner_test.go
+++ b/integration/noderunner/noderunner_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/obscuronet/obscuro-playground/go/common/log/logutil"
+	"github.com/obscuronet/obscuro-playground/integration/common/log"
 
 	"github.com/obscuronet/obscuro-playground/go/config"
 
@@ -34,7 +34,7 @@ const (
 
 // A smoke test to check that we can stand up a standalone Obscuro host and enclave.
 func TestCanStartStandaloneObscuroHostAndEnclave(t *testing.T) {
-	logutil.SetupTestLog(&logutil.TestLogCfg{
+	log.SetupTestLog(&log.TestLogCfg{
 		LogDir:      testLogs,
 		TestType:    "noderunner",
 		TestSubtype: "test",

--- a/integration/simulation/utils.go
+++ b/integration/simulation/utils.go
@@ -6,13 +6,14 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/obscuronet/obscuro-playground/integration/common/log"
+
 	testcommon "github.com/obscuronet/obscuro-playground/integration/common"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/obscuronet/obscuro-playground/go/common"
-	"github.com/obscuronet/obscuro-playground/go/common/log/logutil"
 	"github.com/obscuronet/obscuro-playground/go/enclave/rollupchain"
 	"github.com/obscuronet/obscuro-playground/go/ethadapter/erc20contractlib"
 	"github.com/obscuronet/obscuro-playground/go/rpcclientlib"
@@ -26,7 +27,7 @@ const (
 )
 
 func setupSimTestLog(simType string) {
-	logutil.SetupTestLog(&logutil.TestLogCfg{
+	log.SetupTestLog(&log.TestLogCfg{
 		LogDir:      testLogs,
 		TestType:    "sim-log",
 		TestSubtype: simType,

--- a/integration/walletextension/wallet_extension_test.go
+++ b/integration/walletextension/wallet_extension_test.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 	"time"
 
+	testlog "github.com/obscuronet/obscuro-playground/integration/common/log"
+
 	"github.com/obscuronet/obscuro-playground/go/common/log"
 
 	"github.com/obscuronet/obscuro-playground/go/enclave/rollupchain"
@@ -20,8 +22,6 @@ import (
 	"github.com/obscuronet/obscuro-playground/go/wallet"
 	"github.com/obscuronet/obscuro-playground/integration/erc20contract"
 	"github.com/obscuronet/obscuro-playground/integration/simulation"
-
-	"github.com/obscuronet/obscuro-playground/go/common/log/logutil"
 
 	"github.com/obscuronet/obscuro-playground/go/enclave/bridge"
 
@@ -66,8 +66,8 @@ var (
 	}
 	dummyAccountAddress = common.HexToAddress("0x8D97689C9818892B700e27F316cc3E41e17fBeb9")
 	// The log file used across all the wallet extension tests.
-	logFile = logutil.SetupTestLog(
-		&logutil.TestLogCfg{LogDir: testLogs, TestType: "wal-ext", TestSubtype: "test"},
+	logFile = testlog.SetupTestLog(
+		&testlog.TestLogCfg{LogDir: testLogs, TestType: "wal-ext", TestSubtype: "test"},
 	)
 )
 


### PR DESCRIPTION
### Why is this change needed?

SetUpTestLog is a testing function, and should only be available in the `integration` package.

### What changes were made as part of this PR:

Functional.

- Moves SetUpTestLog and related struct

### What are the key areas to look at
