### PR TITLE
Uses shared chain config across EVM facade and rollup chain.

### DIFF
--- a/go/enclave/db/storage.go
+++ b/go/enclave/db/storage.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"crypto/ecdsa"
 	"fmt"
-	"math/big"
 
 	"github.com/obscuronet/go-obscuro/go/common/log"
 
@@ -28,17 +27,12 @@ type storageImpl struct {
 	chainConfig *params.ChainConfig
 }
 
-func NewStorage(backingDB ethdb.Database, nodeID uint64, obscuroChainID int64) Storage {
-	chainConfig := params.ChainConfig{
-		ChainID:     big.NewInt(obscuroChainID),
-		LondonBlock: gethcommon.Big0,
-	}
-
+func NewStorage(backingDB ethdb.Database, nodeID uint64, chainConfig *params.ChainConfig) Storage {
 	return &storageImpl{
 		db:          backingDB,
 		stateDB:     state.NewDatabase(backingDB),
 		nodeID:      nodeID,
-		chainConfig: &chainConfig,
+		chainConfig: chainConfig,
 	}
 }
 

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/ethereum/go-ethereum/params"
+
 	"github.com/obscuronet/go-obscuro/go/common/profiler"
 
 	"github.com/obscuronet/go-obscuro/go/common/log"
@@ -105,7 +107,11 @@ func NewEnclave(
 	if err != nil {
 		log.Panic("Failed to connect to backing database - %s", err)
 	}
-	storage := db.NewStorage(backingDB, nodeShortID, config.ObscuroChainID)
+	chainConfig := params.ChainConfig{
+		ChainID:     big.NewInt(config.ObscuroChainID),
+		LondonBlock: gethcommon.Big0,
+	}
+	storage := db.NewStorage(backingDB, nodeShortID, &chainConfig)
 
 	// Initialise the Ethereum "Blockchain" structure that will allow us to validate incoming blocks
 	// Todo - check the minimum difficulty parameter
@@ -157,7 +163,7 @@ func NewEnclave(
 	)
 	memp := mempool.New(config.ObscuroChainID)
 
-	chain := rollupchain.New(nodeShortID, config.HostID, storage, l1Blockchain, obscuroBridge, transactionBlobCrypto, memp, rpcem, enclaveKey, config.ObscuroChainID, config.L1ChainID)
+	chain := rollupchain.New(nodeShortID, config.HostID, storage, l1Blockchain, obscuroBridge, transactionBlobCrypto, memp, rpcem, enclaveKey, config.L1ChainID, &chainConfig)
 
 	return &enclaveImpl{
 		config:                config,

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/ethereum/go-ethereum/params"
+
 	"github.com/status-im/keycard-go/hexutils"
 
 	"github.com/obscuronet/go-obscuro/go/common/log"
@@ -47,8 +49,8 @@ const (
 type RollupChain struct {
 	hostID          gethcommon.Address
 	nodeID          uint64
-	obscuroChainID  int64
 	ethereumChainID int64
+	chainConfig     *params.ChainConfig
 
 	storage               db.Storage
 	l1Blockchain          *core.BlockChain
@@ -61,7 +63,7 @@ type RollupChain struct {
 	blockProcessingMutex sync.Mutex
 }
 
-func New(nodeID uint64, hostID gethcommon.Address, storage db.Storage, l1Blockchain *core.BlockChain, bridge *bridge.Bridge, txCrypto crypto.TransactionBlobCrypto, mempool mempool.Manager, rpcem rpcencryptionmanager.RPCEncryptionManager, privateKey *ecdsa.PrivateKey, obscuroChainID int64, ethereumChainID int64) *RollupChain {
+func New(nodeID uint64, hostID gethcommon.Address, storage db.Storage, l1Blockchain *core.BlockChain, bridge *bridge.Bridge, txCrypto crypto.TransactionBlobCrypto, mempool mempool.Manager, rpcem rpcencryptionmanager.RPCEncryptionManager, privateKey *ecdsa.PrivateKey, ethereumChainID int64, chainConfig *params.ChainConfig) *RollupChain {
 	return &RollupChain{
 		nodeID:                nodeID,
 		hostID:                hostID,
@@ -72,8 +74,8 @@ func New(nodeID uint64, hostID gethcommon.Address, storage db.Storage, l1Blockch
 		mempool:               mempool,
 		enclavePrivateKey:     privateKey,
 		rpcEncryptionManager:  rpcem,
-		obscuroChainID:        obscuroChainID,
 		ethereumChainID:       ethereumChainID,
+		chainConfig:           chainConfig,
 		blockProcessingMutex:  sync.Mutex{},
 	}
 }
@@ -287,7 +289,7 @@ func (rc *RollupChain) processState(rollup *obscurocore.Rollup, txs obscurocore.
 	var executedTransactions obscurocore.L2Txs
 	var txReceipts []*types.Receipt
 
-	txResults := evm.ExecuteTransactions(txs, stateDB, rollup.Header, rc.storage, rc.obscuroChainID, 0)
+	txResults := evm.ExecuteTransactions(txs, stateDB, rollup.Header, rc.storage, rc.chainConfig, 0)
 	for _, tx := range txs {
 		result, f := txResults[tx.Hash()]
 		if !f {
@@ -317,7 +319,7 @@ func (rc *RollupChain) processState(rollup *obscurocore.Rollup, txs obscurocore.
 		stateDB,
 	)
 
-	depositResponses := evm.ExecuteTransactions(depositTxs, stateDB, rollup.Header, rc.storage, rc.obscuroChainID, len(executedTransactions))
+	depositResponses := evm.ExecuteTransactions(depositTxs, stateDB, rollup.Header, rc.storage, rc.chainConfig, len(executedTransactions))
 	depositReceipts := make([]*types.Receipt, len(depositResponses))
 	if len(depositResponses) != len(depositTxs) {
 		log.Panic("Sanity check. Some deposit transactions failed.")
@@ -651,7 +653,7 @@ func (rc *RollupChain) ExecuteOffChainTransaction(encryptedParams common.Encrypt
 	}
 	log.Info("!OffChain call: contractAddress=%s, from=%s, data=%s, rollup=r_%d, state=%s", contractAddress.Hex(), from.Hex(), hexutils.BytesToHex(data), common.ShortHash(r.Hash()), r.Header.Root.Hex())
 	s := rc.storage.CreateStateDB(hs.HeadRollup)
-	result, err := evm.ExecuteOffChainCall(from, contractAddress, data, s, r.Header, rc.storage, rc.obscuroChainID)
+	result, err := evm.ExecuteOffChainCall(from, contractAddress, data, s, r.Header, rc.storage, rc.chainConfig)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Why is this change needed?

The EVM facade and rollup chain both require the same chain config, but we have hardcoded it twice. We should use a single chain config that's passed around.

### What changes were made as part of this PR:

Refactoring.

- Uses a single chain config across the EVM facade and rollup chain

### What are the key areas to look at
