### PR TITLE
Returns an error instead of panicking if cannot submit block.

### DIFF
--- a/go/common/enclave.go
+++ b/go/common/enclave.go
@@ -41,7 +41,7 @@ type Enclave interface {
 	// it is the responsibility of the host to gossip the returned rollup
 	// For good functioning the caller should always submit blocks ordered by height
 	// submitting a block before receiving a parent of it, will result in it being ignored
-	SubmitBlock(block types.Block) BlockSubmissionResponse
+	SubmitBlock(block types.Block) (BlockSubmissionResponse, error)
 
 	// SubmitRollup - receive gossiped rollups
 	SubmitRollup(rollup ExtRollup)

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -244,7 +244,7 @@ func (e *enclaveImpl) IngestBlocks(blocks []*types.Block) []common.BlockSubmissi
 }
 
 // SubmitBlock is used to update the enclave with an additional L1 block.
-func (e *enclaveImpl) SubmitBlock(block types.Block) common.BlockSubmissionResponse {
+func (e *enclaveImpl) SubmitBlock(block types.Block) (common.BlockSubmissionResponse, error) {
 	bsr := e.chain.SubmitBlock(block)
 
 	if bsr.RollupHead != nil {
@@ -255,7 +255,7 @@ func (e *enclaveImpl) SubmitBlock(block types.Block) common.BlockSubmissionRespo
 		e.mempool.RemoveMempoolTxs(hr, e.storage)
 	}
 
-	return bsr
+	return bsr, nil
 }
 
 func (e *enclaveImpl) SubmitRollup(rollup common.ExtRollup) {

--- a/go/enclave/rpc_server.go
+++ b/go/enclave/rpc_server.go
@@ -132,7 +132,10 @@ func (s *server) Start(_ context.Context, request *generated.StartRequest) (*gen
 
 func (s *server) SubmitBlock(_ context.Context, request *generated.SubmitBlockRequest) (*generated.SubmitBlockResponse, error) {
 	bl := s.decodeBlock(request.EncodedBlock)
-	blockSubmissionResponse := s.enclave.SubmitBlock(bl)
+	blockSubmissionResponse, err := s.enclave.SubmitBlock(bl)
+	if err != nil {
+		return nil, err
+	}
 
 	msg := rpc.ToBlockSubmissionResponseMsg(blockSubmissionResponse)
 	return &generated.SubmitBlockResponse{BlockSubmissionResponse: &msg}, nil

--- a/go/host/node/node.go
+++ b/go/host/node/node.go
@@ -415,7 +415,10 @@ func (a *Node) processBlocks(blocks []common.EncodedBlock, interrupt *int32) err
 			a.processBlock(decoded)
 
 			// submit each block to the enclave for ingestion plus validation
-			result = a.enclaveClient.SubmitBlock(*decoded)
+			result, err = a.enclaveClient.SubmitBlock(*decoded)
+			if err != nil {
+				return err
+			}
 			a.storeBlockProcessingResult(result)
 		}
 	}


### PR DESCRIPTION
### Why is this change needed?

I've started seeing test failures where a block submission happens after we've shut down the node. Shutting down the node causes it to break its connection to the enclave, which causes panics in subsequent RPC calls to submit further blocks (since the connection is broken) if these happen before the test concludes.

Here is the failure message:

```
Aug 17 12:35:49.990 INF Stopped monitoring for l1 blocks
Aug 17 12:35:49.990 PNC >   Agg0: Failed to submit block. Cause: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing dial tcp 127.0.0.1:31301: connect: connection refused"
```

You can see by the "Stopped monitoring for l1 blocks" message that this is happening at the end of the test, during shutdown.

### What changes were made as part of this PR:

Functional.

- `Enclave.SubmitBlock` now returns an error if the block cannot be submitted, instead of panicking.

### What are the key areas to look at

- ...


### :rotating_light: Definition of Done :rotating_light:
- [ ] Merged into dev-testnet 
- [ ] Passes tests on dev-testnet
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated
