### PR TITLE
Avoids endless HTTP hops when retrieving latest transactions.

### DIFF
--- a/go/host/client_api_obscuro.go
+++ b/go/host/client_api_obscuro.go
@@ -57,7 +57,7 @@ func (api *ObscuroAPI) GetRollupHeaderByNumber(number *big.Int) (*common.Header,
 	if rollupHash == nil {
 		return nil, fmt.Errorf("no rollup with number %d is stored", number.Int64())
 	}
-	
+
 	rollupHeader := api.host.nodeDB.GetRollupHeader(*rollupHash)
 	if rollupHeader == nil {
 		return nil, fmt.Errorf("storage indicates that rollup %d has hash %s, but no such rollup is stored", number.Int64(), rollupHash)

--- a/go/rpcclientlib/obscuro_client.go
+++ b/go/rpcclientlib/obscuro_client.go
@@ -27,6 +27,7 @@ const (
 	RPCNonce                   = "obscuro_nonce"
 	RPCAddViewingKey           = "obscuro_addViewingKey"
 	RPCGetRollupForTx          = "obscuro_getRollupForTx"
+	RPCGetLatestTxs            = "obscuro_getLatestTransactions"
 	RPCStopHost                = "obscuro_stopHost"
 	RPCCall                    = "eth_call"
 	RPCChainID                 = "eth_chainId"

--- a/tools/obscuroscan/obscuroscan.go
+++ b/tools/obscuroscan/obscuroscan.go
@@ -158,37 +158,22 @@ func (o *Obscuroscan) getLatestRollups(resp http.ResponseWriter, _ *http.Request
 
 // Retrieves the last five transaction hashes.
 func (o *Obscuroscan) getLatestTxs(resp http.ResponseWriter, _ *http.Request) {
-	rollupNum, err := o.getLatestRollupNumber()
+	numTransactions := 5
+
+	var txHashes []gethcommon.Hash
+	err := o.client.Call(&txHashes, rpcclientlib.RPCGetLatestTxs, numTransactions)
 	if err != nil {
 		log.Error(err.Error())
 		logAndSendErr(resp, "Could not fetch latest transactions.")
-		return
 	}
 
-	// We walk the chain of rollups, getting the transaction hashes until we've hit at least five.
-	var txHashes []string
-	for {
-		rollup, err := o.getRollupByNumber(int(rollupNum))
-		if err != nil {
-			log.Error(err.Error())
-			logAndSendErr(resp, "Could not fetch latest transactions.")
-			return
-		}
-
-		for _, txHash := range rollup.TxHashes {
-			txHashes = append(txHashes, txHash.String())
-		}
-		if len(txHashes) >= 5 {
-			// It's fine if we return more than five transaction hashes; the front-end will ignore the later ones.
-			break
-		}
-
-		rollupNum--
-		if rollupNum < 0 {
-			for idx := 0; idx < 5-len(txHashes); idx++ {
-				txHashes = append(txHashes, "N/A")
-			}
-			break
+	// We convert the hashes to strings and pad with N/As as needed.
+	txHashStrings := make([]string, numTransactions)
+	for idx := 0; idx < numTransactions; idx++ {
+		if idx < len(txHashes) {
+			txHashStrings[idx] = txHashes[idx].String()
+		} else {
+			txHashStrings[idx] = "N/A"
 		}
 	}
 

--- a/tools/obscuroscan/static/index.js
+++ b/tools/obscuroscan/static/index.js
@@ -55,17 +55,16 @@ async function updateLatestRollups() {
     const rollupFiveField = document.getElementById(idRollupFive);
 
     const latestRollupsResp = await fetch(pathLatestRollups);
-    const latestRollupsRespText = await latestRollupsResp.text()
 
     if (latestRollupsResp.ok) {
-        const latestRollupsJSON = JSON.parse(latestRollupsRespText);
+        const latestRollupsJSON = JSON.parse(await latestRollupsResp.text());
         rollupOneField.innerText = latestRollupsJSON[0];
         rollupTwoField.innerText = latestRollupsJSON[1];
         rollupThreeField.innerText = latestRollupsJSON[2];
         rollupFourField.innerText = latestRollupsJSON[3];
         rollupFiveField.innerText = latestRollupsJSON[4];
     } else {
-        const errMsg = "Failed to fetch latest rollups. Cause: " + latestRollupsRespText
+        const errMsg = "Failed to fetch latest rollups."
         rollupOneField.innerText = errMsg;
         rollupTwoField.innerText = errMsg;
         rollupThreeField.innerText = errMsg;
@@ -83,17 +82,16 @@ async function updateLatestTxs() {
     const txFiveField = document.getElementById(idTxFive);
 
     const latestTxsResp = await fetch(pathLatestTxs);
-    const latestTxsRespText = await latestTxsResp.text();
 
     if (latestTxsResp.ok) {
-        const latestTxsJSON = JSON.parse(latestTxsRespText);
+        const latestTxsJSON = JSON.parse(await latestTxsResp.text());
         txOneField.innerText = latestTxsJSON[0];
         txTwoField.innerText = latestTxsJSON[1];
         txThreeField.innerText = latestTxsJSON[2];
         txFourField.innerText = latestTxsJSON[3];
         txFiveField.innerText = latestTxsJSON[4];
     } else {
-        const errMsg = "Failed to fetch latest rollups. Cause: " + latestTxsRespText
+        const errMsg = "Failed to fetch latest rollups."
         txOneField.innerText = errMsg;
         txTwoField.innerText = errMsg;
         txThreeField.innerText = errMsg;


### PR DESCRIPTION
### Why is this change needed?

Currently, to retrieve the five latest transactions, ObscuroScan makes an RPC request for each rollup in turn, and checks its transactions. This is fine when there is reasonable network traffic, since only a few rollups will be checked. However, if the network is quiet (e.g. during a weekend initially, or before opening to external devs), you can have to work through thousands of rollups to find five transactions. This is very slow.

### What changes were made as part of this PR:

Refactoring.

- There's a single HTTP request between ObscuroScan and the host to get all the latest transactions, rather than one per rollup

### What are the key areas to look at
