### PR TITLE
Removes todo around generating randomness in the enclave

### DIFF
--- a/go/enclave/crypto/crypto.go
+++ b/go/enclave/crypto/crypto.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
+	"io"
 
 	"github.com/obscuronet/go-obscuro/go/common/log"
 
@@ -29,9 +30,7 @@ func GetObscuroKey() *ecdsa.PrivateKey {
 
 func GenerateEntropy() core.SharedEnclaveSecret {
 	secret := make([]byte, core.SharedSecretLen)
-	// todo - check if there is a better way to do this in ego.
-	n, err := rand.Read(secret)
-	if n != core.SharedSecretLen || err != nil {
+	if _, err := io.ReadFull(rand.Reader, secret); err != nil {
 		log.Panic("could not generate secret. Cause: %s", err)
 	}
 	var temp [core.SharedSecretLen]byte


### PR DESCRIPTION
### Why is this change needed?

We left a todo to check that the way we were generating randomness in the enclave was secure. Upon further research, it turned out it was.

### What changes were made as part of this PR:

Refectoring.

- Removes todo
- Uses helper to automate length check

### What are the key areas to look at
