### PR TITLE
Allow multiple viewing keys to be stored (still a single key used for decryption)

### DIFF
--- a/go/rpcclientlib/viewing_key_client.go
+++ b/go/rpcclientlib/viewing_key_client.go
@@ -61,7 +61,7 @@ type ViewingKeyClient struct {
 	obscuroClient Client
 
 	enclavePublicKey *ecies.PublicKey
-	// todo - joel - remove this field
+	// TODO - Use multiple keys below to perform decryption.
 	viewingPrivKey *ecies.PrivateKey // private viewing key to use for decrypting sensitive requests
 
 	viewingKeysPrivate map[common.Address]*ecies.PrivateKey // Maps an address to its private viewing key.

--- a/go/rpcclientlib/viewing_key_client.go
+++ b/go/rpcclientlib/viewing_key_client.go
@@ -65,7 +65,7 @@ type ViewingKeyClient struct {
 	viewingPrivKey *ecies.PrivateKey // private viewing key to use for decrypting sensitive requests
 
 	viewingKeysPrivate map[common.Address]*ecies.PrivateKey // Maps an address to its private viewing key.
-	viewingKeysPublic  map[common.Address][]byte            // Maps an address to its public viewing key.
+	viewingKeysPublic  map[common.Address][]byte            // Maps an address to its public viewing key bytes.
 }
 
 // Call handles JSON rpc requests - if the method is sensitive it will encrypt the args before sending the request and
@@ -77,7 +77,9 @@ func (c *ViewingKeyClient) Call(result interface{}, method string, args ...inter
 		return c.obscuroClient.Call(result, method, args...)
 	}
 
-	// todo - joel - Abort if there's no viewing keys
+	if len(c.viewingKeysPrivate) == 0 {
+		return fmt.Errorf("called sensitive method %s, but no viewing keys are set up", method)
+	}
 
 	var err error
 	if method == RPCCall {

--- a/go/rpcclientlib/viewing_key_client.go
+++ b/go/rpcclientlib/viewing_key_client.go
@@ -144,7 +144,7 @@ func (c *ViewingKeyClient) encryptParamBytes(params []byte) ([]byte, error) {
 
 func (c *ViewingKeyClient) decryptResponse(resultBlob interface{}) ([]byte, error) {
 	if len(c.viewingKeysPrivate) == 0 {
-		return nil, fmt.Errorf("cannot decrypt response as not viewing keys have been set up")
+		return nil, fmt.Errorf("cannot decrypt response as no viewing keys have been set up")
 	}
 
 	resultStr, ok := resultBlob.(string)

--- a/go/rpcclientlib/viewing_key_client.go
+++ b/go/rpcclientlib/viewing_key_client.go
@@ -34,11 +34,11 @@ func NewViewingKeyClient(client Client) (*ViewingKeyClient, error) {
 	enclavePublicKey := ecies.ImportECDSAPublic(enclPubECDSA)
 
 	vkClient := &ViewingKeyClient{
-		obscuroClient:    client,
-		enclavePublicKey: enclavePublicKey,
+		obscuroClient:      client,
+		enclavePublicKey:   enclavePublicKey,
+		viewingKeysPrivate: map[common.Address]*ecies.PrivateKey{},
+		viewingKeysPublic:  map[common.Address][]byte{},
 	}
-	vkClient.viewingKeysPrivate = make(map[common.Address]*ecies.PrivateKey)
-	vkClient.viewingKeysPublic = make(map[common.Address][]byte)
 
 	return vkClient, nil
 }

--- a/go/rpcclientlib/viewing_key_client.go
+++ b/go/rpcclientlib/viewing_key_client.go
@@ -33,10 +33,14 @@ func NewViewingKeyClient(client Client) (*ViewingKeyClient, error) {
 	}
 	enclavePublicKey := ecies.ImportECDSAPublic(enclPubECDSA)
 
-	return &ViewingKeyClient{
+	vkClient := &ViewingKeyClient{
 		obscuroClient:    client,
 		enclavePublicKey: enclavePublicKey,
-	}, nil
+	}
+	vkClient.viewingKeysPrivate = make(map[common.Address]*ecies.PrivateKey)
+	vkClient.viewingKeysPublic = make(map[common.Address][]byte)
+
+	return vkClient, nil
 }
 
 // NewViewingKeyNetworkClient returns a network RPC client with Viewing Key encryption/decryption
@@ -49,10 +53,6 @@ func NewViewingKeyNetworkClient(rpcAddress string) (*ViewingKeyClient, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	vkClient.viewingKeysPrivate = make(map[common.Address]*ecies.PrivateKey)
-	vkClient.viewingKeysPublic = make(map[common.Address][]byte)
-
 	return vkClient, nil
 }
 

--- a/go/rpcclientlib/viewing_key_client_test.go
+++ b/go/rpcclientlib/viewing_key_client_test.go
@@ -3,6 +3,8 @@ package rpcclientlib
 import (
 	"testing"
 
+	"github.com/ethereum/go-ethereum/crypto/ecies"
+
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -14,15 +16,22 @@ const (
 	otherAddressHexPadded      = padding + "71C7656EC7ab88b098defB751B7401B5f6d8976E" // Differs only in the final byte.
 )
 
-var viewingKeyAddress = common.HexToAddress("0x" + viewingKeyAddressHex)
+var (
+	viewingKeyAddressOne = common.HexToAddress("0x" + viewingKeyAddressHex)
+	viewingKeyAddressTwo = common.HexToAddress("0x71C7656EC7ab88b098defB751B7401B5f6d8976D") // Not in the data field.
+	viewingKeyMap        = map[common.Address]*ecies.PrivateKey{
+		viewingKeyAddressOne: nil,
+		viewingKeyAddressTwo: nil,
+	}
+)
 
 func TestCanSearchDataFieldForFrom(t *testing.T) {
 	callParams := map[string]interface{}{"data": dataFieldPrefix + otherAddressHexPadded + viewingKeyAddressHexPadded}
-	address, err := searchDataFieldForFrom(callParams, &viewingKeyAddress)
+	address, err := searchDataFieldForFrom(callParams, viewingKeyMap)
 	if err != nil {
 		t.Fatalf("did not expect an error but got %s", err)
 	}
-	if *address != viewingKeyAddress {
+	if *address != viewingKeyAddressOne {
 		t.Fatal("did not find correct viewing key address in `data` field")
 	}
 }
@@ -30,17 +39,17 @@ func TestCanSearchDataFieldForFrom(t *testing.T) {
 func TestCanSearchDataFieldWhenHasUnexpectedLength(t *testing.T) {
 	incorrectLengthArg := "arg2xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" // Only 31 bytes.
 	callParams := map[string]interface{}{"data": dataFieldPrefix + otherAddressHexPadded + viewingKeyAddressHexPadded + incorrectLengthArg}
-	address, err := searchDataFieldForFrom(callParams, &viewingKeyAddress)
+	address, err := searchDataFieldForFrom(callParams, viewingKeyMap)
 	if err != nil {
 		t.Fatalf("did not expect an error but got %s", err)
 	}
-	if *address != viewingKeyAddress {
+	if *address != viewingKeyAddressOne {
 		t.Fatal("did not find correct viewing key address in `data` field")
 	}
 }
 
 func TestErrorsWhenDataFieldIsMissing(t *testing.T) {
-	_, err := searchDataFieldForFrom(make(map[string]interface{}), &viewingKeyAddress)
+	_, err := searchDataFieldForFrom(make(map[string]interface{}), viewingKeyMap)
 
 	if err == nil {
 		t.Fatal("`data` field was missing but not error was thrown")
@@ -49,7 +58,7 @@ func TestErrorsWhenDataFieldIsMissing(t *testing.T) {
 
 func TestGracefulWhenDataFieldTooShort(t *testing.T) {
 	callParams := map[string]interface{}{"data": "tooshort"}
-	address, err := searchDataFieldForFrom(callParams, &viewingKeyAddress)
+	address, err := searchDataFieldForFrom(callParams, viewingKeyMap)
 	if err != nil {
 		t.Fatalf("did not expect an error but got %s", err)
 	}

--- a/integration/common/viewkey/viewkey.go
+++ b/integration/common/viewkey/viewkey.go
@@ -47,7 +47,7 @@ func GenerateAndRegisterViewingKey(cli *rpcclientlib.ViewingKeyClient, wal walle
 	}
 
 	// submit the signed public key to the enclave so it can encrypt sensitive responses
-	err = cli.RegisterViewingKey(signature)
+	err = cli.RegisterViewingKey(signature, wal.Address())
 	if err != nil {
 		return err
 	}

--- a/integration/walletextension/wallet_extension_test.go
+++ b/integration/walletextension/wallet_extension_test.go
@@ -562,6 +562,7 @@ func generateAndSubmitViewingKey(t *testing.T, walletExtensionAddr string, accou
 
 	submitViewingKeyBodyBytes, err := json.Marshal(map[string]interface{}{
 		walletextension.ReqJSONKeySignature: hex.EncodeToString(signature),
+		walletextension.ReqJSONKeyAddress:   accountAddr,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/tools/walletextension/static/javascript.js
+++ b/tools/walletextension/static/javascript.js
@@ -56,7 +56,7 @@ const initialize = () => {
             return
         }
 
-        const signedViewingKeyJson = {"signature": signature}
+        const signedViewingKeyJson = {"signature": signature, "address": account}
         const submitViewingKeyResp = await fetch(
             pathSubmitViewingKey, {
                 method: methodPost,

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -296,7 +296,7 @@ func (we *WalletExtension) handleSubmitViewingKey(resp http.ResponseWriter, req 
 	signature[64] -= 27
 
 	// We return the hex of the viewing key's public key for MetaMask to sign over.
-	err = we.hostClient.RegisterViewingKey(signature)
+	err = we.hostClient.RegisterViewingKey(signature, common.HexToAddress(reqJSONMap[ReqJSONKeyAddress]))
 	if err != nil {
 		logAndSendErr(resp, fmt.Sprintf("RPC request to register viewing key failed: %s", err))
 		return


### PR DESCRIPTION
### Why is this change needed?

Another step in enabling multiple viewing keys. We still use a single key for decryption, but we allow registration of multiple viewing keys now.

### What changes were made as part of this PR:

Functional.

- Allows multiple viewing keys to be stored, keyed by address

### What are the key areas to look at
