### PR TITLE
Attempts to kill processes on unavailable Geth ports.

### DIFF
--- a/integration/gethnetwork/geth_network.go
+++ b/integration/gethnetwork/geth_network.go
@@ -412,11 +412,10 @@ func ensurePortsAreAvailable(startPort int, websocketStartPort int, numberNodes 
 	if len(unavailablePorts) > 0 {
 		// We attempt to kill the processes on the unavailable ports. This is best-efforts only (e.g. `lsof` may not exist).
 		for _, port := range unavailablePorts {
-			cmd := exec.Command(fmt.Sprintf("kill -9 $(lsof -t -i:%d)", port))
-			err := cmd.Run()
-			if err != nil {
-				// Ignore. This is best-efforts only.
-			}
+			cmdString := fmt.Sprintf("kill -9 $(lsof -t -i:%d)", port)
+			cmd := exec.Command(cmdString)
+			// Ignore any errors. This is best-efforts only.
+			cmd.Run() //nolint:errcheck
 		}
 		time.Sleep(time.Second)
 

--- a/integration/simulation/transaction_injector.go
+++ b/integration/simulation/transaction_injector.go
@@ -40,7 +40,7 @@ import (
 
 const (
 	nonceTimeoutMillis   = 30000 // The timeout in millis to wait for an updated nonce for a wallet.
-	receiptTimeoutMillis = 30000 // The timeout in millis to wait for a receipt for a transaction.
+	receiptTimeoutMillis = 60000 // The timeout in millis to wait for a receipt for a transaction.
 
 	// EnclavePublicKeyHex is the public key of the enclave.
 	// TODO - Retrieve this key from the management contract instead.


### PR DESCRIPTION
### Why is this change needed?

Currently, if the ports needed by a Geth network for a test are unavailable, the test fails.

### What changes were made as part of this PR:

Functional.

- Attempts to kill the processes on the desired ports on a best-efforts basis, before giving up

### What are the key areas to look at

- ...


### :rotating_light: Definition of Done :rotating_light:
- [ ] Merged into dev-testnet 
- [ ] Passes tests on dev-testnet
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated
