### PR TITLE
Splits out command line flags for wallet extension.

### DIFF
--- a/docs/_site/testnet/deploying-a-smart-contract.md
+++ b/docs/_site/testnet/deploying-a-smart-contract.md
@@ -15,9 +15,9 @@ The wallet extension should be run locally so that no sensitive data leaves the 
 1. Open a command line or terminal window on your local machine.
 1. Run `walletextension/main/main()` with the following flags to start the wallet extension:
 
-    ```--nodeRPCHTTPAddress=testnet-http.obscu.ro --nodeRPCWebsocketAddress=testnet-ws.obscu.ro```
+   ```--nodeHost=<Obscuro node's host> --nodePortHTTP=<Obscuro node's HTTP RPC address> --nodePortWS=<Obscuro node's websockets RPC address>```
 
-    The wallet extension is now listening on `http://localhost:3000/`
+   The wallet extension is now listening on `http://localhost:3000/`
 
 1. In MetaMask choose to "Add Network"
 

--- a/docs/_site/testnet/wallet-extension.md
+++ b/docs/_site/testnet/wallet-extension.md
@@ -34,7 +34,7 @@ unencrypted. If the data is not particularly sensitive, it can also be run in an
 
 3. Start the wallet extension by running the `wallet_extension` binary with the following flags:
 
-   ```--nodeRPCHTTPAddress=<Obscuro host RPC HTTP address> --nodeRPCWebsocketAddress=<Obscuro host RPC websocket address>```
+   ```--nodeHost=<Obscuro node's host> --nodePortHTTP=<Obscuro node's HTTP RPC address> --nodePortWS=<Obscuro node's websockets RPC address>```
 
    The wallet extension is now listening on `http://127.0.0.1:3000/`
 

--- a/docs/deploying-a-smart-contract.md
+++ b/docs/deploying-a-smart-contract.md
@@ -15,9 +15,9 @@ The wallet extension should be run locally so that no sensitive data leaves the 
 1. Open a command line or terminal window on your local machine.
 1. Run `walletextension/main/main()` with the following flags to start the wallet extension:
 
-    ```--nodeRPCHTTPAddress=testnet-http.obscu.ro --nodeRPCWebsocketAddress=testnet-ws.obscu.ro```
+   ```--nodeHost=<Obscuro node's host> --nodePortHTTP=<Obscuro node's HTTP RPC address> --nodePortWS=<Obscuro node's websockets RPC address>```
 
-    The wallet extension is now listening on `http://localhost:3000/`
+   The wallet extension is now listening on `http://localhost:3000/`
 
 1. In MetaMask choose to "Add Network"
 

--- a/docs/wallet-extension.md
+++ b/docs/wallet-extension.md
@@ -34,7 +34,7 @@ unencrypted. If the data is not particularly sensitive, it can also be run in an
 
 3. Start the wallet extension by running the `wallet_extension` binary with the following flags:
 
-   ```--nodeRPCHTTPAddress=<Obscuro host RPC HTTP address> --nodeRPCWebsocketAddress=<Obscuro host RPC websocket address>```
+   ```--nodeHost=<Obscuro node's host> --nodePortHTTP=<Obscuro node's HTTP RPC address> --nodePortWS=<Obscuro node's websockets RPC address>```
 
    The wallet extension is now listening on `http://127.0.0.1:3000/`
 

--- a/tools/walletextension/main/cli.go
+++ b/tools/walletextension/main/cli.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 
 	"github.com/obscuronet/go-obscuro/tools/walletextension"
 )
@@ -12,14 +13,17 @@ const (
 	walletExtensionPortDefault = 3000
 	walletExtensionPortUsage   = "The port on which to serve the wallet extension"
 
-	// TODO - Use one flag for the shared HTTP + RPC host, and two other flags for the ports.
-	nodeRPCHTTPAddressName    = "nodeRPCHTTPAddress"
-	nodeRPCHTTPAddressDefault = "testnet.obscu.ro:13000"
-	nodeRPCHTTPAddressUsage   = "The address on which to connect to the node via RPC using HTTP"
+	nodeHostName    = "nodeHost"
+	nodeHostDefault = "testnet.obscu.ro"
+	nodeHostUsage   = "The host on which to connect to the Obscuro node"
 
-	nodeRPCWebsocketAddressName    = "nodeRPCWebsocketAddress"
-	nodeRPCWebsocketAddressDefault = "testnet.obscu.ro:13001"
-	nodeRPCWebsocketAddressUsage   = "The address on which to connect to the node via RPC using websockets"
+	nodeHTTPPortName    = "nodePortHTTP"
+	nodeHTTPPortDefault = 13000
+	nodeHTTPPortUsage   = "The port on which to connect to the Obscuro node via RPC over HTTP"
+
+	nodeWebsocketPortName    = "nodePortWS"
+	nodeWebsocketPortDefault = 13001
+	nodeWebsocketPortUsage   = "The port on which to connect to the Obscuro node via RPC over websockets"
 
 	logPathName    = "logPath"
 	logPathDefault = "wallet_extension_logs.txt"
@@ -28,15 +32,16 @@ const (
 
 func parseCLIArgs() walletextension.Config {
 	walletExtensionPort := flag.Int(walletExtensionPortName, walletExtensionPortDefault, walletExtensionPortUsage)
-	nodeRPCHTTPAddress := flag.String(nodeRPCHTTPAddressName, nodeRPCHTTPAddressDefault, nodeRPCHTTPAddressUsage)
-	nodeRPCWebsocketAddress := flag.String(nodeRPCWebsocketAddressName, nodeRPCWebsocketAddressDefault, nodeRPCWebsocketAddressUsage)
+	nodeHost := flag.String(nodeHostName, nodeHostDefault, nodeHostUsage)
+	nodeHTTPPort := flag.Int(nodeHTTPPortName, nodeHTTPPortDefault, nodeHTTPPortUsage)
+	nodeWebsocketPort := flag.Int(nodeWebsocketPortName, nodeWebsocketPortDefault, nodeWebsocketPortUsage)
 	logPath := flag.String(logPathName, logPathDefault, logPathUsage)
 	flag.Parse()
 
 	return walletextension.Config{
 		WalletExtensionPort:     *walletExtensionPort,
-		NodeRPCHTTPAddress:      *nodeRPCHTTPAddress,
-		NodeRPCWebsocketAddress: *nodeRPCWebsocketAddress,
+		NodeRPCHTTPAddress:      fmt.Sprintf("%s:%d", *nodeHost, nodeHTTPPort),
+		NodeRPCWebsocketAddress: fmt.Sprintf("%s:%d", *nodeHost, nodeWebsocketPort),
 		LogPath:                 *logPath,
 	}
 }


### PR DESCRIPTION
### Why is this change needed?

Previously, the wallet extension had two flags, one for the HTTP address and one for the websocket address. This didn't make too much sense, as the HTTP and websocket port are always on the same host.

### What changes were made as part of this PR:

Refactoring.

- Rationalises the wallet extension flags

### What are the key areas to look at
