### PR TITLE
Handle nil response in wallet extension

### DIFF
--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -165,8 +165,11 @@ func (we *WalletExtension) handleHTTPEthJSON(resp http.ResponseWriter, req *http
 	var rpcResp interface{}
 	err = we.hostClient.Call(&rpcResp, rpcReq.method, rpcReq.params...)
 	if err != nil {
-		logAndSendErr(resp, fmt.Sprintf("rpc request failed: %s", err))
-		return
+		// if err was for a nil response then we will return an RPC result of null to the caller (this is a valid "not-found" response for some methods)
+		if !errors.Is(err, rpcclientlib.ErrNilResponse) {
+			logAndSendErr(resp, fmt.Sprintf("rpc request failed: %s", err))
+			return
+		}
 	}
 
 	respMap := make(map[string]interface{})


### PR DESCRIPTION
### Why is this change needed?

- some methods return nil and that should be propagated to the WalletExtension caller as `"result": null`

### What changes were made as part of this PR:
- Change wallet extension to check for ErrNilResponse and return the null result instead of an error
