### PR TITLE
Refactor contract deployer to do single contract deployments

### DIFF
--- a/testnet/testnet-deploy-contracts.sh
+++ b/testnet/testnet-deploy-contracts.sh
@@ -52,20 +52,30 @@ fi
 # deploy contracts to the geth network
 echo "Deploying contracts to the geth network..."
 docker network create --driver bridge node_network || true
+
+# deploy Obscuro management contract
 docker run --name=contractdeployer \
     --network=node_network \
     --entrypoint /home/go-obscuro/tools/contractdeployer/main/main \
      testnetobscuronet.azurecr.io/obscuronet/obscuro_contractdeployer:latest \
-    --l1NodeHost=${l1host} \
-    --l1NodePort=${l1port} \
+    --nodeHost=${l1host} \
+    --nodePort=${l1port} \
+    --contract=MGMT \
     --privateKey=${pkstring}
-
-# storing the contract addresses to the .env file
-log_output=$(docker logs --tail 1 contractdeployer)
-json_output=$(echo ${log_output} | awk -F"[{}]" '{print "{"$2"}"}')
-mgmtContractAddr=$(echo "${json_output}"  | jq .MgmtContractAddr)
-erc20ContractAddr=$(echo "${json_output}" | jq .ERC20ContractAddr)
-
+# storing the contract address to the .env file (note: this first contract creates/overwrites the .env file)
+mgmtContractAddr=$(docker logs --tail 1 contractdeployer)
 echo "MGMTCONTRACTADDR=${mgmtContractAddr}" > "${testnet_path}/.env"
+
+# deploy ERC20 contract
+docker run --name=contractdeployer \
+    --network=node_network \
+    --entrypoint /home/go-obscuro/tools/contractdeployer/main/main \
+     testnetobscuronet.azurecr.io/obscuronet/obscuro_contractdeployer:latest \
+    --nodeHost=${l1host} \
+    --nodePort=${l1port} \
+    --contract=ERC20 \
+    --privateKey=${pkstring}
+# storing the contract address to the .env file
+mgmtContractAddr=$(docker logs --tail 1 contractdeployer)
 echo "ERC20CONTRACTADDR=${erc20ContractAddr}" >> "${testnet_path}/.env"
 

--- a/testnet/testnet-deploy-contracts.sh
+++ b/testnet/testnet-deploy-contracts.sh
@@ -54,7 +54,7 @@ echo "Deploying contracts to the geth network..."
 docker network create --driver bridge node_network || true
 
 # deploy Obscuro management contract
-docker run --name=contractdeployer \
+docker run --name=mgmtcontractdeployer \
     --network=node_network \
     --entrypoint /home/go-obscuro/tools/contractdeployer/main/main \
      testnetobscuronet.azurecr.io/obscuronet/obscuro_contractdeployer:latest \
@@ -63,11 +63,11 @@ docker run --name=contractdeployer \
     --contractName="MGMT" \
     --privateKey=${pkstring}
 # storing the contract address to the .env file (note: this first contract creates/overwrites the .env file)
-mgmtContractAddr=$(docker logs --tail 1 contractdeployer)
+mgmtContractAddr=$(docker logs --tail 1 mgmtcontractdeployer)
 echo "MGMTCONTRACTADDR=${mgmtContractAddr}" > "${testnet_path}/.env"
 
 # deploy ERC20 contract
-docker run --name=contractdeployer \
+docker run --name=erc20deployer \
     --network=node_network \
     --entrypoint /home/go-obscuro/tools/contractdeployer/main/main \
      testnetobscuronet.azurecr.io/obscuronet/obscuro_contractdeployer:latest \
@@ -76,6 +76,6 @@ docker run --name=contractdeployer \
     --contractName="ERC20" \
     --privateKey=${pkstring}
 # storing the contract address to the .env file
-mgmtContractAddr=$(docker logs --tail 1 contractdeployer)
+erc20ContractAddr=$(docker logs --tail 1 erc20deployer)
 echo "ERC20CONTRACTADDR=${erc20ContractAddr}" >> "${testnet_path}/.env"
 

--- a/testnet/testnet-deploy-contracts.sh
+++ b/testnet/testnet-deploy-contracts.sh
@@ -60,7 +60,7 @@ docker run --name=contractdeployer \
      testnetobscuronet.azurecr.io/obscuronet/obscuro_contractdeployer:latest \
     --nodeHost=${l1host} \
     --nodePort=${l1port} \
