### PR TITLE
Removes second constructor for Geth client. Cleans up Geth client ID field.

### DIFF
--- a/go/ethadapter/geth_rpc_client.go
+++ b/go/ethadapter/geth_rpc_client.go
@@ -21,11 +21,11 @@ import (
 // gethRPCClient implements the EthClient interface and allows connection to a real ethereum node
 type gethRPCClient struct {
 	client *ethclient.Client  // the underlying eth rpc client
-	id     gethcommon.Address // TODO remove the id common.Address
+	id     gethcommon.Address // the address of the Obscuro node this client is for
 }
 
 // NewEthClient instantiates a new ethadapter.EthClient that connects to an ethereum node
-func NewEthClient(ipaddress string, port uint, timeout time.Duration) (EthClient, error) {
+func NewEthClient(ipaddress string, port uint, timeout time.Duration, id gethcommon.Address) (EthClient, error) {
 	client, err := connect(ipaddress, port, timeout)
 	if err != nil {
 		return nil, fmt.Errorf("unable to connect to the eth node - %w", err)

--- a/go/ethadapter/geth_rpc_client.go
+++ b/go/ethadapter/geth_rpc_client.go
@@ -25,7 +25,7 @@ type gethRPCClient struct {
 }
 
 // NewEthClient instantiates a new ethadapter.EthClient that connects to an ethereum node
-func NewEthClient(ipaddress string, port uint, timeout time.Duration, id gethcommon.Address) (EthClient, error) {
+func NewEthClient(ipaddress string, port uint, timeout time.Duration, l2ID gethcommon.Address) (EthClient, error) {
 	client, err := connect(ipaddress, port, timeout)
 	if err != nil {
 		return nil, fmt.Errorf("unable to connect to the eth node - %w", err)
@@ -34,6 +34,7 @@ func NewEthClient(ipaddress string, port uint, timeout time.Duration, id gethcom
 	log.Trace("Initialized eth node connection - addr: %s port: %d", ipaddress, port)
 	return &gethRPCClient{
 		client: client,
+		l2ID:   l2ID,
 	}, nil
 }
 

--- a/go/ethadapter/geth_rpc_client.go
+++ b/go/ethadapter/geth_rpc_client.go
@@ -13,8 +13,6 @@ import (
 
 	"github.com/ethereum/go-ethereum"
 
-	"github.com/obscuronet/go-obscuro/go/config"
-
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -24,21 +22,6 @@ import (
 type gethRPCClient struct {
 	client *ethclient.Client  // the underlying eth rpc client
 	id     gethcommon.Address // TODO remove the id common.Address
-}
-
-// NewEthClientFromConfig instantiates a new ethadapter.EthClient that connects to an ethereum node
-// TODO Refactor this according with https://github.com/obscuronet/go-obscuro/pull/310#discussion_r910705504
-func NewEthClientFromConfig(config config.HostConfig) (EthClient, error) {
-	client, err := connect(config.L1NodeHost, config.L1NodeWebsocketPort, config.L1ConnectionTimeout)
-	if err != nil {
-		return nil, fmt.Errorf("unable to connect to the eth node - %w", err)
-	}
-
-	log.Trace("Initialized eth node connection - port: %d - id: %s", config.L1NodeWebsocketPort, config.ID)
-	return &gethRPCClient{
-		client: client,
-		id:     config.ID,
-	}, nil
 }
 
 // NewEthClient instantiates a new ethadapter.EthClient that connects to an ethereum node

--- a/go/ethadapter/geth_rpc_client.go
+++ b/go/ethadapter/geth_rpc_client.go
@@ -21,7 +21,7 @@ import (
 // gethRPCClient implements the EthClient interface and allows connection to a real ethereum node
 type gethRPCClient struct {
 	client *ethclient.Client  // the underlying eth rpc client
-	id     gethcommon.Address // the address of the Obscuro node this client is for
+	l2ID   gethcommon.Address // the address of the Obscuro node this client is dedicated to
 }
 
 // NewEthClient instantiates a new ethadapter.EthClient that connects to an ethereum node
@@ -47,7 +47,7 @@ func (e *gethRPCClient) FetchHeadBlock() *types.Block {
 
 func (e *gethRPCClient) Info() Info {
 	return Info{
-		ID: e.id,
+		L2ID: e.l2ID,
 	}
 }
 

--- a/go/ethadapter/interface.go
+++ b/go/ethadapter/interface.go
@@ -37,5 +37,5 @@ type EthClient interface {
 
 // Info forces the RPC EthClient to return the data in the same format (independently of its implementation)
 type Info struct {
-	ID gethcommon.Address
+	L2ID gethcommon.Address // the address of the Obscuro node this client is dedicated to
 }

--- a/go/ethadapter/interface.go
+++ b/go/ethadapter/interface.go
@@ -35,7 +35,7 @@ type EthClient interface {
 	EthClient() *ethclient.Client // returns the underlying eth client
 }
 
-// Info forces the RPC EthClient to return the data in the same format (independently of it's implementation)
+// Info forces the RPC EthClient to return the data in the same format (independently of its implementation)
 type Info struct {
 	ID gethcommon.Address
 }

--- a/go/host/hostrunner/host_runner.go
+++ b/go/host/hostrunner/host_runner.go
@@ -30,7 +30,7 @@ func RunHost(config config.HostConfig) {
 	}
 
 	fmt.Println("Connecting to L1 network...")
-	l1Client, err := ethadapter.NewEthClientFromConfig(config)
+	l1Client, err := ethadapter.NewEthClient(config.L1NodeHost, config.L1NodeWebsocketPort, config.L1ConnectionTimeout)
 	if err != nil {
 		log.Panic("could not create Ethereum client. Cause: %s", err)
 	}

--- a/go/host/hostrunner/host_runner.go
+++ b/go/host/hostrunner/host_runner.go
@@ -30,7 +30,7 @@ func RunHost(config config.HostConfig) {
 	}
 
 	fmt.Println("Connecting to L1 network...")
-	l1Client, err := ethadapter.NewEthClient(config.L1NodeHost, config.L1NodeWebsocketPort, config.L1ConnectionTimeout)
+	l1Client, err := ethadapter.NewEthClient(config.L1NodeHost, config.L1NodeWebsocketPort, config.L1ConnectionTimeout, config.ID)
 	if err != nil {
 		log.Panic("could not create Ethereum client. Cause: %s", err)
 	}

--- a/go/host/interfaces.go
+++ b/go/host/interfaces.go
@@ -31,6 +31,6 @@ type StatsCollector interface {
 	// L2Recalc - called when a node has to discard the speculative work built on top of the winner of the gossip round.
 	L2Recalc(id gethcommon.Address)
 	NewBlock(block *types.Block)
-	NewRollup(node gethcommon.Address, rollup *common.EncryptedRollup)
+	NewRollup(node gethcommon.Address)
 	RollupWithMoreRecentProof()
 }

--- a/integration/ethereummock/mock_l1_network.go
+++ b/integration/ethereummock/mock_l1_network.go
@@ -43,7 +43,7 @@ func NewMockEthNetwork(avgBlockDuration time.Duration, avgLatency time.Duration,
 func (n *MockEthNetwork) BroadcastBlock(b common.EncodedBlock, p common.EncodedBlock) {
 	bl, _ := b.DecodeBlock()
 	for _, m := range n.AllNodes {
-		if m.ID != n.CurrentNode.ID {
+		if m.Info().L2ID != n.CurrentNode.Info().L2ID {
 			t := m
 			common.Schedule(n.delay(), func() { t.P2PReceiveBlock(b, p) })
 		} else {
@@ -57,7 +57,7 @@ func (n *MockEthNetwork) BroadcastBlock(b common.EncodedBlock, p common.EncodedB
 // BroadcastTx Broadcasts the L1 tx containing the rollup to the L1 network
 func (n *MockEthNetwork) BroadcastTx(tx *types.Transaction) {
 	for _, m := range n.AllNodes {
-		if m.ID != n.CurrentNode.ID {
+		if m.Info().L2ID != n.CurrentNode.Info().L2ID {
 			t := m
 			// the time to broadcast a tx is half that of a L1 block, because it is smaller.
 			// todo - find a better way to express this
@@ -107,5 +107,5 @@ func printBlock(b *types.Block, m Node) string {
 	}
 
 	return fmt.Sprintf("> M%d: create b_%d(Height=%d, Nonce=%d)[parent=b_%d]. Txs: %v",
-		common.ShortAddress(m.ID), common.ShortHash(b.Hash()), b.NumberU64(), common.ShortNonce(b.Header().Nonce), common.ShortHash(p.Hash()), txs)
+		common.ShortAddress(m.Info().L2ID), common.ShortHash(b.Hash()), b.NumberU64(), common.ShortNonce(b.Header().Nonce), common.ShortHash(p.Hash()), txs)
 }

--- a/integration/ethereummock/node.go
+++ b/integration/ethereummock/node.go
@@ -38,7 +38,7 @@ type TxDB interface {
 }
 
 type StatsCollector interface {
-	// Register when a miner has to process a reorg (a winning block from a fork)
+	// L1Reorg registers when a miner has to process a reorg (a winning block from a fork)
 	L1Reorg(id gethcommon.Address)
 }
 

--- a/integration/gethnetwork/geth_network_test.go
+++ b/integration/gethnetwork/geth_network_test.go
@@ -11,8 +11,6 @@ import (
 
 	"github.com/obscuronet/go-obscuro/go/ethadapter"
 
-	"github.com/obscuronet/go-obscuro/go/config"
-
 	"github.com/obscuronet/go-obscuro/integration"
 
 	"github.com/ethereum/go-ethereum"
@@ -112,12 +110,7 @@ func TestGethTransactionIsMintedOverRPC(t *testing.T) {
 	network := NewGethNetwork(startPort, startPort+defaultWsPortOffset, gethBinaryPath, numNodes, 1, []string{w.Address().String()})
 	defer network.StopNodes()
 
-	hostConfig := config.HostConfig{
-		L1NodeHost:          localhost,
-		L1NodeWebsocketPort: network.WebSocketPorts[0],
-		L1ConnectionTimeout: defaultL1ConnectionTimeout,
-	}
-	ethClient, err := ethadapter.NewEthClientFromConfig(hostConfig)
+	ethClient, err := ethadapter.NewEthClient(localhost, network.WebSocketPorts[0], defaultL1ConnectionTimeout)
 	if err != nil {
 		panic(err)
 	}

--- a/integration/gethnetwork/geth_network_test.go
+++ b/integration/gethnetwork/geth_network_test.go
@@ -110,7 +110,7 @@ func TestGethTransactionIsMintedOverRPC(t *testing.T) {
 	network := NewGethNetwork(startPort, startPort+defaultWsPortOffset, gethBinaryPath, numNodes, 1, []string{w.Address().String()})
 	defer network.StopNodes()
 
-	ethClient, err := ethadapter.NewEthClient(localhost, network.WebSocketPorts[0], defaultL1ConnectionTimeout)
+	ethClient, err := ethadapter.NewEthClient(localhost, network.WebSocketPorts[0], defaultL1ConnectionTimeout, common.HexToAddress("0x0"))
 	if err != nil {
 		panic(err)
 	}

--- a/integration/simulation/network/geth_utils.go
+++ b/integration/simulation/network/geth_utils.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/obscuronet/go-obscuro/go/config"
 	"github.com/obscuronet/go-obscuro/go/ethadapter"
 	"github.com/obscuronet/go-obscuro/go/ethadapter/mgmtcontractlib"
 	"github.com/obscuronet/go-obscuro/go/wallet"
@@ -44,12 +43,7 @@ func SetUpGethNetwork(wallets *params.SimWallets, StartPort int, nrNodes int, bl
 	)
 
 	// connect to the first host to deploy
-	tmpHostConfig := config.HostConfig{
-		L1NodeHost:          Localhost,
-		L1NodeWebsocketPort: gethNetwork.WebSocketPorts[0],
-		L1ConnectionTimeout: DefaultL1ConnectionTimeout,
-	}
-	tmpEthClient, err := ethadapter.NewEthClientFromConfig(tmpHostConfig)
+	tmpEthClient, err := ethadapter.NewEthClient(Localhost, gethNetwork.WebSocketPorts[0], DefaultL1ConnectionTimeout)
 	if err != nil {
 		panic(err)
 	}
@@ -71,7 +65,7 @@ func SetUpGethNetwork(wallets *params.SimWallets, StartPort int, nrNodes int, bl
 
 	ethClients := make([]ethadapter.EthClient, nrNodes)
 	for i := 0; i < nrNodes; i++ {
-		ethClients[i] = createEthClientConnection(int64(i), gethNetwork.WebSocketPorts[i])
+		ethClients[i] = createEthClientConnection(gethNetwork.WebSocketPorts[i])
 	}
 
 	return mgmtContractAddr, erc20ContractAddr[0], erc20ContractAddr[1], ethClients, gethNetwork
@@ -125,14 +119,8 @@ func DeployContract(workerClient ethadapter.EthClient, w wallet.Wallet, contract
 	return nil, fmt.Errorf("failed to mine contract deploy tx into a block after %s. Aborting", time.Since(start))
 }
 
-func createEthClientConnection(id int64, port uint) ethadapter.EthClient {
-	hostConfig := config.HostConfig{
-		ID:                  common.BigToAddress(big.NewInt(id)),
-		L1NodeHost:          Localhost,
-		L1NodeWebsocketPort: port,
-		L1ConnectionTimeout: DefaultL1ConnectionTimeout,
-	}
-	ethnode, err := ethadapter.NewEthClientFromConfig(hostConfig)
+func createEthClientConnection(port uint) ethadapter.EthClient {
+	ethnode, err := ethadapter.NewEthClient(Localhost, port, DefaultL1ConnectionTimeout)
 	if err != nil {
 		panic(err)
 	}

--- a/integration/simulation/network/geth_utils.go
+++ b/integration/simulation/network/geth_utils.go
@@ -43,7 +43,7 @@ func SetUpGethNetwork(wallets *params.SimWallets, StartPort int, nrNodes int, bl
 	)
 
 	// connect to the first host to deploy
-	tmpEthClient, err := ethadapter.NewEthClient(Localhost, gethNetwork.WebSocketPorts[0], DefaultL1ConnectionTimeout)
+	tmpEthClient, err := ethadapter.NewEthClient(Localhost, gethNetwork.WebSocketPorts[0], DefaultL1ConnectionTimeout, common.HexToAddress("0x0"))
 	if err != nil {
 		panic(err)
 	}
@@ -65,7 +65,7 @@ func SetUpGethNetwork(wallets *params.SimWallets, StartPort int, nrNodes int, bl
 
 	ethClients := make([]ethadapter.EthClient, nrNodes)
 	for i := 0; i < nrNodes; i++ {
-		ethClients[i] = createEthClientConnection(gethNetwork.WebSocketPorts[i])
+		ethClients[i] = createEthClientConnection(int64(i), gethNetwork.WebSocketPorts[i])
 	}
 
 	return mgmtContractAddr, erc20ContractAddr[0], erc20ContractAddr[1], ethClients, gethNetwork
@@ -119,8 +119,8 @@ func DeployContract(workerClient ethadapter.EthClient, w wallet.Wallet, contract
 	return nil, fmt.Errorf("failed to mine contract deploy tx into a block after %s. Aborting", time.Since(start))
 }
 
-func createEthClientConnection(port uint) ethadapter.EthClient {
-	ethnode, err := ethadapter.NewEthClient(Localhost, port, DefaultL1ConnectionTimeout)
+func createEthClientConnection(id int64, port uint) ethadapter.EthClient {
+	ethnode, err := ethadapter.NewEthClient(Localhost, port, DefaultL1ConnectionTimeout, common.BigToAddress(big.NewInt(id)))
 	if err != nil {
 		panic(err)
 	}

--- a/integration/simulation/stats/stats.go
+++ b/integration/simulation/stats/stats.go
@@ -63,7 +63,7 @@ func (s *Stats) NewBlock(b *types.Block) {
 	s.statsMu.Unlock()
 }
 
-func (s *Stats) NewRollup(node gethcommon.Address, r *common.EncryptedRollup) {
+func (s *Stats) NewRollup(node gethcommon.Address) {
 	s.statsMu.Lock()
 	s.NoL2Blocks[node]++
 	s.statsMu.Unlock()

--- a/integration/simulation/validate_chain.go
+++ b/integration/simulation/validate_chain.go
@@ -167,7 +167,7 @@ func ExtractDataFromEthereumChain(startBlock *types.Block, endBlock *types.Block
 				if node.IsBlockAncestor(block, r.Header.L1Proof) {
 					// only count the rollup if it is published in the right branch
 					// todo - once logic is added to the l1 - this can be made into a check
-					s.Stats.NewRollup(node.Info().ID, r)
+					s.Stats.NewRollup(node.Info().ID)
 				}
 			}
 		}

--- a/integration/simulation/validate_chain.go
+++ b/integration/simulation/validate_chain.go
@@ -99,7 +99,7 @@ func checkObscuroBlockchainValidity(t *testing.T, s *Simulation, maxL1Height uin
 }
 
 func checkBlockchainOfEthereumNode(t *testing.T, node ethadapter.EthClient, minHeight uint64, s *Simulation) uint64 {
-	nodeAddr := common.ShortAddress(node.Info().ID)
+	nodeAddr := common.ShortAddress(node.Info().L2ID)
 	head := node.FetchHeadBlock()
 	height := head.NumberU64()
 
@@ -128,7 +128,7 @@ func checkBlockchainOfEthereumNode(t *testing.T, node ethadapter.EthClient, minH
 	}
 
 	// compare the number of reorgs for this node against the height
-	reorgs := s.Stats.NoL1Reorgs[node.Info().ID]
+	reorgs := s.Stats.NoL1Reorgs[node.Info().L2ID]
 	eff := float64(reorgs) / float64(height)
 	if eff > s.Params.L1EfficiencyThreshold {
 		t.Errorf("Node %d: The number of reorgs is too high: %d. ", nodeAddr, reorgs)
@@ -167,7 +167,7 @@ func ExtractDataFromEthereumChain(startBlock *types.Block, endBlock *types.Block
 				if node.IsBlockAncestor(block, r.Header.L1Proof) {
 					// only count the rollup if it is published in the right branch
 					// todo - once logic is added to the l1 - this can be made into a check
-					s.Stats.NewRollup(node.Info().ID)
+					s.Stats.NewRollup(node.Info().L2ID)
 				}
 			}
 		}

--- a/integration/smartcontract/smartcontracts_test.go
+++ b/integration/smartcontract/smartcontracts_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/obscuronet/go-obscuro/go/common"
-	"github.com/obscuronet/go-obscuro/go/config"
 	"github.com/obscuronet/go-obscuro/go/ethadapter"
 	"github.com/obscuronet/go-obscuro/go/ethadapter/mgmtcontractlib"
 	"github.com/obscuronet/go-obscuro/go/wallet"
@@ -50,12 +49,7 @@ func runGethNetwork(t *testing.T) *netInfo {
 	)
 
 	// create a client that is connected to node 0 of the network
-	client, err := ethadapter.NewEthClientFromConfig(config.HostConfig{
-		ID:                  gethcommon.Address{1},
-		L1NodeHost:          "127.0.0.1",
-		L1NodeWebsocketPort: gethNetwork.WebSocketPorts[0],
-		L1ConnectionTimeout: 30 * time.Second,
-	})
+	client, err := ethadapter.NewEthClient("127.0.0.1", gethNetwork.WebSocketPorts[0], 30*time.Second)
 	if err != nil {
 		return nil
 	}

--- a/integration/smartcontract/smartcontracts_test.go
+++ b/integration/smartcontract/smartcontracts_test.go
@@ -49,7 +49,7 @@ func runGethNetwork(t *testing.T) *netInfo {
 	)
 
 	// create a client that is connected to node 0 of the network
-	client, err := ethadapter.NewEthClient("127.0.0.1", gethNetwork.WebSocketPorts[0], 30*time.Second)
+	client, err := ethadapter.NewEthClient("127.0.0.1", gethNetwork.WebSocketPorts[0], 30*time.Second, gethcommon.HexToAddress("0x0"))
 	if err != nil {
 		return nil
 	}

--- a/tools/contractdeployer/contract_deployer.go
+++ b/tools/contractdeployer/contract_deployer.go
@@ -37,7 +37,7 @@ func (cd *ContractDeployer) Run() error {
 	// load the wallet
 	w := wallet.NewInMemoryWalletFromPK(cd.config.EthChainID, privateKey)
 	// connect to the l1
-	client, err := ethadapter.NewEthClient(cd.config.L1NodeHost, cd.config.L1NodePort, 30*time.Second)
+	client, err := ethadapter.NewEthClient(cd.config.L1NodeHost, cd.config.L1NodePort, 30*time.Second, common.HexToAddress("0x0"))
 	if err != nil {
 		return fmt.Errorf("unable to connect to the l1 host: %w", err)
 	}

--- a/tools/networkmanager/deploy_contract.go
+++ b/tools/networkmanager/deploy_contract.go
@@ -34,7 +34,7 @@ func DeployContract(config Config) {
 		L1ChainID:        config.l1ChainID,
 	}
 
-	l1Client, err := ethadapter.NewEthClient(config.l1NodeHost, config.l1NodeWebsocketPort, config.l1ConnectionTimeout)
+	l1Client, err := ethadapter.NewEthClient(config.l1NodeHost, config.l1NodeWebsocketPort, config.l1ConnectionTimeout, common.HexToAddress("0x0"))
 	if err != nil {
 		panic(err)
 	}

--- a/tools/networkmanager/deploy_contract.go
+++ b/tools/networkmanager/deploy_contract.go
@@ -30,14 +30,11 @@ func DeployContract(config Config) {
 	}
 
 	hostConfig := obscuroconfig.HostConfig{
-		L1NodeHost:          config.l1NodeHost,
-		L1NodeWebsocketPort: config.l1NodeWebsocketPort,
-		L1ConnectionTimeout: config.l1ConnectionTimeout,
-		PrivateKeyString:    config.privateKeys[0], // We deploy the contract using the first private key.
-		L1ChainID:           config.l1ChainID,
+		PrivateKeyString: config.privateKeys[0], // We deploy the contract using the first private key.
+		L1ChainID:        config.l1ChainID,
 	}
 
-	l1Client, err := ethadapter.NewEthClientFromConfig(hostConfig)
+	l1Client, err := ethadapter.NewEthClient(config.l1NodeHost, config.l1NodeWebsocketPort, config.l1ConnectionTimeout)
 	if err != nil {
 		panic(err)
 	}

--- a/tools/networkmanager/inject_txs.go
+++ b/tools/networkmanager/inject_txs.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"time"
 
+	gethcommon "github.com/ethereum/go-ethereum/common"
+
 	"github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/ethereum/go-ethereum/crypto"
@@ -24,7 +26,7 @@ import (
 
 func InjectTransactions(cfg Config, args []string) {
 	println("Connecting to L1 node...")
-	l1Client, err := ethadapter.NewEthClient(cfg.l1NodeHost, cfg.l1NodeWebsocketPort, cfg.l1ConnectionTimeout)
+	l1Client, err := ethadapter.NewEthClient(cfg.l1NodeHost, cfg.l1NodeWebsocketPort, cfg.l1ConnectionTimeout, gethcommon.HexToAddress("0x0"))
 	if err != nil {
 		panic(fmt.Sprintf("could not create L1 client. Cause: %s", err))
 	}

--- a/tools/networkmanager/inject_txs.go
+++ b/tools/networkmanager/inject_txs.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/obscuronet/go-obscuro/integration/simulation/stats"
 
-	"github.com/obscuronet/go-obscuro/go/config"
 	"github.com/obscuronet/go-obscuro/go/ethadapter"
 	"github.com/obscuronet/go-obscuro/go/ethadapter/erc20contractlib"
 	"github.com/obscuronet/go-obscuro/go/ethadapter/mgmtcontractlib"
@@ -24,13 +23,8 @@ import (
 )
 
 func InjectTransactions(cfg Config, args []string) {
-	hostConfig := config.HostConfig{
-		L1NodeHost:          cfg.l1NodeHost,
-		L1NodeWebsocketPort: cfg.l1NodeWebsocketPort,
-		L1ConnectionTimeout: cfg.l1ConnectionTimeout,
-	}
 	println("Connecting to L1 node...")
-	l1Client, err := ethadapter.NewEthClientFromConfig(hostConfig)
+	l1Client, err := ethadapter.NewEthClient(cfg.l1NodeHost, cfg.l1NodeWebsocketPort, cfg.l1ConnectionTimeout)
 	if err != nil {
 		panic(fmt.Sprintf("could not create L1 client. Cause: %s", err))
 	}

--- a/tools/networkmanager/inject_txs.go
+++ b/tools/networkmanager/inject_txs.go
@@ -2,12 +2,11 @@ package networkmanager
 
 import (
 	"fmt"
+	"github.com/ethereum/go-ethereum/common"
 	"math/big"
 	"os"
 	"strconv"
 	"time"
-
-	gethcommon "github.com/ethereum/go-ethereum/common"
 
 	"github.com/ethereum/go-ethereum/core/types"
 
@@ -26,7 +25,7 @@ import (
 
 func InjectTransactions(cfg Config, args []string) {
 	println("Connecting to L1 node...")
-	l1Client, err := ethadapter.NewEthClient(cfg.l1NodeHost, cfg.l1NodeWebsocketPort, cfg.l1ConnectionTimeout, gethcommon.HexToAddress("0x0"))
+	l1Client, err := ethadapter.NewEthClient(cfg.l1NodeHost, cfg.l1NodeWebsocketPort, cfg.l1ConnectionTimeout, common.HexToAddress("0x0"))
 	if err != nil {
 		panic(fmt.Sprintf("could not create L1 client. Cause: %s", err))
 	}

--- a/tools/networkmanager/inject_txs.go
+++ b/tools/networkmanager/inject_txs.go
@@ -2,11 +2,12 @@ package networkmanager
 
 import (
 	"fmt"
-	"github.com/ethereum/go-ethereum/common"
 	"math/big"
 	"os"
 	"strconv"
 	"time"
+
+	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/ethereum/go-ethereum/core/types"
 


### PR DESCRIPTION
### Why is this change needed?

- There was a todo to be addressed re: the Geth client having two constructors, when one would do
- The Geth client's ID field was used confusingly. Sometimes it was not set, sometimes it was set to a random ID, sometimes it was set to the L2 node ID

### What changes were made as part of this PR:

Refactoring.

- Removes secondary constructor for Geth client
- Forces passing of L2 ID when constructing Geth client
- Clarifies role of L2 ID in Geth client
- Encapsulates ID field in ethereummock.Node
- Removes unused param in `Stats.NewRollup`

### What are the key areas to look at
