### PR TITLE
Management placeholder for ERC20

### DIFF
--- a/go/enclave/rpcencryptionmanager/rpc_encryption_manager.go
+++ b/go/enclave/rpcencryptionmanager/rpc_encryption_manager.go
@@ -23,7 +23,7 @@ import (
 const ViewingKeySignedMsgPrefix = "vk"
 
 // Used when the result to an eth_call is equal to nil. Attempting to encrypt then decrypt nil using ECIES throws an exception.
-var placeholderResult = []byte("<nil result>")
+var placeholderResult = []byte("0x")
 
 // RPCEncryptionManager manages the decryption and encryption of sensitive RPC requests.
 type RPCEncryptionManager struct {


### PR DESCRIPTION
### Why is this change needed?

When the EVM returns nothing in response to an `eth_call`, we need to encrypt _something_ to return (we cannot encrypt empty bytes). So we encrypt a placeholder. However, the old placeholder made Remix unhappy. We should replace it with a placeholder in a form Remix can understand.

### What changes were made as part of this PR:

Functional.

- Switches to placeholder Remix can handle

### What are the key areas to look at
