### PR TITLE
Moves setting of VK address earlier in lifecycle. Clean up.

### DIFF
--- a/integration/common/viewkey/viewkey.go
+++ b/integration/common/viewkey/viewkey.go
@@ -37,7 +37,7 @@ func GenerateAndRegisterViewingKey(cli *rpcclientlib.ViewingKeyClient, wal walle
 	viewingPubKeyBytes := crypto.CompressPubkey(&vk.PublicKey)
 
 	// set key pair on the RPC client
-	cli.SetViewingKey(viewingPrivateKeyECIES, viewingPubKeyBytes)
+	cli.SetViewingKey(viewingPrivateKeyECIES, wal.Address(), viewingPubKeyBytes)
 
 	// sign hex-encoded public key string with the wallet's private key
 	viewingKeyHex := hex.EncodeToString(viewingPubKeyBytes)
@@ -47,7 +47,7 @@ func GenerateAndRegisterViewingKey(cli *rpcclientlib.ViewingKeyClient, wal walle
 	}
 
 	// submit the signed public key to the enclave so it can encrypt sensitive responses
-	err = cli.RegisterViewingKey(wal.Address(), signature)
+	err = cli.RegisterViewingKey(signature)
 	if err != nil {
 		return err
 	}

--- a/integration/walletextension/wallet_extension_test.go
+++ b/integration/walletextension/wallet_extension_test.go
@@ -557,12 +557,11 @@ func makeEthJSONReqAsJSON(t *testing.T, walletExtensionAddr string, method strin
 
 // Generates a signed viewing key and submits it to the wallet extension.
 func generateAndSubmitViewingKey(t *testing.T, walletExtensionAddr string, accountAddr string, accountPrivateKey *ecdsa.PrivateKey) {
-	viewingKey := generateViewingKey(t, walletExtensionAddr)
+	viewingKey := generateViewingKey(t, accountAddr, walletExtensionAddr)
 	signature := signViewingKey(t, accountPrivateKey, viewingKey)
 
 	submitViewingKeyBodyBytes, err := json.Marshal(map[string]interface{}{
-		"address":   accountAddr,
-		"signature": hex.EncodeToString(signature),
+		walletextension.ReqJSONKeySignature: hex.EncodeToString(signature),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -582,8 +581,15 @@ func generateAndSubmitViewingKey(t *testing.T, walletExtensionAddr string, accou
 }
 
 // Generates a viewing key.
-func generateViewingKey(t *testing.T, walletExtensionAddr string) []byte {
-	resp, err := http.Get(httpProtocol + walletExtensionAddr + walletextension.PathGenerateViewingKey) //nolint:noctx
+func generateViewingKey(t *testing.T, accountAddress string, walletExtensionAddr string) []byte {
+	generateViewingKeyBodyBytes, err := json.Marshal(map[string]interface{}{
+		walletextension.ReqJSONKeyAddress: accountAddress,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	generateViewingKeyBody := bytes.NewBuffer(generateViewingKeyBodyBytes)
+	resp, err := http.Post(httpProtocol+walletExtensionAddr+walletextension.PathGenerateViewingKey, "application/json", generateViewingKeyBody) //nolint:noctx
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tools/walletextension/static/javascript.js
+++ b/tools/walletextension/static/javascript.js
@@ -23,22 +23,28 @@ const initialize = () => {
             return
         }
 
-        const viewingKeyResp = await fetch(pathGenerateViewingKey);
+        const accounts = await ethereum.request({method: metamaskRequestAccounts});
+        if (accounts.length === 0) {
+            statusArea.innerText = "No MetaMask accounts found."
+            return
+        }
+        // Accounts is "An array of a single, hexadecimal Ethereum address string.", so we grab the single entry at index zero.
+        const account = accounts[0];
+
+        const addressJson = {"address": account}
+        const viewingKeyResp = await fetch(
+            pathGenerateViewingKey, {
+                method: methodPost,
+                headers: jsonHeaders,
+                body: JSON.stringify(addressJson)
+            }
+        );
         if (!viewingKeyResp.ok) {
             statusArea.innerText = "Failed to generate viewing key."
             return
         }
 
         const viewingKey = await viewingKeyResp.text();
-
-        const accounts = await ethereum.request({method: metamaskRequestAccounts});
-        if (accounts.length === 0) {
-            statusArea.innerText = "No MetaMask accounts found."
-            return
-        }
-        // The array returns "An array of a single, hexadecimal Ethereum address string.")
-        // We use the last created account for the viewing key since it makes most sense for testing.
-        const account = accounts[accounts.length - 1];
 
         const signature = await ethereum.request({
             method: metamaskPersonalSign,
@@ -50,7 +56,7 @@ const initialize = () => {
             return
         }
 
-        const signedViewingKeyJson = {"address": account, "signature": signature}
+        const signedViewingKeyJson = {"signature": signature}
         const submitViewingKeyResp = await fetch(
             pathSubmitViewingKey, {
                 method: methodPost,

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -31,13 +31,15 @@ const (
 	PathSubmitViewingKey   = "/submitviewingkey/"
 	staticDir              = "static"
 
-	reqJSONKeyID      = "id"
-	reqJSONKeyMethod  = "method"
-	reqJSONKeyParams  = "params"
-	resJSONKeyID      = "id"
-	resJSONKeyRPCVer  = "jsonrpc"
-	RespJSONKeyResult = "result"
-	httpCodeErr       = 500
+	reqJSONKeyID        = "id"
+	reqJSONKeyMethod    = "method"
+	reqJSONKeyParams    = "params"
+	ReqJSONKeyAddress   = "address"
+	ReqJSONKeySignature = "signature"
+	resJSONKeyID        = "id"
+	resJSONKeyRPCVer    = "jsonrpc"
+	RespJSONKeyResult   = "result"
+	httpCodeErr         = 500
 
 	// CORS-related constants.
 	corsAllowOrigin  = "Access-Control-Allow-Origin"
@@ -234,7 +236,20 @@ func parseRequest(body []byte) (*rpcRequest, error) {
 }
 
 // Generates a new viewing key.
-func (we *WalletExtension) handleGenerateViewingKey(resp http.ResponseWriter, _ *http.Request) {
+func (we *WalletExtension) handleGenerateViewingKey(resp http.ResponseWriter, req *http.Request) {
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		logAndSendErr(resp, fmt.Sprintf("could not read viewing key and signature from client: %s", err))
+		return
+	}
+
+	var reqJSONMap map[string]string
+	err = json.Unmarshal(body, &reqJSONMap)
+	if err != nil {
+		logAndSendErr(resp, fmt.Sprintf("could not unmarshal viewing key and signature from client to JSON: %s", err))
+		return
+	}
+
 	viewingKeyPrivate, err := crypto.GenerateKey()
 	if err != nil {
 		logAndSendErr(resp, fmt.Sprintf("could not generate new keypair: %s", err))
@@ -242,7 +257,7 @@ func (we *WalletExtension) handleGenerateViewingKey(resp http.ResponseWriter, _ 
 	}
 	viewingPublicKeyBytes := crypto.CompressPubkey(&viewingKeyPrivate.PublicKey)
 	viewingPrivateKeyEcies := ecies.ImportECDSA(viewingKeyPrivate)
-	we.hostClient.SetViewingKey(viewingPrivateKeyEcies, viewingPublicKeyBytes)
+	we.hostClient.SetViewingKey(viewingPrivateKeyEcies, common.HexToAddress(reqJSONMap[ReqJSONKeyAddress]), viewingPublicKeyBytes)
 
 	// We return the hex of the viewing key's public key for MetaMask to sign over.
 	viewingKeyBytes := crypto.CompressPubkey(&viewingKeyPrivate.PublicKey)
@@ -269,18 +284,19 @@ func (we *WalletExtension) handleSubmitViewingKey(resp http.ResponseWriter, req 
 		return
 	}
 
-	// We drop the leading "0x", and transform the V from 27/28 to 0/1.
-	signature, err := hex.DecodeString(reqJSONMap["signature"][2:])
+	//  We drop the leading "0x".
+	signature, err := hex.DecodeString(reqJSONMap[ReqJSONKeySignature][2:])
 	if err != nil {
 		logAndSendErr(resp, fmt.Sprintf("could not decode signature from client to hex: %s", err))
 		return
 	}
-	// This same change is made in geth internals, for legacy reasons to be able to recover the address:
-	//	https://github.com/ethereum/go-ethereum/blob/55599ee95d4151a2502465e0afc7c47bd1acba77/internal/ethapi/api.go#L452-L459
+
+	// We transform the V from 27/28 to 0/1. This same change is made in Geth internals, for legacy reasons to be able
+	// to recover the address: https://github.com/ethereum/go-ethereum/blob/55599ee95d4151a2502465e0afc7c47bd1acba77/internal/ethapi/api.go#L452-L459
 	signature[64] -= 27
 
 	// We return the hex of the viewing key's public key for MetaMask to sign over.
-	err = we.hostClient.RegisterViewingKey(common.HexToAddress(reqJSONMap["address"]), signature)
+	err = we.hostClient.RegisterViewingKey(signature)
 	if err != nil {
 		logAndSendErr(resp, fmt.Sprintf("RPC request to register viewing key failed: %s", err))
 		return


### PR DESCRIPTION
### Why is this change needed?

Currently, when using the viewing key client, the viewing key's address is only passed when submitting the viewing key, not when generating it.

As we move towards supporting multiple viewing keys in a single wallet extension, we'll need to pass the address at generation time, so we can store the generated viewing key against the address.

### What changes were made as part of this PR:

- list of changes
- Is this a functional or refactoring PR ( it needs to be one or the other)

### What are the key areas to look at
