### PR TITLE
Adds method to retrieve a rollup by height.

### DIFF
--- a/go/enclave/db/storage.go
+++ b/go/enclave/db/storage.go
@@ -56,6 +56,19 @@ func (s *storageImpl) FetchGenesisRollup() *core.Rollup {
 	return r
 }
 
+func (s *storageImpl) FetchRollupByHeight(height uint64) *core.Rollup {
+	if height == 0 {
+		return s.FetchGenesisRollup()
+	}
+
+	hash := obscurorawdb.ReadCanonicalHash(s.db, height)
+	if hash == (gethcommon.Hash{}) {
+		return nil
+	}
+	r, _ := s.FetchRollup(hash)
+	return r
+}
+
 func (s *storageImpl) StoreRollup(rollup *core.Rollup) {
 	s.assertSecretAvailable()
 

--- a/go/enclave/db/storage.go
+++ b/go/enclave/db/storage.go
@@ -56,19 +56,6 @@ func (s *storageImpl) FetchGenesisRollup() *core.Rollup {
 	return r
 }
 
-func (s *storageImpl) FetchRollupByHeight(height uint64) *core.Rollup {
-	if height == 0 {
-		return s.FetchGenesisRollup()
-	}
-
-	hash := obscurorawdb.ReadCanonicalHash(s.db, height)
-	if hash == (gethcommon.Hash{}) {
-		return nil
-	}
-	r, _ := s.FetchRollup(hash)
-	return r
-}
-
 func (s *storageImpl) StoreRollup(rollup *core.Rollup) {
 	s.assertSecretAvailable()
 
@@ -86,6 +73,18 @@ func (s *storageImpl) FetchRollup(hash common.L2RootHash) (*core.Rollup, bool) {
 		return r, true
 	}
 	return nil, false
+}
+
+func (s *storageImpl) FetchRollupByHeight(height uint64) (*core.Rollup, bool) {
+	if height == 0 {
+		return s.FetchGenesisRollup(), true
+	}
+
+	hash := obscurorawdb.ReadCanonicalHash(s.db, height)
+	if hash == (gethcommon.Hash{}) {
+		return nil, false
+	}
+	return s.FetchRollup(hash)
 }
 
 func (s *storageImpl) FetchRollups(height uint64) []*core.Rollup {


### PR DESCRIPTION
### Why is this change needed?

The API for `eth_getBalance` requires that we can check the balance at any block. Currently, there is no API to grab the rollup with a specific height.

### What changes were made as part of this PR:

Functional.

- Adds API to get rollup with a specific height

### What are the key areas to look at
