### PR TITLE
Separate view key layer from low-level node client

### DIFF
--- a/go/ethadapter/obscuro_rpc_client.go
+++ b/go/ethadapter/obscuro_rpc_client.go
@@ -27,7 +27,7 @@ type obscuroWalletRPCClient struct {
 
 // NewObscuroRPCClient creates an obscuro RPC client for a given wallet, it will create and register a viewing key for the wallet as part of this setup
 func NewObscuroRPCClient(ipaddress string, port uint, wallet wallet.Wallet) (EthClient, error) {
-	client, err := rpcclientlib.NewClient(fmt.Sprintf("%s:%d", ipaddress, port))
+	client, err := rpcclientlib.NewViewingKeyNetworkClient(fmt.Sprintf("%s:%d", ipaddress, port))
 	if err != nil {
 		return nil, err
 	}

--- a/go/rpcclientlib/client.go
+++ b/go/rpcclientlib/client.go
@@ -28,15 +28,3 @@ type Client interface {
 	// Stop closes the client.
 	Stop()
 }
-
-func NewViewingKeyNetworkClient(rpcAddress string) (*ViewingKeyClient, error) {
-	rpcClient, err := NewNetworkClient(rpcAddress)
-	if err != nil {
-		return nil, err
-	}
-	vkClient, err := NewViewingKeyClient(rpcClient)
-	if err != nil {
-		return nil, err
-	}
-	return vkClient, nil
-}

--- a/go/rpcclientlib/client.go
+++ b/go/rpcclientlib/client.go
@@ -1,0 +1,42 @@
+package rpcclientlib
+
+const (
+	RPCGetID                   = "obscuro_getID"
+	RPCGetCurrentBlockHead     = "obscuro_getCurrentBlockHead"
+	RPCGetBlockHeaderByHash    = "obscuro_getBlockHeaderByHash"
+	RPCGetCurrentRollupHead    = "obscuro_getCurrentRollupHead"
+	RPCGetRollupHeader         = "obscuro_getRollupHeader"
+	RPCGetRollupHeaderByNumber = "obscuro_getRollupHeaderByNumber"
+	RPCGetRollup               = "obscuro_getRollup"
+	RPCNonce                   = "obscuro_nonce"
+	RPCAddViewingKey           = "obscuro_addViewingKey"
+	RPCGetRollupForTx          = "obscuro_getRollupForTx"
+	RPCGetLatestTxs            = "obscuro_getLatestTransactions"
+	RPCStopHost                = "obscuro_stopHost"
+	RPCCall                    = "eth_call"
+	RPCChainID                 = "eth_chainId"
+	RPCGetBalance              = "eth_getBalance"
+	RPCGetTransactionByHash    = "eth_getTransactionByHash"
+	RPCGetTxReceipt            = "eth_getTransactionReceipt"
+	RPCSendRawTransaction      = "eth_sendRawTransaction"
+)
+
+// Client is used by client applications to interact with the Obscuro node
+type Client interface {
+	// Call executes the named method via RPC.
+	Call(result interface{}, method string, args ...interface{}) error
+	// Stop closes the client.
+	Stop()
+}
+
+func NewViewingKeyNetworkClient(rpcAddress string) (*ViewingKeyClient, error) {
+	rpcClient, err := NewNetworkClient(rpcAddress)
+	if err != nil {
+		return nil, err
+	}
+	vkClient, err := NewViewingKeyClient(rpcClient)
+	if err != nil {
+		return nil, err
+	}
+	return vkClient, nil
+}

--- a/go/rpcclientlib/network_client.go
+++ b/go/rpcclientlib/network_client.go
@@ -1,0 +1,34 @@
+package rpcclientlib
+
+import (
+	"fmt"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+// NewNetworkClient returns a client that can make RPC calls to an obscuro node
+func NewNetworkClient(address string) (Client, error) {
+	rpcClient, err := rpc.Dial(http + address)
+	if err != nil {
+		return nil, fmt.Errorf("could not create RPC client on %s. Cause: %w", http+address, err)
+	}
+
+	return &networkClient{
+		rpcClient: rpcClient,
+	}, nil
+}
+
+// networkClient is a Client implementation that wraps eth's rpc.Client to make calls to the obscuro node
+type networkClient struct {
+	rpcClient *rpc.Client
+}
+
+// Call handles JSON rpc requests - if the method is sensitive it will encrypt the args before sending the request and
+//	then decrypts the response before returning.
+// The result must be a pointer so that package json can unmarshal into it. You can also pass nil, in which case the result is ignored.
+func (c *networkClient) Call(result interface{}, method string, args ...interface{}) error {
+	return c.rpcClient.Call(&result, method, args...)
+}
+
+func (c *networkClient) Stop() {
+	c.rpcClient.Close()
+}

--- a/go/rpcclientlib/network_client.go
+++ b/go/rpcclientlib/network_client.go
@@ -2,6 +2,7 @@ package rpcclientlib
 
 import (
 	"fmt"
+
 	"github.com/ethereum/go-ethereum/rpc"
 )
 

--- a/go/rpcclientlib/viewing_key_client.go
+++ b/go/rpcclientlib/viewing_key_client.go
@@ -35,7 +35,7 @@ func NewViewingKeyClient(client Client) (*ViewingKeyClient, error) {
 	}, nil
 }
 
-// ViewingKeyClient is a Client wrapper that manages viewing key registration and decryption
+// ViewingKeyClient is a Client wrapper that implements Client but also has extra functionality for managing viewing key registration and decryption
 type ViewingKeyClient struct {
 	obscuroClient Client
 

--- a/go/rpcclientlib/viewing_key_client.go
+++ b/go/rpcclientlib/viewing_key_client.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/crypto/ecies"

--- a/go/rpcclientlib/viewing_key_client.go
+++ b/go/rpcclientlib/viewing_key_client.go
@@ -4,37 +4,14 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/crypto/ecies"
-	"github.com/ethereum/go-ethereum/rpc"
 )
-
-type RPCMethod uint8
 
 const (
 	http           = "http://"
 	reqJSONKeyFrom = "from"
-
-	RPCGetID                   = "obscuro_getID"
-	RPCGetCurrentBlockHead     = "obscuro_getCurrentBlockHead"
-	RPCGetBlockHeaderByHash    = "obscuro_getBlockHeaderByHash"
-	RPCGetCurrentRollupHead    = "obscuro_getCurrentRollupHead"
-	RPCGetRollupHeader         = "obscuro_getRollupHeader"
-	RPCGetRollupHeaderByNumber = "obscuro_getRollupHeaderByNumber"
-	RPCGetRollup               = "obscuro_getRollup"
-	RPCNonce                   = "obscuro_nonce"
-	RPCAddViewingKey           = "obscuro_addViewingKey"
-	RPCGetRollupForTx          = "obscuro_getRollupForTx"
-	RPCGetLatestTxs            = "obscuro_getLatestTransactions"
-	RPCStopHost                = "obscuro_stopHost"
-	RPCCall                    = "eth_call"
-	RPCChainID                 = "eth_chainId"
-	RPCGetBalance              = "eth_getBalance"
-	RPCGetTransactionByHash    = "eth_getTransactionByHash"
-	RPCGetTxReceipt            = "eth_getTransactionReceipt"
-	RPCSendRawTransaction      = "eth_sendRawTransaction"
 
 	// todo: this is a convenience for testnet testing and will eventually be retrieved from the L1
 	enclavePublicKeyHex = "034d3b7e63a8bcd532ee3d1d6ecad9d67fca7821981a044551f0f0cbec74d0bc5e"
@@ -43,32 +20,7 @@ const (
 // for these methods, the RPC method's requests and responses should be encrypted
 var sensitiveMethods = []string{RPCCall, RPCGetBalance, RPCGetTxReceipt, RPCSendRawTransaction, RPCGetTransactionByHash}
 
-// Client is used by client applications to interact with the Obscuro node.
-type Client interface {
-	// Call executes the named method via RPC.
-	Call(result interface{}, method string, args ...interface{}) error
-	// Stop closes the client.
-	Stop()
-
-	// SetViewingKey sets the current viewing key on the client to be used for all sensitive request decryption
-	SetViewingKey(viewingKey *ecies.PrivateKey, pubKeyBytes []byte)
-
-	// RegisterViewingKey takes a signature for the public key, it verifies the signed public key matches the currently set private viewing key
-	//	and then submits it to the enclave
-	RegisterViewingKey(signerAddr common.Address, signature []byte) error
-}
-
-// RPCClient is a Client implementation that wraps rpc.Client to make calls.
-type networkClient struct {
-	rpcClient        *rpc.Client
-	enclavePublicKey *ecies.PublicKey
-	// todo: add support for multiple keys on the same client?
-	viewingPrivKey *ecies.PrivateKey // private viewing key to use for decrypting sensitive requests
-	viewingPubKey  []byte            // public viewing key, submitted to the enclave
-	viewingKeyAddr common.Address    // address that generated the public key
-}
-
-func NewClient(address string) (Client, error) {
+func NewViewingKeyClient(client Client) (*ViewingKeyClient, error) {
 	// todo: this is a convenience for testnet but needs to replaced by a parameter and/or retrieved from the target host
 	enclPubECDSA, err := crypto.DecompressPubkey(common.Hex2Bytes(enclavePublicKeyHex))
 	if err != nil {
@@ -76,24 +28,30 @@ func NewClient(address string) (Client, error) {
 	}
 	enclavePublicKey := ecies.ImportECDSAPublic(enclPubECDSA)
 
-	rpcClient, err := rpc.Dial(http + address)
-	if err != nil {
-		return nil, fmt.Errorf("could not create RPC client on %s. Cause: %w", http+address, err)
-	}
-
-	return &networkClient{
-		rpcClient:        rpcClient,
+	return &ViewingKeyClient{
+		obscuroClient:    client,
 		enclavePublicKey: enclavePublicKey,
 	}, nil
+}
+
+// ViewingKeyClient is a Client wrapper that manages viewing key registration and decryption
+type ViewingKeyClient struct {
+	obscuroClient Client
+
+	enclavePublicKey *ecies.PublicKey
+	// todo: add support for multiple keys on the same client?
+	viewingPrivKey *ecies.PrivateKey // private viewing key to use for decrypting sensitive requests
+	viewingPubKey  []byte            // public viewing key, submitted to the enclave
+	viewingKeyAddr common.Address    // address that generated the public key
 }
 
 // Call handles JSON rpc requests - if the method is sensitive it will encrypt the args before sending the request and
 //	then decrypts the response before returning.
 // The result must be a pointer so that package json can unmarshal into it. You can also pass nil, in which case the result is ignored.
-func (c *networkClient) Call(result interface{}, method string, args ...interface{}) error {
+func (c *ViewingKeyClient) Call(result interface{}, method string, args ...interface{}) error {
 	if !isSensitive(method) {
 		// for non-sensitive methods or when viewing keys are disabled we just delegate directly to the geth RPC client
-		return c.rpcClient.Call(&result, method, args...)
+		return c.obscuroClient.Call(&result, method, args...)
 	}
 
 	// we setup a generic rawResult to receive the response (then we can decrypt it as necessary into the requested result type)
@@ -119,7 +77,7 @@ func (c *networkClient) Call(result interface{}, method string, args ...interfac
 	if err != nil {
 		return fmt.Errorf("failed to encrypt args for %s call - %w", method, err)
 	}
-	err = c.rpcClient.Call(&rawResult, method, encryptedParams)
+	err = c.obscuroClient.Call(&rawResult, method, encryptedParams)
 	if err != nil {
 		return fmt.Errorf("%s rpc call failed - %w", method, err)
 	}
@@ -144,7 +102,7 @@ func (c *networkClient) Call(result interface{}, method string, args ...interfac
 	return nil
 }
 
-func (c *networkClient) encryptArgs(args ...interface{}) ([]byte, error) {
+func (c *ViewingKeyClient) encryptArgs(args ...interface{}) ([]byte, error) {
 	if len(args) == 0 {
 		return nil, nil
 	}
@@ -157,7 +115,7 @@ func (c *networkClient) encryptArgs(args ...interface{}) ([]byte, error) {
 	return c.encryptParamBytes(paramsJSON)
 }
 
-func (c *networkClient) encryptParamBytes(params []byte) ([]byte, error) {
+func (c *ViewingKeyClient) encryptParamBytes(params []byte) ([]byte, error) {
 	encryptedParams, err := ecies.Encrypt(rand.Reader, c.enclavePublicKey, params, nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("could not encrypt the following request params with enclave public key: %s. Cause: %w", params, err)
@@ -165,7 +123,7 @@ func (c *networkClient) encryptParamBytes(params []byte) ([]byte, error) {
 	return encryptedParams, nil
 }
 
-func (c *networkClient) decryptResponse(resultBlob interface{}) ([]byte, error) {
+func (c *ViewingKeyClient) decryptResponse(resultBlob interface{}) ([]byte, error) {
 	// For some RPC operations, a nil is a valid response (e.g. the transaction for an unrecognised transaction hash).
 	if resultBlob == nil {
 		return nil, nil
@@ -198,7 +156,7 @@ func (c *networkClient) decryptResponse(resultBlob interface{}) ([]byte, error) 
 }
 
 // setResult tries to cast/unmarshal data into the result pointer, based on its type
-func (c *networkClient) setResult(data []byte, result interface{}) error {
+func (c *ViewingKeyClient) setResult(data []byte, result interface{}) error {
 	switch result := result.(type) {
 	case *string:
 		*result = string(data)
@@ -218,16 +176,16 @@ func (c *networkClient) setResult(data []byte, result interface{}) error {
 	}
 }
 
-func (c *networkClient) Stop() {
-	c.rpcClient.Close()
+func (c *ViewingKeyClient) Stop() {
+	c.obscuroClient.Stop()
 }
 
-func (c *networkClient) SetViewingKey(viewingKey *ecies.PrivateKey, viewingPubKeyBytes []byte) {
+func (c *ViewingKeyClient) SetViewingKey(viewingKey *ecies.PrivateKey, viewingPubKeyBytes []byte) {
 	c.viewingPrivKey = viewingKey
 	c.viewingPubKey = viewingPubKeyBytes
 }
 
-func (c *networkClient) RegisterViewingKey(signerAddr common.Address, signature []byte) error {
+func (c *ViewingKeyClient) RegisterViewingKey(signerAddr common.Address, signature []byte) error {
 	c.viewingKeyAddr = signerAddr
 
 	// We encrypt the viewing key bytes
@@ -245,7 +203,7 @@ func (c *networkClient) RegisterViewingKey(signerAddr common.Address, signature 
 }
 
 // enclave requires a from address to be set for the viewing key encryption but sources like metamask often don't set it
-func (c *networkClient) ensureCallParamsHaveFromAddress(method string, args []interface{}) ([]interface{}, error) {
+func (c *ViewingKeyClient) ensureCallParamsHaveFromAddress(method string, args []interface{}) ([]interface{}, error) {
 	if len(args) == 0 {
 		return nil, fmt.Errorf("expected %s params to have a 'from' field but no params found", RPCCall)
 	}

--- a/go/rpcclientlib/viewing_key_client.go
+++ b/go/rpcclientlib/viewing_key_client.go
@@ -35,6 +35,19 @@ func NewViewingKeyClient(client Client) (*ViewingKeyClient, error) {
 	}, nil
 }
 
+// NewViewingKeyNetworkClient returns a network RPC client with Viewing Key encryption/decryption
+func NewViewingKeyNetworkClient(rpcAddress string) (*ViewingKeyClient, error) {
+	rpcClient, err := NewNetworkClient(rpcAddress)
+	if err != nil {
+		return nil, err
+	}
+	vkClient, err := NewViewingKeyClient(rpcClient)
+	if err != nil {
+		return nil, err
+	}
+	return vkClient, nil
+}
+
 // ViewingKeyClient is a Client wrapper that implements Client but also has extra functionality for managing viewing key registration and decryption
 type ViewingKeyClient struct {
 	obscuroClient Client

--- a/integration/common/viewkey/viewkey.go
+++ b/integration/common/viewkey/viewkey.go
@@ -22,7 +22,7 @@ import (
 //	2. simulates signing the key with metamask
 //	3. sets the private key on the client (to decrypt enclave responses)
 //	4. registers the public viewing key with the enclave (to encrypt enclave responses)
-func GenerateAndRegisterViewingKey(cli rpcclientlib.Client, wal wallet.Wallet) error {
+func GenerateAndRegisterViewingKey(cli *rpcclientlib.ViewingKeyClient, wal wallet.Wallet) error {
 	// generate an ECDSA key pair to encrypt sensitive communications with the obscuro enclave
 	vk, err := crypto.GenerateKey()
 	if err != nil {

--- a/integration/noderunner/noderunner_test.go
+++ b/integration/noderunner/noderunner_test.go
@@ -76,7 +76,7 @@ func TestCanStartStandaloneObscuroHostAndEnclave(t *testing.T) {
 
 	go enclaverunner.RunEnclave(enclaveConfig)
 	go hostrunner.RunHost(hostConfig)
-	obscuroClient, err := rpcclientlib.NewClient(rpcServerAddr)
+	obscuroClient, err := rpcclientlib.NewNetworkClient(rpcServerAddr)
 	if err != nil {
 		panic(err)
 	}

--- a/integration/simulation/network/obscuro_node_utils.go
+++ b/integration/simulation/network/obscuro_node_utils.go
@@ -119,11 +119,11 @@ func startStandaloneObscuroNodes(params *params.SimParams, stats *stats.Stats, g
 		)
 
 		nodeRPCAddresses[i] = fmt.Sprintf("%s:%d", Localhost, nodeRPCPortHTTP)
-		cli, err := rpcclientlib.NewViewingKeyNetworkClient(nodeRPCAddresses[i])
+		client, err := rpcclientlib.NewViewingKeyNetworkClient(nodeRPCAddresses[i])
 		if err != nil {
 			panic(err)
 		}
-		obscuroClients[i] = cli
+		obscuroClients[i] = client
 	}
 
 	// start each obscuro node
@@ -150,12 +150,12 @@ func startStandaloneObscuroNodes(params *params.SimParams, stats *stats.Stats, g
 	walletClients := make(map[string]rpcclientlib.Client)
 	var i int
 	for _, w := range params.Wallets.SimObsWallets {
-		cli, err := rpcclientlib.NewViewingKeyNetworkClient(nodeRPCAddresses[i%len(nodeRPCAddresses)])
+		client, err := rpcclientlib.NewViewingKeyNetworkClient(nodeRPCAddresses[i%len(nodeRPCAddresses)])
 		if err != nil {
 			panic(err)
 		}
-		walletClients[w.Address().String()] = cli
-		err = viewkey.GenerateAndRegisterViewingKey(cli, w)
+		walletClients[w.Address().String()] = client
+		err = viewkey.GenerateAndRegisterViewingKey(client, w)
 		if err != nil {
 			panic(err)
 		}
@@ -163,12 +163,12 @@ func startStandaloneObscuroNodes(params *params.SimParams, stats *stats.Stats, g
 	}
 	for _, t := range params.Wallets.Tokens {
 		w := t.L2Owner
-		cli, err := rpcclientlib.NewViewingKeyNetworkClient(nodeRPCAddresses[i%len(nodeRPCAddresses)])
+		client, err := rpcclientlib.NewViewingKeyNetworkClient(nodeRPCAddresses[i%len(nodeRPCAddresses)])
 		if err != nil {
 			panic(err)
 		}
-		walletClients[w.Address().String()] = cli
-		err = viewkey.GenerateAndRegisterViewingKey(cli, w)
+		walletClients[w.Address().String()] = client
+		err = viewkey.GenerateAndRegisterViewingKey(client, w)
 		if err != nil {
 			panic(err)
 		}

--- a/integration/simulation/network/obscuro_node_utils.go
+++ b/integration/simulation/network/obscuro_node_utils.go
@@ -119,7 +119,7 @@ func startStandaloneObscuroNodes(params *params.SimParams, stats *stats.Stats, g
 		)
 
 		nodeRPCAddresses[i] = fmt.Sprintf("%s:%d", Localhost, nodeRPCPortHTTP)
-		cli, err := rpcclientlib.NewNetworkClient(nodeRPCAddresses[i])
+		cli, err := rpcclientlib.NewViewingKeyNetworkClient(nodeRPCAddresses[i])
 		if err != nil {
 			panic(err)
 		}

--- a/integration/simulation/network/obscuro_node_utils.go
+++ b/integration/simulation/network/obscuro_node_utils.go
@@ -119,7 +119,7 @@ func startStandaloneObscuroNodes(params *params.SimParams, stats *stats.Stats, g
 		)
 
 		nodeRPCAddresses[i] = fmt.Sprintf("%s:%d", Localhost, nodeRPCPortHTTP)
-		cli, err := rpcclientlib.NewClient(nodeRPCAddresses[i])
+		cli, err := rpcclientlib.NewNetworkClient(nodeRPCAddresses[i])
 		if err != nil {
 			panic(err)
 		}
@@ -150,12 +150,12 @@ func startStandaloneObscuroNodes(params *params.SimParams, stats *stats.Stats, g
 	walletClients := make(map[string]rpcclientlib.Client)
 	var i int
 	for _, w := range params.Wallets.SimObsWallets {
-		cli, err := rpcclientlib.NewClient(nodeRPCAddresses[i%len(nodeRPCAddresses)])
+		cli, err := rpcclientlib.NewViewingKeyNetworkClient(nodeRPCAddresses[i%len(nodeRPCAddresses)])
 		if err != nil {
 			panic(err)
 		}
 		walletClients[w.Address().String()] = cli
-		err = viewkey.GenerateAndRegisterViewingKey(walletClients[w.Address().String()], w)
+		err = viewkey.GenerateAndRegisterViewingKey(cli, w)
 		if err != nil {
 			panic(err)
 		}
@@ -163,12 +163,12 @@ func startStandaloneObscuroNodes(params *params.SimParams, stats *stats.Stats, g
 	}
 	for _, t := range params.Wallets.Tokens {
 		w := t.L2Owner
-		cli, err := rpcclientlib.NewClient(nodeRPCAddresses[i%len(nodeRPCAddresses)])
+		cli, err := rpcclientlib.NewViewingKeyNetworkClient(nodeRPCAddresses[i%len(nodeRPCAddresses)])
 		if err != nil {
 			panic(err)
 		}
 		walletClients[w.Address().String()] = cli
-		err = viewkey.GenerateAndRegisterViewingKey(walletClients[w.Address().String()], w)
+		err = viewkey.GenerateAndRegisterViewingKey(cli, w)
 		if err != nil {
 			panic(err)
 		}

--- a/tools/networkmanager/inject_txs.go
+++ b/tools/networkmanager/inject_txs.go
@@ -34,7 +34,7 @@ func InjectTransactions(cfg Config, args []string) {
 		panic(fmt.Sprintf("could not create L1 client. Cause: %s", err))
 	}
 	println("Connecting to Obscuro node...")
-	l2Client, err := rpcclientlib.NewClient(cfg.obscuroClientAddress)
+	l2Client, err := rpcclientlib.NewViewingKeyNetworkClient(cfg.obscuroClientAddress)
 	if err != nil {
 		panic(err)
 	}
@@ -86,25 +86,25 @@ func createWalletRPCClients(wallets *params.SimWallets, obscuroNodeAddr string) 
 	clients := make(map[string]rpcclientlib.Client)
 
 	for _, w := range wallets.SimObsWallets {
-		cli, err := rpcclientlib.NewClient(obscuroNodeAddr)
+		cli, err := rpcclientlib.NewViewingKeyNetworkClient(obscuroNodeAddr)
 		if err != nil {
 			panic(err)
 		}
 		clients[w.Address().String()] = cli
 
-		err = viewkey.GenerateAndRegisterViewingKey(clients[w.Address().String()], w)
+		err = viewkey.GenerateAndRegisterViewingKey(cli, w)
 		if err != nil {
 			panic(err)
 		}
 	}
 	for _, t := range wallets.Tokens {
 		w := t.L2Owner
-		cli, err := rpcclientlib.NewClient(obscuroNodeAddr)
+		cli, err := rpcclientlib.NewViewingKeyNetworkClient(obscuroNodeAddr)
 		if err != nil {
 			panic(err)
 		}
 		clients[w.Address().String()] = cli
-		err = viewkey.GenerateAndRegisterViewingKey(clients[w.Address().String()], w)
+		err = viewkey.GenerateAndRegisterViewingKey(cli, w)
 		if err != nil {
 			panic(err)
 		}

--- a/tools/obscuroscan/obscuroscan.go
+++ b/tools/obscuroscan/obscuroscan.go
@@ -55,7 +55,7 @@ type Obscuroscan struct {
 }
 
 func NewObscuroscan(address string) *Obscuroscan {
-	client, err := rpcclientlib.NewClient(address)
+	client, err := rpcclientlib.NewNetworkClient(address)
 	if err != nil {
 		panic(err)
 	}

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -59,7 +59,7 @@ var staticFiles embed.FS
 type WalletExtension struct {
 	enclavePublicKey *ecies.PublicKey // The public key used to encrypt requests for the enclave.
 	hostAddr         string           // The address on which the Obscuro host can be reached.
-	hostClient       rpcclientlib.Client
+	hostClient       *rpcclientlib.ViewingKeyClient
 	server           *http.Server
 }
 
@@ -78,7 +78,7 @@ func NewWalletExtension(config Config) *WalletExtension {
 
 	setLogs(config.LogPath)
 
-	client, err := rpcclientlib.NewClient(config.NodeRPCHTTPAddress)
+	client, err := rpcclientlib.NewViewingKeyNetworkClient(config.NodeRPCHTTPAddress)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
### Why is this change needed?

- getting rid of viewing key enabled flag in the enclave requires we support VK enc/dec in the in-memory client
- separating the view key enc/dec logic means we won't duplicate it

### What changes were made as part of this PR:

- separated the viewing key layer from the RPC layer in our client 
- ViewingKeyClient now wraps an underlying client and in a follow-up I'll have it wrap the in-memory version for the tests

### What are the key areas to look at
- rpcclientlib changes