### PR TITLE
Efficient retrieval of rollup given a tx hash

### DIFF
--- a/go/host/client_api_obscuro.go
+++ b/go/host/client_api_obscuro.go
@@ -53,7 +53,7 @@ func (api *ObscuroAPI) GetRollupHeader(hash gethcommon.Hash) *common.Header {
 
 // GetRollupHeaderByNumber returns the header for the rollup with the given number.
 func (api *ObscuroAPI) GetRollupHeaderByNumber(number *big.Int) (*common.Header, error) {
-	rollupHash := api.host.nodeDB.GetRollupHash(number)
+	rollupHash := api.host.nodeDB.GetRollupHashByNumber(number)
 	if rollupHash == nil {
 		return nil, fmt.Errorf("no rollup with number %d is stored", number.Int64())
 	}

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -475,7 +475,7 @@ func (a *Node) storeBlockProcessingResult(result common.BlockSubmissionResponse)
 	// only update the node rollup headers if the enclave has found a new rollup head
 	if result.FoundNewHead {
 		// adding a header will update the head if it has a higher height
-		a.DB().AddRollupHeader(result.RollupHead)
+		a.DB().AddRollupHeader(result.RollupHead, result.ProducedRollup.TxHashes)
 	}
 
 	// adding a header will update the head if it has a higher height


### PR DESCRIPTION
### Why is this change needed?

ObscuroScan needs the ability to retrieve rollups based on a transaction hash. Currently, it does this by walking the entire chain back to find the transaction hash. This will be very slow as the number of rollups grows.

### What changes were made as part of this PR:

Refactoring.

- Greatly speeds up the recovery of the rollup for a given tx hash

### What are the key areas to look at
