### PR TITLE
Shrink TransactionBlobCrypto interface to not expose encrypt and decrypt methods.

### DIFF
--- a/go/enclave/crypto/crypto.go
+++ b/go/enclave/crypto/crypto.go
@@ -22,7 +22,7 @@ const obscuroPrivateKeyHex = "81acce9620f0adf1728cb8df7f6b8b8df857955eb9e8b7aed6
 func GetObscuroKey() *ecdsa.PrivateKey {
 	key, err := crypto.HexToECDSA(obscuroPrivateKeyHex)
 	if err != nil {
-		panic("Failed to create enclave private key")
+		log.Panic("failed to create enclave private key. Cause: %s", err)
 	}
 	return key
 }

--- a/go/enclave/crypto/transaction_blob_crypto.go
+++ b/go/enclave/crypto/transaction_blob_crypto.go
@@ -24,8 +24,6 @@ const (
 
 // TransactionBlobCrypto handles the encryption and decryption of the transaction blobs stored inside a rollup.
 type TransactionBlobCrypto interface {
-	Encrypt(transactions core.L2Txs) common.EncryptedTransactions
-	Decrypt(encryptedTxs common.EncryptedTransactions) core.L2Txs
 	// ToExtRollup - Transforms an internal rollup as seen by the enclave to an external rollup with an encrypted payload
 	ToExtRollup(r *core.Rollup) common.ExtRollup
 	ToEnclaveRollup(r *common.EncryptedRollup) *core.Rollup
@@ -50,8 +48,28 @@ func NewTransactionBlobCryptoImpl() TransactionBlobCrypto {
 	}
 }
 
+func (t TransactionBlobCryptoImpl) ToExtRollup(r *core.Rollup) common.ExtRollup {
+	txHashes := make([]gethcommon.Hash, len(r.Transactions))
+	for idx, tx := range r.Transactions {
+		txHashes[idx] = tx.Hash()
+	}
+
+	return common.ExtRollup{
+		Header:          r.Header,
+		TxHashes:        txHashes,
+		EncryptedTxBlob: t.encrypt(r.Transactions),
+	}
+}
+
+func (t TransactionBlobCryptoImpl) ToEnclaveRollup(r *common.EncryptedRollup) *core.Rollup {
+	return &core.Rollup{
+		Header:       r.Header,
+		Transactions: t.decrypt(r.Transactions),
+	}
+}
+
 // TODO - Modify this logic so that transactions with different reveal periods are in different blobs, as per the whitepaper.
-func (t TransactionBlobCryptoImpl) Encrypt(transactions core.L2Txs) common.EncryptedTransactions {
+func (t TransactionBlobCryptoImpl) encrypt(transactions core.L2Txs) common.EncryptedTransactions {
 	encodedTxs, err := rlp.EncodeToBytes(transactions)
 	if err != nil {
 		log.Panic("could not encrypt L2 transaction. Cause: %s", err)
@@ -60,7 +78,7 @@ func (t TransactionBlobCryptoImpl) Encrypt(transactions core.L2Txs) common.Encry
 	return t.transactionCipher.Seal(nil, []byte(RollupCipherNonce), encodedTxs, nil)
 }
 
-func (t TransactionBlobCryptoImpl) Decrypt(encryptedTxs common.EncryptedTransactions) core.L2Txs {
+func (t TransactionBlobCryptoImpl) decrypt(encryptedTxs common.EncryptedTransactions) core.L2Txs {
 	encodedTxs, err := t.transactionCipher.Open(nil, []byte(RollupCipherNonce), encryptedTxs, nil)
 	if err != nil {
 		log.Panic("could not decrypt encrypted L2 transactions. Cause: %s", err)
@@ -72,24 +90,4 @@ func (t TransactionBlobCryptoImpl) Decrypt(encryptedTxs common.EncryptedTransact
 	}
 
 	return txs
-}
-
-func (t TransactionBlobCryptoImpl) ToExtRollup(r *core.Rollup) common.ExtRollup {
-	txHashes := make([]gethcommon.Hash, len(r.Transactions))
-	for idx, tx := range r.Transactions {
-		txHashes[idx] = tx.Hash()
-	}
-
-	return common.ExtRollup{
-		Header:          r.Header,
-		TxHashes:        txHashes,
-		EncryptedTxBlob: t.Encrypt(r.Transactions),
-	}
-}
-
-func (t TransactionBlobCryptoImpl) ToEnclaveRollup(r *common.EncryptedRollup) *core.Rollup {
-	return &core.Rollup{
-		Header:       r.Header,
-		Transactions: t.Decrypt(r.Transactions),
-	}
 }

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -391,11 +391,11 @@ func (e *enclaveImpl) GetRollupByHeight(rollupHeight int64) *common.ExtRollup {
 
 func (e *enclaveImpl) Attestation() *common.AttestationReport {
 	if e.enclavePubKey == nil {
-		panic("public key not initialized, we can't produce the attestation report")
+		log.Panic("public key not initialized, we can't produce the attestation report")
 	}
 	report, err := e.attestationProvider.GetReport(e.enclavePubKey, e.config.HostID, e.config.HostAddress)
 	if err != nil {
-		panic("Failed to produce remote report.")
+		log.Panic("Failed to produce remote report.")
 	}
 	return report
 }

--- a/go/enclave/rpc_server.go
+++ b/go/enclave/rpc_server.go
@@ -37,6 +37,11 @@ func StartServer(
 	erc20ContractLib erc20contractlib.ERC20ContractLib,
 	collector StatsCollector,
 ) (func(), error) {
+	tomlConfig, err := toml.Marshal(enclaveConfig)
+	if err != nil {
+		log.Panic("could not print enclave config")
+	}
+
 	lis, err := net.Listen("tcp", enclaveConfig.Address)
 	if err != nil {
 		return nil, fmt.Errorf("enclave RPC server could not listen on port: %w", err)
@@ -61,12 +66,7 @@ func StartServer(
 		go enclaveServer.Stop(context.Background(), nil) //nolint:errcheck
 	}
 
-	tomlConfig, err := toml.Marshal(enclaveConfig)
-	if err != nil {
-		panic("could not print enclave config")
-	}
 	log.Info("Enclave service started with following config:\n%s", tomlConfig)
-
 	return closeHandle, nil
 }
 

--- a/tools/obscuroscan/obscuroscan_test.go
+++ b/tools/obscuroscan/obscuroscan_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/obscuronet/obscuro-playground/go/enclave/core"
+
 	"github.com/obscuronet/obscuro-playground/go/enclave/crypto"
 
 	"github.com/obscuronet/obscuro-playground/integration/datagenerator"
@@ -39,6 +41,7 @@ func TestThrowsIfEncryptedRollupIsInvalid(t *testing.T) {
 
 // Generates an encrypted transaction blob in Base64 encoding.
 func generateEncryptedTxBlob(txs []*common.L2Tx) []byte {
-	txBlob := crypto.NewTransactionBlobCryptoImpl().Encrypt(txs)
+	rollup := core.Rollup{Header: &common.Header{}, Transactions: txs}
+	txBlob := crypto.NewTransactionBlobCryptoImpl().ToExtRollup(&rollup).EncryptedTxBlob
 	return []byte(base64.StdEncoding.EncodeToString(txBlob))
 }


### PR DESCRIPTION
### Why is this change needed?

The `TransactionBlobCrypto` class exposes `Encrypt` and `Decrypt` methods, but these should be encapsulated and not used directly.

### What changes were made as part of this PR:

Functional.

- Removes `Encrypt` and `Decrypt` from `TransactionBlobCrypto` interface
- Fixes tests to work around the encapsulation of these methods

### What are the key areas to look at
