### PR TITLE
Sets chain config correctly for rehydrating receipts.

### DIFF
--- a/go/enclave/db/storage.go
+++ b/go/enclave/db/storage.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/ecdsa"
 	"fmt"
+	"math/big"
 
 	"github.com/obscuronet/go-obscuro/go/common/log"
 
@@ -21,16 +22,23 @@ import (
 )
 
 type storageImpl struct {
-	db      ethdb.Database
-	stateDB state.Database
-	nodeID  uint64
+	db          ethdb.Database
+	stateDB     state.Database
+	nodeID      uint64
+	chainConfig *params.ChainConfig
 }
 
-func NewStorage(backingDB ethdb.Database, nodeID uint64) Storage {
+func NewStorage(backingDB ethdb.Database, nodeID uint64, obscuroChainID int64) Storage {
+	chainConfig := params.ChainConfig{
+		ChainID:     big.NewInt(777),
+		LondonBlock: gethcommon.Big0,
+	}
+
 	return &storageImpl{
-		db:      backingDB,
-		stateDB: state.NewDatabase(backingDB),
-		nodeID:  nodeID,
+		db:          backingDB,
+		stateDB:     state.NewDatabase(backingDB),
+		nodeID:      nodeID,
+		chainConfig: &chainConfig,
 	}
 }
 
@@ -261,8 +269,7 @@ func (s *storageImpl) GetReceiptsByHash(hash gethcommon.Hash) types.Receipts {
 	if number == nil {
 		return nil
 	}
-	// todo - proper ChainConfig, instead of empty object
-	receipts := obscurorawdb.ReadReceipts(s.db, hash, *number, &params.ChainConfig{})
+	receipts := obscurorawdb.ReadReceipts(s.db, hash, *number, s.chainConfig)
 	return receipts
 }
 

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -105,7 +105,7 @@ func NewEnclave(
 	if err != nil {
 		log.Panic("Failed to connect to backing database - %s", err)
 	}
-	storage := db.NewStorage(backingDB, nodeShortID)
+	storage := db.NewStorage(backingDB, nodeShortID, config.ObscuroChainID)
 
 	// Initialise the Ethereum "Blockchain" structure that will allow us to validate incoming blocks
 	// Todo - check the minimum difficulty parameter


### PR DESCRIPTION
### Why is this change needed?

Previously, receipts were rehydrated with incorrect contract addresses. This meant that the correct could not be called.

### What changes were made as part of this PR:

Functional.

- Set chain config correctly

### What are the key areas to look at
