### PR TITLE
Separation of duties for transaction blob crypto.

### DIFF
--- a/go/common/types.go
+++ b/go/common/types.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
-	"github.com/ethereum/go-ethereum/crypto"
+	gethcrypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/rlp"
 	"golang.org/x/crypto/sha3"
 
@@ -135,7 +135,7 @@ var hasherPool = sync.Pool{
 func RLPHash(value interface{}) (common.Hash, error) {
 	var hash common.Hash
 
-	sha := hasherPool.Get().(crypto.KeccakState)
+	sha := hasherPool.Get().(gethcrypto.KeccakState)
 	defer hasherPool.Put(sha)
 	sha.Reset()
 

--- a/go/enclave/bridge/bridge.go
+++ b/go/enclave/bridge/bridge.go
@@ -162,7 +162,7 @@ func (bridge *Bridge) ExtractRollups(b *types.Block, blockResolver db.BlockResol
 			// Ignore rollups created with proofs from different L1 blocks
 			// In case of L1 reorgs, rollups may end published on a fork
 			if blockResolver.IsBlockAncestor(b, r.Header.L1Proof) {
-				rollups = append(rollups, bridge.TransactionBlobCrypto.ToEnclaveRollup(r))
+				rollups = append(rollups, obscurocore.ToEnclaveRollup(r, bridge.TransactionBlobCrypto))
 				common.LogWithID(bridge.NodeID, "Extracted Rollup r_%d from block b_%d",
 					common.ShortHash(r.Hash()),
 					common.ShortHash(b.Hash()),

--- a/go/enclave/core/types.go
+++ b/go/enclave/core/types.go
@@ -4,11 +4,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-const SharedSecretLen = 32
-
-// SharedEnclaveSecret - the entropy
-type SharedEnclaveSecret [SharedSecretLen]byte
-
 // BlockState - Represents the state after an L1 Block was processed.
 type BlockState struct {
 	Block          common.Hash

--- a/go/enclave/crypto/crypto.go
+++ b/go/enclave/crypto/crypto.go
@@ -19,11 +19,11 @@ const (
 	// obscuroPrivateKeyHex is the private key used for sensitive communication with the enclave.
 	// TODO - Replace this fixed key with a key derived from the master seed.
 	obscuroPrivateKeyHex = "81acce9620f0adf1728cb8df7f6b8b8df857955eb9e8b7aed6ef8390c09fc207"
-	SharedSecretLen      = 32
+	sharedSecretLen      = 32
 )
 
 // SharedEnclaveSecret - the entropy
-type SharedEnclaveSecret [SharedSecretLen]byte
+type SharedEnclaveSecret [sharedSecretLen]byte
 
 func GetObscuroKey() *ecdsa.PrivateKey {
 	key, err := crypto.HexToECDSA(obscuroPrivateKeyHex)
@@ -34,38 +34,20 @@ func GetObscuroKey() *ecdsa.PrivateKey {
 }
 
 func GenerateEntropy() SharedEnclaveSecret {
-	secret := make([]byte, SharedSecretLen)
+	secret := make([]byte, sharedSecretLen)
 	if _, err := io.ReadFull(rand.Reader, secret); err != nil {
 		log.Panic("could not generate secret. Cause: %s", err)
 	}
-	var temp [SharedSecretLen]byte
+	var temp [sharedSecretLen]byte
 	copy(temp[:], secret)
 	return temp
-}
-
-// EncryptWithPublicKey encrypts data with public key
-func EncryptWithPublicKey(msg []byte, pub *ecdsa.PublicKey) ([]byte, error) {
-	ciphertext, err := ecies.Encrypt(rand.Reader, ecies.ImportECDSAPublic(pub), msg, nil, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to encrypt with public key. %w", err)
-	}
-	return ciphertext, nil
-}
-
-// DecryptWithPrivateKey decrypts data with private key
-func DecryptWithPrivateKey(ciphertext []byte, priv *ecdsa.PrivateKey) ([]byte, error) {
-	plaintext, err := ecies.ImportECDSA(priv).Decrypt(ciphertext, nil, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to decrypt with private key. %w", err)
-	}
-	return plaintext, nil
 }
 
 func DecryptSecret(secret common.EncryptedSharedEnclaveSecret, privateKey *ecdsa.PrivateKey) (*SharedEnclaveSecret, error) {
 	if privateKey == nil {
 		return nil, errors.New("private key not found - shouldn't happen")
 	}
-	value, err := DecryptWithPrivateKey(secret, privateKey)
+	value, err := decryptWithPrivateKey(secret, privateKey)
 	if err != nil {
 		return nil, err
 	}
@@ -81,9 +63,27 @@ func EncryptSecret(pubKeyEncoded []byte, secret SharedEnclaveSecret, nodeShortID
 		return nil, fmt.Errorf("failed to parse public key %w", err)
 	}
 
-	encKey, err := EncryptWithPublicKey(secret[:], key)
+	encKey, err := encryptWithPublicKey(secret[:], key)
 	if err != nil {
 		common.LogWithID(nodeShortID, "Failed to encrypt key, err: %s\nsecret: %v\npubkey: %v\nencKey:%v", err, secret, pubKeyEncoded, encKey)
 	}
 	return encKey, err
+}
+
+// Encrypts data with public key
+func encryptWithPublicKey(msg []byte, pub *ecdsa.PublicKey) ([]byte, error) {
+	ciphertext, err := ecies.Encrypt(rand.Reader, ecies.ImportECDSAPublic(pub), msg, nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encrypt with public key. %w", err)
+	}
+	return ciphertext, nil
+}
+
+// Decrypts data with private key
+func decryptWithPrivateKey(ciphertext []byte, priv *ecdsa.PrivateKey) ([]byte, error) {
+	plaintext, err := ecies.ImportECDSA(priv).Decrypt(ciphertext, nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decrypt with private key. %w", err)
+	}
+	return plaintext, nil
 }

--- a/go/enclave/crypto/transaction_blob_crypto.go
+++ b/go/enclave/crypto/transaction_blob_crypto.go
@@ -9,8 +9,6 @@ import (
 
 	"github.com/obscuronet/go-obscuro/go/common/log"
 
-	"github.com/obscuronet/go-obscuro/go/enclave/core"
-
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/obscuronet/go-obscuro/go/common"
@@ -20,15 +18,14 @@ const (
 	// RollupEncryptionKeyHex is the AES key used to encrypt and decrypt the transaction blob in rollups.
 	// TODO - Replace this fixed key with derived, rotating keys.
 	RollupEncryptionKeyHex = "bddbc0d46a0666ce57a466168d99c1830b0c65e052d77188f2cbfc3f6486588c"
-	// The nonce's length in bytes.
+	// NonceLength is the nonce's length in bytes for encrypting and decrypting transactions.
 	NonceLength = 12
 )
 
 // TransactionBlobCrypto handles the encryption and decryption of the transaction blobs stored inside a rollup.
 type TransactionBlobCrypto interface {
-	// ToExtRollup - Transforms an internal rollup as seen by the enclave to an external rollup with an encrypted payload
-	ToExtRollup(r *core.Rollup) common.ExtRollup
-	ToEnclaveRollup(r *common.EncryptedRollup) *core.Rollup
+	Encrypt(transactions []*common.L2Tx) common.EncryptedTransactions
+	Decrypt(encryptedTxs common.EncryptedTransactions) []*common.L2Tx
 }
 
 type TransactionBlobCryptoImpl struct {
@@ -50,28 +47,8 @@ func NewTransactionBlobCryptoImpl() TransactionBlobCrypto {
 	}
 }
 
-func (t TransactionBlobCryptoImpl) ToExtRollup(r *core.Rollup) common.ExtRollup {
-	txHashes := make([]gethcommon.Hash, len(r.Transactions))
-	for idx, tx := range r.Transactions {
-		txHashes[idx] = tx.Hash()
-	}
-
-	return common.ExtRollup{
-		Header:          r.Header,
-		TxHashes:        txHashes,
-		EncryptedTxBlob: t.encrypt(r.Transactions),
-	}
-}
-
-func (t TransactionBlobCryptoImpl) ToEnclaveRollup(r *common.EncryptedRollup) *core.Rollup {
-	return &core.Rollup{
-		Header:       r.Header,
-		Transactions: t.decrypt(r.Transactions),
-	}
-}
-
 // TODO - Modify this logic so that transactions with different reveal periods are in different blobs, as per the whitepaper.
-func (t TransactionBlobCryptoImpl) encrypt(transactions []*common.L2Tx) common.EncryptedTransactions {
+func (t TransactionBlobCryptoImpl) Encrypt(transactions []*common.L2Tx) common.EncryptedTransactions {
 	encodedTxs, err := rlp.EncodeToBytes(transactions)
 	if err != nil {
 		log.Panic("could not encrypt L2 transaction. Cause: %s", err)
@@ -88,7 +65,7 @@ func (t TransactionBlobCryptoImpl) encrypt(transactions []*common.L2Tx) common.E
 	return append(nonce, ciphertext...) //nolint:makezero
 }
 
-func (t TransactionBlobCryptoImpl) decrypt(encryptedTxs common.EncryptedTransactions) []*common.L2Tx {
+func (t TransactionBlobCryptoImpl) Decrypt(encryptedTxs common.EncryptedTransactions) []*common.L2Tx {
 	// The nonce is prepended to the ciphertext.
 	nonce := encryptedTxs[0:NonceLength]
 	ciphertext := encryptedTxs[NonceLength:]

--- a/go/enclave/db/interfaces.go
+++ b/go/enclave/db/interfaces.go
@@ -3,6 +3,8 @@ package db
 import (
 	"crypto/ecdsa"
 
+	"github.com/obscuronet/go-obscuro/go/enclave/crypto"
+
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -62,9 +64,9 @@ type BlockStateStorage interface {
 
 type SharedSecretStorage interface {
 	// FetchSecret returns the enclave's secret, returns nil if not found
-	FetchSecret() *core.SharedEnclaveSecret
+	FetchSecret() *crypto.SharedEnclaveSecret
 	// StoreSecret stores a secret in the enclave
-	StoreSecret(secret core.SharedEnclaveSecret)
+	StoreSecret(secret crypto.SharedEnclaveSecret)
 }
 
 type TransactionStorage interface {

--- a/go/enclave/db/rawdb/accessors_metadata.go
+++ b/go/enclave/db/rawdb/accessors_metadata.go
@@ -5,11 +5,11 @@ import (
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/obscuronet/go-obscuro/go/common/log"
-	"github.com/obscuronet/go-obscuro/go/enclave/core"
+	"github.com/obscuronet/go-obscuro/go/enclave/crypto"
 )
 
-func ReadSharedSecret(db ethdb.KeyValueReader) *core.SharedEnclaveSecret {
-	var ss core.SharedEnclaveSecret
+func ReadSharedSecret(db ethdb.KeyValueReader) *crypto.SharedEnclaveSecret {
+	var ss crypto.SharedEnclaveSecret
 
 	enc, _ := db.Get(sharedSecret)
 	if len(enc) == 0 {
@@ -22,7 +22,7 @@ func ReadSharedSecret(db ethdb.KeyValueReader) *core.SharedEnclaveSecret {
 	return &ss
 }
 
-func WriteSharedSecret(db ethdb.KeyValueWriter, ss core.SharedEnclaveSecret) {
+func WriteSharedSecret(db ethdb.KeyValueWriter, ss crypto.SharedEnclaveSecret) {
 	enc, err := rlp.EncodeToBytes(ss)
 	if err != nil {
 		log.Panic("could not encode shared secret. Cause: %s", err)

--- a/go/enclave/db/storage.go
+++ b/go/enclave/db/storage.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/obscuronet/go-obscuro/go/enclave/crypto"
+
 	"github.com/obscuronet/go-obscuro/go/common/log"
 
 	obscurorawdb "github.com/obscuronet/go-obscuro/go/enclave/db/rawdb"
@@ -103,11 +105,11 @@ func (s *storageImpl) FetchHeadBlock() *types.Block {
 	return b
 }
 
-func (s *storageImpl) StoreSecret(secret core.SharedEnclaveSecret) {
+func (s *storageImpl) StoreSecret(secret crypto.SharedEnclaveSecret) {
 	obscurorawdb.WriteSharedSecret(s.db, secret)
 }
 
-func (s *storageImpl) FetchSecret() *core.SharedEnclaveSecret {
+func (s *storageImpl) FetchSecret() *crypto.SharedEnclaveSecret {
 	return obscurorawdb.ReadSharedSecret(s.db)
 }
 

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -222,7 +222,7 @@ func (e *enclaveImpl) Start(block types.Block) {
 func (e *enclaveImpl) ProduceGenesis(blkHash gethcommon.Hash) common.BlockSubmissionResponse {
 	rolGenesis, b := e.chain.ProduceGenesis(blkHash)
 	return common.BlockSubmissionResponse{
-		ProducedRollup: e.transactionBlobCrypto.ToExtRollup(rolGenesis),
+		ProducedRollup: rolGenesis.ToExtRollup(e.transactionBlobCrypto),
 		BlockHeader:    b.Header(),
 		IngestedBlock:  true,
 	}
@@ -257,7 +257,7 @@ func (e *enclaveImpl) SubmitBlock(block types.Block) common.BlockSubmissionRespo
 }
 
 func (e *enclaveImpl) SubmitRollup(rollup common.ExtRollup) {
-	r := e.transactionBlobCrypto.ToEnclaveRollup(rollup.ToRollup())
+	r := obscurocore.ToEnclaveRollup(rollup.ToRollup(), e.transactionBlobCrypto)
 
 	// only store if the parent exists
 	_, found := e.storage.FetchRollup(r.Header.ParentHash)
@@ -388,7 +388,7 @@ func (e *enclaveImpl) GetRollup(rollupHash common.L2RootHash) (*common.ExtRollup
 	if !found {
 		return nil, nil //nolint:nilnil
 	}
-	extRollup := e.transactionBlobCrypto.ToExtRollup(rollup)
+	extRollup := rollup.ToExtRollup(e.transactionBlobCrypto)
 	return &extRollup, nil
 }
 

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -120,7 +120,7 @@ func (rc *RollupChain) IngestBlock(block *types.Block) common.BlockSubmissionRes
 			log.Panic(msgNoRollup)
 		}
 
-		rollup = rc.transactionBlobCrypto.ToExtRollup(hr)
+		rollup = hr.ToExtRollup(rc.transactionBlobCrypto)
 	}
 	return rc.newBlockSubmissionResponse(bs, rollup)
 }
@@ -486,7 +486,7 @@ func (rc *RollupChain) SubmitBlock(block types.Block) common.BlockSubmissionResp
 
 	common.LogWithID(rc.nodeID, "Processed block: b_%d(%d). Produced rollup r_%d", common.ShortHash(block.Hash()), block.NumberU64(), common.ShortHash(r.Hash()))
 
-	return rc.newBlockSubmissionResponse(blockState, rc.transactionBlobCrypto.ToExtRollup(r))
+	return rc.newBlockSubmissionResponse(blockState, r.ToExtRollup(rc.transactionBlobCrypto))
 }
 
 func (rc *RollupChain) produceRollup(b *types.Block, bs *obscurocore.BlockState) *obscurocore.Rollup {
@@ -620,7 +620,7 @@ func (rc *RollupChain) RoundWinner(parent common.L2RootHash) (common.ExtRollup, 
 			obscurocore.PrintTxs(winnerRollup.Transactions),
 			winnerRollup.Header.Root,
 		)
-		return rc.transactionBlobCrypto.ToExtRollup(winnerRollup), true, nil
+		return winnerRollup.ToExtRollup(rc.transactionBlobCrypto), true, nil
 	}
 	return common.ExtRollup{}, false, nil
 }

--- a/tools/obscuroscan/obscuroscan_test.go
+++ b/tools/obscuroscan/obscuroscan_test.go
@@ -42,6 +42,6 @@ func TestThrowsIfEncryptedRollupIsInvalid(t *testing.T) {
 // Generates an encrypted transaction blob in Base64 encoding.
 func generateEncryptedTxBlob(txs []*common.L2Tx) []byte {
 	rollup := core.Rollup{Header: &common.Header{}, Transactions: txs}
-	txBlob := crypto.NewTransactionBlobCryptoImpl().ToExtRollup(&rollup).EncryptedTxBlob
+	txBlob := rollup.ToExtRollup(crypto.NewTransactionBlobCryptoImpl()).EncryptedTxBlob
 	return []byte(base64.StdEncoding.EncodeToString(txBlob))
 }


### PR DESCRIPTION
### Why is this change needed?

`TransactionBlobCrypto` is currently aware of specifics of rollups and how they're mapped back and forth. Its only responsibility should be encrypting and decrypting tx blobs.

### What changes were made as part of this PR:

Refactoring.

- Moves logic for creating rollups and ext rollups out of `TransactionBlobCrypto`
- Makes a few methods and constants non-public

### What are the key areas to look at
