### PR TITLE
Removes L2Txs type, per todo.

### DIFF
--- a/go/common/types.go
+++ b/go/common/types.go
@@ -6,20 +6,20 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/ethereum/go-ethereum/common"
+
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/rlp"
 	"golang.org/x/crypto/sha3"
 
 	"github.com/ethereum/go-ethereum/core/types"
-
-	gethcommon "github.com/ethereum/go-ethereum/common"
 )
 
 type (
-	StateRoot             = gethcommon.Hash
-	L1RootHash            = gethcommon.Hash
-	L2RootHash            = gethcommon.Hash
-	TxHash                = gethcommon.Hash
+	StateRoot             = common.Hash
+	L1RootHash            = common.Hash
+	L2RootHash            = common.Hash
+	TxHash                = common.Hash
 	L2Tx                  = types.Transaction
 	EncryptedTx           []byte // A single transaction, encoded as a JSON list of transaction binary hexes and encrypted using the enclave's public key
 	EncryptedTransactions []byte // A blob of encrypted transactions, as they're stored in the rollup.
@@ -51,14 +51,14 @@ const (
 // Making changes to this struct will require GRPC + GRPC Converters regen
 type Header struct {
 	ParentHash  L2RootHash
-	Agg         gethcommon.Address
+	Agg         common.Address
 	Nonce       Nonce
 	L1Proof     L1RootHash // the L1 block where the Parent was published
 	Root        StateRoot
-	TxHash      gethcommon.Hash // todo - include the synthetic deposits
-	Number      *big.Int        // the rollup height
+	TxHash      common.Hash // todo - include the synthetic deposits
+	Number      *big.Int    // the rollup height
 	Bloom       types.Bloom
-	ReceiptHash gethcommon.Hash
+	ReceiptHash common.Hash
 	Extra       []byte
 	R, S        *big.Int // signature values
 	Withdrawals []Withdrawal
@@ -68,14 +68,14 @@ type Header struct {
 type Withdrawal struct {
 	// Type      uint8 // the type of withdrawal. For now only ERC20. Todo - add this once more ERCs are supported
 	Amount    uint64
-	Recipient gethcommon.Address // the user account that will receive the money
-	Contract  gethcommon.Address // the contract
+	Recipient common.Address // the user account that will receive the money
+	Contract  common.Address // the contract
 }
 
 // ExtRollup is used for communication between the enclave and the outside world.
 type ExtRollup struct {
 	Header          *Header
-	TxHashes        []gethcommon.Hash // The hashes of the transactions included in the rollup
+	TxHashes        []common.Hash // The hashes of the transactions included in the rollup
 	EncryptedTxBlob EncryptedTransactions
 }
 
@@ -83,17 +83,17 @@ type ExtRollup struct {
 // This parallels the Block/extblock split in Go Ethereum.
 type EncryptedRollup struct {
 	Header       *Header
-	TxHashes     []gethcommon.Hash // The hashes of the transactions included in the rollup
+	TxHashes     []common.Hash // The hashes of the transactions included in the rollup
 	Transactions EncryptedTransactions
 	hash         atomic.Value
 }
 
 // AttestationReport represents a signed attestation report from a TEE and some metadata about the source of it to verify it
 type AttestationReport struct {
-	Report      []byte             // the signed bytes of the report which includes some encrypted identifying data
-	PubKey      []byte             // a public key that can be used to send encrypted data back to the TEE securely (should only be used once Report has been verified)
-	Owner       gethcommon.Address // address identifying the owner of the TEE which signed this report, can also be verified from the encrypted Report data
-	HostAddress string             // the IP address on which the host can be contacted by other Obscuro hosts for peer-to-peer communication
+	Report      []byte         // the signed bytes of the report which includes some encrypted identifying data
+	PubKey      []byte         // a public key that can be used to send encrypted data back to the TEE securely (should only be used once Report has been verified)
+	Owner       common.Address // address identifying the owner of the TEE which signed this report, can also be verified from the encrypted Report data
+	HostAddress string         // the IP address on which the host can be contacted by other Obscuro hosts for peer-to-peer communication
 }
 
 func (er ExtRollup) ToRollup() *EncryptedRollup {
@@ -114,8 +114,8 @@ var hasherPool = sync.Pool{
 }
 
 // RLPHash encodes value, hashes the encoded bytes and returns the hash.
-func RLPHash(value interface{}) (gethcommon.Hash, error) {
-	var hash gethcommon.Hash
+func RLPHash(value interface{}) (common.Hash, error) {
+	var hash common.Hash
 
 	sha := hasherPool.Get().(crypto.KeccakState)
 	defer hasherPool.Put(sha)

--- a/go/enclave/core/rollup.go
+++ b/go/enclave/core/rollup.go
@@ -17,7 +17,7 @@ type Rollup struct {
 	hash atomic.Value
 	// size   atomic.Value
 
-	Transactions L2Txs
+	Transactions []*common.L2Tx
 }
 
 // Hash returns the keccak256 hash of b's header.

--- a/go/enclave/core/types.go
+++ b/go/enclave/core/types.go
@@ -1,7 +1,7 @@
 package core
 
 import (
-	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common"
 )
 
 const SharedSecretLen = 32
@@ -11,7 +11,7 @@ type SharedEnclaveSecret [SharedSecretLen]byte
 
 // BlockState - Represents the state after an L1 Block was processed.
 type BlockState struct {
-	Block          gethcommon.Hash
-	HeadRollup     gethcommon.Hash
+	Block          common.Hash
+	HeadRollup     common.Hash
 	FoundNewRollup bool
 }

--- a/go/enclave/core/types.go
+++ b/go/enclave/core/types.go
@@ -2,16 +2,12 @@ package core
 
 import (
 	gethcommon "github.com/ethereum/go-ethereum/common"
-	"github.com/obscuronet/go-obscuro/go/common"
 )
 
 const SharedSecretLen = 32
 
 // SharedEnclaveSecret - the entropy
 type SharedEnclaveSecret [SharedSecretLen]byte
-
-// L2Txs Todo - is this type useful?
-type L2Txs []*common.L2Tx
 
 // BlockState - Represents the state after an L1 Block was processed.
 type BlockState struct {

--- a/go/enclave/crypto/transaction_blob_crypto.go
+++ b/go/enclave/crypto/transaction_blob_crypto.go
@@ -69,7 +69,7 @@ func (t TransactionBlobCryptoImpl) ToEnclaveRollup(r *common.EncryptedRollup) *c
 }
 
 // TODO - Modify this logic so that transactions with different reveal periods are in different blobs, as per the whitepaper.
-func (t TransactionBlobCryptoImpl) encrypt(transactions core.L2Txs) common.EncryptedTransactions {
+func (t TransactionBlobCryptoImpl) encrypt(transactions []*common.L2Tx) common.EncryptedTransactions {
 	encodedTxs, err := rlp.EncodeToBytes(transactions)
 	if err != nil {
 		log.Panic("could not encrypt L2 transaction. Cause: %s", err)
@@ -78,13 +78,13 @@ func (t TransactionBlobCryptoImpl) encrypt(transactions core.L2Txs) common.Encry
 	return t.transactionCipher.Seal(nil, []byte(RollupCipherNonce), encodedTxs, nil)
 }
 
-func (t TransactionBlobCryptoImpl) decrypt(encryptedTxs common.EncryptedTransactions) core.L2Txs {
+func (t TransactionBlobCryptoImpl) decrypt(encryptedTxs common.EncryptedTransactions) []*common.L2Tx {
 	encodedTxs, err := t.transactionCipher.Open(nil, []byte(RollupCipherNonce), encryptedTxs, nil)
 	if err != nil {
 		log.Panic("could not decrypt encrypted L2 transactions. Cause: %s", err)
 	}
 
-	txs := core.L2Txs{}
+	var txs []*common.L2Tx
 	if err := rlp.DecodeBytes(encodedTxs, &txs); err != nil {
 		log.Panic("could not decode encoded L2 transactions. Cause: %s", err)
 	}

--- a/go/enclave/db/rawdb/accessors_chain.go
+++ b/go/enclave/db/rawdb/accessors_chain.go
@@ -93,7 +93,7 @@ func ReadHeaderRLP(db ethdb.KeyValueReader, hash gethcommon.Hash, number uint64)
 	return data
 }
 
-func WriteBody(db ethdb.KeyValueWriter, hash gethcommon.Hash, number uint64, body core.L2Txs) {
+func WriteBody(db ethdb.KeyValueWriter, hash gethcommon.Hash, number uint64, body []*common.L2Tx) {
 	data, err := rlp.EncodeToBytes(body)
 	if err != nil {
 		log.Panic("could not encode L2 transactions. Cause: %s", err)
@@ -102,12 +102,12 @@ func WriteBody(db ethdb.KeyValueWriter, hash gethcommon.Hash, number uint64, bod
 }
 
 // ReadBody retrieves the rollup body corresponding to the hash.
-func ReadBody(db ethdb.KeyValueReader, hash gethcommon.Hash, number uint64) core.L2Txs {
+func ReadBody(db ethdb.KeyValueReader, hash gethcommon.Hash, number uint64) []*common.L2Tx {
 	data := ReadBodyRLP(db, hash, number)
 	if len(data) == 0 {
 		return nil
 	}
-	body := new(core.L2Txs)
+	body := new([]*common.L2Tx)
 	if err := rlp.Decode(bytes.NewReader(data), body); err != nil {
 		log.Panic("could not decode L2 transactions. Cause: %s", err)
 	}

--- a/go/enclave/mempool/interface.go
+++ b/go/enclave/mempool/interface.go
@@ -14,5 +14,5 @@ type Manager interface {
 	// RemoveMempoolTxs removes transactions that are considered immune to re-orgs
 	RemoveMempoolTxs(r *obscurocore.Rollup, resolver db.RollupResolver)
 	// CurrentTxs Returns the transactions that should be included in the current rollup
-	CurrentTxs(head *obscurocore.Rollup, resolver db.RollupResolver) obscurocore.L2Txs
+	CurrentTxs(head *obscurocore.Rollup, resolver db.RollupResolver) []*common.L2Tx
 }

--- a/go/enclave/mempool/manager.go
+++ b/go/enclave/mempool/manager.go
@@ -15,7 +15,7 @@ import (
 // sortByNonce a very primitive way to implement mempool logic that
 // adds transactions sorted by the nonce in the rollup
 // which is what the EVM expects
-type sortByNonce obscurocore.L2Txs
+type sortByNonce []*common.L2Tx
 
 func (c sortByNonce) Len() int           { return len(c) }
 func (c sortByNonce) Swap(i, j int)      { c[i], c[j] = c[j], c[i] }
@@ -87,7 +87,7 @@ func historicTxs(r *obscurocore.Rollup, resolver db.RollupResolver) map[gethcomm
 }
 
 // CurrentTxs - Calculate transactions to be included in the current rollup
-func (db *mempoolManager) CurrentTxs(head *obscurocore.Rollup, resolver db.RollupResolver) obscurocore.L2Txs {
+func (db *mempoolManager) CurrentTxs(head *obscurocore.Rollup, resolver db.RollupResolver) []*common.L2Tx {
 	txs := findTxsNotIncluded(head, db.FetchMempoolTxs(), resolver)
 	sort.Sort(sortByNonce(txs))
 	return txs

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -283,8 +283,8 @@ const nonceTooHigh = "nonce too high"
 // This is where transactions are executed and the state is calculated.
 // Obscuro includes a bridge embedded in the platform, and this method is responsible for processing deposits as well.
 // The rollup can be a final rollup as received from peers or the rollup under construction.
-func (rc *RollupChain) processState(rollup *obscurocore.Rollup, txs obscurocore.L2Txs, stateDB *state.StateDB) (gethcommon.Hash, obscurocore.L2Txs, []*types.Receipt, []*types.Receipt) {
-	var executedTransactions obscurocore.L2Txs
+func (rc *RollupChain) processState(rollup *obscurocore.Rollup, txs []*common.L2Tx, stateDB *state.StateDB) (gethcommon.Hash, []*common.L2Tx, []*types.Receipt, []*types.Receipt) {
+	var executedTransactions []*common.L2Tx
 	var txReceipts []*types.Receipt
 
 	txResults := evm.ExecuteTransactions(txs, stateDB, rollup.Header, rc.storage, rc.obscuroChainID, 0)
@@ -500,7 +500,7 @@ func (rc *RollupChain) produceRollup(b *types.Block, bs *obscurocore.BlockState)
 	}
 
 	// These variables will be used to create the new rollup
-	var newRollupTxs obscurocore.L2Txs
+	var newRollupTxs []*common.L2Tx
 	var newRollupState *state.StateDB
 
 	/*

--- a/integration/simulation/transaction_injector_counter.go
+++ b/integration/simulation/transaction_injector_counter.go
@@ -8,15 +8,14 @@ import (
 	"github.com/obscuronet/go-obscuro/go/ethadapter/erc20contractlib"
 
 	"github.com/obscuronet/go-obscuro/go/common"
-	"github.com/obscuronet/go-obscuro/go/enclave/core"
 )
 
 type txInjectorCounter struct {
 	l1TransactionsLock       sync.RWMutex
 	L1Transactions           []ethadapter.L1Transaction
 	l2TransactionsLock       sync.RWMutex
-	TransferL2Transactions   core.L2Txs
-	WithdrawalL2Transactions core.L2Txs
+	TransferL2Transactions   []*common.L2Tx
+	WithdrawalL2Transactions []*common.L2Tx
 }
 
 func newCounter() *txInjectorCounter {
@@ -54,7 +53,7 @@ func (m *txInjectorCounter) GetL1Transactions() []ethadapter.L1Transaction {
 }
 
 // GetL2Transactions returns all generated non-WithdrawalTx transactions
-func (m *txInjectorCounter) GetL2Transactions() (core.L2Txs, core.L2Txs) {
+func (m *txInjectorCounter) GetL2Transactions() ([]*common.L2Tx, []*common.L2Tx) {
 	return m.TransferL2Transactions, m.WithdrawalL2Transactions
 }
 

--- a/tools/obscuroscan/obscuroscan.go
+++ b/tools/obscuroscan/obscuroscan.go
@@ -16,11 +16,9 @@ import (
 
 	"github.com/obscuronet/go-obscuro/go/enclave/crypto"
 
-	"github.com/ethereum/go-ethereum/rlp"
-	"github.com/obscuronet/go-obscuro/go/enclave/core"
-
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/obscuronet/go-obscuro/go/ethadapter/mgmtcontractlib"
 
 	"github.com/ethereum/go-ethereum/core/types"
@@ -199,7 +197,7 @@ func decryptTxBlob(encryptedTxBytesBase64 []byte) ([]byte, error) {
 		return nil, fmt.Errorf("could not decrypt encrypted L2 transactions. Cause: %w", err)
 	}
 
-	cleartextTxs := core.L2Txs{}
+	var cleartextTxs []*common.L2Tx
 	if err = rlp.DecodeBytes(encodedTxs, &cleartextTxs); err != nil {
 		return nil, fmt.Errorf("could not decode encoded L2 transactions. Cause: %w", err)
 	}


### PR DESCRIPTION
### Why is this change needed?

Addresses a todo by deleting a useless type alias.

### What changes were made as part of this PR:

Refactoring.

- Removes `L2Txs` type

### What are the key areas to look at
