### PR TITLE
Gets balance at specific rollup, not always latest.

### DIFF
--- a/go/enclave/db/interfaces.go
+++ b/go/enclave/db/interfaces.go
@@ -37,6 +37,8 @@ type BlockResolver interface {
 type RollupResolver interface {
 	// FetchRollup returns the rollup with the given hash and true, or (nil, false) if no such rollup is stored
 	FetchRollup(hash common.L2RootHash) (*core.Rollup, bool)
+	// FetchRollupByHeight returns the rollup with the given height and true, or (nil, false) if no such rollup is stored
+	FetchRollupByHeight(height uint64) (*core.Rollup, bool)
 	// FetchRollups returns all the proposed rollups with the given height
 	FetchRollups(height uint64) []*core.Rollup
 	// StoreRollup persists the rollup

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"math/big"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 
@@ -689,7 +688,8 @@ func (rc *RollupChain) GetBalance(encryptedParams common.EncryptedParamsGetBalan
 	}
 	// TODO - Replace all usages of `HexToAddress` with a `SafeHexToAddress` that checks that the string does not exceed 20 bytes.
 	address := gethcommon.HexToAddress(paramList[0])
-	blockNumber, err := strconv.Atoi(paramList[1])
+	blockNumber := gethrpc.BlockNumber(0)
+	err = blockNumber.UnmarshalJSON([]byte(paramList[1]))
 	if err != nil {
 		return nil, fmt.Errorf("could not parse requested rollup number")
 	}
@@ -739,9 +739,9 @@ func (rc *RollupChain) verifySig(r *obscurocore.Rollup) bool {
 }
 
 // Retrieves the rollup with the given height, with special handling for earliest/latest/pending .
-func (rc *RollupChain) getRollup(height int) (*obscurocore.Rollup, error) {
+func (rc *RollupChain) getRollup(height gethrpc.BlockNumber) (*obscurocore.Rollup, error) {
 	var rollup *obscurocore.Rollup
-	switch gethrpc.BlockNumber(height) {
+	switch height {
 	case gethrpc.EarliestBlockNumber:
 		rollup = rc.storage.FetchGenesisRollup()
 	case gethrpc.PendingBlockNumber:

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -749,11 +749,11 @@ func (rc *RollupChain) getRollup(height gethrpc.BlockNumber) (*obscurocore.Rollu
 		return nil, fmt.Errorf("requested balance for pending block. This is not handled currently")
 	case gethrpc.LatestBlockNumber:
 		rollupHash := rc.storage.FetchHeadState().HeadRollup
-		maybeRollup, found := rc.storage.FetchRollup(rollupHash)
+		var found bool
+		rollup, found = rc.storage.FetchRollup(rollupHash)
 		if !found {
 			return nil, fmt.Errorf("rollup with requested height %d was not found", height)
 		}
-		rollup = maybeRollup
 	default:
 		maybeRollup, found := rc.storage.FetchRollupByHeight(uint64(height))
 		if !found {


### PR DESCRIPTION
### Why is this change needed?

Currently, `eth_getBalance` returns the latest balance, not the balance at a specific block.

### What changes were made as part of this PR:

Functional.

- Returns the balance at a specific rollup

### What are the key areas to look at
