### PR TITLE
enables ifshort in the linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,7 +34,7 @@ linters:
     - gosec
     - gosimple
     - govet
-#    - ifshort
+    - ifshort
     - importas
     - ineffassign
     - makezero

--- a/go/enclave/evm/evm_facade.go
+++ b/go/enclave/evm/evm_facade.go
@@ -55,7 +55,7 @@ func executeTransaction(s *state.StateDB, cc *params.ChainConfig, chain *Obscuro
 		return nil, err
 	}
 
-	snap := s.Snapshot()
+	snap := s.Snapshot() //nolint
 
 	// Add some balance to the sender to avoid gas issues.
 	// Todo - this has to be removed once the gas logic is sorted.


### PR DESCRIPTION
### Why is this change needed?

- Reenables the `ifshort` linter 

### What changes were made as part of this PR:

- Adds a comment that ignores ALL linters in the problem line
