### PR TITLE
Pushes wallet extension noise to logs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ tools/obscuroscan/main/main
 # Logs files
 **/enclave_logs.txt
 **/host_logs.txt
+**/wallet_extension_logs.txt
 
 # Temp env files
 testnet/.env

--- a/tools/walletextension/main/cli.go
+++ b/tools/walletextension/main/cli.go
@@ -20,17 +20,23 @@ const (
 	nodeRPCWebsocketAddressName    = "nodeRPCWebsocketAddress"
 	nodeRPCWebsocketAddressDefault = "testnet.obscu.ro:13001"
 	nodeRPCWebsocketAddressUsage   = "The address on which to connect to the node via RPC using websockets"
+
+	logPathName    = "logPath"
+	logPathDefault = ""
+	logPathUsage   = "The path to use for the wallet extension's log file"
 )
 
 func parseCLIArgs() walletextension.Config {
 	walletExtensionPort := flag.Int(walletExtensionPortName, walletExtensionPortDefault, walletExtensionPortUsage)
 	nodeRPCHTTPAddress := flag.String(nodeRPCHTTPAddressName, nodeRPCHTTPAddressDefault, nodeRPCHTTPAddressUsage)
 	nodeRPCWebsocketAddress := flag.String(nodeRPCWebsocketAddressName, nodeRPCWebsocketAddressDefault, nodeRPCWebsocketAddressUsage)
+	logPath := flag.String(logPathName, logPathDefault, logPathUsage)
 	flag.Parse()
 
 	return walletextension.Config{
 		WalletExtensionPort:     *walletExtensionPort,
 		NodeRPCHTTPAddress:      *nodeRPCHTTPAddress,
 		NodeRPCWebsocketAddress: *nodeRPCWebsocketAddress,
+		LogPath:                 *logPath,
 	}
 }

--- a/tools/walletextension/main/cli.go
+++ b/tools/walletextension/main/cli.go
@@ -22,7 +22,7 @@ const (
 	nodeRPCWebsocketAddressUsage   = "The address on which to connect to the node via RPC using websockets"
 
 	logPathName    = "logPath"
-	logPathDefault = ""
+	logPathDefault = "wallet_extension_logs.txt"
 	logPathUsage   = "The path to use for the wallet extension's log file"
 )
 

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -8,12 +8,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/obscuronet/obscuro-playground/go/common/log"
 	"io/fs"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
+
+	"github.com/obscuronet/obscuro-playground/go/common/log"
 
 	"github.com/ethereum/go-ethereum/accounts"
 


### PR DESCRIPTION
### Why is this change needed?

The wallet extension is too loud by default, logging ~four lines for every request (there can be 1+ requests per second).

Ticket: https://github.com/obscuronet/obscuro-internal/issues/633.

### What changes were made as part of this PR:

Functional.

- Removes unnecessary logging of request encryption/response decryption
- Pushes logging to optional log file, with the exception of errors, which are always printed as well

### What are the key areas to look at
