### PR TITLE
add block number to the nonce call

### DIFF
--- a/go/ethadapter/obscuro_rpc_client.go
+++ b/go/ethadapter/obscuro_rpc_client.go
@@ -3,6 +3,7 @@ package ethadapter
 import (
 	"errors"
 	"fmt"
+	"github.com/ethereum/go-ethereum/rpc"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum"
@@ -75,7 +76,9 @@ func (c *obscuroWalletRPCClient) TransactionReceipt(hash gethcommon.Hash) (*type
 
 func (c *obscuroWalletRPCClient) Nonce(address gethcommon.Address) (uint64, error) {
 	var result uint64
-	err := c.client.Call(&result, rpcclientlib.RPCNonce, address)
+	bl := rpc.LatestBlockNumber
+	// todo take the block number as an argument
+	err := c.client.Call(&result, rpcclientlib.RPCNonce, address, rpc.BlockNumberOrHash{BlockNumber: &bl})
 	return result, err
 }
 

--- a/go/ethadapter/obscuro_rpc_client.go
+++ b/go/ethadapter/obscuro_rpc_client.go
@@ -3,8 +3,9 @@ package ethadapter
 import (
 	"errors"
 	"fmt"
-	"github.com/ethereum/go-ethereum/rpc"
 	"math/big"
+
+	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/ethereum/go-ethereum"
 	gethcommon "github.com/ethereum/go-ethereum/common"


### PR DESCRIPTION
### Why is this change needed?

the nonce call fails

### What changes were made as part of this PR:

- functional
- add latest block as default param to the nonce call
- 
### What are the key areas to look at
