### PR TITLE
enable all forks up to london

### DIFF
--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -108,8 +108,19 @@ func NewEnclave(
 		log.Panic("Failed to connect to backing database - %s", err)
 	}
 	chainConfig := params.ChainConfig{
-		ChainID:     big.NewInt(config.ObscuroChainID),
-		LondonBlock: gethcommon.Big0,
+		ChainID:             big.NewInt(config.ObscuroChainID),
+		HomesteadBlock:      gethcommon.Big0,
+		DAOForkBlock:        gethcommon.Big0,
+		EIP150Block:         gethcommon.Big0,
+		EIP155Block:         gethcommon.Big0,
+		EIP158Block:         gethcommon.Big0,
+		ByzantiumBlock:      gethcommon.Big0,
+		ConstantinopleBlock: gethcommon.Big0,
+		PetersburgBlock:     gethcommon.Big0,
+		IstanbulBlock:       gethcommon.Big0,
+		MuirGlacierBlock:    gethcommon.Big0,
+		BerlinBlock:         gethcommon.Big0,
+		LondonBlock:         gethcommon.Big0,
 	}
 	storage := db.NewStorage(backingDB, nodeShortID, &chainConfig)
 


### PR DESCRIPTION
### Why is this change needed?

to avoid crashing the evm 

### What changes were made as part of this PR:

Functional PR.

It turns out that each fork has to be enabled one by one. It's not enough to enable a later one.
What happened is that some prereqs were not run because they were introduced by an earlier fork, and used in a later fork.

### What are the key areas to look at
