### PR TITLE
Dev testnet uses it's own deployer image

### DIFF
--- a/.github/workflows/manual-deploy-dev-testnet.yml
+++ b/.github/workflows/manual-deploy-dev-testnet.yml
@@ -263,10 +263,10 @@ jobs:
     needs: deploy-l2
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: 'Deploy L2 contracts'
         id: deployL2Contracts
         shell: bash
         run: |
-          ./testnet/testnet-deploy-l2-contracts.sh --l2host=dev-obscuronode-0-testnet-${{ GITHUB.RUN_NUMBER }}.uksouth.cloudapp.azure.com
+          ./testnet/testnet-deploy-l2-contracts.sh --l2host=dev-obscuronode-0-testnet-${{ GITHUB.RUN_NUMBER }}.uksouth.cloudapp.azure.com --docker_image=${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/dev_obscuro_contractdeployer:latest

--- a/testnet/testnet-deploy-contracts.sh
+++ b/testnet/testnet-deploy-contracts.sh
@@ -14,6 +14,8 @@ help_and_exit() {
     echo ""
     echo "  l1port             *Optional* Set the l1 port. Defaults to 9000"
     echo ""
+    echo "  docker_image       *Optional* Sets the docker image to use. Defaults to testnetobscuronet.azurecr.io/obscuronet/obscuro_contractdeployer:latest"
+    echo ""
     echo ""
     echo ""
     exit 1  # Exit with error explicitly
@@ -27,6 +29,7 @@ testnet_path="${start_path}"
 
 # Define defaults
 l1port=9000
+deployer_docker_image="testnetobscuronet.azurecr.io/obscuronet/obscuro_contractdeployer:latest"
 
 # Fetch options
 for argument in "$@"
@@ -38,6 +41,7 @@ do
             --l1host)                   l1host=${value} ;;
             --l1port)                   l1port=${value} ;;
             --pkstring)                 pkstring=${value} ;;
+            --docker_image)             docker_image=${value} ;;
             --help)                     help_and_exit ;;
             *)
     esac
@@ -58,7 +62,7 @@ echo "Deploying Obscuro management contract to L1 network"
 docker run --name=mgmtcontractdeployer \
     --network=node_network \
     --entrypoint /home/go-obscuro/tools/contractdeployer/main/main \
-     testnetobscuronet.azurecr.io/obscuronet/obscuro_contractdeployer:latest \
+    "${deployer_docker_image}" \
     --nodeHost=${l1host} \
     --nodePort=${l1port} \
     --l1Deployment \
@@ -74,7 +78,7 @@ echo "Deploying JAM ERC20 contract to L1 network"
 docker run --name=jamerc20deployer \
     --network=node_network \
     --entrypoint /home/go-obscuro/tools/contractdeployer/main/main \
-     testnetobscuronet.azurecr.io/obscuronet/obscuro_contractdeployer:latest \
+     "${deployer_docker_image}" \
     --nodeHost=${l1host} \
     --nodePort=${l1port} \
     --l1Deployment \
@@ -91,7 +95,7 @@ echo "Deploying ETH ERC20 contract to L1 network"
 docker run --name=etherc20deployer \
     --network=node_network \
     --entrypoint /home/go-obscuro/tools/contractdeployer/main/main \
-     testnetobscuronet.azurecr.io/obscuronet/obscuro_contractdeployer:latest \
+     "${deployer_docker_image}" \
     --nodeHost=${l1host} \
     --nodePort=${l1port} \
     --l1Deployment \

--- a/testnet/testnet-deploy-contracts.sh
+++ b/testnet/testnet-deploy-contracts.sh
@@ -29,7 +29,7 @@ testnet_path="${start_path}"
 
 # Define defaults
 l1port=9000
-deployer_docker_image="testnetobscuronet.azurecr.io/obscuronet/obscuro_contractdeployer:latest"
+docker_image="testnetobscuronet.azurecr.io/obscuronet/obscuro_contractdeployer:latest"
 
 # Fetch options
 for argument in "$@"
@@ -62,7 +62,7 @@ echo "Deploying Obscuro management contract to L1 network"
 docker run --name=mgmtcontractdeployer \
     --network=node_network \
     --entrypoint /home/go-obscuro/tools/contractdeployer/main/main \
-    "${deployer_docker_image}" \
+    "${docker_image}" \
     --nodeHost=${l1host} \
     --nodePort=${l1port} \
     --l1Deployment \
@@ -78,7 +78,7 @@ echo "Deploying JAM ERC20 contract to L1 network"
 docker run --name=jamerc20deployer \
     --network=node_network \
     --entrypoint /home/go-obscuro/tools/contractdeployer/main/main \
