### PR TITLE
Encapsulates decryption of the viewing key.

### DIFF
--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -66,8 +66,6 @@ type enclaveImpl struct {
 	enclaveKey    *ecdsa.PrivateKey // this is a key specific to this enclave, which is included in the Attestation. Used for signing rollups and for encryption of the shared secret.
 	enclavePubKey []byte            // the public key of the above
 
-	obscuroNetworkKey *ecdsa.PrivateKey // this is a key known by all the enclaves. Used by users for encrypting transactions.
-
 	transactionBlobCrypto obscurocrypto.TransactionBlobCrypto
 }
 
@@ -167,7 +165,6 @@ func NewEnclave(
 		attestationProvider:   attestationProvider,
 		enclaveKey:            enclaveKey,
 		enclavePubKey:         serializedEnclavePubKey,
-		obscuroNetworkKey:     obscuroKey,
 		transactionBlobCrypto: transactionBlobCrypto,
 	}
 }
@@ -443,12 +440,7 @@ func (e *enclaveImpl) ShareSecret(att *common.AttestationReport) (common.Encrypt
 }
 
 func (e *enclaveImpl) AddViewingKey(encryptedViewingKeyBytes []byte, signature []byte) error {
-	// todo - this should be done in the rpc encryption manager
-	viewingKeyBytes, err := ecies.ImportECDSA(e.obscuroNetworkKey).Decrypt(encryptedViewingKeyBytes, nil, nil)
-	if err != nil {
-		return fmt.Errorf("could not decrypt viewing key when adding it to enclave. Cause: %w", err)
-	}
-	return e.rpcEncryptionManager.AddViewingKey(viewingKeyBytes, signature)
+	return e.rpcEncryptionManager.AddViewingKey(encryptedViewingKeyBytes, signature)
 }
 
 func (e *enclaveImpl) StoreAttestation(att *common.AttestationReport) error {

--- a/go/enclave/rpcencryptionmanager/rpc_encryption_manager.go
+++ b/go/enclave/rpcencryptionmanager/rpc_encryption_manager.go
@@ -52,7 +52,13 @@ func (rpc *RPCEncryptionManager) DecryptBytes(encryptedBytes []byte) ([]byte, er
 }
 
 // AddViewingKey - see the description of Enclave.AddViewingKey.
-func (rpc *RPCEncryptionManager) AddViewingKey(viewingKeyBytes []byte, signature []byte) error {
+func (rpc *RPCEncryptionManager) AddViewingKey(encryptedViewingKeyBytes []byte, signature []byte) error {
+	// We decrypt the viewing key.
+	viewingKeyBytes, err := rpc.enclavePrivateKeyECIES.Decrypt(encryptedViewingKeyBytes, nil, nil)
+	if err != nil {
+		return fmt.Errorf("could not decrypt viewing key when adding it to enclave. Cause: %w", err)
+	}
+
 	// We recalculate the message signed by MetaMask.
 	msgToSign := ViewingKeySignedMsgPrefix + hex.EncodeToString(viewingKeyBytes)
 


### PR DESCRIPTION
### Why is this change needed?

Addresses a todo in the codebase. Viewing keys were previously decrypted by the enclave before being passed to the `RPCEncryptionManager`, but that wasn't a good separation of duties.

### What changes were made as part of this PR:

Functional.

- Encapsulates decryption of viewing key

### What are the key areas to look at
