### PR TITLE
Allows enclaves to configure the minimum gas amount they'll accept

### DIFF
--- a/docs/testnet/changelog.md
+++ b/docs/testnet/changelog.md
@@ -9,3 +9,4 @@
 * Account balances:
   * Added correct calculation of account balances (previously, all accounts were allocated infinite funds).
   * Introduced network faucet account.
+  * Allowed Obscuro enclaves services to configure minimum gas price they'll accept

--- a/docs/testnet/changelog.md
+++ b/docs/testnet/changelog.md
@@ -9,4 +9,4 @@
 * Account balances:
   * Added correct calculation of account balances (previously, all accounts were allocated infinite funds).
   * Introduced network faucet account.
-  * Allowed Obscuro enclaves services to configure minimum gas price they'll accept
+  * Obscuro enclaves services can configure the minimum gas price they'll accept

--- a/go/config/enclave_config.go
+++ b/go/config/enclave_config.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"math/big"
+
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -41,6 +43,8 @@ type EnclaveConfig struct {
 	SqliteDBPath string
 	// ProfilerEnabled starts a profiler instance
 	ProfilerEnabled bool
+	// MinGasPrice is the minimum gas price for mining a transaction
+	MinGasPrice *big.Int
 }
 
 // DefaultEnclaveConfig returns an EnclaveConfig with default values.
@@ -63,5 +67,6 @@ func DefaultEnclaveConfig() EnclaveConfig {
 		EdgelessDBHost:            "",
 		SqliteDBPath:              "",
 		ProfilerEnabled:           false,
+		MinGasPrice:               big.NewInt(1),
 	}
 }

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -282,9 +282,10 @@ func (e *enclaveImpl) SubmitTx(tx common.EncryptedTx) (common.EncryptedResponseS
 		return nil, fmt.Errorf("could not decrypt transaction. Cause: %w", err)
 	}
 
