### PR TITLE
Removes a todo that incorrectly assumes that multiple MetaMask accounts can be returned.

### DIFF
--- a/tools/walletextension/static/javascript.js
+++ b/tools/walletextension/static/javascript.js
@@ -36,7 +36,8 @@ const initialize = () => {
             statusArea.innerText = "No MetaMask accounts found."
             return
         }
-        const account = accounts[0]; // TODO - Allow use of accounts other than the first.
+        // The array only ever contains a single value (per the docs, returns "An array of a single, hexadecimal Ethereum address string.")
+        const account = accounts[0];
 
         const signature = await ethereum.request({
             method: metamaskPersonalSign,


### PR DESCRIPTION
### Why is this change needed?

MetaMask's `eth_requestAccounts` method returns an array. I previously assumed that the user should be able to select any of these accounts, and left a todo to that effect. But actually, upon inspecting the APIs docs, it's clear that this array is always only contains one element.

### What changes were made as part of this PR:

Functional.

- Removes todo
- Adds clarifying comment

### What are the key areas to look at