-    --contract=MGMT \
+    --contractName="MGMT" \
     --privateKey=${pkstring}
 # storing the contract address to the .env file (note: this first contract creates/overwrites the .env file)
 mgmtContractAddr=$(docker logs --tail 1 contractdeployer)
@@ -73,7 +73,7 @@ docker run --name=contractdeployer \
      testnetobscuronet.azurecr.io/obscuronet/obscuro_contractdeployer:latest \
     --nodeHost=${l1host} \
     --nodePort=${l1port} \
-    --contract=ERC20 \
+    --contractName="ERC20" \
     --privateKey=${pkstring}
 # storing the contract address to the .env file
 mgmtContractAddr=$(docker logs --tail 1 contractdeployer)

--- a/testnet/testnet-deploy-contracts.sh
+++ b/testnet/testnet-deploy-contracts.sh
@@ -53,7 +53,8 @@ fi
 echo "Deploying contracts to the geth network..."
 docker network create --driver bridge node_network || true
 
-# deploy Obscuro management contract
+# deploy Obscuro management contract\
+echo "Deploying Obscuro management contract to L1 network"
 docker run --name=mgmtcontractdeployer \
     --network=node_network \
     --entrypoint /home/go-obscuro/tools/contractdeployer/main/main \
@@ -65,8 +66,10 @@ docker run --name=mgmtcontractdeployer \
 # storing the contract address to the .env file (note: this first contract creates/overwrites the .env file)
 mgmtContractAddr=$(docker logs --tail 1 mgmtcontractdeployer)
 echo "MGMTCONTRACTADDR=${mgmtContractAddr}" > "${testnet_path}/.env"
+echo ""
 
 # deploy ERC20 contract
+echo "Deploying ERC20 contract to L1 network"
 docker run --name=erc20deployer \
     --network=node_network \
     --entrypoint /home/go-obscuro/tools/contractdeployer/main/main \
@@ -78,4 +81,4 @@ docker run --name=erc20deployer \
 # storing the contract address to the .env file
 erc20ContractAddr=$(docker logs --tail 1 erc20deployer)
 echo "ERC20CONTRACTADDR=${erc20ContractAddr}" >> "${testnet_path}/.env"
-
+echo ""

--- a/tools/contractdeployer/README.md
+++ b/tools/contractdeployer/README.md
@@ -1,0 +1,18 @@
+# Contract deployer
+
+Deploys contracts to both the obscuro network (L2) and eth network (L1)
+
+## Usage
+
+All commands are executed by running `contractdeployer/main/main()`.
+
+Contract is a string value to select the contract bytecode to deploy, currently only ERC20 and MGMT are supported
+(an ERC20 contract and the obscuro management contract, respectively)
+
+* Example arguments to deploy an L2 contract:
+
+  `--nodeHost=<x> --nodePort=<x> --privateKey=<x> --contract=ERC20`
+
+* Example arguments to deploy an L1 contract:
+
+  `--nodeHost=<x> --nodePort=<x> --privateKey=<x> --contract=MGMT --l1Deployment`

--- a/tools/contractdeployer/README.md
+++ b/tools/contractdeployer/README.md
@@ -15,4 +15,4 @@ Contract is a string value to select the contract bytecode to deploy, currently 
 
 * Example arguments to deploy an L1 contract:
 
-  `--nodeHost=<x> --nodePort=<x> --privateKey=<x> --contract=MGMT --l1Deployment`
+  `--nodeHost=<x> --nodePort=<x> --privateKey=<x> --contract=MGMT`

