### PR TITLE
Enable viewing keys for testnet.

### DIFF
--- a/testnet/docker-compose.non-sgx.yml
+++ b/testnet/docker-compose.non-sgx.yml
@@ -52,7 +52,6 @@ services:
                  "--sqliteDBPath=/data/sqlite.db",
                  "--managementContractAddress=$MGMTCONTRACTADDR",
                  "--erc20ContractAddresses=$ERC20CONTRACTADDR,$ERC20CONTRACTADDR",
-                 "--viewingKeysEnabled=false",
                  "--hostAddress=host:10000",
                  "--profilerEnabled=$PROFILERENABLED"
     ]

--- a/testnet/docker-compose.yml
+++ b/testnet/docker-compose.yml
@@ -56,7 +56,6 @@ services:
                  "--address=:11000",
                  "--managementContractAddress=$MGMTCONTRACTADDR",
                  "--erc20ContractAddresses=$ERC20CONTRACTADDR,$ERC20CONTRACTADDR",
-                 "--viewingKeysEnabled=false",
                  "--hostAddress=host:10000",
                  "--willAttest",
                  "--useInMemoryDB=false",


### PR DESCRIPTION
### Why is this change needed?

Testnet should be using viewing keys. Otherwise, sensitive messages will not be encrypted.

### What changes were made as part of this PR:

Functional.

- Enable viewing keys for testnet

### What are the key areas to look at
