### PR TITLE
enabling viewing keys

### DIFF
--- a/testnet/docker-compose.non-sgx.yml
+++ b/testnet/docker-compose.non-sgx.yml
@@ -53,5 +53,6 @@ services:
                  "--managementContractAddress=$MGMTCONTRACTADDR",
                  "--erc20ContractAddresses=$ERC20CONTRACTADDR,$ERC20CONTRACTADDR",
                  "--hostAddress=host:10000",
-                 "--profilerEnabled=$PROFILERENABLED"
+                 "--profilerEnabled=$PROFILERENABLED",
+                 "--viewingKeysEnabled=true"
     ]

--- a/testnet/docker-compose.yml
+++ b/testnet/docker-compose.yml
@@ -60,7 +60,8 @@ services:
                  "--willAttest",
                  "--useInMemoryDB=false",
                  "--edgelessDBHost=edgelessdb",
-                 "--profilerEnabled=$PROFILERENABLED"
+                 "--profilerEnabled=$PROFILERENABLED",
+                 "--viewingKeysEnabled=true"
     ]
 
   edgelessdb:


### PR DESCRIPTION
### Why is this change needed?

- Enables viewing keys as a default in testnet 