### PR TITLE
Handle case where JSON can't be marshalled in attestation

### DIFF
--- a/go/common/httputil/httputil.go
+++ b/go/common/httputil/httputil.go
@@ -26,8 +26,8 @@ func CreateTLSHTTPClient(caCertPEM string) (*http.Client, error) {
 }
 
 // ExecuteHTTPReq executes an HTTP request:
-//	returns an error if request fails or if the response code was outside the range 200-299
-//	returns response body as bytes if there was a response body
+// * returns an error if request fails or if the response code was outside the range 200-299
+// * returns response body as bytes if there was a response body
 func ExecuteHTTPReq(client *http.Client, req *http.Request) ([]byte, error) {
 	resp, err := client.Do(req)
 	if err != nil {

--- a/go/enclave/core/egoutils/egoutils.go
+++ b/go/enclave/core/egoutils/egoutils.go
@@ -8,7 +8,7 @@ import (
 )
 
 // SealAndPersist uses SGX's ProductKey to encrypt contents string to filepath string
-//	(note: filepath location must be accessible via ego mounts config in enclave.json)
+// (note: filepath location must be accessible via ego mounts config in enclave.json)
 func SealAndPersist(contents string, filepath string) error {
 	f, err := os.Create(filepath)
 	if err != nil {

--- a/go/enclave/db/sql/edb_attestation.go
+++ b/go/enclave/db/sql/edb_attestation.go
@@ -52,7 +52,7 @@ type EdgelessAttestationConstraints struct {
 }
 
 // The values here were the latest values from: https://github.com/edgelesssys/edgelessdb/releases/latest/download/edgelessdb-sgx.json
-// 	This should probably be configurable rather than relying on this hardcoded snapshot
+// This should probably be configurable rather than relying on this hardcoded snapshot
 var defaultEDBConstraints = &EdgelessAttestationConstraints{
 	SecurityVersion: 2,
 	SignerID:        "67d7b00741440d29922a15a9ead427b6faf1d610238ae9826da345cea4fee0fe",

--- a/go/enclave/db/sql/sqlite.go
+++ b/go/enclave/db/sql/sqlite.go
@@ -20,7 +20,7 @@ const (
 )
 
 // CreateTemporarySQLiteDB if dbPath is empty will use a random throwaway temp file,
-// 	otherwise dbPath is a filepath for the db file, allows for tests that care about persistence between restarts
+// otherwise dbPath is a filepath for the db file, allows for tests that care about persistence between restarts
 func CreateTemporarySQLiteDB(dbPath string) (ethdb.Database, error) {
 	if dbPath == "" {
 		tempPath, err := getTempDBFile()

--- a/go/ethadapter/obscuro_rpc_client.go
+++ b/go/ethadapter/obscuro_rpc_client.go
@@ -17,9 +17,8 @@ import (
 // obscuroWalletRPCClient implements the EthClient interface, it's bound to a single wallet (viewing key and address)
 //
 // Note: Why does this exist (why use a geth-focused interface for our obscuro interactions)?
-//  - We have code (like deploying contracts) that we want to run against both L1 and L2, useful to be able to treat them the same
-//	- Maintaining this interface helps ensure we remain closely compatible with eth usability
-//
+// - We have code (like deploying contracts) that we want to run against both L1 and L2, useful to be able to treat them the same
+// - Maintaining this interface helps ensure we remain closely compatible with eth usability
 type obscuroWalletRPCClient struct {
 	client rpcclientlib.Client // the underlying obscuro client - the viewing key and address are stored in here todo: although maybe they shouldn't be...?
 	wallet wallet.Wallet

--- a/go/rpcclientlib/network_client.go
+++ b/go/rpcclientlib/network_client.go
@@ -24,7 +24,7 @@ type networkClient struct {
 }
 
 // Call handles JSON rpc requests - if the method is sensitive it will encrypt the args before sending the request and
-//	then decrypts the response before returning.
+// then decrypts the response before returning.
 // The result must be a pointer so that package json can unmarshal into it. You can also pass nil, in which case the result is ignored.
 func (c *networkClient) Call(result interface{}, method string, args ...interface{}) error {
 	return c.rpcClient.Call(&result, method, args...)

--- a/go/rpcclientlib/viewing_key_client.go
+++ b/go/rpcclientlib/viewing_key_client.go
@@ -60,7 +60,7 @@ type ViewingKeyClient struct {
 }
 
 // Call handles JSON rpc requests - if the method is sensitive it will encrypt the args before sending the request and
-//	then decrypts the response before returning.
+// then decrypts the response before returning.
 // The result must be a pointer so that package json can unmarshal into it. You can also pass nil, in which case the result is ignored.
 func (c *ViewingKeyClient) Call(result interface{}, method string, args ...interface{}) error {
 	if !isSensitive(method) {

--- a/integration/common/viewkey/viewkey.go
+++ b/integration/common/viewkey/viewkey.go
@@ -55,7 +55,7 @@ func GenerateAndRegisterViewingKey(cli *rpcclientlib.ViewingKeyClient, wal walle
 }
 
 // signViewingKey takes a public key bytes as hex and the private key for a wallet, it simulates the back-and-forth to
-//	metamask and returns the signature bytes to register with the enclave
+// MetaMask and returns the signature bytes to register with the enclave
 func signViewingKey(viewingKeyHex string, signerKey *ecdsa.PrivateKey) ([]byte, error) {
 	msgToSign := rpcencryptionmanager.ViewingKeySignedMsgPrefix + viewingKeyHex
 	signature, err := crypto.Sign(accounts.TextHash([]byte(msgToSign)), signerKey)

--- a/integration/gethnetwork/geth_network.go
+++ b/integration/gethnetwork/geth_network.go
@@ -249,7 +249,7 @@ func (network *GethNetwork) IssueCommand(nodeIdx int, command string) string {
 	dataDir := network.dataDirs[nodeIdx]
 
 	args := []string{dataDirFlag, dataDir, attachCmd, path.Join(dataDir, ipcFileName), execFlag, command}
-	cmd := exec.Command(network.gethBinaryPath, args...) // nolint
+	cmd := exec.Command(network.gethBinaryPath, args...) //nolint
 	cmd.Stderr = network.logNodeID(nodeIdx)
 
 	output, err := cmd.Output()
@@ -294,7 +294,7 @@ func (network *GethNetwork) createMiner(dataDir string, idx int) {
 // Creates an account for a Geth node.
 func (network *GethNetwork) createAccount(dataDirPath string) {
 	args := []string{dataDirFlag, dataDirPath, accountCmd, accountNewCmd, passwordFlag, network.passwordFilePath}
-	cmd := exec.Command(network.gethBinaryPath, args...) // nolint
+	cmd := exec.Command(network.gethBinaryPath, args...) //nolint
 	cmd.Stdout = network.logFile
 	cmd.Stderr = network.logFile
 
@@ -331,7 +331,7 @@ func (network *GethNetwork) retrieveAccount(dataDirPath string) string {
 // Initialises a Geth node based on the network genesis file.
 func (network *GethNetwork) initNode(dataDirPath string) {
 	args := []string{dataDirFlag, dataDirPath, initCmd, network.genesisFilePath}
-	cmd := exec.Command(network.gethBinaryPath, args...) // nolint
+	cmd := exec.Command(network.gethBinaryPath, args...) //nolint
 	cmd.Stdout = network.logFile
 	cmd.Stderr = network.logFile
 
@@ -354,7 +354,7 @@ func (network *GethNetwork) startMiner(dataDirPath string, idx int) {
 		httpAddrFlag, "0.0.0.0", wsAddrFlag, "0.0.0.0", httpVhostsFlag, "*", gasLimitFlag,
 		blockProductionIntervalFlag, strconv.Itoa(network.blockTimeSecs),
 	}
-	cmd := exec.Command(network.gethBinaryPath, args...) // nolint
+	cmd := exec.Command(network.gethBinaryPath, args...) //nolint
 
 	cmd.Stdout = network.logNodeID(idx)
 	cmd.Stderr = network.logNodeID(idx)

--- a/integration/simulation/network/obscuro_node_utils.go
+++ b/integration/simulation/network/obscuro_node_utils.go
@@ -72,7 +72,7 @@ func startInMemoryObscuroNodes(params *params.SimParams, stats *stats.Stats, gen
 
 // setupWalletClientsWithoutViewingKeys will configure the existing obscuro clients to be used as wallet clients,
 // (we typically keep a client per wallet so their viewing keys are available and registered but they can share clients
-// 	if no viewing keys are in use)
+// if no viewing keys are in use)
 func setupWalletClientsWithoutViewingKeys(params *params.SimParams, obscuroClients []rpcclientlib.Client) map[string]rpcclientlib.Client {
 	walletClients := make(map[string]rpcclientlib.Client)
 	var i int

--- a/integration/smartcontract/smartcontracts_test.go
+++ b/integration/smartcontract/smartcontracts_test.go
@@ -524,9 +524,8 @@ func attestedNodeHostAddressesAreStored(t *testing.T, mgmtContractLib *debugMgmt
 
 // detectSimpleFork agg A initializes the network, agg A creates 3 correct rollups, then makes a depth 2 fork and expects the contract to detect
 //
-//                    -> 4'-> 5'
-//   0 -> 1 -> 2 -> 3 -> 4 -> 5  -> 6 (contract marked with invalid withdrawals)
-//
+// -> 4'-> 5'
+// 0 -> 1 -> 2 -> 3 -> 4 -> 5  -> 6 (contract marked with invalid withdrawals)
 func detectSimpleFork(t *testing.T, mgmtContractLib *debugMgmtContractLib, w *debugWallet, client ethadapter.EthClient) {
 	secretBytes := []byte("This is super random")
 	// crypto.GenerateKey will generate a PK that does not play along this test

--- a/tools/networkmanager/inject_txs.go
+++ b/tools/networkmanager/inject_txs.go
@@ -173,7 +173,7 @@ func checkDepositsSuccessful(txInjector *simulation.TransactionInjector, l1Clien
 			MgmtContractLib:  mgmtContractLib,
 		},
 	}
-	deposits, _, _, _ := simulation.ExtractDataFromEthereumChain(startBlock, currentBlock, l1Client, &dummySim) // nolint:dogsled
+	deposits, _, _, _ := simulation.ExtractDataFromEthereumChain(startBlock, currentBlock, l1Client, &dummySim) //nolint:dogsled
 
 	if len(deposits) != len(txInjector.TxTracker.L1Transactions) {
 		println(fmt.Sprintf("Injected %d deposits into the L1 but %d were missing.",

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -174,7 +174,7 @@ func (we *WalletExtension) handleHTTPEthJSON(resp http.ResponseWriter, req *http
 
 	// https://github.com/ethereum/EIPs/blob/master/EIPS/eip-658.md
 	// TODO fix this upstream on the decode
-	if result, found := respMap["result"]; found { // nolint
+	if result, found := respMap["result"]; found { //nolint
 		if resultMap, ok := result.(map[string]interface{}); ok {
 			if val, foundRoot := resultMap["root"]; foundRoot {
 				if val == "0x" {


### PR DESCRIPTION
### Why is this change needed?

There is an edgecase where the JSON fails to be marshalled when verifying an attestation. This case should be caught and flagged.

### What changes were made as part of this PR:

Functional.

- Catch JSON marshalling error in attestation verification

### What are the key areas to look at
