### PR TITLE
Adds logic to set eth_call `from` field using `data` field as a fallback.

### DIFF
--- a/go/rpcclientlib/viewing_key_client.go
+++ b/go/rpcclientlib/viewing_key_client.go
@@ -225,6 +225,8 @@ func (c *ViewingKeyClient) addFromAddressToCallParamsIfMissing(method string, ar
 		return args, nil
 	}
 
+	// TODO - Once we support multiple viewing keys, set the `from` field to the single viewing key if there's exactly one.
+
 	// We ensure that the `data` field is present.
 	if callParams[reqJSONKeyData] == nil {
 		return nil, fmt.Errorf("eth_call request did not have its `from` or its `data` field set. Aborting " +

--- a/go/rpcclientlib/viewing_key_client.go
+++ b/go/rpcclientlib/viewing_key_client.go
@@ -268,6 +268,8 @@ func parseCallParams(args []interface{}) (map[string]interface{}, error) {
 	return callParams, nil
 }
 
+// todo - joel - add tests
+
 // Extracts the arguments from the request's `data` field. If any of them, after removing padding, match the viewing
 // key address, we return that address. Otherwise, we return nil.
 func (c *ViewingKeyClient) extractFromInDataField(callParams map[string]interface{}) (*common.Address, error) {

--- a/go/rpcclientlib/viewing_key_client.go
+++ b/go/rpcclientlib/viewing_key_client.go
@@ -264,6 +264,8 @@ func (c *ViewingKeyClient) addFromAddressToCallParamsIfMissing(method string, ar
 		}
 	}
 
+	// TODO - Consider defining an additional fallback to set the `from` field if the above all fail.
+
 	return nil, fmt.Errorf("eth_call request did not have its `from` field set, and its `data` field " +
 		"did not contain an address matching a viewing key. Aborting request as it will not be possible to " +
 		"encrypt the response")

--- a/go/rpcclientlib/viewing_key_client.go
+++ b/go/rpcclientlib/viewing_key_client.go
@@ -76,7 +76,7 @@ func (c *ViewingKeyClient) Call(result interface{}, method string, args ...inter
 	if method == RPCCall {
 		// RPCCall is a sensitive method that requires a viewing key lookup but the 'from' field is not mandatory in geth
 		//	and is often not included from metamask etc. So we ensure it is populated here.
-		args, err = c.addFromAddressToCallParamsIfMissing(method, args)
+		args, err = c.addFromAddressToCallParamsIfMissing(args)
 		if err != nil {
 			return err
 		}
@@ -203,7 +203,7 @@ func (c *ViewingKeyClient) RegisterViewingKey(signature []byte) error {
 // The enclave requires the `from` field to be set so that it can encrypt the response, but sources like MetaMask often
 // don't set it. So we check whether it's present; if absent, we walk through the arguments in the request's `data`
 // field, and if any of the arguments match our viewing key address, we set the `from` field to that address.
-func (c *ViewingKeyClient) addFromAddressToCallParamsIfMissing(method string, args []interface{}) ([]interface{}, error) {
+func (c *ViewingKeyClient) addFromAddressToCallParamsIfMissing(args []interface{}) ([]interface{}, error) {
 	if len(args) == 0 {
 		return nil, fmt.Errorf("expected %s params to have a 'from' field but no params found", RPCCall)
 	}
@@ -212,12 +212,12 @@ func (c *ViewingKeyClient) addFromAddressToCallParamsIfMissing(method string, ar
 	if !ok {
 		callParamsJSON, ok := args[0].([]byte)
 		if !ok {
-			return nil, fmt.Errorf("expected %s first param to be a map or json encoded bytes but was %t", method, args[0])
+			return nil, fmt.Errorf("expected eth_call first param to be a map or json encoded bytes but was %t", args[0])
 		}
 
 		err := json.Unmarshal(callParamsJSON, &callParams)
 		if err != nil {
-			return nil, fmt.Errorf("expected %s first param to be a map or json encoded bytes, failed to decode: %w", method, err)
+			return nil, fmt.Errorf("expected eth_call first param to be a map or json encoded bytes, failed to decode: %w", err)
 		}
 	}
 

--- a/go/rpcclientlib/viewing_key_client_test.go
+++ b/go/rpcclientlib/viewing_key_client_test.go
@@ -1,0 +1,59 @@
+package rpcclientlib
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+const (
+	dataFieldPrefix            = "0xmethodID"
+	padding                    = "000000000000000000000000"
+	viewingKeyAddressHex       = "71C7656EC7ab88b098defB751B7401B5f6d8976F"
+	viewingKeyAddressHexPadded = padding + viewingKeyAddressHex
+	otherAddressHexPadded      = padding + "71C7656EC7ab88b098defB751B7401B5f6d8976E" // Differs only in the final byte.
+)
+
+var viewingKeyAddress = common.HexToAddress("0x" + viewingKeyAddressHex)
+
+func TestCanSearchDataFieldForFrom(t *testing.T) {
+	callParams := map[string]interface{}{"data": dataFieldPrefix + otherAddressHexPadded + viewingKeyAddressHexPadded}
+	address, err := searchDataFieldForFrom(callParams, &viewingKeyAddress)
+	if err != nil {
+		t.Fatalf("did not expect an error but got %s", err)
+	}
+	if *address != viewingKeyAddress {
+		t.Fatal("did not find correct viewing key address in `data` field")
+	}
+}
+
+func TestCanSearchDataFieldWhenHasUnexpectedLength(t *testing.T) {
+	incorrectLengthArg := "arg2xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" // Only 31 bytes.
+	callParams := map[string]interface{}{"data": dataFieldPrefix + otherAddressHexPadded + viewingKeyAddressHexPadded + incorrectLengthArg}
+	address, err := searchDataFieldForFrom(callParams, &viewingKeyAddress)
+	if err != nil {
+		t.Fatalf("did not expect an error but got %s", err)
+	}
+	if *address != viewingKeyAddress {
+		t.Fatal("did not find correct viewing key address in `data` field")
+	}
+}
+
+func TestErrorsWhenDataFieldIsMissing(t *testing.T) {
+	_, err := searchDataFieldForFrom(make(map[string]interface{}), &viewingKeyAddress)
+
+	if err == nil {
+		t.Fatal("`data` field was missing but not error was thrown")
+	}
+}
+
+func TestGracefulWhenDataFieldTooShort(t *testing.T) {
+	callParams := map[string]interface{}{"data": "tooshort"}
+	address, err := searchDataFieldForFrom(callParams, &viewingKeyAddress)
+	if err != nil {
+		t.Fatalf("did not expect an error but got %s", err)
+	}
+	if address != nil {
+		t.Fatal("`data` field was too short but address was found anyway")
+	}
+}


### PR DESCRIPTION
### Why is this change needed?

Currently, the WE sets the `from` field on an eth_call request using the current VK. However, as we start supporting multiple VKs, this will not be possible.

We add logic to try and find the `from` field in the eth_call's `data` field, as a fallback.

### What changes were made as part of this PR:

Functional.

- If `eth_call` has missing `from` field, try and determine how to set it based on the `data` field

### What are the key areas to look at