--- a/tools/contractdeployer/cli.go
+++ b/tools/contractdeployer/cli.go
@@ -8,21 +8,21 @@ import (
 // DefaultConfig stores the contract deployer default config
 func DefaultConfig() *Config {
 	return &Config{
-		NodeHost:   "",
-		NodePort:   0,
-		PrivateKey: "",
-		ChainID:    big.NewInt(1337),
-		Contract:   "",
+		NodeHost:     "",
+		NodePort:     0,
+		PrivateKey:   "",
+		ChainID:      big.NewInt(1337),
+		ContractName: "",
 	}
 }
 
 // Config is the structure that a contract deployer config is parsed into.
 type Config struct {
-	NodeHost   string   // host for the client connection
-	NodePort   uint     // port for client connection
-	PrivateKey string   // private key to be used for the contract deployer address
-	ChainID    *big.Int // chain ID we're deploying too
-	Contract   string   // the name of the contract to deploy (e.g. ERC20 or MGMT)
+	NodeHost     string   // host for the client connection
+	NodePort     uint     // port for client connection
+	PrivateKey   string   // private key to be used for the contract deployer address
+	ChainID      *big.Int // chain ID we're deploying too
+	ContractName string   // the name of the contract to deploy (e.g. ERC20 or MGMT)
 }
 
 // ParseConfig returns a Config after parsing all available flags
@@ -31,7 +31,7 @@ func ParseConfig() *Config {
 
 	nodeHost := flag.String(nodeHostName, defaultConfig.NodeHost, nodeHostUsage)
 	nodePort := flag.Uint64(nodePortName, uint64(defaultConfig.NodePort), nodePortUsage)
-	contract := flag.String(contractName, defaultConfig.Contract, contractUsage)
+	contractName := flag.String(contractNameName, defaultConfig.ContractName, contractNameUsage)
 	privateKeyStr := flag.String(privateKeyName, defaultConfig.PrivateKey, privateKeyUsage)
 	ChainID := flag.Int64(chainIDName, defaultConfig.ChainID.Int64(), chainIDUsage)
 
@@ -41,7 +41,7 @@ func ParseConfig() *Config {
 	defaultConfig.NodePort = uint(*nodePort)
 	defaultConfig.PrivateKey = *privateKeyStr
 	defaultConfig.ChainID = big.NewInt(*ChainID)
-	defaultConfig.Contract = *contract
+	defaultConfig.ContractName = *contractName
 
 	return defaultConfig
 }

--- a/tools/contractdeployer/cli.go
+++ b/tools/contractdeployer/cli.go
@@ -8,40 +8,40 @@ import (
 // DefaultConfig stores the contract deployer default config
 func DefaultConfig() *Config {
 	return &Config{
-		L1NodeHost:       "",
-		L1NodePort:       0,
-		MgmtContractPath: "",
-		PrivateKey:       "",
-		EthChainID:       big.NewInt(1337),
+		NodeHost:   "",
+		NodePort:   0,
+		PrivateKey: "",
+		ChainID:    big.NewInt(1337),
+		Contract:   "",
 	}
 }
 
 // Config is the structure that a contract deployer config is parsed into.
 type Config struct {
-	L1NodeHost       string
-	L1NodePort       uint
-	MgmtContractPath string
-	PrivateKey       string
-	EthChainID       *big.Int
+	NodeHost   string   // host for the client connection
+	NodePort   uint     // port for client connection
+	PrivateKey string   // private key to be used for the contract deployer address
+	ChainID    *big.Int // chain ID we're deploying too
+	Contract   string   // the name of the contract to deploy (e.g. ERC20 or MGMT)
 }
 
 // ParseConfig returns a Config after parsing all available flags
 func ParseConfig() *Config {
 	defaultConfig := DefaultConfig()
 
-	l1NodeHost := flag.String(l1NodeHostName, defaultConfig.L1NodeHost, l1NodeHostUsage)
-	l1NodePort := flag.Uint64(l1NodePortName, uint64(defaultConfig.L1NodePort), l1NodePortUsage)
-	mgmtContractPath := flag.String(mgmtContractPathName, defaultConfig.MgmtContractPath, mgmtContractPathUsage)
+	nodeHost := flag.String(nodeHostName, defaultConfig.NodeHost, nodeHostUsage)
+	nodePort := flag.Uint64(nodePortName, uint64(defaultConfig.NodePort), nodePortUsage)
+	contract := flag.String(contractName, defaultConfig.Contract, contractUsage)
 	privateKeyStr := flag.String(privateKeyName, defaultConfig.PrivateKey, privateKeyUsage)
-	ethChainID := flag.Int64(chainIDName, defaultConfig.EthChainID.Int64(), chainIDUsage)
+	ChainID := flag.Int64(chainIDName, defaultConfig.ChainID.Int64(), chainIDUsage)
 
 	flag.Parse()
 
-	defaultConfig.L1NodeHost = *l1NodeHost
-	defaultConfig.L1NodePort = uint(*l1NodePort)
-	defaultConfig.MgmtContractPath = *mgmtContractPath
+	defaultConfig.NodeHost = *nodeHost
+	defaultConfig.NodePort = uint(*nodePort)
 	defaultConfig.PrivateKey = *privateKeyStr
-	defaultConfig.EthChainID = big.NewInt(*ethChainID)
+	defaultConfig.ChainID = big.NewInt(*ChainID)
+	defaultConfig.Contract = *contract
 
 	return defaultConfig
 }

--- a/tools/contractdeployer/cli_flags.go
+++ b/tools/contractdeployer/cli_flags.go
@@ -2,18 +2,18 @@ package contractdeployer
 
 // Flag names, defaults and usages.
 const (
-	l1NodeHostName  = "l1NodeHost"
-	l1NodeHostUsage = "The host on which to connect to the Ethereum client"
+	nodeHostName  = "nodeHost"
+	nodeHostUsage = "The host on which to connect the RPC client"
 
-	l1NodePortName  = "l1NodePort"
-	l1NodePortUsage = "The port on which to connect to the Ethereum client"
+	nodePortName  = "nodePort"
+	nodePortUsage = "The port on which to connect the RPC client"
 
-	mgmtContractPathName  = "mgmtContractPath"
-	mgmtContractPathUsage = "The path of the management contract path"
+	contractName  = "contract"
+	contractUsage = "The name of the contract bytecode to be deploy (e.g. `MGMT` or `ERC20`)"
 
 	privateKeyName  = "privateKey"
-	privateKeyUsage = "The private key for the L1 node account"
+	privateKeyUsage = "The private key for the node account"
 
 	chainIDName  = "chainID"
-	chainIDUsage = "The ID of the L1 chain"
+	chainIDUsage = "The ID of the chain"
 )

--- a/tools/contractdeployer/cli_flags.go
+++ b/tools/contractdeployer/cli_flags.go
@@ -8,8 +8,8 @@ const (
 	nodePortName  = "nodePort"
 	nodePortUsage = "The port on which to connect the RPC client"
 
-	contractName  = "contract"
-	contractUsage = "The name of the contract bytecode to be deploy (e.g. `MGMT` or `ERC20`)"
+	contractNameName  = "contractName"
+	contractNameUsage = "The name of the contract bytecode to be deploy (e.g. `MGMT` or `ERC20`)"
 
 	privateKeyName  = "privateKey"
 	privateKeyUsage = "The private key for the node account"

--- a/tools/contractdeployer/contract_deployer.go
+++ b/tools/contractdeployer/contract_deployer.go
@@ -121,7 +121,7 @@ func setupClient(cfg *Config, _ wallet.Wallet) (ethadapter.EthClient, error) {
 }
 
 func getContractCode(cfg *Config) ([]byte, error) {
-	switch cfg.Contract {
+	switch cfg.ContractName {
 	case mgmtContract:
 		return common.Hex2Bytes(mgmtcontractlib.MgmtContractByteCode), nil
 
@@ -129,6 +129,6 @@ func getContractCode(cfg *Config) ([]byte, error) {
 		return common.Hex2Bytes(erc20contractlib.ERC20ContractABI), nil
 
 	default:
-		return nil, fmt.Errorf("unrecognised contract %s - no bytecode configured for that contract name", cfg.Contract)
+		return nil, fmt.Errorf("unrecognised contract %s - no bytecode configured for that contract name", cfg.ContractName)
 	}
 }

--- a/tools/contractdeployer/contract_deployer.go
+++ b/tools/contractdeployer/contract_deployer.go
@@ -2,106 +2,133 @@ package contractdeployer
 
 // TODO we might merge this with the network manager package
 import (
-	"errors"
 	"fmt"
 	"math/big"
 	"time"
 
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/obscuronet/go-obscuro/go/ethadapter/erc20contractlib"
+	"github.com/obscuronet/go-obscuro/go/ethadapter/mgmtcontractlib"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/obscuronet/go-obscuro/go/common/log"
 	"github.com/obscuronet/go-obscuro/go/ethadapter"
-	"github.com/obscuronet/go-obscuro/go/ethadapter/mgmtcontractlib"
 	"github.com/obscuronet/go-obscuro/go/wallet"
-	"github.com/obscuronet/go-obscuro/integration/erc20contract"
+)
+
+const (
+	mgmtContract  = "MGMT"
+	erc20Contract = "ERC20"
 )
 
 type ContractDeployer struct {
-	config *Config
+	client       ethadapter.EthClient
+	wallet       wallet.Wallet
+	contractCode []byte
 }
 
-func NewContractDeployer(config *Config) *ContractDeployer {
-	return &ContractDeployer{
-		config: config,
+func NewContractDeployer(config *Config) (*ContractDeployer, error) {
+	wallet, err := setupWallet(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to setup wallet - %w", err)
 	}
+	client, err := setupClient(config, wallet)
+	if err != nil {
+		return nil, fmt.Errorf("failed to setup client - %w", err)
+	}
+	contractCode, err := getContractCode(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find contract bytecode to deploy - %w", err)
+	}
+
+	return &ContractDeployer{
+		client:       client,
+		wallet:       wallet,
+		contractCode: contractCode,
+	}, nil
 }
 
 func (cd *ContractDeployer) Run() error {
-	// connect to the L1
-	privateKey, err := crypto.HexToECDSA(cd.config.PrivateKey)
+	nonce, err := cd.client.Nonce(cd.wallet.Address())
 	if err != nil {
-		return fmt.Errorf("could not recover private key from hex. Cause: %w", err)
+		return err
+	}
+	cd.wallet.SetNonce(nonce)
+
+	deployContractTx := types.LegacyTx{
+		Nonce:    cd.wallet.GetNonceAndIncrement(),
+		GasPrice: big.NewInt(2000000000),
+		Gas:      1025_000_000,
+		Data:     cd.contractCode,
 	}
 
-	// load the wallet
-	w := wallet.NewInMemoryWalletFromPK(cd.config.EthChainID, privateKey)
-	// connect to the l1
-	client, err := ethadapter.NewEthClient(cd.config.L1NodeHost, cd.config.L1NodePort, 30*time.Second, common.HexToAddress("0x0"))
+	signedTx, err := cd.wallet.SignTransaction(&deployContractTx)
 	if err != nil {
-		return fmt.Errorf("unable to connect to the l1 host: %w", err)
+		return err
 	}
 
-	// deploy the contracts
-	contractAddr, err := deployContract(client, w, common.Hex2Bytes(mgmtcontractlib.MgmtContractByteCode))
+	err = cd.client.SendTransaction(signedTx)
 	if err != nil {
-		return fmt.Errorf("unable to deploy contract to the l1 host: %w", err)
-	}
-	erc20contractAddr, err := deployContract(client, w, common.Hex2Bytes(erc20contract.ContractByteCode))
-	if err != nil {
-		return fmt.Errorf("unable to deploy contract to the l1 host: %w", err)
+		return err
 	}
 
-	// print the contract address
-	fmt.Printf("{\"MgmtContractAddr\":\"%s\", \"ERC20ContractAddr\":\"%s\"}",
-		contractAddr.Hex(),
-		erc20contractAddr.Hex(),
-	)
+	var start time.Time
+	var receipt *types.Receipt
+	var contractAddr *common.Address
+	for start = time.Now(); time.Since(start) < 80*time.Second; time.Sleep(2 * time.Second) {
+		receipt, err = cd.client.TransactionReceipt(signedTx.Hash())
+		if err == nil && receipt != nil {
+			if receipt.Status != types.ReceiptStatusSuccessful {
+				return fmt.Errorf("unable to deploy contract, receipt status unsuccessful: %v", receipt)
+			}
+			log.Info("Contract successfully deployed to %s", receipt.ContractAddress)
+			contractAddr = &receipt.ContractAddress
+			break
+		}
+
+		log.Info("Contract deploy tx has not been mined into a block after %s...", time.Since(start))
+	}
+	if contractAddr == nil {
+		return fmt.Errorf("failed to mine contract deploy tx into a block after %s. Aborting", time.Since(start))
+	}
+
+	// print the contract address, to be read if necessary by the caller (important: this must be the last message output by the script)
+	fmt.Print(contractAddr.Hex())
+
 	// this is a safety sleep to make sure the output is printed
 	time.Sleep(5 * time.Second)
 	return nil
 }
 
-// deployContract deploys a contract (with a tremendous amount of gas)
-// TODO This should be in a package somewhere + we should early exit if the error other than not found
-func deployContract(c ethadapter.EthClient, w wallet.Wallet, contractBytes []byte) (*common.Address, error) {
-	nonce, err := c.Nonce(w.Address())
+func setupWallet(cfg *Config) (wallet.Wallet, error) {
+	privateKey, err := crypto.HexToECDSA(cfg.PrivateKey)
+	if err != nil {
+		return nil, fmt.Errorf("could not recover private key from hex. Cause: %w", err)
+	}
+
+	// load the wallet
+	return wallet.NewInMemoryWalletFromPK(cfg.ChainID, privateKey), nil
+}
+
+func setupClient(cfg *Config, _ wallet.Wallet) (ethadapter.EthClient, error) {
+	// connect to the l1
+	client, err := ethadapter.NewEthClient(cfg.NodeHost, cfg.NodePort, 30*time.Second, common.HexToAddress("0x0"))
 	if err != nil {
 		return nil, err
 	}
-	w.SetNonce(nonce)
+	return client, nil
+}
 
-	deployContractTx := types.LegacyTx{
-		Nonce:    w.GetNonceAndIncrement(),
-		GasPrice: big.NewInt(2000000000),
-		Gas:      1025_000_000,
-		Data:     contractBytes,
+func getContractCode(cfg *Config) ([]byte, error) {
+	switch cfg.Contract {
+	case mgmtContract:
+		return common.Hex2Bytes(mgmtcontractlib.MgmtContractByteCode), nil
+
+	case erc20Contract:
+		return common.Hex2Bytes(erc20contractlib.ERC20ContractABI), nil
+
+	default:
+		return nil, fmt.Errorf("unrecognised contract %s - no bytecode configured for that contract name", cfg.Contract)
 	}
-
-	signedTx, err := w.SignTransaction(&deployContractTx)
-	if err != nil {
-		return nil, err
-	}
-
-	err = c.SendTransaction(signedTx)
-	if err != nil {
-		return nil, err
-	}
-
-	var start time.Time
-	var receipt *types.Receipt
-	for start = time.Now(); time.Since(start) < 80*time.Second; time.Sleep(2 * time.Second) {
-		receipt, err = c.TransactionReceipt(signedTx.Hash())
-		if err == nil && receipt != nil {
-			if receipt.Status != types.ReceiptStatusSuccessful {
-				return nil, errors.New("unable to deploy contract")
-			}
-			log.Info("Contract successfully deployed to %s", receipt.ContractAddress)
-			return &receipt.ContractAddress, nil
-		}
-
-		log.Info("Contract deploy tx has not been mined into a block after %s...", time.Since(start))
-	}
-
-	return nil, fmt.Errorf("failed to mine contract deploy tx into a block after %s. Aborting", time.Since(start))
 }

--- a/tools/contractdeployer/main/main.go
+++ b/tools/contractdeployer/main/main.go
@@ -8,7 +8,12 @@ import (
 func main() {
 	log.SetLogLevel(log.DisabledLevel)
 	config := contractdeployer.ParseConfig()
-	deployer := contractdeployer.NewContractDeployer(config)
+	deployer, err := contractdeployer.NewContractDeployer(config)
+	if err != nil {
+		// todo: why is this log level stuff setup in this way (why not print here or use logs everywhere)
+		log.SetLogLevel(log.TraceLevel)
+		log.Panic("%s", err)
+	}
 	if err := deployer.Run(); err != nil {
 		log.SetLogLevel(log.TraceLevel)
 		log.Panic("%s", err)


### PR DESCRIPTION
### Why is this change needed?

- we want to deploy L1 and L2 contracts as part of testnet setup, this is to pave the way for that
- I think most flexible way to be able to use this tool for that stuff is to have it be called once per contract it is deploying rather than having preset hardcoded bundles of contracts to deploy

### What changes were made as part of this PR:

*refactor*
- add 'contract' param that for now accepts 'MGMT' or 'ERC20' as a value, and then deploys the associated bytecode
- output deployed address as final line of output (to replace the json blob that was getting output before)

### What are the key areas to look at
- `testnet-deploy-contracts.sh` for change in how it is called (and how the output is read)
- `contract_deployer.go` for whether refactor is sensible (it prepares us to be able to add an --L1Deployment boolean flag that will build the client etc. differently)