### PR TITLE
Docs fix. Defaults to testnet node addresses. Better error message on failed request parse.

### DIFF
--- a/docs/testnet/essentials.md
+++ b/docs/testnet/essentials.md
@@ -7,7 +7,7 @@ An easy-to-read list of essential parameters and configuration settings for Obsc
 
 ## Custom Network for MetaMask
 - **Network Name:** `Obscuro Testnet`
-- **New PRC URL:** `http://127.0.0.1:3000/`
+- **New RPC URL:** `http://127.0.0.1:3000/`
 - **Chain ID:** `777`
 - **Currency Symbol:** `OBX`
 

--- a/docs/testnet/wallet-extension.md
+++ b/docs/testnet/wallet-extension.md
@@ -32,10 +32,7 @@ unencrypted. If the data is not particularly sensitive, it can also be run in an
 
     * For other OSes and architectures, see `Compiling the binary`, below
 
-2. Open a terminal window of command prompt. Start the wallet extension by running the `wallet_extension` binary with the following flags:
-
-   ```--nodeRPCHTTPAddress=testnet.obscu.ro:13000 --nodeRPCWebsocketAddress=testnet.obscu.ro:13001```
-
+2. Open a terminal window of command prompt and start the wallet extension by running the `wallet_extension` binary. 
    The wallet extension is now listening on `http://127.0.0.1:3000/`
 
 3. Sign into MetaMask

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -631,7 +631,7 @@ func extractCallParams(decryptedParams []byte) (gethcommon.Address, gethcommon.A
 	var paramsJSONMap []interface{}
 	err := json.Unmarshal(decryptedParams, &paramsJSONMap)
 	if err != nil {
-		return gethcommon.Address{}, gethcommon.Address{}, nil, fmt.Errorf("could not parse JSON params in Call request. Cause: %w", err)
+		return gethcommon.Address{}, gethcommon.Address{}, nil, fmt.Errorf("could not parse JSON params in eth_call request. JSON params are: %s. Cause: %w", string(decryptedParams), err)
 	}
 
 	txArgs := paramsJSONMap[0] // The first argument is the transaction arguments, the second the block, the third the state overrides.
@@ -669,7 +669,7 @@ func (rc *RollupChain) GetBalance(encryptedParams common.EncryptedParamsGetBalan
 	var paramsJSONMap []string
 	err = json.Unmarshal(paramBytes, &paramsJSONMap)
 	if err != nil {
-		return nil, fmt.Errorf("could not parse JSON params in GetBalance request. Cause: %w", err)
+		return nil, fmt.Errorf("could not parse JSON params in eth_getBalance request. JSON params are: %s. Cause: %w", string(paramBytes), err)
 	}
 	address := gethcommon.HexToAddress(paramsJSONMap[0]) // The first argument is the address, the second the block.
 

--- a/go/enclave/rpcencryptionmanager/rpc_encryption_manager.go
+++ b/go/enclave/rpcencryptionmanager/rpc_encryption_manager.go
@@ -108,7 +108,7 @@ func (rpc *RPCEncryptionManager) ExtractTxHash(encryptedParams common.EncryptedP
 	var paramsJSONList []string
 	err = json.Unmarshal(paramBytes, &paramsJSONList)
 	if err != nil {
-		return gethcommon.Hash{}, fmt.Errorf("could not parse JSON params in eth_getTransactionReceipt request. Cause: %w", err)
+		return gethcommon.Hash{}, fmt.Errorf("could not parse JSON params in eth_getTransactionReceipt request. JSON params are: %s. Cause: %w", string(paramBytes), err)
 	}
 	txHash := gethcommon.HexToHash(paramsJSONList[0]) // The only argument is the transaction hash.
 	return txHash, err

--- a/tools/walletextension/main/cli.go
+++ b/tools/walletextension/main/cli.go
@@ -14,11 +14,11 @@ const (
 
 	// TODO - Use one flag for the shared HTTP + RPC host, and two other flags for the ports.
 	nodeRPCHTTPAddressName    = "nodeRPCHTTPAddress"
-	nodeRPCHTTPAddressDefault = "127.0.0.1:13000" // TODO - Default to pointing to a testnet node.
+	nodeRPCHTTPAddressDefault = "testnet.obscu.ro:13000"
 	nodeRPCHTTPAddressUsage   = "The address on which to connect to the node via RPC using HTTP"
 
 	nodeRPCWebsocketAddressName    = "nodeRPCWebsocketAddress"
-	nodeRPCWebsocketAddressDefault = "127.0.0.1:13001" // TODO - Default to pointing to a testnet node.
+	nodeRPCWebsocketAddressDefault = "testnet.obscu.ro:13001"
 	nodeRPCWebsocketAddressUsage   = "The address on which to connect to the node via RPC using websockets"
 )
 


### PR DESCRIPTION
### Why is this change needed?

- When the enclave fails to parse a JSON request, it doesn't provide sufficient information to diagnose it
- The wallet extension should default to the testnet nodes for ease of use, but doesn't
- There's a typo in the docs ("PRC" instead of "RPC")

### What changes were made as part of this PR:

Functional.

- Fixes the above

### What are the key areas to look at
