### PR TITLE
increase the size of the `val` column

### DIFF
--- a/go/enclave/db/sql/sqlite.go
+++ b/go/enclave/db/sql/sqlite.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	tempDirName = "obscuro-persistence"
-	createQry   = `create table if not exists keyvalue (ky varbinary(64) primary key, val blob); delete from keyvalue;`
+	createQry   = `create table if not exists keyvalue (ky varbinary(64) primary key, val mediumblob); delete from keyvalue;`
 )
 
 // CreateTemporarySQLiteDB if dbPath is empty will use a random throwaway temp file,


### PR DESCRIPTION
### Why is this change needed?

testnet failing with:
```[35mCRIT [0m[08-16|10:31:37.050] Failed to store block body               [35merr[0m="Error 1406: Data too long for column 'val' at row 1"```


### What changes were made as part of this PR:

functional
-increase the size of the blob field

### What are the key areas to look at
