### PR TITLE
Prevents potential Slowloris attack.

### DIFF
--- a/tools/obscuroscan/obscuroscan.go
+++ b/tools/obscuroscan/obscuroscan.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/obscuronet/go-obscuro/go/common/log"
 
@@ -86,7 +87,7 @@ func (o *Obscuroscan) Serve(hostAndPort string) {
 	}
 	serveMux.Handle(pathRoot, http.FileServer(http.FS(noPrefixStaticFiles)))
 
-	o.server = &http.Server{Addr: hostAndPort, Handler: serveMux}
+	o.server = &http.Server{Addr: hostAndPort, Handler: serveMux, ReadHeaderTimeout: 10 * time.Second}
 
 	err = o.server.ListenAndServe()
 	if !errors.Is(err, http.ErrServerClosed) {

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -11,6 +11,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/obscuronet/go-obscuro/go/common/log"
 
@@ -105,7 +106,7 @@ func (we *WalletExtension) Serve(hostAndPort string) {
 	}
 	serveMux.Handle(pathViewingKeys, http.StripPrefix(pathViewingKeys, http.FileServer(http.FS(noPrefixStaticFiles))))
 
-	we.server = &http.Server{Addr: hostAndPort, Handler: serveMux}
+	we.server = &http.Server{Addr: hostAndPort, Handler: serveMux, ReadHeaderTimeout: 10 * time.Second}
 
 	err = we.server.ListenAndServe()
 	if !errors.Is(err, http.ErrServerClosed) {


### PR DESCRIPTION
### Why is this change needed?

Linter was complaining about Slowloris attack, because ObscuroScan and the wallet extension never timeout requests.

### What changes were made as part of this PR:

Functional.

- Adds a ten-second timeout for requests to ObscuroScan and the wallet extension

### What are the key areas to look at