-     "${deployer_docker_image}" \
+     "${docker_image}" \
     --nodeHost=${l1host} \
     --nodePort=${l1port} \
     --l1Deployment \
@@ -95,7 +95,7 @@ echo "Deploying ETH ERC20 contract to L1 network"
 docker run --name=etherc20deployer \
     --network=node_network \
     --entrypoint /home/go-obscuro/tools/contractdeployer/main/main \
-     "${deployer_docker_image}" \
+     "${docker_image}" \
     --nodeHost=${l1host} \
     --nodePort=${l1port} \
     --l1Deployment \

--- a/testnet/testnet-deploy-l2-contracts.sh
+++ b/testnet/testnet-deploy-l2-contracts.sh
@@ -10,11 +10,13 @@ help_and_exit() {
     echo ""
     echo "  l2host             *Required* Set the l2 host address"
     echo ""
-    echo "  jampkstring           *Optional* Set the pkstring to deploy JAM contract"
+    echo "  jampkstring        *Optional* Set the pkstring to deploy JAM contract"
     echo ""
-    echo "  ethpkstring           *Optional* Set the pkstring to deploy ETH contract"
+    echo "  ethpkstring        *Optional* Set the pkstring to deploy ETH contract"
     echo ""
     echo "  l2port             *Optional* Set the l2 port. Defaults to 10000"
+    echo ""
+    echo "  docker_image       *Optional* Sets the docker image to use. Defaults to testnetobscuronet.azurecr.io/obscuronet/obscuro_contractdeployer:latest"
     echo ""
     echo ""
     echo ""
@@ -33,6 +35,7 @@ l2port=13000
 jampkstring="6e384a07a01263518a09a5424c7b6bbfc3604ba7d93f47e3a455cbdd7f9f0682"
 ethpkstring="4bfe14725e685901c062ccd4e220c61cf9c189897b6c78bd18d7f51291b2b8f8"
 jamerc20address="0xf3a8bd422097bFdd9B3519Eaeb533393a1c561aC"
+docker_image="testnetobscuronet.azurecr.io/obscuronet/obscuro_contractdeployer:latest"
 
 # Fetch options
 for argument in "$@"
@@ -43,8 +46,9 @@ do
     case "$key" in
             --l2host)                   l2host=${value} ;;
             --l2port)                   l2port=${value} ;;
-            --jampkstring)                 jampkstring=${value} ;;
-            --ethpkstring)                 ethpkstring=${value} ;;
+            --jampkstring)              jampkstring=${value} ;;
+            --ethpkstring)              ethpkstring=${value} ;;
+            --docker_image)             docker_image=${value} ;;
             --help)                     help_and_exit ;;
             *)
     esac
@@ -62,7 +66,7 @@ docker network create --driver bridge node_network || true
 docker run --name=jamL2deployer \
     --network=node_network \
     --entrypoint /home/go-obscuro/tools/contractdeployer/main/main \
-     testnetobscuronet.azurecr.io/obscuronet/obscuro_contractdeployer:latest \
+     "${docker_image}" \
     --nodeHost=${l2host} \
     --nodePort=${l2port} \
     --contractName="L2ERC20" \
@@ -74,7 +78,7 @@ echo "Deploying ETH ERC20 contract to the obscuro network..."
 docker run --name=ethL2deployer \
     --network=node_network \
     --entrypoint /home/go-obscuro/tools/contractdeployer/main/main \
-     testnetobscuronet.azurecr.io/obscuronet/obscuro_contractdeployer:latest \
+     "${docker_image}" \
     --nodeHost=${l2host} \
     --nodePort=${l2port} \
     --contractName="L2ERC20" \
@@ -86,7 +90,7 @@ echo "Deploying Guessing game contract to the obscuro network..."
 docker run --name=guessingGameL2deployer \
     --network=node_network \
     --entrypoint /home/go-obscuro/tools/contractdeployer/main/main \
-     testnetobscuronet.azurecr.io/obscuronet/obscuro_contractdeployer:latest \
+     "${docker_image}" \
     --nodeHost=${l2host} \
     --nodePort=${l2port} \
     --contractName="GUESS" \


### PR DESCRIPTION
### Why is this change needed?

- Fixes reported issue of https://github.com/obscuronet/go-obscuro/runs/7872816190?check_suite_focus=true

### What changes were made as part of this PR:

- fix


### :rotating_light: Definition of Done :rotating_light:
- [ ] Merged into dev-testnet 
- [ ] Passes tests on dev-testnet
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated
