### PR TITLE
Moray/readme metamask + programmatic deployment 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,8 +30,10 @@ integration/simulation/cmd/cmd
 go/host/main/main
 go/enclave/main/main
 tools/walletextension/main/main
+tools/walletextension/main/wallet_extension
 tools/networkmanager/main/main
 tools/obscuroscan/main/main
+
 
 # Logs files
 **/enclave_logs.txt

--- a/README.md
+++ b/README.md
@@ -361,7 +361,34 @@ account on the L1 network used to deploy the Obscuro Management and the ERC20 co
 - `0x0000000000000000000000000000000000000001` is the host id of the Obscuro node when starting in a local mode
 - `0xeDa66Cc53bd2f26896f6Ba6b736B1Ca325DE04eF` is the address of the Obscuro Management contract which is known a-priori as a nonce of 0 is used 
 - `0xC0370e0b5C1A41D447BDdA655079A1B977C71aA9` is the address of the ERC20 contract which is known a-priori as a nonce of 1 is used
-                                             
+                                
+
+### Deploying contracts into a local testnet
+Deploying and interacting with contracts on Obscuro requires the wallet extension to be running. The wallet extension is the Obscuro 
+component that ensures that sensitive information in RPC requests between client applications and Obscuro cannot be seen by third parties. 
+The wallet extension should be run local to the client application and is described in more detail at 
+[docs/testnet/wallet-extension.md](docs/testnet/wallet-extension.md).
+
+To start the wallet extension to run against a local testnet use the below;
+
+```
+cd ./tools/walletextension/main/
+go build -o wallet_extension 
+./wallet_extension -nodeHost 127.0.0.1 -nodePortHTTP 13000 -nodePortWS 13001
+```
+
+Once the wallet extension is running, a contract can be deployed and interacted with either manually using Metamask and Remix (see 
+[docs/testnet/deploying-a-smart-contract.md](docs/testnet/deploying-a-smart-contract.md)) or programmatically e.g. using web3.py
+(see [docs/testnet/deploying-a-smart-contract-programmatically.md](docs/testnet/deploying-a-smart-contract-programmatically.md)). 
+
+Note that in order to interact with the main cloud hosted testnet, all that needs to be changed is to start the wallet extension using 
+the default parameters, where the `nodeHost` will default to the testnet host URL `testnet.obscu.ro` i.e. 
+
+```
+cd ./tools/walletextension/main/
+go build -o wallet_extension 
+./wallet_extension 
+```
 
 ## Community 
 

