### PR TITLE
Resets transaction blob view and scrolls screen correctly on rollup lookup failure.

### DIFF
--- a/tools/obscuroscan/static/index.js
+++ b/tools/obscuroscan/static/index.js
@@ -122,6 +122,8 @@ async function displayRollup(rollupID) {
     if (!rollupResp.ok) {
         rollupArea.innerText = "Failed to fetch rollup."
         blockArea.innerText = "Failed to fetch block."
+        decryptedTxsArea.innerText = "Failed to decrypt transaction blob."
+        resultPane.scrollIntoView();
         return
     }
 


### PR DESCRIPTION
### Why is this change needed?

Previously, if looking up a rollup or transaction failed, it wouldn't reset the transaction blob or scroll the screen to display the result.

### What changes were made as part of this PR:

Functional.

- Resets transaction blob view and scrolls screen correctly on rollup lookup failure

### What are the key areas to look at
