### PR TITLE
Use last account

### DIFF
--- a/tools/walletextension/static/javascript.js
+++ b/tools/walletextension/static/javascript.js
@@ -36,8 +36,9 @@ const initialize = () => {
             statusArea.innerText = "No MetaMask accounts found."
             return
         }
-        // The array only ever contains a single value (per the docs, returns "An array of a single, hexadecimal Ethereum address string.")
-        const account = accounts[0];
+        // The array returns "An array of a single, hexadecimal Ethereum address string.")
+        // We use the last created account for the viewing key since it makes most sense for testing.
+        const account = accounts[accounts.length - 1];
 
         const signature = await ethereum.request({
             method: metamaskPersonalSign,


### PR DESCRIPTION
### Why is this change needed?

testing is difficult since MM has to be reinstalled every time
by using the latest created account, we can avoid this problem

### What changes were made as part of this PR:

-functional
- use the last account in the array
### What are the key areas to look at