-	// todo - joel - use config entry, here and in error below below
-	if decryptedTx.GasPrice().Cmp(big.NewInt(1)) == -1 {
-		log.Info(fmt.Sprintf("rejected transaction %s. Gas price was only %d, wanted at least %d", decryptedTx.Hash(), decryptedTx.GasPrice()), 1)
+	txGasPrice := decryptedTx.GasPrice()
+	minGasPrice := e.config.MinGasPrice
+	if txGasPrice.Cmp(minGasPrice) == -1 {
+		log.Info(fmt.Sprintf("rejected transaction %s. Gas price was only %d, wanted at least %d", decryptedTx.Hash(), txGasPrice, minGasPrice))
 		return nil, fmt.Errorf("could not decrypt transaction. Cause: %w", err)
 	}
 

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -281,6 +281,13 @@ func (e *enclaveImpl) SubmitTx(tx common.EncryptedTx) (common.EncryptedResponseS
 		log.Info(fmt.Sprintf("could not decrypt transaction. Cause: %s", err))
 		return nil, fmt.Errorf("could not decrypt transaction. Cause: %w", err)
 	}
+
+	// todo - joel - use config entry, here and in error below below
+	if decryptedTx.GasPrice().Cmp(big.NewInt(1)) == -1 {
+		log.Info(fmt.Sprintf("rejected transaction %s. Gas price was only %d, wanted at least %d", decryptedTx.Hash(), decryptedTx.GasPrice()), 1)
+		return nil, fmt.Errorf("could not decrypt transaction. Cause: %w", err)
+	}
+
 	err = e.mempool.AddMempoolTx(decryptedTx)
 	if err != nil {
 		return nil, err

--- a/go/enclave/enclaverunner/cli.go
+++ b/go/enclave/enclaverunner/cli.go
@@ -3,6 +3,7 @@ package enclaverunner
 import (
 	"flag"
 	"fmt"
+	"math/big"
 	"os"
 	"strings"
 
@@ -30,6 +31,7 @@ type EnclaveConfigToml struct {
 	EdgelessDBHost            string
 	SqliteDBPath              string
 	ProfilerEnabled           bool
+	MinGasPrice               int64
 }
 
 // ParseConfig returns a config.EnclaveConfig based on either the file identified by the `config` flag, or the flags
@@ -55,6 +57,7 @@ func ParseConfig() config.EnclaveConfig {
 	edgelessDBHost := flag.String(edgelessDBHostName, cfg.EdgelessDBHost, flagUsageMap[edgelessDBHostName])
 	sqliteDBPath := flag.String(sqliteDBPathName, cfg.SqliteDBPath, flagUsageMap[sqliteDBPathName])
 	profilerEnabled := flag.Bool(profilerEnabledName, cfg.ProfilerEnabled, flagUsageMap[profilerEnabledName])
+	minGasPrice := flag.Int64(minGasPriceName, cfg.MinGasPrice.Int64(), flagUsageMap[minGasPriceName])
 
 	flag.Parse()
 
@@ -90,6 +93,7 @@ func ParseConfig() config.EnclaveConfig {
 	cfg.EdgelessDBHost = *edgelessDBHost
 	cfg.SqliteDBPath = *sqliteDBPath
 	cfg.ProfilerEnabled = *profilerEnabled
+	cfg.MinGasPrice = big.NewInt(*minGasPrice)
 
 	return cfg
 }

--- a/go/enclave/enclaverunner/cli_flags.go
+++ b/go/enclave/enclaverunner/cli_flags.go
@@ -19,6 +19,7 @@ const (
 	edgelessDBHostName            = "edgelessDBHost"
 	sqliteDBPathName              = "sqliteDBPath"
 	profilerEnabledName           = "profilerEnabled"
+	minGasPriceName               = "minGasPrice"
 )
 
 // Returns a map of the flag usages.
@@ -42,5 +43,6 @@ func getFlagUsageMap() map[string]string {
 		edgelessDBHostName:            "Host address for the edgeless DB instance (can be empty if useInMemoryDB is true or if not using attestation",
 		sqliteDBPathName:              "Filepath for the sqlite DB persistence file (can be empty if a throwaway file in /tmp/ is acceptable or if using InMemory DB or if using attestation/EdgelessDB)",
 		profilerEnabledName:           "Runs a profiler instance (Defaults to false)",
+		minGasPriceName:               "The minimum gas price for mining a transaction",
 	}
 }

--- a/integration/simulation/network/network_utils.go
+++ b/integration/simulation/network/network_utils.go
@@ -87,6 +87,7 @@ func createInMemObscuroNode(
 		GenesisJSON:            genesisJSON,
 		UseInMemoryDB:          true,
 		ERC20ContractAddresses: wallets.AllEthAddresses(),
+		MinGasPrice:            big.NewInt(1),
 	}
 	enclaveClient := enclave.NewEnclave(enclaveConfig, mgmtContractLib, stableTokenContractLib, stats)
 

--- a/integration/simulation/network/obscuro_node_utils.go
+++ b/integration/simulation/network/obscuro_node_utils.go
@@ -203,6 +203,7 @@ func startRemoteEnclaveServers(startAt int, params *params.SimParams, stats *sta
 			GenesisJSON:            nil,
 			UseInMemoryDB:          false,
 			ERC20ContractAddresses: params.Wallets.AllEthAddresses(),
+			MinGasPrice:            big.NewInt(1),
 		}
 		_, err := enclave.StartServer(enclaveConfig, params.MgmtContractLib, params.ERC20ContractLib, stats)
 		if err != nil {

--- a/integration/simulation/simulation.go
+++ b/integration/simulation/simulation.go
@@ -161,7 +161,7 @@ func (s *Simulation) deployObscuroERC20s() {
 			deployContractTx := types.DynamicFeeTx{
 				Nonce:     NextNonce(s.RPCHandles, owner),
 				Gas:       1025_000_000,
-				GasFeeCap: gethcommon.Big1,
+				GasFeeCap: gethcommon.Big1, // This field is used to derive the gas price for dynamic fee transactions.
 				Data:      contractBytes,
 			}
 			signedTx, err := owner.SignTransaction(&deployContractTx)

--- a/integration/simulation/simulation.go
+++ b/integration/simulation/simulation.go
@@ -159,9 +159,10 @@ func (s *Simulation) deployObscuroERC20s() {
 			contractBytes := erc20contract.L2BytecodeWithDefaultSupply(string(token))
 
 			deployContractTx := types.DynamicFeeTx{
-				Nonce: NextNonce(s.RPCHandles, owner),
-				Gas:   1025_000_000,
-				Data:  contractBytes,
+				Nonce:     NextNonce(s.RPCHandles, owner),
+				Gas:       1025_000_000,
+				GasFeeCap: gethcommon.Big1,
+				Data:      contractBytes,
 			}
 			signedTx, err := owner.SignTransaction(&deployContractTx)
 			if err != nil {


### PR DESCRIPTION
### Why is this change needed?

Currently, enclaves accept any gas price. They should be able to choose to reject txs with insufficient gas.

### What changes were made as part of this PR:

Functional.

- Enclave can configure minimum gas price for accepting transaction
- Transactions with an insufficient gas price are rejected

### What are the key areas to look at

- ...


### :rotating_light: Definition of Done :rotating_light:
- [ ] Merged into dev-testnet 
- [ ] Passes tests on dev-testnet
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated
