### PR TITLE
Return nil rather than error for non-existent receipt

### DIFF
--- a/go/enclave/db/interfaces.go
+++ b/go/enclave/db/interfaces.go
@@ -74,7 +74,7 @@ type TransactionStorage interface {
 	GetReceiptsByHash(hash gethcommon.Hash) types.Receipts
 
 	// GetTransaction - returns the positional metadata of the tx by hash
-	GetTransaction(txHash gethcommon.Hash) (*types.Transaction, gethcommon.Hash, uint64, uint64, error)
+	GetTransaction(txHash gethcommon.Hash) (*types.Transaction, gethcommon.Hash, uint64, uint64)
 
 	// GetTransactionReceipt - returns the receipt of a tx by tx hash
 	GetTransactionReceipt(txHash gethcommon.Hash) (*types.Receipt, error)

--- a/go/enclave/db/storage.go
+++ b/go/enclave/db/storage.go
@@ -3,6 +3,7 @@ package db
 import (
 	"bytes"
 	"crypto/ecdsa"
+	"errors"
 	"fmt"
 
 	"github.com/obscuronet/go-obscuro/go/common/log"
@@ -26,6 +27,9 @@ type storageImpl struct {
 	nodeID      uint64
 	chainConfig *params.ChainConfig
 }
+
+// ErrTxNotFound indicates that a transaction could not be found.
+var ErrTxNotFound = errors.New("transaction not found")
 
 func NewStorage(backingDB ethdb.Database, nodeID uint64, chainConfig *params.ChainConfig) Storage {
 	return &storageImpl{
@@ -267,18 +271,15 @@ func (s *storageImpl) GetReceiptsByHash(hash gethcommon.Hash) types.Receipts {
 	return receipts
 }
 
-func (s *storageImpl) GetTransaction(txHash gethcommon.Hash) (*types.Transaction, gethcommon.Hash, uint64, uint64, error) {
+func (s *storageImpl) GetTransaction(txHash gethcommon.Hash) (*types.Transaction, gethcommon.Hash, uint64, uint64) {
 	tx, blockHash, blockNumber, index := obscurorawdb.ReadTransaction(s.db, txHash)
-	return tx, blockHash, blockNumber, index, nil
+	return tx, blockHash, blockNumber, index
 }
 
 func (s *storageImpl) GetSender(txHash gethcommon.Hash) (gethcommon.Address, error) {
-	tx, _, _, _, err := s.GetTransaction(txHash) //nolint:dogsled
-	if err != nil {
-		return gethcommon.Address{}, fmt.Errorf("could not retrieve transaction with hash %s. Cause: %w", txHash.Hex(), err)
-	}
+	tx, _, _, _ := s.GetTransaction(txHash) //nolint:dogsled
 	if tx == nil {
-		return gethcommon.Address{}, fmt.Errorf("could not retrieve transaction with hash %s", txHash.Hex())
+		return gethcommon.Address{}, ErrTxNotFound
 	}
 	// todo - make the signer a field of the rollup chain
 	msg, err := tx.AsMessage(types.NewLondonSigner(tx.ChainId()), nil)
@@ -289,7 +290,11 @@ func (s *storageImpl) GetSender(txHash gethcommon.Hash) (gethcommon.Address, err
 }
 
 func (s *storageImpl) GetTransactionReceipt(txHash gethcommon.Hash) (*types.Receipt, error) {
-	_, blockHash, _, index := obscurorawdb.ReadTransaction(s.db, txHash)
+	tx, blockHash, _, index := obscurorawdb.ReadTransaction(s.db, txHash)
+	if tx == nil {
+		return nil, ErrTxNotFound
+	}
+
 	receipts := s.GetReceiptsByHash(blockHash)
 	if len(receipts) <= int(index) {
 		return nil, fmt.Errorf("receipt index not matching the transactions in block: %s", blockHash.Hex())

--- a/go/host/client_api_eth.go
+++ b/go/host/client_api_eth.go
@@ -77,6 +77,9 @@ func (api *EthereumAPI) GetTransactionReceipt(_ context.Context, encryptedParams
 	if err != nil {
 		return nil, err
 	}
+	if encryptedResponse == nil {
+		return nil, err
+	}
 	encryptedResponseHex := gethcommon.Bytes2Hex(encryptedResponse)
 	return &encryptedResponseHex, nil
 }

--- a/go/host/client_api_eth.go
+++ b/go/host/client_api_eth.go
@@ -72,12 +72,13 @@ func (api *EthereumAPI) Call(_ context.Context, encryptedParams common.Encrypted
 
 // GetTransactionReceipt returns the transaction receipt for the given transaction hash, encrypted with the viewing key
 // corresponding to the original transaction submitter and encoded as hex.
-func (api *EthereumAPI) GetTransactionReceipt(_ context.Context, encryptedParams common.EncryptedParamsGetTxReceipt) (string, error) {
+func (api *EthereumAPI) GetTransactionReceipt(_ context.Context, encryptedParams common.EncryptedParamsGetTxReceipt) (*string, error) {
 	encryptedResponse, err := api.host.EnclaveClient.GetTransactionReceipt(encryptedParams)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return gethcommon.Bytes2Hex(encryptedResponse), nil
+	encryptedResponseHex := gethcommon.Bytes2Hex(encryptedResponse)
+	return &encryptedResponseHex, nil
 }
 
 // EstimateGas is a placeholder for an RPC method required by MetaMask/Remix.

--- a/go/host/enclave_client.go
+++ b/go/host/enclave_client.go
@@ -313,6 +313,7 @@ func (c *EnclaveRPCClient) GetTransactionReceipt(encryptedParams common.Encrypte
 	if err != nil {
 		return nil, err
 	}
+
 	return response.EncryptedTxReceipt, nil
 }
 

--- a/go/host/enclave_client.go
+++ b/go/host/enclave_client.go
@@ -313,7 +313,6 @@ func (c *EnclaveRPCClient) GetTransactionReceipt(encryptedParams common.Encrypte
 	if err != nil {
 		return nil, err
 	}
-
 	return response.EncryptedTxReceipt, nil
 }
 

--- a/go/host/in_mem_obscuro_client.go
+++ b/go/host/in_mem_obscuro_client.go
@@ -160,7 +160,7 @@ func (c *inMemObscuroClient) getTransactionReceipt(result interface{}, args []in
 	if err != nil {
 		return fmt.Errorf("`obscuro_getTransactionReceipt` call failed. Cause: %w", err)
 	}
-	*result.(*string) = encryptedResponse
+	*result.(*string) = *encryptedResponse
 	return nil
 }
 

--- a/go/rpcclientlib/obscuro_client.go
+++ b/go/rpcclientlib/obscuro_client.go
@@ -166,6 +166,11 @@ func (c *networkClient) encryptParamBytes(params []byte) ([]byte, error) {
 }
 
 func (c *networkClient) decryptResponse(resultBlob interface{}) ([]byte, error) {
+	// For some RPC operations, a nil is a valid response (e.g. the transaction for an unrecognised transaction hash).
+	if resultBlob == nil {
+		return nil, nil
+	}
+
 	if c.viewingPrivKey == nil {
 		// todo: remove this non-decryption part when we make viewing key encryption mandatory across all tests
 		// extract result from the data as-is, in case we can't decrypt/process it below

--- a/integration/walletextension/wallet_extension_test.go
+++ b/integration/walletextension/wallet_extension_test.go
@@ -661,7 +661,8 @@ func createObscuroNetwork(t *testing.T) (func(), error) {
 			t.Fatalf("could not get receipt for Obscuro ERC20 deployment transaction after 20 seconds")
 		}
 		txReceiptResp := makeEthJSONReq(t, walletExtensionAddr, rpcclientlib.RPCGetTxReceipt, []string{txHash})
-		isTxOnChain := !strings.Contains(string(txReceiptResp), "could not retrieve transaction with hash")
+		// We check whether the transaction receipt request gives a nil result, meaning the receipt isn't available.
+		isTxOnChain := !strings.Contains(string(txReceiptResp), "\"result\":\"\"")
 		if isTxOnChain {
 			break
 		}


### PR DESCRIPTION
### Why is this change needed?

Geth returns `nil` if you request a transaction receipt that does not exist via RPC. Our RPC API returns an error instead. We should follow their approach.

### What changes were made as part of this PR:

Functional.

- Return `nil` receipt for transaction receipt if transaction cannot be found
- Skip decryption in RPC client if result is `nil`

### What are the key areas to look at
