### PR TITLE
Return nil rather than error for unfound transactions and blocks

### DIFF
--- a/go/common/enclave.go
+++ b/go/common/enclave.go
@@ -68,10 +68,10 @@ type Enclave interface {
 	// GetTransactionReceipt returns a transaction receipt given its signed hash, or nil if the transaction is unknown
 	GetTransactionReceipt(encryptedParams EncryptedParamsGetTxReceipt) (EncryptedResponseGetTxReceipt, error)
 
-	// GetRollup returns the rollup with the given hash
+	// GetRollup returns the rollup with the given hash, or nil if no such rollup exists.
 	GetRollup(rollupHash L2RootHash) (*ExtRollup, error)
 
-	// GetRollupByHeight returns the canonical rollup with the given height.
+	// GetRollupByHeight returns the canonical rollup with the given height, or nil if no such rollup exists.
 	GetRollupByHeight(rollupHeight int64) (*ExtRollup, error)
 
 	// AddViewingKey - Decrypts, verifies and saves viewing keys.

--- a/go/enclave/db/interfaces.go
+++ b/go/enclave/db/interfaces.go
@@ -74,7 +74,7 @@ type TransactionStorage interface {
 	GetReceiptsByHash(hash gethcommon.Hash) types.Receipts
 
 	// GetTransaction - returns the positional metadata of the tx by hash
-	GetTransaction(txHash gethcommon.Hash) (*types.Transaction, gethcommon.Hash, uint64, uint64)
+	GetTransaction(txHash gethcommon.Hash) (*types.Transaction, gethcommon.Hash, uint64, uint64, error)
 
 	// GetTransactionReceipt - returns the receipt of a tx by tx hash
 	GetTransactionReceipt(txHash gethcommon.Hash) (*types.Receipt, error)

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -334,11 +334,12 @@ func (e *enclaveImpl) GetTransaction(encryptedParams common.EncryptedParamsGetTx
 	txHash := gethcommon.HexToHash(paramList[0])
 
 	// Unlike in the Geth impl, we do not try and retrieve unconfirmed transactions from the mempool.
-	tx, blockHash, blockNumber, index := e.storage.GetTransaction(txHash)
-
-	if tx == nil {
-		// If there's no transaction, there's no `from` field we can use to determine which key to use to encrypt the response.
-		return nil, fmt.Errorf("transaction does not exist")
+	tx, blockHash, blockNumber, index, err := e.storage.GetTransaction(txHash)
+	if err != nil {
+		if errors.Is(err, db.ErrTxNotFound) {
+			return nil, nil
+		}
+		return nil, err
 	}
 
 	// Unlike in the Geth impl, we hardcode the use of a London signer.

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -385,24 +385,23 @@ func (e *enclaveImpl) GetTransactionReceipt(encryptedParams common.EncryptedPara
 
 func (e *enclaveImpl) GetRollup(rollupHash common.L2RootHash) (*common.ExtRollup, error) {
 	rollup, found := e.storage.FetchRollup(rollupHash)
-	if found {
-		extRollup := e.transactionBlobCrypto.ToExtRollup(rollup)
-		return &extRollup, nil
+	if !found {
+		return nil, nil //nolint:nilnil
 	}
-	return nil, fmt.Errorf("rollup with hash %s could not be found", rollupHash.Hex())
+	extRollup := e.transactionBlobCrypto.ToExtRollup(rollup)
+	return &extRollup, nil
 }
 
 func (e *enclaveImpl) GetRollupByHeight(rollupHeight int64) (*common.ExtRollup, error) {
 	// TODO - Consider improving efficiency by directly fetching rollup by number.
 	rollup := e.storage.FetchHeadRollup()
-	maxRollupHeight := rollup.NumberU64()
 
 	// -1 is used by Ethereum to indicate that we should fetch the head.
 	if rollupHeight != -1 {
 		for {
 			if rollup == nil {
 				// We've reached the head of the chain without finding the block.
-				return nil, fmt.Errorf("rollup with height %d could not be found. Max rollup height was %d", rollupHeight, maxRollupHeight)
+				return nil, nil //nolint:nilnil
 			}
 			if rollup.Number().Int64() == rollupHeight {
 				// We have found the block.
@@ -410,7 +409,7 @@ func (e *enclaveImpl) GetRollupByHeight(rollupHeight int64) (*common.ExtRollup, 
 			}
 			if rollup.Number().Int64() < rollupHeight {
 				// The current block number is below the sought number. Continuing to walk up the chain is pointless.
-				return nil, fmt.Errorf("rollup with height %d could not be found. Max rollup height was %d", rollupHeight, maxRollupHeight)
+				return nil, nil //nolint:nilnil
 			}
 
 			// We grab the next rollup and loop.

--- a/go/host/client_api_eth.go
+++ b/go/host/client_api_eth.go
@@ -46,6 +46,9 @@ func (api *EthereumAPI) GetBalance(_ context.Context, encryptedParams common.Enc
 // GetBlockByNumber returns the rollup with the given height as a block. No transactions are included.
 func (api *EthereumAPI) GetBlockByNumber(_ context.Context, number rpc.BlockNumber, _ bool) (map[string]interface{}, error) {
 	extRollup, err := api.host.EnclaveClient.GetRollupByHeight(number.Int64())
+	if extRollup == nil {
+		return nil, err
+	}
 	return extRollupToBlock(extRollup), err
 }
 
@@ -78,7 +81,7 @@ func (api *EthereumAPI) GetTransactionReceipt(_ context.Context, encryptedParams
 		return nil, err
 	}
 	if encryptedResponse == nil {
-		return nil, err
+		return nil, nil //nolint:nilnil
 	}
 	encryptedResponseHex := gethcommon.Bytes2Hex(encryptedResponse)
 	return &encryptedResponseHex, nil

--- a/go/host/client_api_eth.go
+++ b/go/host/client_api_eth.go
@@ -71,7 +71,7 @@ func (api *EthereumAPI) Call(_ context.Context, encryptedParams common.Encrypted
 }
 
 // GetTransactionReceipt returns the transaction receipt for the given transaction hash, encrypted with the viewing key
-// corresponding to the original transaction submitter and encoded as hex.
+// corresponding to the original transaction submitter and encoded as hex, or nil if no matching transaction exists.
 func (api *EthereumAPI) GetTransactionReceipt(_ context.Context, encryptedParams common.EncryptedParamsGetTxReceipt) (*string, error) {
 	encryptedResponse, err := api.host.EnclaveClient.GetTransactionReceipt(encryptedParams)
 	if err != nil {
@@ -126,13 +126,17 @@ func (api *EthereumAPI) GetTransactionCount(_ context.Context, address gethcommo
 }
 
 // GetTransactionByHash returns the transaction with the given hash, encrypted with the viewing key corresponding to the
-// `from` field and encoded as hex.
-func (api *EthereumAPI) GetTransactionByHash(_ context.Context, encryptedParams common.EncryptedParamsGetTxByHash) (string, error) {
+// `from` field and encoded as hex, or nil if no matching transaction exists.
+func (api *EthereumAPI) GetTransactionByHash(_ context.Context, encryptedParams common.EncryptedParamsGetTxByHash) (*string, error) {
 	encryptedResponse, err := api.host.EnclaveClient.GetTransaction(encryptedParams)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return gethcommon.Bytes2Hex(encryptedResponse), nil
+	if encryptedResponse == nil {
+		return nil, err
+	}
+	encryptedResponseHex := gethcommon.Bytes2Hex(encryptedResponse)
+	return &encryptedResponseHex, nil
 }
 
 // Maps an external rollup to a block.

--- a/go/host/in_mem_obscuro_client.go
+++ b/go/host/in_mem_obscuro_client.go
@@ -120,7 +120,7 @@ func (c *inMemObscuroClient) getTransactionByHash(result interface{}, args []int
 	if err != nil {
 		return fmt.Errorf("`eth_getTransactionByHash` call failed. Cause: %w", err)
 	}
-	*result.(*string) = encryptedTx
+	*result.(*string) = *encryptedTx
 	return nil
 }
 


### PR DESCRIPTION
### Why is this change needed?

External tooling will work better if we align ourselves to the Geth API, which returns nil rather than error for the following API methods:

* `GetBlockByNumber`
* `GetBlockByHash`
* `GetTransactionByHash`

### What changes were made as part of this PR:

Functional.

- Methods above now return `nil` instead of error

### What are the key areas to look at
