### PR TITLE
Improve logging

### DIFF
--- a/go/enclave/core/utils.go
+++ b/go/enclave/core/utils.go
@@ -35,7 +35,7 @@ func PrintTxs(txs []*common.L2Tx) (txsString []string) {
 }
 
 func printTx(t *common.L2Tx, txsString []string) []string {
-	txsString = append(txsString, fmt.Sprintf("%d,", common.ShortHash(t.Hash())))
+	txsString = append(txsString, fmt.Sprintf("%s,", t.Hash().Hex()))
 	return txsString
 }
 

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -344,7 +344,7 @@ func (rc *RollupChain) processState(rollup *obscurocore.Rollup, txs obscurocore.
 func (rc *RollupChain) validateRollup(rollup *obscurocore.Rollup, rootHash gethcommon.Hash, txReceipts []*types.Receipt, depositReceipts []*types.Receipt, stateDB *state.StateDB) bool {
 	h := rollup.Header
 	if !bytes.Equal(rootHash.Bytes(), h.Root.Bytes()) {
-		dump := stateDB.Dump(&state.DumpConfig{})
+		dump := strings.Replace(string(stateDB.Dump(&state.DumpConfig{})), "\n", "", -1)
 		log.Error("Verify rollup r_%d: Calculated a different state. This should not happen as there are no malicious actors yet. \nGot: %s\nExp: %s\nHeight:%d\nTxs:%v\nState: %s.\nDeposits: %+v",
 			common.ShortHash(rollup.Hash()), rootHash, h.Root, h.Number, obscurocore.PrintTxs(rollup.Transactions), dump, depositReceipts)
 		return false
@@ -469,7 +469,7 @@ func (rc *RollupChain) SubmitBlock(block types.Block) common.BlockSubmissionResp
 		return common.BlockSubmissionResponse{IngestedBlock: false}
 	}
 
-	common.LogWithID(rc.nodeID, "Update state: %d", common.ShortHash(block.Hash()))
+	common.LogWithID(rc.nodeID, "Update state: b_%d", common.ShortHash(block.Hash()))
 	blockState := rc.updateState(&block)
 	if blockState == nil {
 		return rc.noBlockStateBlockSubmissionResponse(&block)
@@ -564,8 +564,8 @@ func (rc *RollupChain) produceRollup(b *types.Block, bs *obscurocore.BlockState)
 	}
 
 	// Uncomment this if you want to debug issues related to root state hashes not matching
-	// dump := newRollupState.Dump(&state.DumpConfig{})
-	// log.Info("Create rollup. State: %s", dump)
+	dump := strings.Replace(string(newRollupState.Dump(&state.DumpConfig{})), "\n", "", -1)
+	log.Info("Create rollup. State: %s", dump)
 
 	return r
 }

--- a/go/ethadapter/erc20contractlib/obscuro_ERC20_contract_ABI.go
+++ b/go/ethadapter/erc20contractlib/obscuro_ERC20_contract_ABI.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/obscuronet/obscuro-playground/go/common/log"
 
-	"github.com/obscuronet/obscuro-playground/go/common"
-
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -36,7 +34,7 @@ func DecodeTransferTx(t *types.Transaction) (bool, *gethcommon.Address, *big.Int
 	}
 	method, err := obscuroERC20ContractABIJSON.MethodById(t.Data()[:methodBytesLen])
 	if err != nil {
-		log.Info("Could not decode tx %d, Err: %s", common.ShortHash(t.Hash()), err)
+		log.Trace("Could not decode tx %s, Err: %s", t.Hash().Hex(), err)
 		return false, nil, nil
 	}
 


### PR DESCRIPTION
### Why is this change needed?

investigate when testnet crashes

### What changes were made as part of this PR:

- functional PR
- always print the hex of a tx to be able to trace it from metamask
- dump the entire state every time a rollup is created to allow a more accurate diff when it crashes

### What are the key areas to look at
