### PR TITLE
Sets time field in rollup headers.

### DIFF
--- a/go/enclave/core/rollup.go
+++ b/go/enclave/core/rollup.go
@@ -3,6 +3,7 @@ package core
 import (
 	"math/big"
 	"sync/atomic"
+	"time"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -44,6 +45,7 @@ func EmptyRollup(agg gethcommon.Address, parent *common.Header, blkHash gethcomm
 		L1Proof:     blkHash,
 		RollupNonce: nonce,
 		Number:      big.NewInt(int64(parent.Number.Uint64() + 1)),
+		Time:        uint64(time.Now().Unix()),
 	}
 	r := Rollup{
 		Header: &h,
@@ -67,6 +69,7 @@ func NewRollup(blkHash gethcommon.Hash, parent *Rollup, height uint64, a gethcom
 		Number:      big.NewInt(int64(height)),
 		Withdrawals: withdrawals,
 		ReceiptHash: types.EmptyRootHash,
+		Time:        uint64(time.Now().Unix()),
 	}
 	r := Rollup{
 		Header:       &h,

--- a/go/enclave/core/rollup.go
+++ b/go/enclave/core/rollup.go
@@ -45,7 +45,8 @@ func EmptyRollup(agg gethcommon.Address, parent *common.Header, blkHash gethcomm
 		L1Proof:     blkHash,
 		RollupNonce: nonce,
 		Number:      big.NewInt(int64(parent.Number.Uint64() + 1)),
-		Time:        uint64(time.Now().Unix()),
+		// TODO - Consider how this time should align with the time of the L1 block used as proof.
+		Time: uint64(time.Now().Unix()),
 	}
 	r := Rollup{
 		Header: &h,


### PR DESCRIPTION
### Why is this change needed?

Needed so that we can report average rollup time easily in ObscuroScan. It's also an expected field in headers.

### What changes were made as part of this PR:

Functional.

- Sets the time in rollup headers

### What are the key areas to look at
