### PR TITLE
Adds dummy fee history method.

### DIFF
--- a/go/host/client_api_eth.go
+++ b/go/host/client_api_eth.go
@@ -150,6 +150,17 @@ func (api *EthereumAPI) GetTransactionByHash(_ context.Context, encryptedParams 
 	return &encryptedResponseHex, nil
 }
 
+// FeeHistory is a placeholder for an RPC method required by MetaMask/Remix.
+func (api *EthereumAPI) FeeHistory(context.Context, rpc.DecimalOrHex, rpc.BlockNumber, []float64) (*feeHistoryResult, error) {
+	// TODO - Return a non-dummy fee history.
+	return &feeHistoryResult{
+		OldestBlock:  (*hexutil.Big)(big.NewInt(0)),
+		Reward:       [][]*hexutil.Big{},
+		BaseFee:      []*hexutil.Big{},
+		GasUsedRatio: []float64{},
+	}, nil
+}
+
 // Maps an external rollup to a block.
 func headerWithHashesToBlock(headerWithHashes *common.HeaderWithTxHashes) map[string]interface{} {
 	header := headerWithHashes.Header
@@ -174,4 +185,12 @@ func headerWithHashesToBlock(headerWithHashes *common.HeaderWithTxHashes) map[st
 		"mixHash":       header.MixDigest,
 		"baseFeePerGas": header.BaseFee,
 	}
+}
+
+// Structure returned by Geth `eth_feeHistory` API.
+type feeHistoryResult struct {
+	OldestBlock  *hexutil.Big     `json:"oldestBlock"`
+	Reward       [][]*hexutil.Big `json:"reward,omitempty"`
+	BaseFee      []*hexutil.Big   `json:"baseFeePerGas,omitempty"`
+	GasUsedRatio []float64        `json:"gasUsedRatio"`
 }

--- a/go/host/client_api_eth.go
+++ b/go/host/client_api_eth.go
@@ -151,9 +151,9 @@ func (api *EthereumAPI) GetTransactionByHash(_ context.Context, encryptedParams 
 }
 
 // FeeHistory is a placeholder for an RPC method required by MetaMask/Remix.
-func (api *EthereumAPI) FeeHistory(context.Context, rpc.DecimalOrHex, rpc.BlockNumber, []float64) (*feeHistoryResult, error) {
+func (api *EthereumAPI) FeeHistory(context.Context, rpc.DecimalOrHex, rpc.BlockNumber, []float64) (*FeeHistoryResult, error) {
 	// TODO - Return a non-dummy fee history.
-	return &feeHistoryResult{
+	return &FeeHistoryResult{
 		OldestBlock:  (*hexutil.Big)(big.NewInt(0)),
 		Reward:       [][]*hexutil.Big{},
 		BaseFee:      []*hexutil.Big{},
@@ -187,8 +187,8 @@ func headerWithHashesToBlock(headerWithHashes *common.HeaderWithTxHashes) map[st
 	}
 }
 
-// Structure returned by Geth `eth_feeHistory` API.
-type feeHistoryResult struct {
+// FeeHistoryResult is the structure returned by Geth `eth_feeHistory` API.
+type FeeHistoryResult struct {
 	OldestBlock  *hexutil.Big     `json:"oldestBlock"`
 	Reward       [][]*hexutil.Big `json:"reward,omitempty"`
 	BaseFee      []*hexutil.Big   `json:"baseFeePerGas,omitempty"`


### PR DESCRIPTION
### Why is this change needed?

MetaMask expects the `eth_feeHistory` endpoint to exist. Not having it is not an issue, but causes log noise.

### What changes were made as part of this PR:

Functional.

- Adds dummy `eth_feeHistory` endpoint

### What are the key areas to look at
