### PR TITLE
Fix wallet extension tests

### DIFF
--- a/go/enclave/rpcencryptionmanager/rpc_encryption_manager.go
+++ b/go/enclave/rpcencryptionmanager/rpc_encryption_manager.go
@@ -22,9 +22,8 @@ import (
 // signed as-is.
 const ViewingKeySignedMsgPrefix = "vk"
 
-// PlaceholderResult is used when the result to an eth_call is equal to nil. Attempting to encrypt then decrypt nil
-// using ECIES throws an exception.
-var PlaceholderResult = []byte("<nil result>")
+// Used when the result to an eth_call is equal to nil. Attempting to encrypt then decrypt nil using ECIES throws an exception.
+var placeholderResult = []byte("<nil result>")
 
 // RPCEncryptionManager manages the decryption and encryption of sensitive RPC requests.
 type RPCEncryptionManager struct {
@@ -93,7 +92,7 @@ func (rpc *RPCEncryptionManager) EncryptWithViewingKey(address gethcommon.Addres
 	}
 
 	if bytes == nil {
-		bytes = PlaceholderResult
+		bytes = placeholderResult
 	}
 
 	encryptedBytes, err := ecies.Encrypt(rand.Reader, viewingKey, bytes, nil, nil)

--- a/integration/walletextension/wallet_extension_test.go
+++ b/integration/walletextension/wallet_extension_test.go
@@ -400,6 +400,8 @@ func TestCanSubmitTxAndGetTxReceiptAndTxAfterSubmittingViewingKey(t *testing.T) 
 	}
 	sendTxJSON := makeEthJSONReqAsJSON(t, walletExtensionAddr, walletextension.ReqJSONMethodSendRawTx, []interface{}{txBinaryHex})
 
+	time.Sleep(6 * time.Second) // We wait for the deployment of the contract to the Obscuro network.
+
 	// We get the transaction receipt for the Obscuro ERC20 contract deployment.
 	txHash, ok := sendTxJSON[walletextension.RespJSONKeyResult].(string)
 	if !ok {

--- a/integration/walletextension/wallet_extension_test.go
+++ b/integration/walletextension/wallet_extension_test.go
@@ -638,13 +638,16 @@ func createObscuroNetwork(t *testing.T) (func(), error) {
 	if !ok {
 		panic("could not retrieve transaction hash from JSON result")
 	}
+
+	// We check once per second for twenty seconds whether the Obscuro ERC20 contract is deployed.
 	counter := 0
 	for {
 		if counter > 20 {
 			t.Fatalf("could not get receipt for Obscuro ERC20 deployment transaction after 20 seconds")
 		}
 		txReceiptResp := makeEthJSONReq(t, walletExtensionAddr, walletextension.ReqJSONMethodGetTxReceipt, []string{txHash})
-		if !strings.Contains(string(txReceiptResp), "could not retrieve transaction with hash") {
+		isTxOnChain := !strings.Contains(string(txReceiptResp), "could not retrieve transaction with hash")
+		if isTxOnChain {
 			break
 		}
 		time.Sleep(1 * time.Second)

--- a/integration/walletextension/wallet_extension_test.go
+++ b/integration/walletextension/wallet_extension_test.go
@@ -239,11 +239,11 @@ func TestCanCallAfterSubmittingViewingKey(t *testing.T) {
 
 	// We submit a transaction to the Obscuro ERC20 contract. By transferring an amount of zero, we avoid the need to
 	// deposit any funds in the ERC20 contract.
-	transferTxBytes := erc20contractlib.CreateTransferTxData(accountAddress, 0)
+	balanceOfBytes := erc20contractlib.CreateBalanceOfData(accountAddress)
 	reqParams := map[string]interface{}{
 		reqJSONKeyTo:   bridge.WBtcContract,
 		reqJSONKeyFrom: accountAddress.String(),
-		reqJSONKeyData: "0x" + common.Bytes2Hex(transferTxBytes),
+		reqJSONKeyData: "0x" + common.Bytes2Hex(balanceOfBytes),
 	}
 	callJSON := makeEthJSONReqAsJSON(t, walletExtensionAddr, walletextension.ReqJSONMethodCall, []interface{}{reqParams, latestBlock})
 


### PR DESCRIPTION
### Why is this change needed?

The wallet extension tests had two bugs that were cancelling each other out:

- We were asserting that the result of an ERC20 getBalance call should be empty bytes, when it should be nil bytes
- We were not waiting for the ERC20 contract to be deployed, so we were calling a non-existent contract and getting empty bytes

### What changes were made as part of this PR:

Functional.

- Fixes the two bugs above

### What are the key areas to look at
