### PR TITLE
Add viewing keys in tx injector

### DIFF
--- a/integration/common/viewkey/viewkey.go
+++ b/integration/common/viewkey/viewkey.go
@@ -1,0 +1,60 @@
+package viewkey
+
+import (
+	"crypto/ecdsa"
+	"encoding/hex"
+	"github.com/ethereum/go-ethereum/accounts"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/crypto/ecies"
+	"github.com/obscuronet/go-obscuro/go/enclave/rpcencryptionmanager"
+	"github.com/obscuronet/go-obscuro/go/rpcclientlib"
+	"github.com/obscuronet/go-obscuro/go/wallet"
+)
+
+// GenerateAndRegisterViewingKey take an obscuro client and a wallet, it generates a keypair, simulates signing the key,
+//	configures it on the client and registers the viewing key with the enclave
+func GenerateAndRegisterViewingKey(cli rpcclientlib.Client, wal wallet.Wallet) {
+	vk, err := crypto.GenerateKey()
+	if err != nil {
+		panic(err)
+	}
+	viewingPrivateKeyEcies := ecies.ImportECDSA(vk)
+	viewingPubKey := crypto.CompressPubkey(&vk.PublicKey)
+	cli.SetViewingKey(viewingPrivateKeyEcies, viewingPubKey)
+
+	viewingKeyHex := hex.EncodeToString(viewingPubKey)
+
+	signature := signViewingKey(viewingKeyHex, wal.PrivateKey())
+
+	err = cli.RegisterViewingKey(wal.Address(), signature)
+	if err != nil {
+		panic(err)
+	}
+}
+
+// signViewingKey takes a public key bytes as hex and the private key for a wallet, it simulates the back-and-forth to
+//	metamask and returns the signature bytes to register with the enclave
+func signViewingKey(viewingKeyHex string, signerKey *ecdsa.PrivateKey) []byte {
+	msgToSign := rpcencryptionmanager.ViewingKeySignedMsgPrefix + viewingKeyHex
+	signature, err := crypto.Sign(accounts.TextHash([]byte(msgToSign)), signerKey)
+	if err != nil {
+		panic(err)
+	}
+
+	// We have to transform the V from 0/1 to 27/28, and add the leading "0".
+	signature[64] += 27
+	signatureWithLeadBytes := append([]byte("0"), signature...)
+
+	// this string encoded signature is what the wallet extension would receive after it is signed by metamask
+	sigStr := hex.EncodeToString(signatureWithLeadBytes)
+	// and then we extract the signature bytes in the same way as the wallet extension
+	outputSig, err := hex.DecodeString(sigStr[2:])
+	if err != nil {
+		panic(err)
+	}
+	// This same change is made in geth internals, for legacy reasons to be able to recover the address:
+	//	https://github.com/ethereum/go-ethereum/blob/55599ee95d4151a2502465e0afc7c47bd1acba77/internal/ethapi/api.go#L452-L459
+	outputSig[64] -= 27
+
+	return outputSig
+}

--- a/integration/common/viewkey/viewkey.go
+++ b/integration/common/viewkey/viewkey.go
@@ -3,6 +3,7 @@ package viewkey
 import (
 	"crypto/ecdsa"
 	"encoding/hex"
+
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/crypto/ecies"

--- a/integration/simulation/network/azureenclave.go
+++ b/integration/simulation/network/azureenclave.go
@@ -76,7 +76,7 @@ func (n *networkWithAzureEnclaves) Create(params *params.SimParams, stats *stats
 	return &Clients{
 		EthClients:     n.gethClients,
 		ObscuroClients: n.obscuroClients,
-		walletClients:  walletClients,
+		WalletClients:  walletClients,
 	}, nil
 }
 

--- a/integration/simulation/network/azureenclave.go
+++ b/integration/simulation/network/azureenclave.go
@@ -41,7 +41,7 @@ func NewNetworkWithAzureEnclaves(enclaveIps []string, wallets *params.SimWallets
 	}
 }
 
