### PR TITLE
disable caching of the rollup hash and logging

### DIFF
--- a/go/common/types.go
+++ b/go/common/types.go
@@ -12,8 +12,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/core/types"
 
-	"github.com/ethereum/go-ethereum/log"
-
 	gethcommon "github.com/ethereum/go-ethereum/common"
 )
 
@@ -156,7 +154,7 @@ func (h *Header) Hash() L2RootHash {
 	cp.S = nil
 	hash, err := RLPHash(cp)
 	if err != nil {
-		log.Error("err hashing the l2roothash")
+		panic("err hashing a rollup header")
 	}
 	return hash
 }

--- a/go/enclave/core/rollup.go
+++ b/go/enclave/core/rollup.go
@@ -23,9 +23,10 @@ type Rollup struct {
 // Hash returns the keccak256 hash of b's header.
 // The hash is computed on the first call and cached thereafter.
 func (r *Rollup) Hash() common.L2RootHash {
-	if hash := r.hash.Load(); hash != nil {
-		return hash.(common.L2RootHash)
-	}
+	// Temporarily disabling the caching of the hash because it's causing bugs
+	//if hash := r.hash.Load(); hash != nil {
+	//	return hash.(common.L2RootHash)
+	//}
 	v := r.Header.Hash()
 	r.hash.Store(v)
 	return v
@@ -33,18 +34,6 @@ func (r *Rollup) Hash() common.L2RootHash {
 
 func (r *Rollup) NumberU64() uint64 { return r.Header.Number.Uint64() }
 func (r *Rollup) Number() *big.Int  { return new(big.Int).Set(r.Header.Number) }
-
-func NewHeader(parent *gethcommon.Hash, height uint64, a gethcommon.Address) *common.Header {
-	parentHash := common.GenesisHash
-	if parent != nil {
-		parentHash = *parent
-	}
-	return &common.Header{
-		Agg:        a,
-		ParentHash: parentHash,
-		Number:     big.NewInt(int64(height)),
-	}
-}
 
 func EmptyRollup(agg gethcommon.Address, parent *common.Header, blkHash gethcommon.Hash, nonce common.Nonce) *Rollup {
 	h := common.Header{

--- a/go/enclave/db/rawdb/accessors_chain.go
+++ b/go/enclave/db/rawdb/accessors_chain.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"encoding/binary"
 
+	"github.com/status-im/keycard-go/hexutils"
+
 	"github.com/obscuronet/obscuro-playground/go/common/log"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
@@ -115,7 +117,7 @@ func ReadBody(db ethdb.KeyValueReader, hash gethcommon.Hash, number uint64) core
 // WriteBodyRLP stores an RLP encoded block body into the database.
 func WriteBodyRLP(db ethdb.KeyValueWriter, hash gethcommon.Hash, number uint64, rlp rlp.RawValue) {
 	if err := db.Put(rollupBodyKey(number, hash), rlp); err != nil {
-		log.Panic("could not put block body into DB. Cause: %s", err)
+		log.Panic("could not put rollup body into DB. Cause: %s", err)
 	}
 }
 
@@ -123,7 +125,7 @@ func WriteBodyRLP(db ethdb.KeyValueWriter, hash gethcommon.Hash, number uint64, 
 func ReadBodyRLP(db ethdb.KeyValueReader, hash gethcommon.Hash, number uint64) rlp.RawValue {
 	data, err := db.Get(rollupBodyKey(number, hash))
 	if err != nil {
-		log.Panic("could not retrieve block body from DB. Cause: %s", err)
+		log.Panic("could not retrieve rollup body :r_%d from DB. Cause: %s. Key: %s", common.ShortHash(hash), err, hexutils.BytesToHex(rollupBodyKey(number, hash)))
 	}
 	return data
 }

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -479,12 +479,14 @@ func (rc *RollupChain) SubmitBlock(block types.Block) common.BlockSubmissionResp
 	r := rc.produceRollup(&block, blockState)
 
 	rc.signRollup(r)
+
+	// Sanity check the produced rollup
 	rc.checkRollup(r)
 
 	// todo - should store proposal rollups in a different storage as they are ephemeral (round based)
 	rc.storage.StoreRollup(r)
 
-	common.LogWithID(rc.nodeID, "Processed block: b_%d(%d)", common.ShortHash(block.Hash()), block.NumberU64())
+	common.LogWithID(rc.nodeID, "Processed block: b_%d(%d). Produced rollup r_%d", common.ShortHash(block.Hash()), block.NumberU64(), common.ShortHash(r.Hash()))
 
 	return rc.newBlockSubmissionResponse(blockState, rc.transactionBlobCrypto.ToExtRollup(r))
 }

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -335,8 +335,10 @@ func (a *Node) startProcessing() {
 
 		case r := <-a.rollupsP2PCh:
 			rol, err := common.DecodeRollup(r)
-			common.TraceWithID(a.shortID, "Received rollup: r_%d from A%d",
+			common.TraceWithID(a.shortID, "Received rollup: r_%d(%d) parent: r_%d from A%d",
 				common.ShortHash(rol.Hash()),
+				rol.Header.Number,
+				common.ShortHash(rol.Header.ParentHash),
 				common.ShortAddress(rol.Header.Agg),
 			)
 			if err != nil {

--- a/integration/ethereummock/db.go
+++ b/integration/ethereummock/db.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"sync"
 
+	"github.com/obscuronet/obscuro-playground/go/common/log"
+
 	"github.com/obscuronet/obscuro-playground/go/common"
 
 	"github.com/obscuronet/obscuro-playground/go/enclave/core"
@@ -159,7 +161,7 @@ func removeCommittedTransactions(
 
 		p, f := resolver.ParentBlock(b)
 		if !f {
-			panic("wtf")
+			log.Panic("Should not happen. Parent not found")
 		}
 
 		b = p

--- a/integration/ethereummock/mock_l1_network.go
+++ b/integration/ethereummock/mock_l1_network.go
@@ -103,7 +103,7 @@ func printBlock(b *types.Block, m Node) string {
 	}
 	p, f := m.Resolver.ParentBlock(b)
 	if !f {
-		panic("wtf")
+		log.Panic("Should not happen. Parent not found")
 	}
 
 	return fmt.Sprintf("> M%d: create b_%d(Height=%d, Nonce=%d)[parent=b_%d]. Txs: %v",

--- a/integration/ethereummock/utils.go
+++ b/integration/ethereummock/utils.go
@@ -3,6 +3,8 @@ package ethereummock
 import (
 	"bytes"
 
+	"github.com/obscuronet/obscuro-playground/go/common/log"
+
 	"github.com/obscuronet/obscuro-playground/go/common"
 
 	"github.com/ethereum/go-ethereum/core/types"
@@ -20,25 +22,25 @@ func LCA(blockA *types.Block, blockB *types.Block, resolver db.BlockResolver) *t
 	if blockA.NumberU64() > blockB.NumberU64() {
 		p, f := resolver.ParentBlock(blockA)
 		if !f {
-			panic("wtf")
+			log.Panic("Should not happen. Parent not found")
 		}
 		return LCA(p, blockB, resolver)
 	}
 	if blockB.NumberU64() > blockA.NumberU64() {
 		p, f := resolver.ParentBlock(blockB)
 		if !f {
-			panic("wtf")
+			log.Panic("Should not happen. Parent not found")
 		}
 
 		return LCA(blockA, p, resolver)
 	}
 	parentBlockA, f := resolver.ParentBlock(blockA)
 	if !f {
-		panic("wtf")
+		log.Panic("Should not happen. Parent not found")
 	}
 	parentBlockB, f := resolver.ParentBlock(blockB)
 	if !f {
-		panic("wtf")
+		log.Panic("Should not happen. Parent not found")
 	}
 
 	return LCA(parentBlockA, parentBlockB, resolver)
@@ -62,7 +64,7 @@ func allIncludedTransactions(b *types.Block, r db.BlockResolver, db TxDB) map[co
 	newMap := make(map[common.TxHash]*types.Transaction)
 	p, f := r.ParentBlock(b)
 	if !f {
-		panic("wtf")
+		log.Panic("Should not happen. Parent not found")
 	}
 	for k, v := range allIncludedTransactions(p, r, db) {
 		newMap[k] = v


### PR DESCRIPTION
### Why is this change needed?

When the enclave encounters a transaction with a nonce that is too high it crashes.
The bug turns out to be because the hash of a rollup magically changes when it is converted from an internal enclave rollup to an external rollup. 
This means that the rollup that was written to storage when it was created can't be retrieved later.

### What changes were made as part of this PR:

Functional

- disabling the caching of the hash seems to solve this problem. This requires further investigation.
- Upon investigating this, I improved some log messages along the way.

### What are the key areas to look at
