### PR TITLE
Waits for host when starting wallet extension.

### DIFF
--- a/tools/walletextension/main/main.go
+++ b/tools/walletextension/main/main.go
@@ -16,6 +16,8 @@ const (
 
 func main() {
 	config := parseCLIArgs()
+	jsonConfig, _ := json.MarshalIndent(config, "", "  ")
+	fmt.Printf("Wallet extension starting with following config: \n%s\n", string(jsonConfig))
 
 	// We wait thirty seconds for a connection to the node. If we cannot establish one, we exit the program.
 	fmt.Printf("Waiting up to thirty seconds for connection to host at %s...\n", config.NodeRPCHTTPAddress)
@@ -31,7 +33,7 @@ func main() {
 
 		counter--
 		if counter <= 0 {
-			fmt.Printf("Could not establish connection to host at %s. Exiting.", config.NodeRPCHTTPAddress)
+			fmt.Printf("Exiting. Could not establish connection to host at %s. Cause: %s\n", config.NodeRPCHTTPAddress, err)
 			return
 		}
 		time.Sleep(time.Second)
@@ -41,9 +43,7 @@ func main() {
 	defer walletExtension.Shutdown()
 	walletExtensionAddr := fmt.Sprintf("%s:%d", localhost, config.WalletExtensionPort)
 	go walletExtension.Serve(walletExtensionAddr)
-	s, _ := json.MarshalIndent(config, "", "  ")
-	fmt.Printf("Wallet extension started with following config: \n%s\n\n", string(s))
-	fmt.Printf("💡 Visit http://%s/viewingkeys/ to generate an ephemeral viewing key.\n", walletExtensionAddr)
+	fmt.Printf("💡 Wallet extension started - visit http://%s/viewingkeys/ to generate an ephemeral viewing key.\n", walletExtensionAddr)
 
 	select {}
 }

--- a/tools/walletextension/main/main.go
+++ b/tools/walletextension/main/main.go
@@ -3,25 +3,47 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"net"
+	"time"
 
 	"github.com/obscuronet/go-obscuro/tools/walletextension"
 )
 
 const (
+	tcp       = "tcp"
 	localhost = "127.0.0.1"
 )
 
 func main() {
 	config := parseCLIArgs()
+
+	// We wait thirty seconds for a connection to the node. If we cannot establish one, we exit the program.
+	fmt.Printf("Waiting up to thirty seconds for connection to host at %s...\n", config.NodeRPCHTTPAddress)
+	counter := 30
+	for {
+		conn, err := net.Dial(tcp, config.NodeRPCHTTPAddress)
+		if conn != nil {
+			conn.Close()
+		}
+		if err == nil {
+			break
+		}
+
+		counter--
+		if counter <= 0 {
+			fmt.Printf("Could not establish connection to host at %s. Exiting.", config.NodeRPCHTTPAddress)
+			return
+		}
+		time.Sleep(time.Second)
+	}
+
 	walletExtension := walletextension.NewWalletExtension(config)
 	defer walletExtension.Shutdown()
-
 	walletExtensionAddr := fmt.Sprintf("%s:%d", localhost, config.WalletExtensionPort)
 	go walletExtension.Serve(walletExtensionAddr)
 	s, _ := json.MarshalIndent(config, "", "  ")
-	fmt.Printf("Wallet extension config: \n%s", string(s))
-	fmt.Println()
-	fmt.Printf("Wallet extension started.\n💡 Visit http://%s/viewingkeys/ to generate an ephemeral viewing key.\n", walletExtensionAddr)
+	fmt.Printf("Wallet extension started with following config: \n%s\n\n", string(s))
+	fmt.Printf("💡 Visit http://%s/viewingkeys/ to generate an ephemeral viewing key.\n", walletExtensionAddr)
 
 	select {}
 }


### PR DESCRIPTION
### Why is this change needed?

See https://github.com/obscuronet/obscuro-internal/issues/665.

Previously, the wallet extension would immediately start taking requests and trying to send them to the host. These requests would eventually lead to timeouts, but it wasn't always clear whether it was a genuine timeout, or the host just couldn't be reached.

### What changes were made as part of this PR:

Functional.

- Wallet extension pauses at start-up for 30 seconds to try and connect to host, and exits if it cannot connect

### What are the key areas to look at