--- a/docs/testnet/deploying-a-smart-contract-programmatically.md
+++ b/docs/testnet/deploying-a-smart-contract-programmatically.md
@@ -1,0 +1,7 @@
+# Deploying a Smart Contract to Obscuro Testnet Programmatically
+Using the steps below you will programmatically create a new contract on to Obscuro Testnet and interact with it via 
+call functions. The example uses [web3.py](https://web3py.readthedocs.io/en/stable/) as a reference but the principles 
+of usage will be the same in any web3 language implementation. 
+
+
+.

--- a/docs/testnet/deploying-a-smart-contract-programmatically.md
+++ b/docs/testnet/deploying-a-smart-contract-programmatically.md
@@ -4,14 +4,14 @@ call functions. The example uses [Python](https://www.python.org/) and [web3.py]
 as a reference but the principles of usage will be the same in any web3 language implementation. 
 
 A full working example can be seen in [deploying-a-smart-contract-programmatically.py](deploying-a-smart-contract-programmatically.py).
-Usage of the example requires Python > 3.9.13, solc == 0.8.15 and the web3, requests, and json modules. It is 
-assumed solc has been installed using homebrew, and therefore resides in `/opt/homebrew/bin/solc`. It is additionally 
-assumed the wallet extension is running on the local host, with default values `WHOST=127.0.0.1` and `WPORT=3000`.
+Usage of the example requires Python > 3.9.13, solc 0.8.15 and the web3, requests, and json modules. It is assumed solc 
+has been installed using homebrew and resides in `/opt/homebrew/bin/solc` and that the wallet extension is running on 
+the local host with default values `WHOST=127.0.0.1` and `WPORT=3000`.
 
 A walk through and explanation of the steps performed is given below;
 
 ## Connect to the network and create a local private key
-The wallet extension acts as an HTTP server to mediate RPC requests as defined [handling-sensitive-data.md](handling-sensitive-data.md).
+The wallet extension acts as an HTTP server to mediate RPC requests as defined in [handling-sensitive-data.md](handling-sensitive-data.md).
 In the below a connection is made on the wallet extension host and port, a private key is locally created and the 
 associated account stored for later usage. 
 ```python
@@ -22,8 +22,8 @@ associated account stored for later usage.
 ```
 
 ## Generate a viewing key, sign and post back to the wallet extension
-The enclave encodes all communication to the wallet extension using viewing keys. HTTP RPC endpoints exist in the 
-wallet extension to facility requesting a viewing key, and to then sign and return it to the enclave. 
+The enclave encodes all communication to the wallet extension using viewing keys. HTTP endpoints exist in the wallet 
+extension to facilitate requesting a viewing key, and to sign and return it to the enclave. 
 ```python 
     response = requests.get('http://%s:%d/generateviewingkey/' % (WHOST, WPORT))
     signed_msg = w3.eth.account.sign_message(encode_defunct(text='vk' + response.text), private_key=private_key)
@@ -35,9 +35,8 @@ wallet extension to facility requesting a viewing key, and to then sign and retu
 
 ## Compile the contract and build the local deployment transaction
 A contract can be built using solc and a transaction created for deploying the contract. Construction of the transaction 
-currently requires `gasPrice` and `gas` to be explicitly defined (the need to perform this will be removed in a later 
-release). An arbitrary `gasPrice` should be given with the below value representative of the value at the time of writing 
-on the Ropsten test network. 
+requires `gasPrice` and `gas` to be explicitly defined (the need to perform this will be removed in a later 
+release). An arbitrary `gasPrice` should be given e.g. the current price on the Ropsten test network. 
 ```python 
     compiled_sol = compile_source(guesser, output_values=['abi', 'bin'], solc_binary='/opt/homebrew/bin/solc')
     contract_id, contract_interface = compiled_sol.popitem()
@@ -56,7 +55,7 @@ on the Ropsten test network.
 ```
 
 ## Sign the transaction and send to the network 
-Using the account the transaction should be signed and submitted to the Obscuro Testnet. 
+Using the account the transaction can be signed and submitted to the Obscuro Testnet. 
 ```python
     signed_tx = account.signTransaction(build_tx)
     tx_hash = None
@@ -68,9 +67,9 @@ Using the account the transaction should be signed and submitted to the Obscuro 
 ```
 
 ## Wait for the transaction receipt 
-Once submitted the transaction receipt needs to be obtained in order to get the deployed contract address. At the 
-moment an explicit loop and timeout needs to be performed in the user implementation until the semantics of the 
-call becomes fully blocking. 
+Once submitted the transaction receipt can be obtained in order to get the deployed contract address. An explicit loop 
+and timeout needs to be performed in the user implementation until the semantics of the call becomes fully blocking in 
+a later release. 
 ```python
     start = time.time()
     tx_receipt = None
@@ -93,7 +92,7 @@ call becomes fully blocking.
 ```
 
 ## Create the contract using the abi and contract address
-Once the transaction receipt is received functions call can be made against the contract. 
+Once the transaction receipt is received function calls can be made against the contract. 
 ```python
     contract = w3.eth.contract(address=tx_receipt.contractAddress, abi=abi)
     contract.functions.guess(guess).call()

--- a/docs/testnet/deploying-a-smart-contract-programmatically.md
+++ b/docs/testnet/deploying-a-smart-contract-programmatically.md
@@ -1,7 +1,101 @@
 # Deploying a Smart Contract to Obscuro Testnet Programmatically
-Using the steps below you will programmatically create a new contract on to Obscuro Testnet and interact with it via 
-call functions. The example uses [web3.py](https://web3py.readthedocs.io/en/stable/) as a reference but the principles 
-of usage will be the same in any web3 language implementation. 
+The steps below demonstrate how to programmatically create a new contract on to Obscuro Testnet and interact with it via 
+call functions. The example uses [Python](https://www.python.org/) and [web3.py](https://web3py.readthedocs.io/en/stable/) 
+as a reference but the principles of usage will be the same in any web3 language implementation. 
 
+A full working example can be seen in [deploying-a-smart-contract-programmatically.py](deploying-a-smart-contract-programmatically.py).
+Usage of the example requires Python > 3.9.13, solc == 0.8.15 and the web3, requests, and json modules. It is 
+assumed solc has been installed using homebrew, and therefore resides in `/opt/homebrew/bin/solc`. It is additionally 
+assumed the wallet extension is running on the local host, with default values `WHOST=127.0.0.1` and `WPORT=3000`.
 
-.
+A walk through and explanation of the steps performed is given below;
+
+## Connect to the network and create a local private key
+The wallet extension acts as an HTTP server to mediate RPC requests as defined [handling-sensitive-data.md](handling-sensitive-data.md).
+In the below a connection is made on the wallet extension host and port, a private key is locally created and the 
+associated account stored for later usage. 
+```python
+    w3 = Web3(Web3.HTTPProvider('http://%s:%d' % (WHOST, WPORT)))
+    private_key = secrets.token_hex(32)
+    account = w3.eth.account.privateKeyToAccount(private_key)
+    logging.info('Using account with address %s' % account.address)
+```
+
+## Generate a viewing key, sign and post back to the wallet extension
+The enclave encodes all communication to the wallet extension using viewing keys. HTTP RPC endpoints exist in the 
+wallet extension to facility requesting a viewing key, and to then sign and return it to the enclave. 
+```python 
+    response = requests.get('http://%s:%d/generateviewingkey/' % (WHOST, WPORT))
+    signed_msg = w3.eth.account.sign_message(encode_defunct(text='vk' + response.text), private_key=private_key)
+
+    data = {"address": account.address, "signature": signed_msg.signature.hex()}
+    headers = {'Accept': 'application/json', 'Content-Type': 'application/json'}
+    requests.post('http://%s:%d/submitviewingkey/' % (WHOST, WPORT), data=json.dumps(data), headers=headers)
+```
+
+## Compile the contract and build the local deployment transaction
+A contract can be built using solc and a transaction created for deploying the contract. Construction of the transaction 
+currently requires `gasPrice` and `gas` to be explicitly defined (the need to perform this will be removed in a later 
+release). An arbitrary `gasPrice` should be given with the below value representative of the value at the time of writing 
+on the Ropsten test network. 
+```python 
+    compiled_sol = compile_source(guesser, output_values=['abi', 'bin'], solc_binary='/opt/homebrew/bin/solc')
+    contract_id, contract_interface = compiled_sol.popitem()
+    bytecode = contract_interface['bin']
+    abi = contract_interface['abi']
+    contract = w3.eth.contract(abi=abi, bytecode=bytecode)
+    build_tx = contract.constructor(random.randrange(0, 100)).buildTransaction(
+        {
+            'from': account.address,
+            'nonce': w3.eth.getTransactionCount(account.address),
+            'gasPrice': 1499934385,
+            'gas': 720000,
+            'chainId': 777
+        }
+    )
+```
+
+## Sign the transaction and send to the network 
+Using the account the transaction should be signed and submitted to the Obscuro Testnet. 
+```python
+    signed_tx = account.signTransaction(build_tx)
+    tx_hash = None
+    try:
+        tx_hash = w3.eth.sendRawTransaction(signed_tx.rawTransaction)
+    except Exception as e:
+        logging.error('Error sending raw transaction %s' % e)
+        return
+```
+
+## Wait for the transaction receipt 
+Once submitted the transaction receipt needs to be obtained in order to get the deployed contract address. At the 
+moment an explicit loop and timeout needs to be performed in the user implementation until the semantics of the 
+call becomes fully blocking. 
+```python
+    start = time.time()
+    tx_receipt = None
+    while True:
+        if (time.time() - start) > 30:
+            logging.error('Timed out waiting for transaction receipt ... aborting')
+            return
+
+        try:
+            tx_receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
+            if tx_receipt.status == 0:
+                logging.error('Transaction receipt has failed status ... aborting')
+                return
+            else:
+                logging.info('Received transaction receipt')
+                break
+        except Exception as e:
+            logging.info('Waiting for transaction receipt')
+            time.sleep(1)
+```
+
+## Create the contract using the abi and contract address
+Once the transaction receipt is received functions call can be made against the contract. 
+```python
+    contract = w3.eth.contract(address=tx_receipt.contractAddress, abi=abi)
+    contract.functions.guess(guess).call()
+```
+

--- a/docs/testnet/deploying-a-smart-contract-programmatically.md
+++ b/docs/testnet/deploying-a-smart-contract-programmatically.md
@@ -34,7 +34,7 @@ extension to facilitate requesting a viewing key, and to sign and return it to t
 ```
 
 ## Compile the contract and build the local deployment transaction
-A contract can be built using solc and a transaction created for deploying the contract. Construction of the transaction 
+A contract can be compiled using solc and a transaction created for deploying the contract. Construction of the transaction 
 requires `gasPrice` and `gas` to be explicitly defined (the need to perform this will be removed in a later 
 release). An arbitrary `gasPrice` should be given e.g. the current price on the Ropsten test network. 
 ```python 

--- a/docs/testnet/deploying-a-smart-contract-programmatically.py
+++ b/docs/testnet/deploying-a-smart-contract-programmatically.py
@@ -1,0 +1,140 @@
+import secrets
+import requests
+import json
+import time
+import logging
+import random
+from web3 import Web3
+from solcx import compile_source
+from eth_account.messages import encode_defunct
+
+WPORT = 3000
+WHOST = '127.0.0.1'
+LOWER = 0
+UPPER = 100
+
+guesser = '''
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+contract Guesser {
+    address public owner;
+    uint256 public number;
+
+    constructor(uint256 _initialNumber) {
+        owner = msg.sender;
+        number=_initialNumber;
+    }
+
+    function guess(uint256 i) view public returns (int) {
+        if (i<number) return 1;
+        if (i>number) return -1;
+        return 0;
+    }
+
+    function destroy() public {
+        require(msg.sender == owner, "You are not the owner");
+        selfdestruct(payable(address(this)));
+    }
+}
+'''
+
+def guess(contract, max_guesses=100):
+    lower = LOWER
+    upper = UPPER
+    nguess = 0
+    while True:
+        nguess += 1
+        if nguess > max_guesses:
+            logging.warn("Exceeded guess count ... exiting")
+            return None
+
+        guess = random.randrange(lower, upper)
+        ret = contract.functions.guess(guess).call()
+        if ret == 1:
+            logging.info("Guess is %d, need to go higher" % guess)
+            lower = guess + 1
+        elif ret == -1:
+            logging.info("Guess is %d, need to go lower" % guess)
+            upper = guess
+        else:
+            logging.info("You've guessed the secret %s" % guess)
+            return guess
+
+
+def run():
+    # connect to the network, create a local private key and convert into the account
+    w3 = Web3(Web3.HTTPProvider('http://%s:%d' % (WHOST, WPORT)))
+    private_key = secrets.token_hex(32)
+    account = w3.eth.account.privateKeyToAccount(private_key)
+    logging.info('Using account with address %s' % account.address)
+
+    # generate a viewing key for this account, sign and post it to the wallet extension
+    response = requests.get('http://%s:%d/generateviewingkey/' % (WHOST, WPORT))
+    signed_msg = w3.eth.account.sign_message(encode_defunct(text='vk' + response.text), private_key=private_key)
+
+    data = {"address": account.address, "signature": signed_msg.signature.hex()}
+    headers = {'Accept': 'application/json', 'Content-Type': 'application/json'}
+    requests.post('http://%s:%d/submitviewingkey/' % (WHOST, WPORT), data=json.dumps(data), headers=headers)
+
+    # compile the guessing game and build the deployment transaction
+    logging.info('Compiling the guessing game application')
+    compiled_sol = compile_source(guesser, output_values=['abi', 'bin'], solc_binary='/opt/homebrew/bin/solc')
+    contract_id, contract_interface = compiled_sol.popitem()
+    bytecode = contract_interface['bin']
+    abi = contract_interface['abi']
+    contract = w3.eth.contract(abi=abi, bytecode=bytecode)
+    build_tx = contract.constructor(random.randrange(LOWER, UPPER)).buildTransaction(
+        {
+            'from': account.address,
+            'nonce': w3.eth.getTransactionCount(account.address),
+            'gasPrice': 1499934385,
+            'gas': 720000,
+            'chainId': 777
+        }
+    )
+
+    # Sign the transaction and send to the network
+    logging.info('Signing and sending raw transaction')
+    signed_tx = account.signTransaction(build_tx)
+    tx_hash = None
+    try:
+        tx_hash = w3.eth.sendRawTransaction(signed_tx.rawTransaction)
+    except Exception as e:
+        logging.error('Error sending raw transaction %s' % e)
+        return
+
+    # wait for the transaction receipt and check the status
+    logging.info('Waiting for transaction receipt')
+    start = time.time()
+    tx_receipt = None
+    while True:
+        if (time.time() - start) > 30:
+            logging.error('Timed out waiting for transaction receipt ... aborting')
+            return
+
+        try:
+            tx_receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
+            if tx_receipt.status == 0:
+                logging.error('Transaction receipt has failed status ... aborting')
+                return
+            else:
+                logging.info('Received transaction receipt')
+                break
+        except Exception as e:
+            logging.info('Waiting for transaction receipt')
+            time.sleep(1)
+
+    # construct the contract using the contract address
+    contract = w3.eth.contract(address=tx_receipt.contractAddress, abi=abi)
+
+    # guess the number
+    logging.info('Starting guessing game')
+    guess(contract)
+
+
+if __name__ == '__main__':
+    logging.getLogRecordFactory()
+    logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s %(message)s')
+    run()
+


### PR DESCRIPTION
### Why is this change needed?

- Adds a section to the top level readme that references docs on how to deploy a contract with metamask
- Adds a section to demonstrate how to programmatically deploy and interact with a contract on to Obscuro Testnet

### What changes were made as part of this PR:

- update the top level readme for referencing docs on using metamask for manual deployment 
- added deploying-a-smart-contract-programmatically.md and deploying-a-smart-contract-programmatically.py into docs/testnet and referenced the md file in the top level readme. 

### What are the key areas to look at

- check that deploying-a-smart-contract-programmatically.md supplies enough information to be useful to a user and whether more detail is required
