### PR TITLE
Fixes Golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -26,6 +26,7 @@ jobs:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: v1.45.2
           args: --timeout=5m --verbose
+          skip-cache: true
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -27,9 +27,6 @@ jobs:
           version: v1.48.0
           args: --timeout=5m --verbose
           skip-pkg-cache: true
-          skip-dirs:
-            - design
-            - docs
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,7 +19,10 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.17
+      - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -26,7 +26,7 @@ jobs:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: v1.45.2
           args: --timeout=5m --verbose
-          skip-cache: true
+          skip-pkg-cache: true
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -27,6 +27,9 @@ jobs:
           version: v1.48.0
           args: --timeout=5m --verbose
           skip-pkg-cache: true
+          skip-dirs:
+            - design
+            - docs
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -24,7 +24,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.45.2
+          version: v1.48.0
           args: --timeout=5m --verbose
           skip-pkg-cache: true
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,7 @@
+run:
+  skip-dirs:
+    - design
+    - docs
 linters:
   # Disable all linters.
   # Default: false

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,7 +38,6 @@ linters:
     - gosec
     - gosimple
     - govet
-    - ifshort
     - importas
     - ineffassign
     - makezero

--- a/go/enclave/db/sql/edb_attestation.go
+++ b/go/enclave/db/sql/edb_attestation.go
@@ -16,7 +16,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -183,7 +183,7 @@ func httpGetCertQuote(tlsConfig *tls.Config, host, path string) (string, []byte,
 	if err != nil {
 		return "", nil, err
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", nil, err
 	}

--- a/go/enclave/db/sql/sqlite.go
+++ b/go/enclave/db/sql/sqlite.go
@@ -31,7 +31,7 @@ func CreateTemporarySQLiteDB(dbPath string) (ethdb.Database, error) {
 	}
 	// determine if a db file already exists, we don't want to overwrite it
 	_, err := os.Stat(dbPath)
-	existingDB := err == nil //nolint:ifshort
+	existingDB := err == nil
 
 	db, err := sql.Open("sqlite3", dbPath)
 	if err != nil {

--- a/go/enclave/evm/evm_facade.go
+++ b/go/enclave/evm/evm_facade.go
@@ -55,7 +55,7 @@ func executeTransaction(s *state.StateDB, cc *params.ChainConfig, chain *Obscuro
 		return nil, err
 	}
 
-	snap := s.Snapshot() //nolint
+	snap := s.Snapshot()
 
 	// Add some balance to the sender to avoid gas issues.
 	// Todo - this has to be removed once the gas logic is sorted.

--- a/go/ethadapter/mgmtcontractlib/mgmt_contract_lib.go
+++ b/go/ethadapter/mgmtcontractlib/mgmt_contract_lib.go
@@ -5,7 +5,7 @@ import (
 	"compress/gzip"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/big"
 	"strings"
 
@@ -351,5 +351,5 @@ func Decompress(in []byte) ([]byte, error) {
 	}
 	defer gz.Close()
 
-	return ioutil.ReadAll(gz)
+	return io.ReadAll(gz)
 }

--- a/go/host/p2p/p2p.go
+++ b/go/host/p2p/p2p.go
@@ -2,7 +2,7 @@ package p2p
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -114,7 +114,7 @@ func (p *p2pImpl) handle(conn net.Conn, callback host.Host) {
 		defer conn.Close()
 	}
 
-	encodedMsg, err := ioutil.ReadAll(conn)
+	encodedMsg, err := io.ReadAll(conn)
 	if err != nil {
 		common.WarnWithID(p.nodeID, "failed to read message from peer: %v", err)
 		return

--- a/integration/gethnetwork/geth_network.go
+++ b/integration/gethnetwork/geth_network.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -133,11 +132,8 @@ func NewGethNetwork(portStart int, websocketPortStart int, gethBinaryPath string
 	timestamp := strconv.FormatInt(time.Now().UnixMilli(), 10)
 	buildDir := path.Join(basepath, buildDirBase, timestamp)
 	// We create a data directory for each node.
-	nodesDir, err := ioutil.TempDir("", timestamp)
+	nodesDir := os.TempDir()
 	fmt.Printf("Geth nodes created in: %s\n", nodesDir)
-	if err != nil {
-		panic(err)
-	}
 	dataDirs := make([]string, numNodes)
 	for i := 0; i < numNodes; i++ {
 		nodeFolder := nodeFolderName + strconv.Itoa(i+1)
@@ -306,7 +302,7 @@ func (network *GethNetwork) createAccount(dataDirPath string) {
 // Adds a Geth node's account public key to the `network` object.
 func (network *GethNetwork) retrieveAccount(dataDirPath string) string {
 	dir := path.Join(dataDirPath, keystoreDir)
-	files, _ := ioutil.ReadDir(dir)
+	files, _ := os.ReadDir(dir)
 	for _, file := range files {
 		// `ReadDir` returns the folder itself, as well as the files within it.
 		if file.IsDir() {

--- a/integration/gethnetwork/geth_network.go
+++ b/integration/gethnetwork/geth_network.go
@@ -132,8 +132,11 @@ func NewGethNetwork(portStart int, websocketPortStart int, gethBinaryPath string
 	timestamp := strconv.FormatInt(time.Now().UnixMilli(), 10)
 	buildDir := path.Join(basepath, buildDirBase, timestamp)
 	// We create a data directory for each node.
-	nodesDir := os.TempDir()
+	nodesDir, err := os.MkdirTemp("", timestamp)
 	fmt.Printf("Geth nodes created in: %s\n", nodesDir)
+	if err != nil {
+		panic(err)
+	}
 	dataDirs := make([]string, numNodes)
 	for i := 0; i < numNodes; i++ {
 		nodeFolder := nodeFolderName + strconv.Itoa(i+1)

--- a/integration/walletextension/wallet_extension_test.go
+++ b/integration/walletextension/wallet_extension_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"math/big"
 	"net/http"
@@ -530,7 +531,7 @@ func makeEthJSONReq(t *testing.T, walletExtensionAddr string, method string, par
 	if resp.Body != nil {
 		defer resp.Body.Close()
 	}
-	respBody, err := ioutil.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/integration/walletextension/wallet_extension_test.go
+++ b/integration/walletextension/wallet_extension_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/big"
 	"net/http"
 	"strings"
@@ -588,7 +587,7 @@ func generateViewingKey(t *testing.T, walletExtensionAddr string) []byte {
 	if err != nil {
 		t.Fatal(err)
 	}
-	viewingKey, err := ioutil.ReadAll(resp.Body)
+	viewingKey, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tools/azuredeployer/azure_deployer.go
+++ b/tools/azuredeployer/azure_deployer.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"os"
@@ -181,7 +180,7 @@ func runSetupScript(ipAddress string, paramsFile string, setupScript string) {
 
 // Read a JSON file into a map.
 func readJSON(path string) *map[string]interface{} {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		log.Fatalf("failed to read file at %s: %v", path, err)
 	}

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -7,8 +7,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"time"
@@ -148,7 +148,7 @@ func (we *WalletExtension) handleHTTPEthJSON(resp http.ResponseWriter, req *http
 		return
 	}
 
-	body, err := ioutil.ReadAll(req.Body)
+	body, err := io.ReadAll(req.Body)
 	if err != nil {
 		logAndSendErr(resp, fmt.Sprintf("could not read JSON-RPC request body: %s", err))
 		return
@@ -256,7 +256,7 @@ func (we *WalletExtension) handleGenerateViewingKey(resp http.ResponseWriter, _ 
 
 // Submits the viewing key and signed bytes to the enclave.
 func (we *WalletExtension) handleSubmitViewingKey(resp http.ResponseWriter, req *http.Request) {
-	body, err := ioutil.ReadAll(req.Body)
+	body, err := io.ReadAll(req.Body)
 	if err != nil {
 		logAndSendErr(resp, fmt.Sprintf("could not read viewing key and signature from client: %s", err))
 		return


### PR DESCRIPTION
### Why is this change needed?

- To fix the linter

### What changes were made as part of this PR:

- Updated to version 1.48.0
- Fixed the go version of the linter to 1.17
- Updated config to skip some directories (design and docs)

# Update the local linter ( mac ): 
```
curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
```
And update the tooling using the new path: 
```
> which golangci-lint
/Users/otherview/go/bin/golangci-lint
```




