### PR TITLE
Avoid nonce reuse when encrypting transaction blobs

### DIFF
--- a/go/common/types.go
+++ b/go/common/types.go
@@ -22,7 +22,7 @@ type (
 	TxHash                = common.Hash
 	L2Tx                  = types.Transaction
 	EncryptedTx           []byte // A single transaction, encoded as a JSON list of transaction binary hexes and encrypted using the enclave's public key
-	EncryptedTransactions []byte // A blob of encrypted transactions, as they're stored in the rollup.
+	EncryptedTransactions []byte // A blob of encrypted transactions, as they're stored in the rollup, with the nonce prepended.
 
 	EncryptedParamsGetBalance   []byte // The params for an RPC getBalance request, as a JSON object encrypted with the public key of the enclave.
 	EncryptedParamsCall         []byte // As above, but for an RPC call request.

--- a/go/enclave/crypto/transaction_blob_crypto.go
+++ b/go/enclave/crypto/transaction_blob_crypto.go
@@ -3,7 +3,9 @@ package crypto
 import (
 	"crypto/aes"
 	"crypto/cipher"
+	"crypto/rand"
 	"fmt"
+	"io"
 
 	"github.com/obscuronet/go-obscuro/go/common/log"
 
@@ -15,11 +17,11 @@ import (
 )
 
 const (
-	// TODO - This fixed nonce is insecure, and should be removed alongside the fixed rollup encryption key.
-	RollupCipherNonce = "000000000000"
 	// RollupEncryptionKeyHex is the AES key used to encrypt and decrypt the transaction blob in rollups.
 	// TODO - Replace this fixed key with derived, rotating keys.
 	RollupEncryptionKeyHex = "bddbc0d46a0666ce57a466168d99c1830b0c65e052d77188f2cbfc3f6486588c"
+	// The nonce's length in bytes.
+	nonceLength = 12
 )
 
 // TransactionBlobCrypto handles the encryption and decryption of the transaction blobs stored inside a rollup.
@@ -75,11 +77,23 @@ func (t TransactionBlobCryptoImpl) encrypt(transactions []*common.L2Tx) common.E
 		log.Panic("could not encrypt L2 transaction. Cause: %s", err)
 	}
 
-	return t.transactionCipher.Seal(nil, []byte(RollupCipherNonce), encodedTxs, nil)
+	nonce := make([]byte, nonceLength)
+	if _, err = io.ReadFull(rand.Reader, nonce); err != nil {
+		log.Panic("could not generate nonce to encrypt transactions. Cause: %s", err)
+	}
+
+	// TODO - Ensure this nonce is not used too many times (2^32?) with the same key, to avoid risk of repeat.
+	ciphertext := t.transactionCipher.Seal(nil, nonce, encodedTxs, nil)
+	// We prepend the nonce to the ciphertext, so that it can be retrieved when decrypting.
+	return append(nonce, ciphertext...)
 }
 
 func (t TransactionBlobCryptoImpl) decrypt(encryptedTxs common.EncryptedTransactions) []*common.L2Tx {
-	encodedTxs, err := t.transactionCipher.Open(nil, []byte(RollupCipherNonce), encryptedTxs, nil)
+	// The nonce is prepended to the ciphertext.
+	nonce := encryptedTxs[0:nonceLength]
+	ciphertext := encryptedTxs[nonceLength:]
+
+	encodedTxs, err := t.transactionCipher.Open(nil, nonce, ciphertext, nil)
 	if err != nil {
 		log.Panic("could not decrypt encrypted L2 transactions. Cause: %s", err)
 	}

--- a/go/enclave/crypto/transaction_blob_crypto.go
+++ b/go/enclave/crypto/transaction_blob_crypto.go
@@ -21,7 +21,7 @@ const (
 	// TODO - Replace this fixed key with derived, rotating keys.
 	RollupEncryptionKeyHex = "bddbc0d46a0666ce57a466168d99c1830b0c65e052d77188f2cbfc3f6486588c"
 	// The nonce's length in bytes.
-	nonceLength = 12
+	NonceLength = 12
 )
 
 // TransactionBlobCrypto handles the encryption and decryption of the transaction blobs stored inside a rollup.
@@ -77,7 +77,7 @@ func (t TransactionBlobCryptoImpl) encrypt(transactions []*common.L2Tx) common.E
 		log.Panic("could not encrypt L2 transaction. Cause: %s", err)
 	}
 
-	nonce := make([]byte, nonceLength)
+	nonce := make([]byte, NonceLength)
 	if _, err = io.ReadFull(rand.Reader, nonce); err != nil {
 		log.Panic("could not generate nonce to encrypt transactions. Cause: %s", err)
 	}
@@ -85,13 +85,13 @@ func (t TransactionBlobCryptoImpl) encrypt(transactions []*common.L2Tx) common.E
 	// TODO - Ensure this nonce is not used too many times (2^32?) with the same key, to avoid risk of repeat.
 	ciphertext := t.transactionCipher.Seal(nil, nonce, encodedTxs, nil)
 	// We prepend the nonce to the ciphertext, so that it can be retrieved when decrypting.
-	return append(nonce, ciphertext...)
+	return append(nonce, ciphertext...) //nolint:makezero
 }
 
 func (t TransactionBlobCryptoImpl) decrypt(encryptedTxs common.EncryptedTransactions) []*common.L2Tx {
 	// The nonce is prepended to the ciphertext.
-	nonce := encryptedTxs[0:nonceLength]
-	ciphertext := encryptedTxs[nonceLength:]
+	nonce := encryptedTxs[0:NonceLength]
+	ciphertext := encryptedTxs[NonceLength:]
 
 	encodedTxs, err := t.transactionCipher.Open(nil, nonce, ciphertext, nil)
 	if err != nil {

--- a/tools/obscuroscan/obscuroscan.go
+++ b/tools/obscuroscan/obscuroscan.go
@@ -360,7 +360,10 @@ func decryptTxBlob(encryptedTxBytesBase64 []byte) ([]byte, error) {
 		return nil, fmt.Errorf("could not initialise wrapper for AES cipher for enclave rollup key. Cause: %w", err)
 	}
 
-	encodedTxs, err := transactionCipher.Open(nil, []byte(crypto.RollupCipherNonce), encryptedTxBytes, nil)
+	// The nonce is prepended to the ciphertext.
+	nonce := encryptedTxBytes[0:crypto.NonceLength]
+	ciphertext := encryptedTxBytes[crypto.NonceLength:]
+	encodedTxs, err := transactionCipher.Open(nil, nonce, ciphertext, nil)
 	if err != nil {
 		return nil, fmt.Errorf("could not decrypt encrypted L2 transactions. Cause: %w", err)
 	}


### PR DESCRIPTION
### Why is this change needed?

Currently, we reuse the same nonce every time we encrypt a transaction blob. This is insecure.

### What changes were made as part of this PR:

Refactoring.

- Uses a unique nonce per transaction blob encrypted

### What are the key areas to look at
