### PR TITLE
Documents the rollup encryption key.

### DIFF
--- a/docs/testnet/essentials.md
+++ b/docs/testnet/essentials.md
@@ -14,3 +14,14 @@ An easy-to-read list of essential parameters and configuration settings for Obsc
 ## ObscuroScan
 - **URL:** http://testnet-obscuroscan.uksouth.azurecontainer.io/
 
+## Rollup Encryption/Decryption Key
+The symmetric key used to encrypt and decrypt transaction blobs in rollups on the Obscuro Testnet:
+
+```
+bddbc0d46a0666ce57a466168d99c1830b0c65e052d77188f2cbfc3f6486588c
+```
+
+N.B. Decrypting transaction blobs is only possible on testnet, where the rollup encryption key is long-lived and 
+well-known. On mainnet, rollups will use rotating keys that are not known to anyone - or anything - other than the 
+Obscuro enclaves.
+


### PR DESCRIPTION
### Why is this change needed?

See https://github.com/obscuronet/obscuro-internal/issues/685: "Rather than use ObscuroScan a Testnet participant might want to independently decrypt the encrypted transaction blob. To achieve this they will need to use the shared secret used in Testnet. Make the shared secret available on the docsite for Testnet."

### What changes were made as part of this PR:

Functional.

- Adds the shared secret to the docsite

### What are the key areas to look at
