### PR TITLE
Adds timeouts for host to host P2P connections

### DIFF
--- a/go/config/host_config.go
+++ b/go/config/host_config.go
@@ -9,6 +9,7 @@ import (
 const (
 	defaultRPCTimeoutSecs          = 10
 	defaultL1ConnectionTimeoutSecs = 15
+	defaultP2PTimeoutSecs          = 10
 )
 
 // HostConfig contains the full configuration for an Obscuro host.
@@ -29,12 +30,8 @@ type HostConfig struct {
 	ClientRPCPortWS uint64
 	// Host on which to handle client RPC requests
 	ClientRPCHost string
-	// Timeout duration for RPC requests from client applications
-	ClientRPCTimeout time.Duration
 	// Address on which to connect to the enclave
 	EnclaveRPCAddress string
-	// Timeout duration for RPC requests to the enclave service
-	EnclaveRPCTimeout time.Duration
 	// P2PBindAddress is the address where the P2P server is bound to
 	P2PBindAddress string
 	// P2PPublicAddress is the advertised P2P server address
@@ -43,8 +40,14 @@ type HostConfig struct {
 	L1NodeHost string
 	// The websocket port of the connected L1 node
 	L1NodeWebsocketPort uint
+	// Timeout duration for RPC requests from client applications
+	ClientRPCTimeout time.Duration
+	// Timeout duration for RPC requests to the enclave service
+	EnclaveRPCTimeout time.Duration
 	// Timeout duration for connecting to the L1 node
 	L1ConnectionTimeout time.Duration
+	// Timeout duration for messaging between hosts.
+	P2PConnectionTimeout time.Duration
 	// The rollup contract address on the L1 network
 	RollupContractAddress common.Address
 	// LogLevel determines the verbosity of output logs
@@ -72,14 +75,15 @@ func DefaultHostConfig() HostConfig {
 		HasClientRPCWebsockets: false,
 		ClientRPCPortWS:        13001,
 		ClientRPCHost:          "127.0.0.1",
-		ClientRPCTimeout:       time.Duration(defaultRPCTimeoutSecs) * time.Second,
 		EnclaveRPCAddress:      "127.0.0.1:11000",
-		EnclaveRPCTimeout:      time.Duration(defaultRPCTimeoutSecs) * time.Second,
 		P2PBindAddress:         "0.0.0.0:10000",
 		P2PPublicAddress:       "127.0.0.1:10000",
 		L1NodeHost:             "127.0.0.1",
 		L1NodeWebsocketPort:    8546,
+		ClientRPCTimeout:       time.Duration(defaultRPCTimeoutSecs) * time.Second,
+		EnclaveRPCTimeout:      time.Duration(defaultRPCTimeoutSecs) * time.Second,
 		L1ConnectionTimeout:    time.Duration(defaultL1ConnectionTimeoutSecs) * time.Second,
+		P2PConnectionTimeout:   time.Duration(defaultP2PTimeoutSecs) * time.Second,
 		RollupContractAddress:  common.BytesToAddress([]byte("")),
 		LogLevel:               "info",
 		LogPath:                "",

--- a/go/host/hostrunner/cli.go
+++ b/go/host/hostrunner/cli.go
@@ -23,14 +23,15 @@ type HostConfigToml struct {
 	HasClientRPCWebsockets bool
 	ClientRPCPortWS        uint
 	ClientRPCHost          string
-	ClientRPCTimeout       int
 	EnclaveRPCAddress      string
-	EnclaveRPCTimeout      int
 	P2PBindAddress         string
 	P2PPublicAddress       string
 	L1NodeHost             string
 	L1NodeWebsocketPort    uint
+	ClientRPCTimeout       int
+	EnclaveRPCTimeout      int
 	L1ConnectionTimeout    int
+	P2PConnectionTimeout   int
 	RollupContractAddress  string
 	LogLevel               string
 	LogPath                string
@@ -53,14 +54,15 @@ func ParseConfig() config.HostConfig {
 	clientRPCPortHTTP := flag.Uint64(clientRPCPortHTTPName, cfg.ClientRPCPortHTTP, flagUsageMap[clientRPCPortHTTPName])
 	clientRPCPortWS := flag.Uint64(clientRPCPortWSName, cfg.ClientRPCPortWS, flagUsageMap[clientRPCPortWSName])
 	clientRPCHost := flag.String(clientRPCHostName, cfg.ClientRPCHost, flagUsageMap[clientRPCHostName])
-	clientRPCTimeoutSecs := flag.Uint64(clientRPCTimeoutSecsName, uint64(cfg.ClientRPCTimeout.Seconds()), flagUsageMap[clientRPCTimeoutSecsName])
 	enclaveRPCAddress := flag.String(enclaveRPCAddressName, cfg.EnclaveRPCAddress, flagUsageMap[enclaveRPCAddressName])
-	enclaveRPCTimeoutSecs := flag.Uint64(enclaveRPCTimeoutSecsName, uint64(cfg.EnclaveRPCTimeout.Seconds()), flagUsageMap[enclaveRPCTimeoutSecsName])
 	p2pBindAddress := flag.String(p2pBindAddressName, cfg.P2PBindAddress, flagUsageMap[p2pBindAddressName])
 	p2pPublicAddress := flag.String(p2pPublicAddressName, cfg.P2PPublicAddress, flagUsageMap[p2pPublicAddressName])
 	l1NodeHost := flag.String(l1NodeHostName, cfg.L1NodeHost, flagUsageMap[l1NodeHostName])
 	l1NodePort := flag.Uint64(l1NodePortName, uint64(cfg.L1NodeWebsocketPort), flagUsageMap[l1NodePortName])
+	clientRPCTimeoutSecs := flag.Uint64(clientRPCTimeoutSecsName, uint64(cfg.ClientRPCTimeout.Seconds()), flagUsageMap[clientRPCTimeoutSecsName])
+	enclaveRPCTimeoutSecs := flag.Uint64(enclaveRPCTimeoutSecsName, uint64(cfg.EnclaveRPCTimeout.Seconds()), flagUsageMap[enclaveRPCTimeoutSecsName])
 	l1ConnectionTimeoutSecs := flag.Uint64(l1ConnectionTimeoutSecsName, uint64(cfg.L1ConnectionTimeout.Seconds()), flagUsageMap[l1ConnectionTimeoutSecsName])
+	p2pConnectionTimeoutSecs := flag.Uint64(p2pConnectionTimeoutSecsName, uint64(cfg.P2PConnectionTimeout.Seconds()), flagUsageMap[p2pConnectionTimeoutSecsName])
 	rollupContractAddress := flag.String(rollupContractAddrName, cfg.RollupContractAddress.Hex(), flagUsageMap[rollupContractAddrName])
 	logLevel := flag.String(logLevelName, cfg.LogLevel, flagUsageMap[logLevelName])
 	logPath := flag.String(logPathName, cfg.LogPath, flagUsageMap[logPathName])
@@ -83,14 +85,15 @@ func ParseConfig() config.HostConfig {
 	cfg.HasClientRPCWebsockets = true
 	cfg.ClientRPCPortWS = *clientRPCPortWS
 	cfg.ClientRPCHost = *clientRPCHost
-	cfg.ClientRPCTimeout = time.Duration(*enclaveRPCTimeoutSecs) * time.Second
 	cfg.EnclaveRPCAddress = *enclaveRPCAddress
-	cfg.EnclaveRPCTimeout = time.Duration(*clientRPCTimeoutSecs) * time.Second
 	cfg.P2PBindAddress = *p2pBindAddress
 	cfg.P2PPublicAddress = *p2pPublicAddress
 	cfg.L1NodeHost = *l1NodeHost
 	cfg.L1NodeWebsocketPort = uint(*l1NodePort)
+	cfg.ClientRPCTimeout = time.Duration(*enclaveRPCTimeoutSecs) * time.Second
+	cfg.EnclaveRPCTimeout = time.Duration(*clientRPCTimeoutSecs) * time.Second
 	cfg.L1ConnectionTimeout = time.Duration(*l1ConnectionTimeoutSecs) * time.Second
+	cfg.P2PConnectionTimeout = time.Duration(*p2pConnectionTimeoutSecs) * time.Second
 	cfg.RollupContractAddress = common.HexToAddress(*rollupContractAddress)
 	cfg.PrivateKeyString = *privateKeyStr
 	cfg.LogLevel = *logLevel
@@ -124,14 +127,15 @@ func fileBasedConfig(configPath string) config.HostConfig {
 		HasClientRPCWebsockets: tomlConfig.HasClientRPCWebsockets,
 		ClientRPCPortWS:        uint64(tomlConfig.ClientRPCPortWS),
 		ClientRPCHost:          tomlConfig.ClientRPCHost,
-		ClientRPCTimeout:       time.Duration(tomlConfig.ClientRPCTimeout) * time.Second,
 		EnclaveRPCAddress:      tomlConfig.EnclaveRPCAddress,
-		EnclaveRPCTimeout:      time.Duration(tomlConfig.EnclaveRPCTimeout) * time.Second,
 		P2PBindAddress:         tomlConfig.P2PBindAddress,
 		P2PPublicAddress:       tomlConfig.P2PPublicAddress,
 		L1NodeHost:             tomlConfig.L1NodeHost,
 		L1NodeWebsocketPort:    tomlConfig.L1NodeWebsocketPort,
+		ClientRPCTimeout:       time.Duration(tomlConfig.ClientRPCTimeout) * time.Second,
+		EnclaveRPCTimeout:      time.Duration(tomlConfig.EnclaveRPCTimeout) * time.Second,
 		L1ConnectionTimeout:    time.Duration(tomlConfig.L1ConnectionTimeout) * time.Second,
+		P2PConnectionTimeout:   time.Duration(tomlConfig.P2PConnectionTimeout) * time.Second,
 		RollupContractAddress:  common.HexToAddress(tomlConfig.RollupContractAddress),
 		LogLevel:               tomlConfig.LogLevel,
 		LogPath:                tomlConfig.LogPath,

--- a/go/host/hostrunner/cli_flags.go
+++ b/go/host/hostrunner/cli_flags.go
@@ -2,55 +2,57 @@ package hostrunner
 
 // Flag names.
 const (
-	configName                  = "config"
-	nodeIDName                  = "id"
-	isGenesisName               = "isGenesis"
-	gossipRoundNanosName        = "gossipRoundNanos"
-	clientRPCPortHTTPName       = "clientRPCPortHttp"
-	clientRPCPortWSName         = "clientRPCPortWs"
-	clientRPCHostName           = "clientRPCHost"
-	clientRPCTimeoutSecsName    = "clientRPCTimeoutSecs"
-	enclaveRPCAddressName       = "enclaveRPCAddress"
-	enclaveRPCTimeoutSecsName   = "enclaveRPCTimeoutSecs"
-	p2pBindAddressName          = "p2pBindAddress"
-	p2pPublicAddressName        = "p2pPublicAddress"
-	l1NodeHostName              = "l1NodeHost"
-	l1NodePortName              = "l1NodePort"
-	l1ConnectionTimeoutSecsName = "l1ConnectionTimeoutSecs"
-	rollupContractAddrName      = "rollupContractAddress"
-	logLevelName                = "logLevel"
-	logPathName                 = "logPath"
-	privateKeyName              = "privateKey"
-	l1ChainIDName               = "l1ChainID"
-	obscuroChainIDName          = "obscuroChainID"
-	profilerEnabledName         = "profilerEnabled"
+	configName                   = "config"
+	nodeIDName                   = "id"
+	isGenesisName                = "isGenesis"
+	gossipRoundNanosName         = "gossipRoundNanos"
+	clientRPCPortHTTPName        = "clientRPCPortHttp"
+	clientRPCPortWSName          = "clientRPCPortWs"
+	clientRPCHostName            = "clientRPCHost"
+	enclaveRPCAddressName        = "enclaveRPCAddress"
+	p2pBindAddressName           = "p2pBindAddress"
+	p2pPublicAddressName         = "p2pPublicAddress"
+	l1NodeHostName               = "l1NodeHost"
+	l1NodePortName               = "l1NodePort"
+	clientRPCTimeoutSecsName     = "clientRPCTimeoutSecs"
+	enclaveRPCTimeoutSecsName    = "enclaveRPCTimeoutSecs"
+	l1ConnectionTimeoutSecsName  = "l1ConnectionTimeoutSecs"
+	p2pConnectionTimeoutSecsName = "p2pConnectionTimeoutSecs"
+	rollupContractAddrName       = "rollupContractAddress"
+	logLevelName                 = "logLevel"
+	logPathName                  = "logPath"
+	privateKeyName               = "privateKey"
+	l1ChainIDName                = "l1ChainID"
+	obscuroChainIDName           = "obscuroChainID"
+	profilerEnabledName          = "profilerEnabled"
 )
 
 // Returns a map of the flag usages.
 // While we could just use constants instead of a map, this approach allows us to test that all the expected flags are defined.
 func getFlagUsageMap() map[string]string {
 	return map[string]string{
-		configName:                  "The path to the node's config file. Overrides all other flags",
-		nodeIDName:                  "The 20 bytes of the node's address",
-		isGenesisName:               "Whether the node is the first node to join the network",
-		gossipRoundNanosName:        "The duration of the gossip round",
-		clientRPCPortHTTPName:       "The port on which to listen for client application RPC requests over HTTP",
-		clientRPCPortWSName:         "The port on which to listen for client application RPC requests over websockets",
-		clientRPCHostName:           "The host on which to handle client application RPC requests",
-		clientRPCTimeoutSecsName:    "The timeout for client <-> host RPC communication",
-		enclaveRPCAddressName:       "The address to use to connect to the Obscuro enclave service",
-		enclaveRPCTimeoutSecsName:   "The timeout for host <-> enclave RPC communication",
-		p2pBindAddressName:          "The address where the p2p server is bound to. Defaults to 0.0.0.0:10000",
-		p2pPublicAddressName:        "The P2P address where the other servers should connect to. Defaults to 127.0.0.1:10000",
-		l1NodeHostName:              "The host on which to connect to the Ethereum client",
-		l1NodePortName:              "The port on which to connect to the Ethereum client",
-		l1ConnectionTimeoutSecsName: "The timeout for connecting to the Ethereum client",
-		rollupContractAddrName:      "The management contract address on the L1",
-		logLevelName:                "The verbosity level of logs. (Defaults to Info)",
-		logPathName:                 "The path to use for the host's log file",
-		privateKeyName:              "The private key for the L1 node account",
-		l1ChainIDName:               "An integer representing the unique chain id of the Ethereum chain used as an L1 (default 1337)",
-		obscuroChainIDName:          "An integer representing the unique chain id of the Obscuro chain (default 777)",
-		profilerEnabledName:         "Runs a profiler instance (Defaults to false)",
+		configName:                   "The path to the node's config file. Overrides all other flags",
+		nodeIDName:                   "The 20 bytes of the node's address",
+		isGenesisName:                "Whether the node is the first node to join the network",
+		gossipRoundNanosName:         "The duration of the gossip round",
+		clientRPCPortHTTPName:        "The port on which to listen for client application RPC requests over HTTP",
+		clientRPCPortWSName:          "The port on which to listen for client application RPC requests over websockets",
+		clientRPCHostName:            "The host on which to handle client application RPC requests",
+		enclaveRPCAddressName:        "The address to use to connect to the Obscuro enclave service",
+		p2pBindAddressName:           "The address where the p2p server is bound to. Defaults to 0.0.0.0:10000",
+		p2pPublicAddressName:         "The P2P address where the other servers should connect to. Defaults to 127.0.0.1:10000",
+		l1NodeHostName:               "The host on which to connect to the Ethereum client",
+		l1NodePortName:               "The port on which to connect to the Ethereum client",
+		clientRPCTimeoutSecsName:     "The timeout for client <-> host RPC communication",
+		enclaveRPCTimeoutSecsName:    "The timeout for host <-> enclave RPC communication",
+		l1ConnectionTimeoutSecsName:  "The timeout for connecting to the Ethereum client",
+		p2pConnectionTimeoutSecsName: "The timeout for host <-> host P2P messaging",
+		rollupContractAddrName:       "The management contract address on the L1",
+		logLevelName:                 "The verbosity level of logs. (Defaults to Info)",
+		logPathName:                  "The path to use for the host's log file",
+		privateKeyName:               "The private key for the L1 node account",
+		l1ChainIDName:                "An integer representing the unique chain id of the Ethereum chain used as an L1 (default 1337)",
+		obscuroChainIDName:           "An integer representing the unique chain id of the Obscuro chain (default 777)",
+		profilerEnabledName:          "Runs a profiler instance (Defaults to false)",
 	}
 }


### PR DESCRIPTION
### Why is this change needed?

See https://github.com/obscuronet/obscuro-internal/issues/704.

Currently, host P2P connections never time out (possibly the OS eventually cuts them off, not sure). In addition, P2P messages are not broadcast in parallel. So a single unreachable node can block broadcast for the entire network.

### What changes were made as part of this PR:

Functional.

- Adds timeout for P2P connections
- Makes timeout configurable
- Broadcasts P2P messages in parallel

### What are the key areas to look at
