### PR TITLE
Uses t.Cleanup to simplify wallet extension tests.

### DIFF
--- a/integration/walletextension/wallet_extension_test.go
+++ b/integration/walletextension/wallet_extension_test.go
@@ -108,9 +108,7 @@ func TestCanGetOwnBalanceAfterSubmittingViewingKey(t *testing.T) {
 	setupWalletTestLog("bal-with-viewing-key")
 
 	createWalletExtension(t)
-
 	createObscuroNetwork(t)
-
 	accountAddr, _ := registerPrivateKey(t)
 
 	getBalanceJSON := makeEthJSONReqAsJSON(t, walletExtensionAddr, rpcclientlib.RPCGetBalance, []string{accountAddr.String(), latestBlock})
@@ -124,9 +122,7 @@ func TestCannotGetAnothersBalanceAfterSubmittingViewingKey(t *testing.T) {
 	setupWalletTestLog("others-bal-with-viewing-key")
 
 	createWalletExtension(t)
-
 	createObscuroNetwork(t)
-
 	registerPrivateKey(t)
 
 	respBody := makeEthJSONReq(t, walletExtensionAddr, rpcclientlib.RPCGetBalance, []string{dummyAccountAddress.Hex(), latestBlock})
@@ -141,7 +137,6 @@ func TestCannotCallWithoutSubmittingViewingKey(t *testing.T) {
 	setupWalletTestLog("call-no-viewing-key")
 
 	createWalletExtension(t)
-
 	createObscuroNetwork(t)
 
 	// We generate an account, but do not register it with the node.
@@ -171,9 +166,7 @@ func TestCanCallAfterSubmittingViewingKey(t *testing.T) {
 	setupWalletTestLog("call-with-viewing-key")
 
 	createWalletExtension(t)
-
 	createObscuroNetwork(t)
-
 	accountAddress, _ := registerPrivateKey(t)
 
 	// We submit a transaction to the Obscuro ERC20 contract. By transferring an amount of zero, we avoid the need to
@@ -196,9 +189,7 @@ func TestCanCallWithoutSettingFromField(t *testing.T) {
 	setupWalletTestLog("call-no-from-field")
 
 	createWalletExtension(t)
-
 	createObscuroNetwork(t)
-
 	accountAddress, _ := registerPrivateKey(t)
 
 	// We submit a transaction to the Obscuro ERC20 contract. By transferring an amount of zero, we avoid the need to
@@ -220,9 +211,7 @@ func TestCannotCallForAnotherAddressAfterSubmittingViewingKey(t *testing.T) {
 	setupWalletTestLog("others-call-with-viewing-key")
 
 	createWalletExtension(t)
-
 	createObscuroNetwork(t)
-
 	registerPrivateKey(t)
 
 	// We submit a transaction to the Obscuro ERC20 contract. By transferring an amount of zero, we avoid the need to
@@ -247,7 +236,6 @@ func TestCannotSubmitTxWithoutSubmittingViewingKey(t *testing.T) {
 	setupWalletTestLog("submit-tx-no-viewing-key")
 
 	createWalletExtension(t)
-
 	createObscuroNetwork(t)
 
 	privateKey, err := crypto.GenerateKey()
@@ -280,10 +268,9 @@ func TestCanSubmitTxAndGetTxReceiptAndTxAfterSubmittingViewingKey(t *testing.T) 
 	setupWalletTestLog("submit-tx-with-viewing-key")
 
 	createWalletExtension(t)
-
 	createObscuroNetwork(t)
-
 	_, privateKey := registerPrivateKey(t)
+
 	txWallet := wallet.NewInMemoryWalletFromPK(big.NewInt(integration.ObscuroChainID), privateKey)
 	tx := types.LegacyTx{
 		Nonce:    0,
@@ -324,9 +311,7 @@ func TestCannotSubmitTxFromAnotherAddressAfterSubmittingViewingKey(t *testing.T)
 	setupWalletTestLog("others-submit-tx-with-viewing-key")
 
 	createWalletExtension(t)
-
 	createObscuroNetwork(t)
-
 	registerPrivateKey(t)
 
 	// We submit a transaction using another account.
@@ -358,7 +343,6 @@ func TestCanDecryptSuccessfullyAfterSubmittingMultipleViewingKeys(t *testing.T) 
 	setupWalletTestLog("bal-with-mult-viewing-keys")
 
 	createWalletExtension(t)
-
 	createObscuroNetwork(t)
 
 	// We submit a viewing key for a random account.

--- a/integration/walletextension/wallet_extension_test.go
+++ b/integration/walletextension/wallet_extension_test.go
@@ -80,16 +80,8 @@ var (
 func TestCanMakeNonSensitiveRequestWithoutSubmittingViewingKey(t *testing.T) {
 	setupWalletTestLog("req-no-viewing-key")
 
-	walletExtension := walletextension.NewWalletExtension(walletExtensionConfig)
-	defer walletExtension.Shutdown()
-	go walletExtension.Serve(walletExtensionAddr)
-	waitForWalletExtension(t, walletExtensionAddr)
-
-	stopHandle, err := createObscuroNetwork(t)
-	defer stopHandle()
-	if err != nil {
-		t.Fatalf("failed to create test Obscuro network. Cause: %s", err)
-	}
+	createWalletExtension(t)
+	createObscuroNetwork(t)
 
 	respJSON := makeEthJSONReqAsJSON(t, walletExtensionAddr, rpcclientlib.RPCChainID, []string{})
 
@@ -101,16 +93,8 @@ func TestCanMakeNonSensitiveRequestWithoutSubmittingViewingKey(t *testing.T) {
 func TestCannotGetBalanceWithoutSubmittingViewingKey(t *testing.T) {
 	setupWalletTestLog("bal-no-viewing-key")
 
-	walletExtension := walletextension.NewWalletExtension(walletExtensionConfig)
-	defer walletExtension.Shutdown()
-	go walletExtension.Serve(walletExtensionAddr)
-	waitForWalletExtension(t, walletExtensionAddr)
-
-	stopHandle, err := createObscuroNetwork(t)
-	defer stopHandle()
-	if err != nil {
-		t.Fatalf("failed to create test Obscuro network. Cause: %s", err)
-	}
+	createWalletExtension(t)
+	createObscuroNetwork(t)
 
 	respBody := makeEthJSONReq(t, walletExtensionAddr, rpcclientlib.RPCGetBalance, []string{dummyAccountAddress.Hex(), latestBlock})
 
@@ -123,16 +107,9 @@ func TestCannotGetBalanceWithoutSubmittingViewingKey(t *testing.T) {
 func TestCanGetOwnBalanceAfterSubmittingViewingKey(t *testing.T) {
 	setupWalletTestLog("bal-with-viewing-key")
 
-	walletExtension := walletextension.NewWalletExtension(walletExtensionConfig)
-	defer walletExtension.Shutdown()
-	go walletExtension.Serve(walletExtensionAddr)
-	waitForWalletExtension(t, walletExtensionAddr)
+	createWalletExtension(t)
 
-	stopHandle, err := createObscuroNetwork(t)
-	defer stopHandle()
-	if err != nil {
-		t.Fatalf("failed to create test Obscuro network. Cause: %s", err)
-	}
+	createObscuroNetwork(t)
 
 	accountAddr, _ := registerPrivateKey(t)
 
@@ -146,16 +123,9 @@ func TestCanGetOwnBalanceAfterSubmittingViewingKey(t *testing.T) {
 func TestCannotGetAnothersBalanceAfterSubmittingViewingKey(t *testing.T) {
 	setupWalletTestLog("others-bal-with-viewing-key")
 
-	walletExtension := walletextension.NewWalletExtension(walletExtensionConfig)
-	defer walletExtension.Shutdown()
-	go walletExtension.Serve(walletExtensionAddr)
-	waitForWalletExtension(t, walletExtensionAddr)
+	createWalletExtension(t)
 
-	stopHandle, err := createObscuroNetwork(t)
-	defer stopHandle()
-	if err != nil {
-		t.Fatalf("failed to create test Obscuro network. Cause: %s", err)
-	}
+	createObscuroNetwork(t)
 
 	registerPrivateKey(t)
 
@@ -170,16 +140,9 @@ func TestCannotGetAnothersBalanceAfterSubmittingViewingKey(t *testing.T) {
 func TestCannotCallWithoutSubmittingViewingKey(t *testing.T) {
 	setupWalletTestLog("call-no-viewing-key")
 
-	walletExtension := walletextension.NewWalletExtension(walletExtensionConfig)
-	defer walletExtension.Shutdown()
-	go walletExtension.Serve(walletExtensionAddr)
-	waitForWalletExtension(t, walletExtensionAddr)
+	createWalletExtension(t)
 
-	stopHandle, err := createObscuroNetwork(t)
-	defer stopHandle()
-	if err != nil {
-		t.Fatalf("failed to create test Obscuro network. Cause: %s", err)
-	}
+	createObscuroNetwork(t)
 
 	// We generate an account, but do not register it with the node.
 	privateKey, err := crypto.GenerateKey()
@@ -207,16 +170,9 @@ func TestCannotCallWithoutSubmittingViewingKey(t *testing.T) {
 func TestCanCallAfterSubmittingViewingKey(t *testing.T) {
 	setupWalletTestLog("call-with-viewing-key")
 
-	walletExtension := walletextension.NewWalletExtension(walletExtensionConfig)
-	defer walletExtension.Shutdown()
-	go walletExtension.Serve(walletExtensionAddr)
-	waitForWalletExtension(t, walletExtensionAddr)
+	createWalletExtension(t)
 
-	stopHandle, err := createObscuroNetwork(t)
-	defer stopHandle()
-	if err != nil {
-		t.Fatalf("failed to create test Obscuro network. Cause: %s", err)
-	}
+	createObscuroNetwork(t)
 
 	accountAddress, _ := registerPrivateKey(t)
 
@@ -239,16 +195,9 @@ func TestCanCallAfterSubmittingViewingKey(t *testing.T) {
 func TestCanCallWithoutSettingFromField(t *testing.T) {
 	setupWalletTestLog("call-no-from-field")
 
-	walletExtension := walletextension.NewWalletExtension(walletExtensionConfig)
-	defer walletExtension.Shutdown()
-	go walletExtension.Serve(walletExtensionAddr)
-	waitForWalletExtension(t, walletExtensionAddr)
+	createWalletExtension(t)
 
-	stopHandle, err := createObscuroNetwork(t)
-	defer stopHandle()
-	if err != nil {
-		t.Fatalf("failed to create test Obscuro network. Cause: %s", err)
-	}
+	createObscuroNetwork(t)
 
 	accountAddress, _ := registerPrivateKey(t)
 
@@ -270,16 +219,9 @@ func TestCanCallWithoutSettingFromField(t *testing.T) {
 func TestCannotCallForAnotherAddressAfterSubmittingViewingKey(t *testing.T) {
 	setupWalletTestLog("others-call-with-viewing-key")
 
-	walletExtension := walletextension.NewWalletExtension(walletExtensionConfig)
-	defer walletExtension.Shutdown()
-	go walletExtension.Serve(walletExtensionAddr)
-	waitForWalletExtension(t, walletExtensionAddr)
+	createWalletExtension(t)
 
-	stopHandle, err := createObscuroNetwork(t)
-	defer stopHandle()
-	if err != nil {
-		t.Fatalf("failed to create test Obscuro network. Cause: %s", err)
-	}
+	createObscuroNetwork(t)
 
 	registerPrivateKey(t)
 
@@ -304,16 +246,9 @@ func TestCannotCallForAnotherAddressAfterSubmittingViewingKey(t *testing.T) {
 func TestCannotSubmitTxWithoutSubmittingViewingKey(t *testing.T) {
 	setupWalletTestLog("submit-tx-no-viewing-key")
 
-	walletExtension := walletextension.NewWalletExtension(walletExtensionConfig)
-	defer walletExtension.Shutdown()
-	go walletExtension.Serve(walletExtensionAddr)
-	waitForWalletExtension(t, walletExtensionAddr)
+	createWalletExtension(t)
 
-	stopHandle, err := createObscuroNetwork(t)
-	defer stopHandle()
-	if err != nil {
-		t.Fatalf("failed to create test Obscuro network. Cause: %s", err)
-	}
+	createObscuroNetwork(t)
 
 	privateKey, err := crypto.GenerateKey()
 	if err != nil {
@@ -344,16 +279,9 @@ func TestCannotSubmitTxWithoutSubmittingViewingKey(t *testing.T) {
 func TestCanSubmitTxAndGetTxReceiptAndTxAfterSubmittingViewingKey(t *testing.T) {
 	setupWalletTestLog("submit-tx-with-viewing-key")
 
-	walletExtension := walletextension.NewWalletExtension(walletExtensionConfig)
-	defer walletExtension.Shutdown()
-	go walletExtension.Serve(walletExtensionAddr)
-	waitForWalletExtension(t, walletExtensionAddr)
+	createWalletExtension(t)
 
-	stopHandle, err := createObscuroNetwork(t)
-	defer stopHandle()
-	if err != nil {
-		t.Fatalf("failed to create test Obscuro network. Cause: %s", err)
-	}
+	createObscuroNetwork(t)
 
 	_, privateKey := registerPrivateKey(t)
 	txWallet := wallet.NewInMemoryWalletFromPK(big.NewInt(integration.ObscuroChainID), privateKey)
@@ -395,16 +323,9 @@ func TestCanSubmitTxAndGetTxReceiptAndTxAfterSubmittingViewingKey(t *testing.T) 
 func TestCannotSubmitTxFromAnotherAddressAfterSubmittingViewingKey(t *testing.T) {
 	setupWalletTestLog("others-submit-tx-with-viewing-key")
 
-	walletExtension := walletextension.NewWalletExtension(walletExtensionConfig)
-	defer walletExtension.Shutdown()
-	go walletExtension.Serve(walletExtensionAddr)
-	waitForWalletExtension(t, walletExtensionAddr)
+	createWalletExtension(t)
 
-	stopHandle, err := createObscuroNetwork(t)
-	defer stopHandle()
-	if err != nil {
-		t.Fatalf("failed to create test Obscuro network. Cause: %s", err)
-	}
+	createObscuroNetwork(t)
 
 	registerPrivateKey(t)
 
@@ -436,16 +357,9 @@ func TestCannotSubmitTxFromAnotherAddressAfterSubmittingViewingKey(t *testing.T)
 func TestCanDecryptSuccessfullyAfterSubmittingMultipleViewingKeys(t *testing.T) {
 	setupWalletTestLog("bal-with-mult-viewing-keys")
 
-	walletExtension := walletextension.NewWalletExtension(walletExtensionConfig)
-	defer walletExtension.Shutdown()
-	go walletExtension.Serve(walletExtensionAddr)
-	waitForWalletExtension(t, walletExtensionAddr)
+	createWalletExtension(t)
 
-	stopHandle, err := createObscuroNetwork(t)
-	defer stopHandle()
-	if err != nil {
-		t.Fatalf("failed to create test Obscuro network. Cause: %s", err)
-	}
+	createObscuroNetwork(t)
 
 	// We submit a viewing key for a random account.
 	var accountAddrs []string
@@ -466,6 +380,14 @@ func TestCanDecryptSuccessfullyAfterSubmittingMultipleViewingKeys(t *testing.T) 
 	if getBalanceJSON[respJSONKeyResult] != zeroBalance {
 		t.Fatalf("Expected balance of %s, got %s", zeroBalance, getBalanceJSON[respJSONKeyResult])
 	}
+}
+
+// Creates and serves a wallet extension.
+func createWalletExtension(t *testing.T) {
+	walletExtension := walletextension.NewWalletExtension(walletExtensionConfig)
+	t.Cleanup(walletExtension.Shutdown)
+	go walletExtension.Serve(walletExtensionAddr)
+	waitForWalletExtension(t, walletExtensionAddr)
 }
 
 // Waits for wallet extension to be ready. Times out after three seconds.
@@ -608,7 +530,7 @@ func signViewingKey(t *testing.T, privateKey *ecdsa.PrivateKey, viewingKey []byt
 }
 
 // Creates a single-node Obscuro network for testing, and deploys an ERC20 contract to it.
-func createObscuroNetwork(t *testing.T) (func(), error) {
+func createObscuroNetwork(t *testing.T) {
 	// Create the Obscuro network.
 	numberOfNodes := 1
 	wallets := params.NewSimWallets(1, numberOfNodes, integration.EthereumChainID, integration.ObscuroChainID)
@@ -623,9 +545,10 @@ func createObscuroNetwork(t *testing.T) (func(), error) {
 	}
 	simStats := stats.NewStats(simParams.NumberOfNodes)
 	obscuroNetwork := network.NewNetworkOfSocketNodes(wallets)
+	t.Cleanup(obscuroNetwork.TearDown)
 	clients, err := obscuroNetwork.Create(&simParams, simStats)
 	if err != nil {
-		return obscuroNetwork.TearDown, err
+		panic(fmt.Sprintf("failed to create test Obscuro network. Cause: %s", err))
 	}
 
 	// Deploy an ERC20 contract to the Obscuro network.
@@ -639,7 +562,7 @@ func createObscuroNetwork(t *testing.T) (func(), error) {
 	generateAndSubmitViewingKey(t, walletExtensionAddr, walletExtensionAddr, txWallet.PrivateKey())
 	txBinaryHex, err := formatTxForSubmission(txWallet, &deployContractTx)
 	if err != nil {
-		return obscuroNetwork.TearDown, err
+		panic(fmt.Sprintf("failed to create test Obscuro network. Cause: %s", err))
 	}
 
 	sendTxJSON := makeEthJSONReqAsJSON(t, walletExtensionAddr, rpcclientlib.RPCSendRawTransaction, []interface{}{txBinaryHex})
@@ -666,8 +589,6 @@ func createObscuroNetwork(t *testing.T) (func(), error) {
 		time.Sleep(1 * time.Second)
 		counter++
 	}
-
-	return obscuroNetwork.TearDown, nil
 }
 
 // Formats a transaction for submission to the enclave.


### PR DESCRIPTION
### Why is this change needed?

Previously, we used `defer` instead of `t.Cleanup` in the wallet extension tests. This forced us to write lots of duplicated codes so that the `defer`s were called in the right places.

### What changes were made as part of this PR:

Refactoring.

### What are the key areas to look at

- ...


### :rotating_light: Definition of Done :rotating_light:
- [ ] Merged into dev-testnet 
- [ ] Passes tests on dev-testnet
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated
