### PR TITLE
Relies on enclave config defaults where suitable.

### DIFF
--- a/integration/simulation/network/network_utils.go
+++ b/integration/simulation/network/network_utils.go
@@ -78,20 +78,16 @@ func createInMemObscuroNode(
 		HasClientRPCHTTP:    false,
 	}
 
-	enclaveConfig := config.EnclaveConfig{
-		HostID:                 hostConfig.ID,
-		L1ChainID:              integration.EthereumChainID,
-		ObscuroChainID:         integration.ObscuroChainID,
-		WillAttest:             false,
-		ValidateL1Blocks:       validateBlocks,
-		GenesisJSON:            genesisJSON,
-		UseInMemoryDB:          true,
-		ERC20ContractAddresses: wallets.AllEthAddresses(),
-	}
+	enclaveConfig := config.DefaultEnclaveConfig()
+	enclaveConfig.HostID = hostConfig.ID
+	enclaveConfig.ValidateL1Blocks = validateBlocks
+	enclaveConfig.GenesisJSON = genesisJSON
+	enclaveConfig.ERC20ContractAddresses = wallets.AllEthAddresses()
+
 	enclaveClient := enclave.NewEnclave(enclaveConfig, mgmtContractLib, stableTokenContractLib, stats)
 
 	// create an in memory obscuro node
-	node := node.NewHost(
+	inMemNode := node.NewHost(
 		hostConfig,
 		stats,
 		obscuroInMemNetwork,
@@ -100,9 +96,9 @@ func createInMemObscuroNode(
 		ethWallet,
 		mgmtContractLib,
 	)
-	obscuroInMemNetwork.CurrentNode = node
-	node.ConnectToEthNode(ethClient)
-	return node
+	obscuroInMemNetwork.CurrentNode = inMemNode
+	inMemNode.ConnectToEthNode(ethClient)
+	return inMemNode
 }
 
 func createSocketObscuroNode(
@@ -142,7 +138,7 @@ func createSocketObscuroNode(
 	// create a socket obscuro node
 	nodeP2p := p2p.NewSocketP2PLayer(hostConfig)
 
-	node := node.NewHost(
+	socketNode := node.NewHost(
 		hostConfig,
 		stats,
 		nodeP2p,
@@ -152,8 +148,8 @@ func createSocketObscuroNode(
 		mgmtContractLib,
 	)
 
-	node.ConnectToEthNode(ethClient)
-	return node
+	socketNode.ConnectToEthNode(ethClient)
+	return socketNode
 }
 
 func defaultMockEthNodeCfg(nrNodes int, avgBlockDuration time.Duration) ethereum_mock.MiningConfig {

--- a/integration/simulation/network/obscuro_node_utils.go
+++ b/integration/simulation/network/obscuro_node_utils.go
@@ -16,8 +16,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/obscuronet/go-obscuro/go/config"
 	"github.com/obscuronet/go-obscuro/go/enclave"
-	"github.com/obscuronet/go-obscuro/integration"
-
 	"github.com/obscuronet/go-obscuro/go/ethadapter"
 	"github.com/obscuronet/go-obscuro/go/rpcclientlib"
 	"github.com/obscuronet/go-obscuro/integration/simulation/p2p"
@@ -190,20 +188,13 @@ func createRPCClientsForWallet(nodeRPCAddresses []string, wal wallet.Wallet) []r
 func startRemoteEnclaveServers(startAt int, params *params.SimParams, stats *stats.Stats) {
 	for i := startAt; i < params.NumberOfNodes; i++ {
 		// create a remote enclave server
-		enclaveAddr := fmt.Sprintf("%s:%d", Localhost, params.StartPort+DefaultEnclaveOffset+i)
-		hostAddr := fmt.Sprintf("%s:%d", Localhost, params.StartPort+DefaultHostP2pOffset+i)
-		enclaveConfig := config.EnclaveConfig{
-			HostID:                 common.BigToAddress(big.NewInt(int64(i))),
-			HostAddress:            hostAddr,
-			Address:                enclaveAddr,
-			L1ChainID:              integration.EthereumChainID,
-			ObscuroChainID:         integration.ObscuroChainID,
-			ValidateL1Blocks:       false,
-			WillAttest:             false,
-			GenesisJSON:            nil,
-			UseInMemoryDB:          false,
-			ERC20ContractAddresses: params.Wallets.AllEthAddresses(),
-		}
+		enclaveConfig := config.DefaultEnclaveConfig()
+		enclaveConfig.HostID = common.BigToAddress(big.NewInt(int64(i)))
+		enclaveConfig.HostAddress = fmt.Sprintf("%s:%d", Localhost, params.StartPort+DefaultHostP2pOffset+i)
+		enclaveConfig.Address = fmt.Sprintf("%s:%d", Localhost, params.StartPort+DefaultEnclaveOffset+i)
+		enclaveConfig.UseInMemoryDB = false
+		enclaveConfig.ERC20ContractAddresses = params.Wallets.AllEthAddresses()
+
 		_, err := enclave.StartServer(enclaveConfig, params.MgmtContractLib, params.ERC20ContractLib, stats)
 		if err != nil {
 			panic(fmt.Sprintf("failed to create enclave server: %v", err))


### PR DESCRIPTION
### Why is this change needed?

In the integration tests, we use a mishmash of setting enclave config and leaving other fields unset. I've moved it to using the default config as a base, updating it where necessary.

### What changes were made as part of this PR:

Refactoring.

- Uses enclave config defaults where suitable

### What are the key areas to look at

- ...


### :rotating_light: Definition of Done :rotating_light:
- [ ] Merged into dev-testnet 
- [ ] Passes tests on dev-testnet
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated
