### PR TITLE
Was converting wrong array to JSON.

### DIFF
--- a/tools/obscuroscan/obscuroscan.go
+++ b/tools/obscuroscan/obscuroscan.go
@@ -178,7 +178,7 @@ func (o *Obscuroscan) getLatestTxs(resp http.ResponseWriter, _ *http.Request) {
 		}
 	}
 
-	jsonTxHashes, err := json.Marshal(txHashes)
+	jsonTxHashes, err := json.Marshal(txHashStrings)
 	if err != nil {
 		log.Error("could not return latest transaction hashes to client. Cause: %s", err)
 		logAndSendErr(resp, "Could not fetch latest transactions.")

--- a/tools/obscuroscan/static/index.js
+++ b/tools/obscuroscan/static/index.js
@@ -42,7 +42,7 @@ async function updateStats() {
     if (numRollupsResp.ok) {
         numRollupsField.innerText = "Total rollups: " + await numRollupsResp.text();
     } else {
-        numRollupsField.innerText = "Failed to fetch number of rollups. Cause: " + await numRollupsResp.text()
+        numRollupsField.innerText = "Failed to fetch number of rollups."
     }
 }
 
@@ -120,8 +120,8 @@ async function displayRollup(rollupID) {
     });
 
     if (!rollupResp.ok) {
-        rollupArea.innerText = "Failed to fetch rollup. Cause: " + await rollupResp.text()
-        blockArea.innerText = "Failed to fetch block. Cause: Could not retrieve rollup."
+        rollupArea.innerText = "Failed to fetch rollup."
+        blockArea.innerText = "Failed to fetch block."
         return
     }
 
@@ -137,7 +137,7 @@ async function displayRollup(rollupID) {
         const json = JSON.parse(await blockResp.text())
         blockArea.innerText = JSON.stringify(json, null, "\t");
     } else {
-        blockArea.innerText = "Failed to fetch block. Cause: " + await blockResp.text()
+        blockArea.innerText = "Failed to fetch block."
     }
 
     const encryptedTxBlob = rollupJSON[jsonKeyEncryptedTxBlob]
@@ -150,7 +150,7 @@ async function displayRollup(rollupID) {
         const json = JSON.parse(await decryptTxBlobResp.text())
         decryptedTxsArea.innerText = JSON.stringify(json, null, "\t");
     } else {
-        decryptedTxsArea.innerText = "Failed to decrypt transaction blob. Cause: " + await decryptTxBlobResp.text()
+        decryptedTxsArea.innerText = "Failed to decrypt transaction blob."
     }
 
     resultPane.scrollIntoView();


### PR DESCRIPTION
### Why is this change needed?

Previously, the wrong JSON array was returned to the front-end, leading to fields of `Undefined` rather than `N/A`.

### What changes were made as part of this PR:

Functional.

- Fixes bug where latest transactions initially shows `Undefined`
- Removes info on causes from front-end (this is pushed to the logs now)

### What are the key areas to look at
