### PR TITLE
Use error for RPC nil response

### DIFF
--- a/go/ethadapter/obscuro_rpc_client.go
+++ b/go/ethadapter/obscuro_rpc_client.go
@@ -15,9 +15,7 @@ import (
 	"github.com/obscuronet/go-obscuro/integration/common/viewkey"
 )
 
-var (
-	ErrReceiptNotFound = errors.New("receipt not found, received nil response")
-)
+var ErrReceiptNotFound = errors.New("receipt not found, received nil response")
 
 // obscuroWalletRPCClient implements the EthClient interface, it's bound to a single wallet (viewing key and address)
 //
@@ -67,7 +65,7 @@ func (c *obscuroWalletRPCClient) TransactionReceipt(hash gethcommon.Hash) (*type
 	var r types.Receipt
 	err := c.client.Call(&r, rpcclientlib.RPCGetTxReceipt, hash)
 	if err != nil {
-		if err == rpcclientlib.ErrNilResponse {
+		if errors.Is(err, rpcclientlib.ErrNilResponse) {
 			return nil, ErrReceiptNotFound
 		}
 		return nil, err

--- a/go/ethadapter/obscuro_rpc_client.go
+++ b/go/ethadapter/obscuro_rpc_client.go
@@ -1,6 +1,7 @@
 package ethadapter
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
 
@@ -12,6 +13,10 @@ import (
 	"github.com/obscuronet/go-obscuro/go/rpcclientlib"
 	"github.com/obscuronet/go-obscuro/go/wallet"
 	"github.com/obscuronet/go-obscuro/integration/common/viewkey"
+)
+
+var (
+	ErrReceiptNotFound = errors.New("receipt not found, received nil response")
 )
 
 // obscuroWalletRPCClient implements the EthClient interface, it's bound to a single wallet (viewing key and address)
@@ -62,6 +67,9 @@ func (c *obscuroWalletRPCClient) TransactionReceipt(hash gethcommon.Hash) (*type
 	var r types.Receipt
 	err := c.client.Call(&r, rpcclientlib.RPCGetTxReceipt, hash)
 	if err != nil {
+		if err == rpcclientlib.ErrNilResponse {
+			return nil, ErrReceiptNotFound
+		}
 		return nil, err
 	}
 	return &r, nil

--- a/go/rpcclientlib/client.go
+++ b/go/rpcclientlib/client.go
@@ -1,5 +1,9 @@
 package rpcclientlib
 
+import (
+	"errors"
+)
+
 const (
 	RPCGetID                   = "obscuro_getID"
 	RPCGetCurrentBlockHead     = "obscuro_getCurrentBlockHead"
@@ -23,9 +27,11 @@ const (
 	RPCSendRawTransaction      = "eth_sendRawTransaction"
 )
 
+var ErrNilResponse = errors.New("nil response received from Obscuro node")
+
 // Client is used by client applications to interact with the Obscuro node
 type Client interface {
-	// Call executes the named method via RPC.
+	// Call executes the named method via RPC. (Returns `ErrNilResponse` on nil response from Node, this is used as "not found" for some method calls)
 	Call(result interface{}, method string, args ...interface{}) error
 	// Stop closes the client.
 	Stop()

--- a/go/rpcclientlib/viewing_key_client.go
+++ b/go/rpcclientlib/viewing_key_client.go
@@ -92,9 +92,14 @@ func (c *ViewingKeyClient) Call(result interface{}, method string, args ...inter
 		return fmt.Errorf("%s rpc call failed - %w", method, err)
 	}
 
-	// if caller not interested in response or there was a nil response, we're done
-	if result == nil || rawResult == nil {
+	// if caller not interested in response, we're done
+	if result == nil {
 		return nil
+	}
+
+	if rawResult == nil {
+		// note: some methods return nil for 'not found', caller can check for this Error type to verify
+		return ErrNilResponse
 	}
 
 	// method is sensitive, so we decrypt it before unmarshalling the result


### PR DESCRIPTION
### Why is this change needed?

- we can't populate the typed pointer in the rpc client when we have a nil response
- we return a specific Nil Response error so that caller can check for it (no more onerous than if they had to nil-check their data type, and this is more idiomatic Go)

### What changes were made as part of this PR:

- add nil response to client
- add nil transaction response to higher-level client

### Evidence
The contract deployment now succeeds against testnet:
```
Preparing contract deployer with config: {
  "NodeHost": "obscuronode-0-testnet-1.uksouth.cloudapp.azure.com",
  "NodePort": 13000,
  "IsL1Deployment": false,
  "PrivateKey": "6e384a07a01263518a09a5424c7b6bbfc3604ba7d93f47e3a455cbdd7f9f0682",
  "ChainID": 777,
  "ContractName": "L2ERC20",
  "ConstructorParams": [
    "JAM",
    "JAM",
    "1000000000000000000000"
  ]
}
0xdDb7b4973DfC4F151BF7DEf4fD3ABFd899Bc1778
```