### PR TITLE
Rename BTC dummy token to OBX

### DIFF
--- a/go/enclave/bridge/bridge.go
+++ b/go/enclave/bridge/bridge.go
@@ -34,19 +34,19 @@ import (
 type ERC20 int
 
 const (
-	BTC ERC20 = iota
+	OBX ERC20 = iota
 	ETH
 )
 
-var WBtcOwner, _ = crypto.HexToECDSA("6e384a07a01263518a09a5424c7b6bbfc3604ba7d93f47e3a455cbdd7f9f0682")
+var WOBXOwner, _ = crypto.HexToECDSA("6e384a07a01263518a09a5424c7b6bbfc3604ba7d93f47e3a455cbdd7f9f0682")
 
-// WBtcContract X- address of the deployed "btc" erc20 on the L2
-var WBtcContract = gethcommon.BytesToAddress(gethcommon.Hex2Bytes("f3a8bd422097bFdd9B3519Eaeb533393a1c561aC"))
+// WOBXContract X- address of the deployed "obx" erc20 on the L2
+var WOBXContract = gethcommon.BytesToAddress(gethcommon.Hex2Bytes("f3a8bd422097bFdd9B3519Eaeb533393a1c561aC"))
 
-var WEthOnwer, _ = crypto.HexToECDSA("4bfe14725e685901c062ccd4e220c61cf9c189897b6c78bd18d7f51291b2b8f8")
+var WETHOwner, _ = crypto.HexToECDSA("4bfe14725e685901c062ccd4e220c61cf9c189897b6c78bd18d7f51291b2b8f8")
 
-// WEthContract - address of the deployed "eth" erc20 on the L2
-var WEthContract = gethcommon.BytesToAddress(gethcommon.Hex2Bytes("9802F661d17c65527D7ABB59DAAD5439cb125a67"))
+// WETHContract - address of the deployed "eth" erc20 on the L2
+var WETHContract = gethcommon.BytesToAddress(gethcommon.Hex2Bytes("9802F661d17c65527D7ABB59DAAD5439cb125a67"))
 
 // BridgeAddress - address of the virtual bridge
 var BridgeAddress = gethcommon.BytesToAddress(gethcommon.Hex2Bytes("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"))
@@ -79,7 +79,7 @@ type Bridge struct {
 }
 
 func New(
-	btcAddress *gethcommon.Address,
+	obxAddress *gethcommon.Address,
 	ethAddress *gethcommon.Address,
 	mgmtContractLib mgmtcontractlib.MgmtContractLib,
 	erc20ContractLib erc20contractlib.ERC20ContractLib,
@@ -90,18 +90,18 @@ func New(
 ) *Bridge {
 	tokens := make(map[ERC20]*ERC20Mapping, 0)
 
-	tokens[BTC] = &ERC20Mapping{
-		Name:      BTC,
-		L1Address: btcAddress,
-		Owner:     wallet.NewInMemoryWalletFromPK(big.NewInt(obscuroChainID), WBtcOwner),
-		L2Address: &WBtcContract,
+	tokens[OBX] = &ERC20Mapping{
+		Name:      OBX,
+		L1Address: obxAddress,
+		Owner:     wallet.NewInMemoryWalletFromPK(big.NewInt(obscuroChainID), WOBXOwner),
+		L2Address: &WOBXContract,
 	}
 
 	tokens[ETH] = &ERC20Mapping{
 		Name:      ETH,
 		L1Address: ethAddress,
-		Owner:     wallet.NewInMemoryWalletFromPK(big.NewInt(obscuroChainID), WEthOnwer),
-		L2Address: &WEthContract,
+		Owner:     wallet.NewInMemoryWalletFromPK(big.NewInt(obscuroChainID), WETHOwner),
+		L2Address: &WETHContract,
 	}
 
 	return &Bridge{
@@ -173,7 +173,7 @@ func (bridge *Bridge) ExtractRollups(b *types.Block, blockResolver db.BlockResol
 	return rollups
 }
 
-// this function creates a synthetic Obscuro transfer transaction based on deposits into the L1 bridge.
+// NewDepositTx creates a synthetic Obscuro transfer transaction based on deposits into the L1 bridge.
 // Todo - has to go through a few more iterations
 func (bridge *Bridge) NewDepositTx(contract *gethcommon.Address, address gethcommon.Address, amount uint64, rollupState *state.StateDB, adjustNonce uint64) *common.L2Tx {
 	transferERC20data := erc20contractlib.CreateTransferTxData(address, amount)
@@ -255,7 +255,6 @@ func (bridge *Bridge) ExtractDeposits(
 }
 
 // Todo - this has to be implemented differently based on how we define the ObsERC20
-// this belongs in the bridge
 func (bridge *Bridge) RollupPostProcessingWithdrawals(newHeadRollup *obscurocore.Rollup, state *state.StateDB, receiptsMap map[gethcommon.Hash]*types.Receipt) []common.Withdrawal {
 	w := make([]common.Withdrawal, 0)
 	// go through each transaction and check if the withdrawal was processed correctly

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -84,7 +84,7 @@ func NewEnclave(
 	collector StatsCollector,
 ) common.Enclave {
 	if len(config.ERC20ContractAddresses) < 2 {
-		log.Panic("failed to initialise enclave. At least two ERC20 contract addresses are required - the BTC " +
+		log.Panic("failed to initialise enclave. At least two ERC20 contract addresses are required - the OBX " +
 			"ERC20 address and the ETH ERC20 address")
 	}
 

--- a/integration/simulation/network/azureenclave.go
+++ b/integration/simulation/network/azureenclave.go
@@ -42,20 +42,20 @@ func NewNetworkWithAzureEnclaves(enclaveIps []string, wallets *params.SimWallets
 }
 
 func (n *networkWithAzureEnclaves) Create(params *params.SimParams, stats *stats.Stats) (*RPCHandles, error) {
-	params.MgmtContractAddr, params.BtcErc20Address, params.EthErc20Address, n.gethClients, n.gethNetwork = SetUpGethNetwork(
+	params.MgmtContractAddr, params.ObxErc20Address, params.EthErc20Address, n.gethClients, n.gethNetwork = SetUpGethNetwork(
 		n.wallets,
 		params.StartPort,
 		params.NumberOfNodes,
 		int(params.AvgBlockDuration.Seconds()),
 	)
 	params.MgmtContractLib = mgmtcontractlib.NewMgmtContractLib(params.MgmtContractAddr)
-	params.ERC20ContractLib = erc20contractlib.NewERC20ContractLib(params.MgmtContractAddr, params.BtcErc20Address, params.EthErc20Address)
+	params.ERC20ContractLib = erc20contractlib.NewERC20ContractLib(params.MgmtContractAddr, params.ObxErc20Address, params.EthErc20Address)
 
 	fmt.Printf("Please start the edgeless DB instances. Then start the docker image on the azure server with below cmds:\n")
 	for i := 0; i < len(n.azureEnclaveIps); i++ {
 		fmt.Printf("sudo docker run --net enclavenet --name enclave -h enclave -e OE_SIMULATION=0 --privileged -v /dev/sgx:/dev/sgx -p %d:%d/tcp obscuro_enclave --willAttest --useInMemoryDB=false "+
 			"--edgelessDBHost obscuroedb --hostID %d --address :11000 --managementContractAddress %s  --erc20ContractAddresses %s,%s\n",
-			enclavePort, enclavePort, i, params.MgmtContractAddr.Hex(), params.BtcErc20Address.Hex(), params.EthErc20Address.Hex())
+			enclavePort, enclavePort, i, params.MgmtContractAddr.Hex(), params.ObxErc20Address.Hex(), params.EthErc20Address.Hex())
 	}
 	time.Sleep(10 * time.Second)
 

--- a/integration/simulation/network/dockerenclave.go
+++ b/integration/simulation/network/dockerenclave.go
@@ -60,14 +60,14 @@ func (n *basicNetworkOfNodesWithDockerEnclave) Create(params *params.SimParams, 
 	}
 
 	// We start a geth network with all necessary contracts deployed.
-	params.MgmtContractAddr, params.BtcErc20Address, params.EthErc20Address, n.gethClients, n.gethNetwork = SetUpGethNetwork(
+	params.MgmtContractAddr, params.ObxErc20Address, params.EthErc20Address, n.gethClients, n.gethNetwork = SetUpGethNetwork(
 		n.wallets,
 		params.StartPort,
 		params.NumberOfNodes,
 		int(params.AvgBlockDuration.Seconds()),
 	)
 	params.MgmtContractLib = mgmtcontractlib.NewMgmtContractLib(params.MgmtContractAddr)
-	params.ERC20ContractLib = erc20contractlib.NewERC20ContractLib(params.MgmtContractAddr, params.BtcErc20Address, params.EthErc20Address)
+	params.ERC20ContractLib = erc20contractlib.NewERC20ContractLib(params.MgmtContractAddr, params.ObxErc20Address, params.EthErc20Address)
 
 	// Start the enclave docker containers with the right addresses.
 	n.startDockerEnclaves(params)
@@ -114,7 +114,7 @@ func (n *basicNetworkOfNodesWithDockerEnclave) setupAndCheckDocker() error {
 
 func (n *basicNetworkOfNodesWithDockerEnclave) startDockerEnclaves(params *params.SimParams) {
 	// We create the Docker containers and set up a hook to terminate them at the end of the test.
-	n.containerIDs = createDockerContainers(n.ctx, n.client, params.NumberOfNodes, params.StartPort, params.MgmtContractAddr.Hex(), []string{params.BtcErc20Address.Hex(), params.EthErc20Address.Hex()})
+	n.containerIDs = createDockerContainers(n.ctx, n.client, params.NumberOfNodes, params.StartPort, params.MgmtContractAddr.Hex(), []string{params.ObxErc20Address.Hex(), params.EthErc20Address.Hex()})
 
 	// We start the Docker containers.
 	for id := range n.containerIDs {

--- a/integration/simulation/network/geth_network.go
+++ b/integration/simulation/network/geth_network.go
@@ -28,7 +28,7 @@ func NewNetworkInMemoryGeth(wallets *params.SimWallets) Network {
 // Create inits and starts the nodes, wires them up, and populates the network objects
 func (n *networkInMemGeth) Create(params *params.SimParams, stats *stats.Stats) (*RPCHandles, error) {
 	// kickoff the network with the prefunded wallet addresses
-	params.MgmtContractAddr, params.BtcErc20Address, params.EthErc20Address, n.gethClients, n.gethNetwork = SetUpGethNetwork(
+	params.MgmtContractAddr, params.ObxErc20Address, params.EthErc20Address, n.gethClients, n.gethNetwork = SetUpGethNetwork(
 		n.wallets,
 		params.StartPort,
 		params.NumberOfNodes,
@@ -36,7 +36,7 @@ func (n *networkInMemGeth) Create(params *params.SimParams, stats *stats.Stats) 
 	)
 
 	params.MgmtContractLib = mgmtcontractlib.NewMgmtContractLib(params.MgmtContractAddr)
-	params.ERC20ContractLib = erc20contractlib.NewERC20ContractLib(params.MgmtContractAddr, params.BtcErc20Address, params.EthErc20Address)
+	params.ERC20ContractLib = erc20contractlib.NewERC20ContractLib(params.MgmtContractAddr, params.ObxErc20Address, params.EthErc20Address)
 
 	// Start the obscuro nodes and return the handles
 	var walletClients map[string]rpcclientlib.Client

--- a/integration/simulation/network/inmemory.go
+++ b/integration/simulation/network/inmemory.go
@@ -37,8 +37,8 @@ func (n *basicNetworkOfInMemoryNodes) Create(params *params.SimParams, stats *st
 	n.obscuroClients = make([]rpcclientlib.Client, params.NumberOfNodes)
 
 	// Invent some addresses to assign as the L1 erc20 contracts
-	dummyBTCAddress := common.HexToAddress("AA")
-	params.Wallets.Tokens[bridge.BTC].L1ContractAddress = &dummyBTCAddress
+	dummyOBXAddress := common.HexToAddress("AA")
+	params.Wallets.Tokens[bridge.OBX].L1ContractAddress = &dummyOBXAddress
 	dummyETHAddress := common.HexToAddress("BB")
 	params.Wallets.Tokens[bridge.ETH].L1ContractAddress = &dummyETHAddress
 

--- a/integration/simulation/network/socket.go
+++ b/integration/simulation/network/socket.go
@@ -35,7 +35,7 @@ func NewNetworkOfSocketNodes(wallets *params.SimWallets) Network {
 
 func (n *networkOfSocketNodes) Create(params *params.SimParams, stats *stats.Stats) (*RPCHandles, error) {
 	// kickoff the network with the prefunded wallet addresses
-	params.MgmtContractAddr, params.BtcErc20Address, params.EthErc20Address, n.gethClients, n.gethNetwork = SetUpGethNetwork(
+	params.MgmtContractAddr, params.ObxErc20Address, params.EthErc20Address, n.gethClients, n.gethNetwork = SetUpGethNetwork(
 		n.wallets,
 		params.StartPort,
 		params.NumberOfNodes,
@@ -43,7 +43,7 @@ func (n *networkOfSocketNodes) Create(params *params.SimParams, stats *stats.Sta
 	)
 
 	params.MgmtContractLib = mgmtcontractlib.NewMgmtContractLib(params.MgmtContractAddr)
-	params.ERC20ContractLib = erc20contractlib.NewERC20ContractLib(params.MgmtContractAddr, params.BtcErc20Address, params.EthErc20Address)
+	params.ERC20ContractLib = erc20contractlib.NewERC20ContractLib(params.MgmtContractAddr, params.ObxErc20Address, params.EthErc20Address)
 
 	// Start the enclaves
 	startRemoteEnclaveServers(0, params, stats)

--- a/integration/simulation/params/params.go
+++ b/integration/simulation/params/params.go
@@ -35,9 +35,9 @@ type SimParams struct {
 	// MgmtContractAddr defines the management contract address
 	MgmtContractAddr *common.Address
 
-	// BtcErc20Address - the address of the "Btc" ERC20
-	BtcErc20Address *common.Address
-	// EthErc20Address - the address of the "Eth" ERC20
+	// ObxErc20Address - the address of the "OBX" ERC20
+	ObxErc20Address *common.Address
+	// EthErc20Address - the address of the "ETH" ERC20
 	EthErc20Address *common.Address
 
 	// Contains all the wallets required by the simulation

--- a/integration/simulation/params/wallet_utils.go
+++ b/integration/simulation/params/wallet_utils.go
@@ -54,17 +54,17 @@ func NewSimWallets(nrSimWallets int, nNodes int, ethereumChainID int64, obscuroC
 	mcOwnerWallet := datagenerator.RandomWallet(ethereumChainID)
 
 	// create the L1 addresses of the two tokens, and connect them to the hardcoded addresses from the enclave
-	btc := SimToken{
-		Name:              bridge.BTC,
+	obx := SimToken{
+		Name:              bridge.OBX,
 		L1Owner:           datagenerator.RandomWallet(ethereumChainID),
-		L2Owner:           wallet.NewInMemoryWalletFromPK(big.NewInt(obscuroChainID), bridge.WBtcOwner),
-		L2ContractAddress: &bridge.WBtcContract,
+		L2Owner:           wallet.NewInMemoryWalletFromPK(big.NewInt(obscuroChainID), bridge.WOBXOwner),
+		L2ContractAddress: &bridge.WOBXContract,
 	}
 	eth := SimToken{
 		Name:              bridge.ETH,
 		L1Owner:           datagenerator.RandomWallet(ethereumChainID),
-		L2Owner:           wallet.NewInMemoryWalletFromPK(big.NewInt(obscuroChainID), bridge.WEthOnwer),
-		L2ContractAddress: &bridge.WEthContract,
+		L2Owner:           wallet.NewInMemoryWalletFromPK(big.NewInt(obscuroChainID), bridge.WETHOwner),
+		L2ContractAddress: &bridge.WETHContract,
 	}
 
 	return &SimWallets{
@@ -73,7 +73,7 @@ func NewSimWallets(nrSimWallets int, nNodes int, ethereumChainID int64, obscuroC
 		SimEthWallets: simEthWallets,
 		SimObsWallets: simObsWallets,
 		Tokens: map[bridge.ERC20]*SimToken{
-			bridge.BTC: &btc,
+			bridge.OBX: &obx,
 			bridge.ETH: &eth,
 		},
 	}
@@ -89,7 +89,7 @@ func (w *SimWallets) AllEthWallets() []wallet.Wallet {
 
 func (w *SimWallets) AllEthAddresses() []*common.Address {
 	addresses := make([]*common.Address, 0)
-	addresses = append(addresses, w.Tokens[bridge.BTC].L1ContractAddress)
+	addresses = append(addresses, w.Tokens[bridge.OBX].L1ContractAddress)
 	addresses = append(addresses, w.Tokens[bridge.ETH].L1ContractAddress)
 	return addresses
 }

--- a/integration/simulation/transaction_injector.go
+++ b/integration/simulation/transaction_injector.go
@@ -115,7 +115,7 @@ func NewTransactionInjector(
 // Deposits an initial balance in to each wallet
 // Generates and issues L1 and L2 transactions to the network
 func (ti *TransactionInjector) Start() {
-	ti.deployObscuroERC20(ti.wallets.Tokens[bridge.BTC].L2Owner)
+	ti.deployObscuroERC20(ti.wallets.Tokens[bridge.OBX].L2Owner)
 	ti.deployObscuroERC20(ti.wallets.Tokens[bridge.ETH].L2Owner)
 
 	// enough time to process everywhere
@@ -127,7 +127,7 @@ func (ti *TransactionInjector) Start() {
 		txData := &ethadapter.L1DepositTx{
 			Amount:        initialBalance,
 			To:            ti.mgmtContractAddr,
-			TokenContract: ti.wallets.Tokens[bridge.BTC].L1ContractAddress,
+			TokenContract: ti.wallets.Tokens[bridge.OBX].L1ContractAddress,
 			Sender:        &addr,
 		}
 		tx := ti.erc20ContractLib.CreateDepositTx(txData, w.GetNonceAndIncrement())
@@ -243,7 +243,7 @@ func (ti *TransactionInjector) issueRandomDeposits() {
 		txData := &ethadapter.L1DepositTx{
 			Amount:        v,
 			To:            ti.mgmtContractAddr,
-			TokenContract: ti.wallets.Tokens[bridge.BTC].L1ContractAddress,
+			TokenContract: ti.wallets.Tokens[bridge.OBX].L1ContractAddress,
 			Sender:        &addr,
 		}
 		tx := ti.erc20ContractLib.CreateDepositTx(txData, ethWallet.GetNonceAndIncrement())
@@ -373,7 +373,7 @@ func (ti *TransactionInjector) newTx(data []byte, nonce uint64) types.TxData {
 		Gas:      gas,
 		GasPrice: gethcommon.Big0,
 		Data:     data,
-		To:       ti.wallets.Tokens[bridge.BTC].L2ContractAddress,
+		To:       ti.wallets.Tokens[bridge.OBX].L2ContractAddress,
 	}
 }
 

--- a/integration/simulation/validate_chain.go
+++ b/integration/simulation/validate_chain.go
@@ -272,7 +272,7 @@ func checkBlockchainOfObscuroNode(
 	totalAmountInSystem := s.Stats.TotalDepositedAmount - totalSuccessfullyWithdrawn
 	total := uint64(0)
 	for _, wallet := range s.Params.Wallets.SimObsWallets {
-		total += balance(nodeClient, wallet.Address(), s.Params.Wallets.Tokens[bridge.BTC].L2ContractAddress)
+		total += balance(nodeClient, wallet.Address(), s.Params.Wallets.Tokens[bridge.OBX].L2ContractAddress)
 	}
 
 	if total != totalAmountInSystem {

--- a/integration/walletextension/wallet_extension_test.go
+++ b/integration/walletextension/wallet_extension_test.go
@@ -206,7 +206,7 @@ func TestCannotCallWithoutSubmittingViewingKey(t *testing.T) {
 	// deposit any funds in the ERC20 contract.
 	transferTxBytes := erc20contractlib.CreateTransferTxData(accountAddress, 0)
 	reqParams := map[string]interface{}{
-		reqJSONKeyTo:   bridge.WBtcContract,
+		reqJSONKeyTo:   bridge.WOBXContract,
 		reqJSONKeyFrom: accountAddress.String(),
 		reqJSONKeyData: "0x" + common.Bytes2Hex(transferTxBytes),
 	}
@@ -246,7 +246,7 @@ func TestCanCallAfterSubmittingViewingKey(t *testing.T) {
 	balanceData := erc20contractlib.CreateBalanceOfData(accountAddress)
 	convertedData := (hexutil.Bytes)(balanceData)
 	reqParams := map[string]interface{}{
-		reqJSONKeyTo:   bridge.WBtcContract.Hex(),
+		reqJSONKeyTo:   bridge.WOBXContract.Hex(),
 		reqJSONKeyFrom: accountAddress.String(),
 		reqJSONKeyData: convertedData,
 	}
@@ -285,7 +285,7 @@ func TestCanCallWithoutSettingFromField(t *testing.T) {
 	balanceData := erc20contractlib.CreateBalanceOfData(accountAddress)
 	convertedData := (hexutil.Bytes)(balanceData)
 	reqParams := map[string]interface{}{
-		reqJSONKeyTo:   bridge.WBtcContract,
+		reqJSONKeyTo:   bridge.WOBXContract,
 		reqJSONKeyData: convertedData,
 	}
 	callJSON := makeEthJSONReqAsJSON(t, walletExtensionAddr, rpcclientlib.RPCCall, []interface{}{reqParams, latestBlock})
@@ -322,7 +322,7 @@ func TestCannotCallForAnotherAddressAfterSubmittingViewingKey(t *testing.T) {
 	balanceData := erc20contractlib.CreateBalanceOfData(dummyAccountAddress)
 	convertedData := (hexutil.Bytes)(balanceData)
 	reqParams := map[string]interface{}{
-		reqJSONKeyTo: bridge.WBtcContract,
+		reqJSONKeyTo: bridge.WOBXContract,
 		// We send the request from a different address than the one we created a viewing key for.
 		reqJSONKeyFrom: dummyAccountAddress.Hex(),
 		reqJSONKeyData: convertedData,
@@ -633,7 +633,7 @@ func createObscuroNetwork(t *testing.T) (func(), error) {
 	}
 
 	// Deploy an ERC20 contract to the Obscuro network.
-	txWallet := wallets.Tokens[bridge.BTC].L2Owner
+	txWallet := wallets.Tokens[bridge.OBX].L2Owner
 	deployContractTx := types.LegacyTx{
 		Nonce:    simulation.NextNonce(clients, txWallet),
 		Gas:      1025_000_000,


### PR DESCRIPTION
### Why is this change needed?

At the moment the two hardcoded ERC20 contracts are called BTC and ETH. I'm going to rename the BTC one to OBX if there are no objections. Long term we might not be modelling OBX as an ERC20, but for now we want one of our bridge-able tokens should be 'canonical' OBX

### What changes were made as part of this PR:

*refactor*
- rename BTC to OBX
- some tidying up