### PR TITLE
Adds special handling for the fact that non-existent tx receipts now returns empty string.

### DIFF
--- a/integration/simulation/utils.go
+++ b/integration/simulation/utils.go
@@ -114,6 +114,10 @@ func getTransactionReceipt(client rpcclientlib.Client, txHash gethcommon.Hash) m
 		panic(fmt.Errorf("simulation failed due to failed %s RPC call. Cause: %w", rpcclientlib.RPCGetTxReceipt, err))
 	}
 
+	if encryptedResponse == "" {
+		panic(fmt.Errorf("simulation failed because there was no receipt for transaction %s", txHash))
+	}
+
 	var responseJSONMap map[string]interface{}
 	err = json.Unmarshal(gethcommon.Hex2Bytes(encryptedResponse), &responseJSONMap)
 	if err != nil {


### PR DESCRIPTION
### Why is this change needed?

Requesting the receipt for a non-existent transaction now returns the empty string, not an error. The simulation utils need to be updated to account for that.

### What changes were made as part of this PR:

Refactoring.

- Handles the special case of the receipt being empty

### What are the key areas to look at
