### PR TITLE
re-ingests blocks

### DIFF
--- a/go/ethadapter/geth_rpc_client.go
+++ b/go/ethadapter/geth_rpc_client.go
@@ -143,7 +143,7 @@ func (e *gethRPCClient) Nonce(account gethcommon.Address) (uint64, error) {
 }
 
 func (e *gethRPCClient) BlockListener() (chan *types.Header, ethereum.Subscription) {
-	ch := make(chan *types.Header, 1)
+	ch := make(chan *types.Header, 100)
 	sub, err := e.client.SubscribeNewHead(context.Background(), ch)
 	if err != nil {
 		log.Panic("could not subscribe for new head blocks. Cause: %s", err)

--- a/go/ethadapter/geth_rpc_client.go
+++ b/go/ethadapter/geth_rpc_client.go
@@ -143,6 +143,8 @@ func (e *gethRPCClient) Nonce(account gethcommon.Address) (uint64, error) {
 }
 
 func (e *gethRPCClient) BlockListener() (chan *types.Header, ethereum.Subscription) {
+	// this channel holds blocks that have been received from the geth network but not yet processed by the host,
+	// with more than 1 capacity the buffer provides resilience in case of intermittent RPC or processing issues
 	ch := make(chan *types.Header, 100)
 	sub, err := e.client.SubscribeNewHead(context.Background(), ch)
 	if err != nil {

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -676,14 +676,14 @@ func (a *Node) monitorBlocks() {
 			// get the latest known blk
 			lastBlk, err := a.ethClient.BlockByNumber(lastBlkNumber)
 			if err != nil {
-				log.Panic("%s", err)
+				log.Panic("catching up on missed blocks, unable to fetch tip block - reason: %s", err)
 			}
 
 			// iterate from the tip (last known block) to the last one known by the node
 			for lastBlk.Hash().Hex() != lastKnownBlkHash.Hex() {
 				blockParent, err := a.ethClient.BlockByHash(lastBlk.ParentHash())
 				if err != nil {
-					log.Panic("could not fetch block's parent with hash %s. Cause: %s", lastBlk.ParentHash(), err)
+					log.Panic("catching up on missed blocks, could not fetch block's parent with hash %s. Cause: %s", lastBlk.ParentHash(), err)
 				}
 
 				// issue the block to the ingestion channel


### PR DESCRIPTION
### Why is this change needed?

- https://github.com/obscuronet/obscuro-internal/issues/659

### What changes were made as part of this PR:

- Functional
- After restarting the subscriber, reingests any missing blocks
