### PR TITLE
Fix tx execution bug, and improve logging

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,7 +34,7 @@ linters:
     - gosec
     - gosimple
     - govet
-    - ifshort
+#    - ifshort
     - importas
     - ineffassign
     - makezero

--- a/go/common/logging.go
+++ b/go/common/logging.go
@@ -3,10 +3,15 @@ package common
 import (
 	"fmt"
 
+	"github.com/ethereum/go-ethereum/common"
+
 	"github.com/obscuronet/obscuro-playground/go/common/log"
 )
 
-const logPattern = ">   Agg%d: %s"
+const (
+	logPattern    = ">   Agg%d: %s"
+	txExecPattern = "!Tx %s: %s"
+)
 
 // LogWithID logs a message at INFO level with the aggregator's identity prepended.
 func LogWithID(nodeID uint64, msg string, args ...interface{}) {
@@ -36,4 +41,10 @@ func ErrorWithID(nodeID uint64, msg string, args ...interface{}) {
 func PanicWithID(nodeID uint64, msg string, args ...interface{}) {
 	formattedMsg := fmt.Sprintf(msg, args...)
 	log.Panic(logPattern, nodeID, formattedMsg)
+}
+
+// LogTXExecution - logs at INFO level with the tx hash prepended
+func LogTXExecution(txHash common.Hash, msg string, args ...interface{}) {
+	formattedMsg := fmt.Sprintf(msg, args...)
+	log.Info(txExecPattern, txHash.Hex(), formattedMsg)
 }

--- a/integration/simulation/transaction_injector.go
+++ b/integration/simulation/transaction_injector.go
@@ -232,6 +232,8 @@ func (ti *TransactionInjector) issueRandomTransfers() {
 			continue
 		}
 
+		// todo - retrieve receipt
+
 		go ti.Counter.trackTransferL2Tx(signedTx)
 		SleepRndBtw(ti.avgBlockDuration/4, ti.avgBlockDuration)
 	}
@@ -302,6 +304,7 @@ func (ti *TransactionInjector) issueRandomWithdrawals() {
 // issueInvalidL2Txs creates and issues invalidly-signed L2 transactions proportional to the simulation time.
 // These transactions should be rejected by the nodes, and thus we expect them to not affect the simulation
 func (ti *TransactionInjector) issueInvalidL2Txs() {
+	// todo - also issue transactions with insufficient gas
 	for txCounter := 0; ti.shouldKeepIssuing(txCounter); txCounter++ {
 		fromWallet := ti.rndObsWallet()
 		toWallet := ti.rndObsWallet()
@@ -371,10 +374,11 @@ func (ti *TransactionInjector) newCustomObscuroWithdrawalTx(amount uint64) types
 }
 
 func (ti *TransactionInjector) newTx(data []byte, nonce uint64) types.TxData {
+	gas := uint64(1_000_000)
 	return &types.LegacyTx{
 		Nonce:    nonce,
 		Value:    gethcommon.Big0,
-		Gas:      1_000_000,
+		Gas:      gas,
 		GasPrice: gethcommon.Big0,
 		Data:     data,
 		To:       ti.wallets.Tokens[bridge.BTC].L2ContractAddress,


### PR DESCRIPTION
### Why is this change needed?

Transactions with too little gas kill the enclave. 
Logging needs to also be a bit better to help diagnose issues

### What changes were made as part of this PR:

1. Fix a bug where an account was credited even though the transaction that triggered that crediting would fail. 
2. Improve some log messages, and standardise them
3. Previously all transactions that errored were excluded which is not the right behaviour. Now only transactions that fail because the nonce was too high are excluded.
4. Disable the "ifshort" lint check because it's broken.

### What are the key areas to look at
- The evm_facade