### PR TITLE
Add L2 contract deployments to local testnet readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,8 @@ only a single Obscuro node is started, it must be set as a genesis node.
 ```
 ./testnet-local-gethnetwork.sh --pkaddresses=0x13E23Ca74DE0206C56ebaE8D51b5622EFF1E9944,0x0654D8B60033144D567f25bF41baC1FB0D60F23B
 ./testnet-deploy-contracts.sh --l1host=gethnetwork --pkstring=f52e5418e349dccdda29b6ac8b0abe6576bb7713886aa85abea6181ba731f9bb
-./start-obscuro-node.sh --sgx_enabled=false --host_id=0x0000000000000000000000000000000000000001 --l1host=gethnetwork --mgmtcontractaddr=0xeDa66Cc53bd2f26896f6Ba6b736B1Ca325DE04eF --obxerc20addr=0xC0370e0b5C1A41D447BDdA655079A1B977C71aA9 --etherc20addr=0x51D43a3Ca257584E770B6188232b199E76B022A2 --is_genesis=true 
+./start-obscuro-node.sh --sgx_enabled=false --host_id=0x0000000000000000000000000000000000000001 --l1host=gethnetwork --mgmtcontractaddr=0xeDa66Cc53bd2f26896f6Ba6b736B1Ca325DE04eF --obxerc20addr=0xC0370e0b5C1A41D447BDdA655079A1B977C71aA9 --etherc20addr=0x51D43a3Ca257584E770B6188232b199E76B022A2 --is_genesis=true
+./testnet-deploy-l2-contracts.sh --l2host=testnet-host-1 
 ```
 
 where;


### PR DESCRIPTION
### Why is this change needed?

- missed important step for local testnet to have parity with main testnet

