### PR TITLE
Better errors when ObscuroScan fails. Catches case where rollup hash is nil.

### DIFF
--- a/tools/obscuroscan/obscuroscan.go
+++ b/tools/obscuroscan/obscuroscan.go
@@ -127,8 +127,14 @@ func (o *Obscuroscan) getHeadRollup(resp http.ResponseWriter, _ *http.Request) {
 		return
 	}
 
+	headRollupHash := headRollupHeader.Hash()
+	if headRollupHash == (gethcommon.Hash{}) {
+		logAndSendErr(resp, "head rollup was retrieved but hash was nil")
+		return
+	}
+
 	var headRollup *common.ExtRollup
-	err = o.client.Call(&headRollup, rpcclientlib.RPCGetRollup, headRollupHeader.Hash())
+	err = o.client.Call(&headRollup, rpcclientlib.RPCGetRollup, headRollupHash)
 	if err != nil {
 		logAndSendErr(resp, fmt.Sprintf("could not retrieve head rollup. Cause: %s", err))
 		return

--- a/tools/obscuroscan/static/block_monitor.js
+++ b/tools/obscuroscan/static/block_monitor.js
@@ -17,7 +17,7 @@ const initialize = () => {
             const json = JSON.parse(await headBlockResp.text())
             blockHeadArea.innerText = JSON.stringify(json, null, "\t");
         } else {
-            blockHeadArea.innerText = "Failed to fetch head block."
+            blockHeadArea.innerText = "Failed to fetch head block. Cause: " + await headBlockResp.text()
         }
     }, 1000);
 
@@ -28,7 +28,7 @@ const initialize = () => {
             const json = JSON.parse(await headRollupResp.text())
             headRollupArea.innerText = JSON.stringify(json, null, "\t");
         } else {
-            headRollupArea.innerText = "Failed to fetch head rollup."
+            headRollupArea.innerText = "Failed to fetch head rollup. Cause: " + await headRollupResp.text()
         }
     }, 1000);
 }


### PR DESCRIPTION
### Why is this change needed?

Errors in ObscuroScan can be too opaque.

### What changes were made as part of this PR:

Functional.

- Provides error cause when getting head block or rollup fails
- Catches special case where rollup hash is nil

### What are the key areas to look at