-func (n *networkWithAzureEnclaves) Create(params *params.SimParams, stats *stats.Stats) (*Clients, error) {
+func (n *networkWithAzureEnclaves) Create(params *params.SimParams, stats *stats.Stats) (*RPCHandles, error) {
 	params.MgmtContractAddr, params.BtcErc20Address, params.EthErc20Address, n.gethClients, n.gethNetwork = SetUpGethNetwork(
 		n.wallets,
 		params.StartPort,
@@ -73,10 +73,10 @@ func (n *networkWithAzureEnclaves) Create(params *params.SimParams, stats *stats
 	obscuroClients, walletClients := startStandaloneObscuroNodes(params, stats, n.gethClients, n.enclaveAddresses)
 	n.obscuroClients = obscuroClients
 
-	return &Clients{
-		EthClients:     n.gethClients,
-		ObscuroClients: n.obscuroClients,
-		WalletClients:  walletClients,
+	return &RPCHandles{
+		EthClients:                    n.gethClients,
+		ObscuroClients:                n.obscuroClients,
+		VirtualWalletExtensionClients: walletClients,
 	}, nil
 }
 

--- a/integration/simulation/network/azureenclave.go
+++ b/integration/simulation/network/azureenclave.go
@@ -76,7 +76,7 @@ func (n *networkWithAzureEnclaves) Create(params *params.SimParams, stats *stats
 	return &Clients{
 		EthClients:     n.gethClients,
 		ObscuroClients: n.obscuroClients,
-		WalletClients:  walletClients,
+		walletClients:  walletClients,
 	}, nil
 }
 

--- a/integration/simulation/network/azureenclave.go
+++ b/integration/simulation/network/azureenclave.go
@@ -41,7 +41,7 @@ func NewNetworkWithAzureEnclaves(enclaveIps []string, wallets *params.SimWallets
 	}
 }
 
-func (n *networkWithAzureEnclaves) Create(params *params.SimParams, stats *stats.Stats) ([]ethadapter.EthClient, []rpcclientlib.Client, error) {
+func (n *networkWithAzureEnclaves) Create(params *params.SimParams, stats *stats.Stats) (*Clients, error) {
 	params.MgmtContractAddr, params.BtcErc20Address, params.EthErc20Address, n.gethClients, n.gethNetwork = SetUpGethNetwork(
 		n.wallets,
 		params.StartPort,
@@ -70,10 +70,14 @@ func (n *networkWithAzureEnclaves) Create(params *params.SimParams, stats *stats
 		n.enclaveAddresses[i] = fmt.Sprintf("%s:%d", Localhost, params.StartPort+DefaultEnclaveOffset+i)
 	}
 
-	obscuroClients := startStandaloneObscuroNodes(params, stats, n.gethClients, n.enclaveAddresses)
+	obscuroClients, walletClients := startStandaloneObscuroNodes(params, stats, n.gethClients, n.enclaveAddresses)
 	n.obscuroClients = obscuroClients
 
-	return n.gethClients, n.obscuroClients, nil
+	return &Clients{
+		EthClients:     n.gethClients,
+		ObscuroClients: n.obscuroClients,
+		WalletClients:  walletClients,
+	}, nil
 }
 
 func (n *networkWithAzureEnclaves) TearDown() {

--- a/integration/simulation/network/dockerenclave.go
+++ b/integration/simulation/network/dockerenclave.go
@@ -53,7 +53,7 @@ func NewBasicNetworkOfNodesWithDockerEnclave(wallets *params.SimWallets) Network
 
 // Create initializes Obscuro nodes with their own Dockerised enclave servers that communicate with peers via sockets, wires them up, and populates the network objects
 // TODO - Use individual Docker containers for the Obscuro nodes and Ethereum nodes.
-func (n *basicNetworkOfNodesWithDockerEnclave) Create(params *params.SimParams, stats *stats.Stats) (*Clients, error) {
+func (n *basicNetworkOfNodesWithDockerEnclave) Create(params *params.SimParams, stats *stats.Stats) (*RPCHandles, error) {
 	// We create Docker client, and finish early if docker or the enclave image are not available.
 	if err := n.setupAndCheckDocker(); err != nil {
 		return nil, err
@@ -81,10 +81,10 @@ func (n *basicNetworkOfNodesWithDockerEnclave) Create(params *params.SimParams, 
 	obscuroClients, walletClients := startStandaloneObscuroNodes(params, stats, n.gethClients, n.enclaveAddresses)
 	n.obscuroClients = obscuroClients
 
-	return &Clients{
-		EthClients:     n.gethClients,
-		ObscuroClients: obscuroClients,
-		WalletClients:  walletClients,
+	return &RPCHandles{
+		EthClients:                    n.gethClients,
+		ObscuroClients:                obscuroClients,
+		VirtualWalletExtensionClients: walletClients,
 	}, nil
 }
 

--- a/integration/simulation/network/dockerenclave.go
+++ b/integration/simulation/network/dockerenclave.go
@@ -84,7 +84,7 @@ func (n *basicNetworkOfNodesWithDockerEnclave) Create(params *params.SimParams, 
 	return &Clients{
 		EthClients:     n.gethClients,
 		ObscuroClients: obscuroClients,
-		walletClients:  walletClients,
+		WalletClients:  walletClients,
 	}, nil
 }
 

--- a/integration/simulation/network/dockerenclave.go
+++ b/integration/simulation/network/dockerenclave.go
@@ -53,10 +53,10 @@ func NewBasicNetworkOfNodesWithDockerEnclave(wallets *params.SimWallets) Network
 
 // Create initializes Obscuro nodes with their own Dockerised enclave servers that communicate with peers via sockets, wires them up, and populates the network objects
 // TODO - Use individual Docker containers for the Obscuro nodes and Ethereum nodes.
-func (n *basicNetworkOfNodesWithDockerEnclave) Create(params *params.SimParams, stats *stats.Stats) ([]ethadapter.EthClient, []rpcclientlib.Client, error) {
+func (n *basicNetworkOfNodesWithDockerEnclave) Create(params *params.SimParams, stats *stats.Stats) (*Clients, error) {
 	// We create Docker client, and finish early if docker or the enclave image are not available.
 	if err := n.setupAndCheckDocker(); err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	// We start a geth network with all necessary contracts deployed.
@@ -78,10 +78,14 @@ func (n *basicNetworkOfNodesWithDockerEnclave) Create(params *params.SimParams, 
 	}
 
 	// Start the standalone obscuro nodes connected to the enclaves and to the geth nodes
-	obscuroClients := startStandaloneObscuroNodes(params, stats, n.gethClients, n.enclaveAddresses)
+	obscuroClients, walletClients := startStandaloneObscuroNodes(params, stats, n.gethClients, n.enclaveAddresses)
 	n.obscuroClients = obscuroClients
 
-	return n.gethClients, obscuroClients, nil
+	return &Clients{
+		EthClients:     n.gethClients,
+		ObscuroClients: obscuroClients,
+		WalletClients:  walletClients,
+	}, nil
 }
 
 func (n *basicNetworkOfNodesWithDockerEnclave) TearDown() {

--- a/integration/simulation/network/dockerenclave.go
+++ b/integration/simulation/network/dockerenclave.go
@@ -84,7 +84,7 @@ func (n *basicNetworkOfNodesWithDockerEnclave) Create(params *params.SimParams, 
 	return &Clients{
 		EthClients:     n.gethClients,
 		ObscuroClients: obscuroClients,
-		WalletClients:  walletClients,
+		walletClients:  walletClients,
 	}, nil
 }
 

--- a/integration/simulation/network/geth_network.go
+++ b/integration/simulation/network/geth_network.go
@@ -45,7 +45,7 @@ func (n *networkInMemGeth) Create(params *params.SimParams, stats *stats.Stats) 
 	return &Clients{
 		EthClients:     n.gethClients,
 		ObscuroClients: n.obscuroClients,
-		walletClients:  walletClients,
+		WalletClients:  walletClients,
 	}, nil
 }
 

--- a/integration/simulation/network/geth_network.go
+++ b/integration/simulation/network/geth_network.go
@@ -45,7 +45,7 @@ func (n *networkInMemGeth) Create(params *params.SimParams, stats *stats.Stats) 
 	return &Clients{
 		EthClients:     n.gethClients,
 		ObscuroClients: n.obscuroClients,
-		WalletClients:  walletClients,
+		walletClients:  walletClients,
 	}, nil
 }
 

--- a/integration/simulation/network/geth_network.go
+++ b/integration/simulation/network/geth_network.go
@@ -26,7 +26,7 @@ func NewNetworkInMemoryGeth(wallets *params.SimWallets) Network {
 }
 
 // Create inits and starts the nodes, wires them up, and populates the network objects
-func (n *networkInMemGeth) Create(params *params.SimParams, stats *stats.Stats) (*Clients, error) {
+func (n *networkInMemGeth) Create(params *params.SimParams, stats *stats.Stats) (*RPCHandles, error) {
 	// kickoff the network with the prefunded wallet addresses
 	params.MgmtContractAddr, params.BtcErc20Address, params.EthErc20Address, n.gethClients, n.gethNetwork = SetUpGethNetwork(
 		n.wallets,
@@ -42,10 +42,10 @@ func (n *networkInMemGeth) Create(params *params.SimParams, stats *stats.Stats) 
 	var walletClients map[string]rpcclientlib.Client
 	n.obscuroClients, walletClients = startInMemoryObscuroNodes(params, stats, n.gethNetwork.GenesisJSON, n.gethClients)
 
-	return &Clients{
-		EthClients:     n.gethClients,
-		ObscuroClients: n.obscuroClients,
-		WalletClients:  walletClients,
+	return &RPCHandles{
+		EthClients:                    n.gethClients,
+		ObscuroClients:                n.obscuroClients,
+		VirtualWalletExtensionClients: walletClients,
 	}, nil
 }
 

--- a/integration/simulation/network/geth_network.go
+++ b/integration/simulation/network/geth_network.go
@@ -26,7 +26,7 @@ func NewNetworkInMemoryGeth(wallets *params.SimWallets) Network {
 }
 
 // Create inits and starts the nodes, wires them up, and populates the network objects
-func (n *networkInMemGeth) Create(params *params.SimParams, stats *stats.Stats) ([]ethadapter.EthClient, []rpcclientlib.Client, error) {
+func (n *networkInMemGeth) Create(params *params.SimParams, stats *stats.Stats) (*Clients, error) {
 	// kickoff the network with the prefunded wallet addresses
 	params.MgmtContractAddr, params.BtcErc20Address, params.EthErc20Address, n.gethClients, n.gethNetwork = SetUpGethNetwork(
 		n.wallets,
@@ -39,9 +39,14 @@ func (n *networkInMemGeth) Create(params *params.SimParams, stats *stats.Stats) 
 	params.ERC20ContractLib = erc20contractlib.NewERC20ContractLib(params.MgmtContractAddr, params.BtcErc20Address, params.EthErc20Address)
 
 	// Start the obscuro nodes and return the handles
-	n.obscuroClients = startInMemoryObscuroNodes(params, stats, n.gethNetwork.GenesisJSON, n.gethClients)
+	var walletClients map[string]rpcclientlib.Client
+	n.obscuroClients, walletClients = startInMemoryObscuroNodes(params, stats, n.gethNetwork.GenesisJSON, n.gethClients)
 
-	return n.gethClients, n.obscuroClients, nil
+	return &Clients{
+		EthClients:     n.gethClients,
+		ObscuroClients: n.obscuroClients,
+		WalletClients:  walletClients,
+	}, nil
 }
 
 func (n *networkInMemGeth) TearDown() {

--- a/integration/simulation/network/inmemory.go
+++ b/integration/simulation/network/inmemory.go
@@ -104,7 +104,7 @@ func (n *basicNetworkOfInMemoryNodes) Create(params *params.SimParams, stats *st
 	return &Clients{
 		EthClients:     l1Clients,
 		ObscuroClients: n.obscuroClients,
-		walletClients:  walletClients,
+		WalletClients:  walletClients,
 	}, nil
 }
 

--- a/integration/simulation/network/inmemory.go
+++ b/integration/simulation/network/inmemory.go
@@ -30,7 +30,7 @@ func NewBasicNetworkOfInMemoryNodes() Network {
 }
 
 // Create inits and starts the nodes, wires them up, and populates the network objects
-func (n *basicNetworkOfInMemoryNodes) Create(params *params.SimParams, stats *stats.Stats) ([]ethadapter.EthClient, []rpcclientlib.Client, error) {
+func (n *basicNetworkOfInMemoryNodes) Create(params *params.SimParams, stats *stats.Stats) (*Clients, error) {
 	l1Clients := make([]ethadapter.EthClient, params.NumberOfNodes)
 	n.ethNodes = make([]*ethereum_mock.Node, params.NumberOfNodes)
 	obscuroNodes := make([]*host.Node, params.NumberOfNodes)
@@ -99,7 +99,13 @@ func (n *basicNetworkOfInMemoryNodes) Create(params *params.SimParams, stats *st
 		time.Sleep(params.AvgBlockDuration / 3)
 	}
 
-	return l1Clients, n.obscuroClients, nil
+	walletClients := setupWalletClientsWithoutViewingKeys(params, n.obscuroClients)
+
+	return &Clients{
+		EthClients:     l1Clients,
+		ObscuroClients: n.obscuroClients,
+		WalletClients:  walletClients,
+	}, nil
 }
 
 func (n *basicNetworkOfInMemoryNodes) TearDown() {

--- a/integration/simulation/network/inmemory.go
+++ b/integration/simulation/network/inmemory.go
@@ -104,7 +104,7 @@ func (n *basicNetworkOfInMemoryNodes) Create(params *params.SimParams, stats *st
 	return &Clients{
 		EthClients:     l1Clients,
 		ObscuroClients: n.obscuroClients,
-		WalletClients:  walletClients,
+		walletClients:  walletClients,
 	}, nil
 }
 

--- a/integration/simulation/network/inmemory.go
+++ b/integration/simulation/network/inmemory.go
@@ -30,7 +30,7 @@ func NewBasicNetworkOfInMemoryNodes() Network {
 }
 
 // Create inits and starts the nodes, wires them up, and populates the network objects
-func (n *basicNetworkOfInMemoryNodes) Create(params *params.SimParams, stats *stats.Stats) (*Clients, error) {
+func (n *basicNetworkOfInMemoryNodes) Create(params *params.SimParams, stats *stats.Stats) (*RPCHandles, error) {
 	l1Clients := make([]ethadapter.EthClient, params.NumberOfNodes)
 	n.ethNodes = make([]*ethereum_mock.Node, params.NumberOfNodes)
 	obscuroNodes := make([]*host.Node, params.NumberOfNodes)
@@ -101,10 +101,10 @@ func (n *basicNetworkOfInMemoryNodes) Create(params *params.SimParams, stats *st
 
 	walletClients := setupWalletClientsWithoutViewingKeys(params, n.obscuroClients)
 
-	return &Clients{
-		EthClients:     l1Clients,
-		ObscuroClients: n.obscuroClients,
-		WalletClients:  walletClients,
+	return &RPCHandles{
+		EthClients:                    l1Clients,
+		ObscuroClients:                n.obscuroClients,
+		VirtualWalletExtensionClients: walletClients,
 	}, nil
 }
 

--- a/integration/simulation/network/network.go
+++ b/integration/simulation/network/network.go
@@ -27,7 +27,7 @@ type Network interface {
 type Clients struct {
 	EthClients     []ethadapter.EthClient         // an eth client per eth node in the network
 	ObscuroClients []rpcclientlib.Client          // an obscuro client per obscuro node in the network
-	WalletClients  map[string]rpcclientlib.Client // an obscuro client per wallet (configured with viewing key where applicable)
+	walletClients  map[string]rpcclientlib.Client // an obscuro client per wallet (configured with viewing key where applicable)
 }
 
 func (n *Clients) RndEthClient() ethadapter.EthClient {
@@ -41,5 +41,5 @@ func (n *Clients) RndObscuroClient() rpcclientlib.Client {
 // ObscuroWalletClient fetches client for given wallet if it exists
 func (n *Clients) ObscuroWalletClient(wallet wallet.Wallet) rpcclientlib.Client {
 	addr := wallet.Address().String()
-	return n.WalletClients[addr]
+	return n.walletClients[addr]
 }

--- a/integration/simulation/network/network.go
+++ b/integration/simulation/network/network.go
@@ -38,7 +38,7 @@ func (n *Clients) RndObscuroClient() rpcclientlib.Client {
 	return n.ObscuroClients[rand.Intn(len(n.ObscuroClients))] //nolint:gosec
 }
 
-// ObscuroWalletClient fetches client for given wallet if it exists, or adds it to the cache if not
+// ObscuroWalletClient fetches client for given wallet if it exists
 func (n *Clients) ObscuroWalletClient(wallet wallet.Wallet) rpcclientlib.Client {
 	addr := wallet.Address().String()
 	return n.WalletClients[addr]

--- a/integration/simulation/network/network.go
+++ b/integration/simulation/network/network.go
@@ -27,7 +27,7 @@ type Network interface {
 type Clients struct {
 	EthClients     []ethadapter.EthClient         // an eth client per eth node in the network
 	ObscuroClients []rpcclientlib.Client          // an obscuro client per obscuro node in the network
-	walletClients  map[string]rpcclientlib.Client // an obscuro client per wallet (configured with viewing key where applicable)
+	WalletClients  map[string]rpcclientlib.Client // an obscuro client per wallet (configured with viewing key where applicable)
 }
 
 func (n *Clients) RndEthClient() ethadapter.EthClient {
@@ -41,5 +41,5 @@ func (n *Clients) RndObscuroClient() rpcclientlib.Client {
 // ObscuroWalletClient fetches client for given wallet if it exists
 func (n *Clients) ObscuroWalletClient(wallet wallet.Wallet) rpcclientlib.Client {
 	addr := wallet.Address().String()
-	return n.walletClients[addr]
+	return n.WalletClients[addr]
 }

--- a/integration/simulation/network/obscuro_node_utils.go
+++ b/integration/simulation/network/obscuro_node_utils.go
@@ -75,10 +75,13 @@ func startInMemoryObscuroNodes(params *params.SimParams, stats *stats.Stats, gen
 	return obscuroClients, walletClients
 }
 
-// setupWalletClientsWithoutViewingKeys will round-robin wallets onto the existing obscuro clients, no viewing keys registered.
+// setupWalletClientsWithoutViewingKeys will configure the existing obscuro clients to be used as wallet clients,
+// (we typically keep a client per wallet so their viewing keys are available and registered but they can share clients
+// 	if no viewing keys are in use)
 func setupWalletClientsWithoutViewingKeys(params *params.SimParams, obscuroClients []rpcclientlib.Client) map[string]rpcclientlib.Client {
 	walletClients := make(map[string]rpcclientlib.Client)
 	var i int
+	// loop through all the L2 wallets we're using and round-robin allocate them the rpc clients we have for each host
 	for _, w := range params.Wallets.SimObsWallets {
 		walletClients[w.Address().String()] = obscuroClients[i%len(obscuroClients)]
 		i++

--- a/integration/simulation/network/obscuro_node_utils.go
+++ b/integration/simulation/network/obscuro_node_utils.go
@@ -88,6 +88,7 @@ func setupWalletClientsWithoutViewingKeys(params *params.SimParams, obscuroClien
 	return walletClients
 }
 
+// todo: this method is quite heavy, should refactor to separate out the creation of the nodes, starting of the nodes, setup of the RPC clients etc.
 func startStandaloneObscuroNodes(params *params.SimParams, stats *stats.Stats, gethClients []ethadapter.EthClient, enclaveAddresses []string) ([]rpcclientlib.Client, map[string]rpcclientlib.Client) {
 	// handle to the obscuro clients
 	nodeRPCAddresses := make([]string, params.NumberOfNodes)

--- a/integration/simulation/network/obscuro_node_utils.go
+++ b/integration/simulation/network/obscuro_node_utils.go
@@ -75,7 +75,7 @@ func startInMemoryObscuroNodes(params *params.SimParams, stats *stats.Stats, gen
 	return obscuroClients, walletClients
 }
 
-// setupWalletClientsWithoutViewingKeys round-robin the wallets onto the different obscuro nodes, register them each a viewing key
+// setupWalletClientsWithoutViewingKeys will round-robin wallets onto the existing obscuro clients, no viewing keys registered.
 func setupWalletClientsWithoutViewingKeys(params *params.SimParams, obscuroClients []rpcclientlib.Client) map[string]rpcclientlib.Client {
 	walletClients := make(map[string]rpcclientlib.Client)
 	var i int

--- a/integration/simulation/network/obscuro_node_utils.go
+++ b/integration/simulation/network/obscuro_node_utils.go
@@ -2,10 +2,11 @@ package network
 
 import (
 	"fmt"
-	"github.com/obscuronet/go-obscuro/integration/common/viewkey"
 	"math/big"
 	"sync"
 	"time"
+
+	"github.com/obscuronet/go-obscuro/integration/common/viewkey"
 
 	"github.com/obscuronet/go-obscuro/go/common/log"
 

--- a/integration/simulation/network/socket.go
+++ b/integration/simulation/network/socket.go
@@ -59,7 +59,7 @@ func (n *networkOfSocketNodes) Create(params *params.SimParams, stats *stats.Sta
 	return &Clients{
 		EthClients:     n.gethClients,
 		ObscuroClients: n.obscuroClients,
-		walletClients:  walletClients,
+		WalletClients:  walletClients,
 	}, nil
 }
 

--- a/integration/simulation/network/socket.go
+++ b/integration/simulation/network/socket.go
@@ -59,7 +59,7 @@ func (n *networkOfSocketNodes) Create(params *params.SimParams, stats *stats.Sta
 	return &Clients{
 		EthClients:     n.gethClients,
 		ObscuroClients: n.obscuroClients,
-		WalletClients:  walletClients,
+		walletClients:  walletClients,
 	}, nil
 }
 

--- a/integration/simulation/network/socket.go
+++ b/integration/simulation/network/socket.go
@@ -33,7 +33,7 @@ func NewNetworkOfSocketNodes(wallets *params.SimWallets) Network {
 	}
 }
 
-func (n *networkOfSocketNodes) Create(params *params.SimParams, stats *stats.Stats) (*Clients, error) {
+func (n *networkOfSocketNodes) Create(params *params.SimParams, stats *stats.Stats) (*RPCHandles, error) {
 	// kickoff the network with the prefunded wallet addresses
 	params.MgmtContractAddr, params.BtcErc20Address, params.EthErc20Address, n.gethClients, n.gethNetwork = SetUpGethNetwork(
 		n.wallets,
@@ -56,10 +56,10 @@ func (n *networkOfSocketNodes) Create(params *params.SimParams, stats *stats.Sta
 	obscuroClients, walletClients := startStandaloneObscuroNodes(params, stats, n.gethClients, n.enclaveAddresses)
 	n.obscuroClients = obscuroClients
 
-	return &Clients{
-		EthClients:     n.gethClients,
-		ObscuroClients: n.obscuroClients,
-		WalletClients:  walletClients,
+	return &RPCHandles{
+		EthClients:                    n.gethClients,
+		ObscuroClients:                n.obscuroClients,
+		VirtualWalletExtensionClients: walletClients,
 	}, nil
 }
 

--- a/integration/simulation/network/socket.go
+++ b/integration/simulation/network/socket.go
@@ -33,7 +33,7 @@ func NewNetworkOfSocketNodes(wallets *params.SimWallets) Network {
 	}
 }
 
-func (n *networkOfSocketNodes) Create(params *params.SimParams, stats *stats.Stats) ([]ethadapter.EthClient, []rpcclientlib.Client, error) {
+func (n *networkOfSocketNodes) Create(params *params.SimParams, stats *stats.Stats) (*Clients, error) {
 	// kickoff the network with the prefunded wallet addresses
 	params.MgmtContractAddr, params.BtcErc20Address, params.EthErc20Address, n.gethClients, n.gethNetwork = SetUpGethNetwork(
 		n.wallets,
@@ -53,10 +53,14 @@ func (n *networkOfSocketNodes) Create(params *params.SimParams, stats *stats.Sta
 		n.enclaveAddresses[i] = fmt.Sprintf("%s:%d", Localhost, params.StartPort+DefaultEnclaveOffset+i)
 	}
 
-	obscuroClients := startStandaloneObscuroNodes(params, stats, n.gethClients, n.enclaveAddresses)
+	obscuroClients, walletClients := startStandaloneObscuroNodes(params, stats, n.gethClients, n.enclaveAddresses)
 	n.obscuroClients = obscuroClients
 
-	return n.gethClients, n.obscuroClients, nil
+	return &Clients{
+		EthClients:     n.gethClients,
+		ObscuroClients: n.obscuroClients,
+		WalletClients:  walletClients,
+	}, nil
 }
 
 func (n *networkOfSocketNodes) TearDown() {

--- a/integration/simulation/output_stats.go
+++ b/integration/simulation/output_stats.go
@@ -38,14 +38,14 @@ func NewOutputStats(simulation *Simulation) *OutputStats {
 }
 
 func (o *OutputStats) populateHeights() {
-	obscuroClient := o.simulation.ObscuroClients[0]
+	obscuroClient := o.simulation.NetworkClients.ObscuroClients[0]
 	o.l1Height = int(getCurrentBlockHeadHeight(obscuroClient))
 	o.l2Height = int(getCurrentRollupHead(obscuroClient).Number.Uint64())
 }
 
 func (o *OutputStats) countBlockChain() {
-	l1Node := o.simulation.EthClients[0]
-	l2Client := o.simulation.ObscuroClients[0]
+	l1Node := o.simulation.NetworkClients.EthClients[0]
+	l2Client := o.simulation.NetworkClients.ObscuroClients[0]
 
 	// iterate the Node Headers and get the rollups
 	for header := getCurrentRollupHead(l2Client); header != nil && !bytes.Equal(header.Hash().Bytes(), common.GenesisHash.Bytes()); header = getRollupHeader(l2Client, header.ParentHash) {

--- a/integration/simulation/output_stats.go
+++ b/integration/simulation/output_stats.go
@@ -38,14 +38,14 @@ func NewOutputStats(simulation *Simulation) *OutputStats {
 }
 
 func (o *OutputStats) populateHeights() {
-	obscuroClient := o.simulation.NetworkClients.ObscuroClients[0]
+	obscuroClient := o.simulation.RPCHandles.ObscuroClients[0]
 	o.l1Height = int(getCurrentBlockHeadHeight(obscuroClient))
 	o.l2Height = int(getCurrentRollupHead(obscuroClient).Number.Uint64())
 }
 
 func (o *OutputStats) countBlockChain() {
-	l1Node := o.simulation.NetworkClients.EthClients[0]
-	l2Client := o.simulation.NetworkClients.ObscuroClients[0]
+	l1Node := o.simulation.RPCHandles.EthClients[0]
+	l2Client := o.simulation.RPCHandles.ObscuroClients[0]
 
 	// iterate the Node Headers and get the rollups
 	for header := getCurrentRollupHead(l2Client); header != nil && !bytes.Equal(header.Hash().Bytes(), common.GenesisHash.Bytes()); header = getRollupHeader(l2Client, header.ParentHash) {

--- a/integration/simulation/simulation.go
+++ b/integration/simulation/simulation.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/obscuronet/go-obscuro/integration/simulation/network"
+
 	"github.com/obscuronet/go-obscuro/go/common/log"
 
 	"github.com/obscuronet/go-obscuro/go/common"
-
-	"github.com/obscuronet/go-obscuro/go/rpcclientlib"
 
 	"github.com/obscuronet/go-obscuro/go/ethadapter"
 
@@ -21,8 +21,7 @@ const initialBalance = 5000
 
 // Simulation represents all the data required to inject transactions on a network
 type Simulation struct {
-	EthClients       []ethadapter.EthClient // the list of mock ethereum clients
-	ObscuroClients   []rpcclientlib.Client  // the list of Obscuro host clients
+	NetworkClients   *network.Clients
 	AvgBlockDuration uint64
 	TxInjector       *TransactionInjector
 	SimulationTime   time.Duration
@@ -63,7 +62,7 @@ func (s *Simulation) Stop() {
 
 func (s *Simulation) WaitForObscuroGenesis() {
 	// grab an L1 client
-	client := s.EthClients[0]
+	client := s.NetworkClients.EthClients[0]
 
 	for {
 		// spin through the L1 blocks periodically to see if the genesis rollup has arrived

--- a/integration/simulation/simulation.go
+++ b/integration/simulation/simulation.go
@@ -21,7 +21,7 @@ const initialBalance = 5000
 
 // Simulation represents all the data required to inject transactions on a network
 type Simulation struct {
-	NetworkClients   *network.Clients
+	RPCHandles       *network.RPCHandles
 	AvgBlockDuration uint64
 	TxInjector       *TransactionInjector
 	SimulationTime   time.Duration
@@ -62,7 +62,7 @@ func (s *Simulation) Stop() {
 
 func (s *Simulation) WaitForObscuroGenesis() {
 	// grab an L1 client
-	client := s.NetworkClients.EthClients[0]
+	client := s.RPCHandles.EthClients[0]
 
 	for {
 		// spin through the L1 blocks periodically to see if the genesis rollup has arrived

--- a/integration/simulation/simulation_tester.go
+++ b/integration/simulation/simulation_tester.go
@@ -49,7 +49,7 @@ func testSimulation(t *testing.T, netw network.Network, params *params.SimParams
 	)
 
 	simulation := Simulation{
-		NetworkClients:   networkClients,
+		RPCHandles:       networkClients,
 		AvgBlockDuration: uint64(params.AvgBlockDuration),
 		TxInjector:       txInjector,
 		SimulationTime:   params.SimulationTime,

--- a/integration/simulation/simulation_tester.go
+++ b/integration/simulation/simulation_tester.go
@@ -30,7 +30,7 @@ func testSimulation(t *testing.T, netw network.Network, params *params.SimParams
 	stats := stats2.NewStats(params.NumberOfNodes) // todo - temporary object used to collect metrics. Needs to be replaced with something better
 
 	defer netw.TearDown()
-	ethClients, obscuroClients, err := netw.Create(params, stats)
+	networkClients, err := netw.Create(params, stats)
 	// Return early if the network was not created
 	if err != nil {
 		fmt.Printf("Could not run test: %s\n", err)
@@ -40,18 +40,16 @@ func testSimulation(t *testing.T, netw network.Network, params *params.SimParams
 	txInjector := NewTransactionInjector(
 		params.AvgBlockDuration,
 		stats,
-		ethClients,
+		networkClients,
 		params.Wallets,
 		params.MgmtContractAddr,
-		obscuroClients,
 		params.MgmtContractLib,
 		params.ERC20ContractLib,
 		0,
 	)
 
 	simulation := Simulation{
-		EthClients:       ethClients,
-		ObscuroClients:   obscuroClients,
+		NetworkClients:   networkClients,
 		AvgBlockDuration: uint64(params.AvgBlockDuration),
 		TxInjector:       txInjector,
 		SimulationTime:   params.SimulationTime,

--- a/integration/simulation/validate_chain.go
+++ b/integration/simulation/validate_chain.go
@@ -57,8 +57,8 @@ func checkEthereumBlockchainValidity(t *testing.T, s *Simulation) uint64 {
 	// Sanity check number for a minimum height
 	minHeight := uint64(float64(s.Params.SimulationTime.Microseconds()) / (2 * float64(s.Params.AvgBlockDuration)))
 
-	heights := make([]uint64, len(s.EthClients))
-	for i, node := range s.EthClients {
+	heights := make([]uint64, len(s.NetworkClients.EthClients))
+	for i, node := range s.NetworkClients.EthClients {
 		heights[i] = checkBlockchainOfEthereumNode(t, node, minHeight, s)
 	}
 
@@ -83,10 +83,10 @@ func checkObscuroBlockchainValidity(t *testing.T, s *Simulation, maxL1Height uin
 	minHeight := uint64(float64(s.Params.SimulationTime.Microseconds()) / (2 * float64(s.Params.AvgBlockDuration)))
 
 	// process the blockchain of each node in parallel to minimize the difference between them since they are still running
-	heights := make([]uint64, len(s.ObscuroClients))
+	heights := make([]uint64, len(s.NetworkClients.ObscuroClients))
 	var wg sync.WaitGroup
-	for idx := range s.ObscuroClients {
-		obscuroClient := s.ObscuroClients[idx]
+	for idx := range s.NetworkClients.ObscuroClients {
+		obscuroClient := s.NetworkClients.ObscuroClients[idx]
 		wg.Add(1)
 		go checkBlockchainOfObscuroNode(t, obscuroClient, minHeight, maxL1Height, s, &wg, heights, idx)
 	}

--- a/integration/simulation/validate_chain.go
+++ b/integration/simulation/validate_chain.go
@@ -57,8 +57,8 @@ func checkEthereumBlockchainValidity(t *testing.T, s *Simulation) uint64 {
 	// Sanity check number for a minimum height
 	minHeight := uint64(float64(s.Params.SimulationTime.Microseconds()) / (2 * float64(s.Params.AvgBlockDuration)))
 
-	heights := make([]uint64, len(s.NetworkClients.EthClients))
-	for i, node := range s.NetworkClients.EthClients {
+	heights := make([]uint64, len(s.RPCHandles.EthClients))
+	for i, node := range s.RPCHandles.EthClients {
 		heights[i] = checkBlockchainOfEthereumNode(t, node, minHeight, s)
 	}
 
@@ -83,10 +83,10 @@ func checkObscuroBlockchainValidity(t *testing.T, s *Simulation, maxL1Height uin
 	minHeight := uint64(float64(s.Params.SimulationTime.Microseconds()) / (2 * float64(s.Params.AvgBlockDuration)))
 
 	// process the blockchain of each node in parallel to minimize the difference between them since they are still running
-	heights := make([]uint64, len(s.NetworkClients.ObscuroClients))
+	heights := make([]uint64, len(s.RPCHandles.ObscuroClients))
 	var wg sync.WaitGroup
-	for idx := range s.NetworkClients.ObscuroClients {
-		obscuroClient := s.NetworkClients.ObscuroClients[idx]
+	for idx := range s.RPCHandles.ObscuroClients {
+		obscuroClient := s.RPCHandles.ObscuroClients[idx]
 		wg.Add(1)
 		go checkBlockchainOfObscuroNode(t, obscuroClient, minHeight, maxL1Height, s, &wg, heights, idx)
 	}

--- a/integration/walletextension/wallet_extension_test.go
+++ b/integration/walletextension/wallet_extension_test.go
@@ -627,7 +627,7 @@ func createObscuroNetwork(t *testing.T) (func(), error) {
 	}
 	simStats := stats.NewStats(simParams.NumberOfNodes)
 	obscuroNetwork := network.NewNetworkOfSocketNodes(wallets)
-	_, l2Clients, err := obscuroNetwork.Create(&simParams, simStats)
+	clients, err := obscuroNetwork.Create(&simParams, simStats)
 	if err != nil {
 		return obscuroNetwork.TearDown, err
 	}
@@ -635,7 +635,7 @@ func createObscuroNetwork(t *testing.T) (func(), error) {
 	// Deploy an ERC20 contract to the Obscuro network.
 	txWallet := wallets.Tokens[bridge.BTC].L2Owner
 	deployContractTx := types.LegacyTx{
-		Nonce:    simulation.NextNonce(l2Clients[0], txWallet),
+		Nonce:    simulation.NextNonce(clients, txWallet),
 		Gas:      1025_000_000,
 		GasPrice: common.Big0,
 		Data:     common.Hex2Bytes(erc20contract.ContractByteCode),

--- a/tools/networkmanager/inject_txs.go
+++ b/tools/networkmanager/inject_txs.go
@@ -2,11 +2,12 @@ package networkmanager
 
 import (
 	"fmt"
-	"github.com/obscuronet/go-obscuro/integration/common/viewkey"
 	"math/big"
 	"os"
 	"strconv"
 	"time"
+
+	"github.com/obscuronet/go-obscuro/integration/common/viewkey"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/obscuronet/go-obscuro/integration/simulation/network"

--- a/tools/networkmanager/inject_txs.go
+++ b/tools/networkmanager/inject_txs.go
@@ -47,10 +47,10 @@ func InjectTransactions(cfg Config, args []string) {
 	wallets := createWallets(cfg, l1Client, l2Client)
 	walletClients := createWalletRPCClients(wallets, cfg.obscuroClientAddress)
 
-	netwClients := &network.Clients{
-		EthClients:     []ethadapter.EthClient{l1Client},
-		ObscuroClients: []rpcclientlib.Client{l2Client},
-		WalletClients:  walletClients,
+	netwClients := &network.RPCHandles{
+		EthClients:                    []ethadapter.EthClient{l1Client},
+		ObscuroClients:                []rpcclientlib.Client{l2Client},
+		VirtualWalletExtensionClients: walletClients,
 	}
 
 	txInjector := simulation.NewTransactionInjector(

--- a/tools/networkmanager/inject_txs.go
+++ b/tools/networkmanager/inject_txs.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/obscuronet/go-obscuro/integration/simulation/network"
 
 	"github.com/ethereum/go-ethereum/core/types"
 
@@ -41,13 +42,16 @@ func InjectTransactions(cfg Config, args []string) {
 	erc20ContractLib := erc20contractlib.NewERC20ContractLib(&cfg.mgmtContractAddress, &cfg.erc20ContractAddress)
 	avgBlockDuration := time.Second
 
+	netwClients := &network.Clients{
+		EthClients:     []ethadapter.EthClient{l1Client},
+		ObscuroClients: []rpcclientlib.Client{l2Client},
+	}
 	txInjector := simulation.NewTransactionInjector(
 		avgBlockDuration,
 		simStats,
-		[]ethadapter.EthClient{l1Client},
+		netwClients,
 		createWallets(cfg, l1Client, l2Client),
 		&cfg.mgmtContractAddress,
-		[]rpcclientlib.Client{l2Client},
 		mgmtContractLib,
 		erc20ContractLib,
 		parseNumOfTxs(args),


### PR DESCRIPTION
### Why is this change needed?

- we want to make sure we test the viewing key encryption paths with the simulations
- we want to use a version of transaction injector to smoke test for testnet issues

### What changes were made as part of this PR:

*functional*
- Create rpc client per wallet for testing, register viewing key for it
- Bundled together the different types of client that come out of create network

### What are the key areas to look at
- transaction_injector.go (where the correct client for the wallet is now used with its viewing key for encryption)
- obscuro_node_utils.go (where the wallet clients are setup and viewing keys registered)
- network.Clients struct in network.go (where some convenience methods for interacting with the networks are provided)