### PR TITLE
refactor wallet extension to use a map of clients

### DIFF
--- a/go/ethadapter/obscuro_rpc_client.go
+++ b/go/ethadapter/obscuro_rpc_client.go
@@ -33,11 +33,11 @@ type obscuroWalletRPCClient struct {
 
 // NewObscuroRPCClient creates an obscuro RPC client for a given wallet, it will create and register a viewing key for the wallet as part of this setup
 func NewObscuroRPCClient(ipaddress string, port uint, wallet wallet.Wallet) (EthClient, error) {
-	client, err := rpcclientlib.NewViewingKeyNetworkClient(fmt.Sprintf("%s:%d", ipaddress, port))
+	vk, err := viewkey.GenerateAndSignViewingKey(wallet)
 	if err != nil {
 		return nil, err
 	}
-	err = viewkey.GenerateAndRegisterViewingKey(client, wallet)
+	client, err := rpcclientlib.NewEncNetworkClient(fmt.Sprintf("%s:%d", ipaddress, port), vk)
 	if err != nil {
 		return nil, err
 	}

--- a/go/ethadapter/obscuro_rpc_client.go
+++ b/go/ethadapter/obscuro_rpc_client.go
@@ -16,7 +16,6 @@ import (
 	"github.com/obscuronet/go-obscuro/go/common"
 	"github.com/obscuronet/go-obscuro/go/rpcclientlib"
 	"github.com/obscuronet/go-obscuro/go/wallet"
-	"github.com/obscuronet/go-obscuro/integration/common/viewkey"
 )
 
 var ErrReceiptNotFound = errors.New("receipt not found, received nil response")
@@ -33,7 +32,7 @@ type obscuroWalletRPCClient struct {
 
 // NewObscuroRPCClient creates an obscuro RPC client for a given wallet, it will create and register a viewing key for the wallet as part of this setup
 func NewObscuroRPCClient(ipaddress string, port uint, wallet wallet.Wallet) (EthClient, error) {
-	vk, err := viewkey.GenerateAndSignViewingKey(wallet)
+	vk, err := rpcclientlib.GenerateAndSignViewingKey(wallet)
 	if err != nil {
 		return nil, err
 	}

--- a/go/rpcclientlib/network_client.go
+++ b/go/rpcclientlib/network_client.go
@@ -6,6 +6,28 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
+const (
+	http = "http://"
+)
+
+// networkClient is a Client implementation that wraps Geth's rpc.Client to make calls to the obscuro node
+type networkClient struct {
+	rpcClient *rpc.Client
+}
+
+// NewEncNetworkClient returns a network RPC client with Viewing Key encryption/decryption
+func NewEncNetworkClient(rpcAddress string, viewingKey *ViewingKey) (*EncRPCClient, error) {
+	rpcClient, err := NewNetworkClient(rpcAddress)
+	if err != nil {
+		return nil, err
+	}
+	encClient, err := NewEncRPCClient(rpcClient, viewingKey)
+	if err != nil {
+		return nil, err
+	}
+	return encClient, nil
+}
+
 // NewNetworkClient returns a client that can make RPC calls to an Obscuro node
 func NewNetworkClient(address string) (Client, error) {
 	rpcClient, err := rpc.Dial(http + address)
@@ -16,11 +38,6 @@ func NewNetworkClient(address string) (Client, error) {
 	return &networkClient{
 		rpcClient: rpcClient,
 	}, nil
-}
-
-// networkClient is a Client implementation that wraps Geth's rpc.Client to make calls to the obscuro node
-type networkClient struct {
-	rpcClient *rpc.Client
 }
 
 // Call handles JSON rpc requests - if the method is sensitive it will encrypt the args before sending the request and

--- a/go/rpcclientlib/viewing_key.go
+++ b/go/rpcclientlib/viewing_key.go
@@ -1,23 +1,30 @@
-package viewkey
+package rpcclientlib
 
 import (
 	"crypto/ecdsa"
 	"encoding/hex"
 	"fmt"
 
+	"github.com/ethereum/go-ethereum/common"
+
 	"github.com/obscuronet/go-obscuro/go/enclave/rpc"
 
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/crypto/ecies"
-	"github.com/obscuronet/go-obscuro/go/rpcclientlib"
 	"github.com/obscuronet/go-obscuro/go/wallet"
 )
 
-// This package contains viewing key utils for testing and simulations
+// ViewingKey encapsulates the signed viewing key for an account for use in encrypted communication with an enclave
+type ViewingKey struct {
+	Account    *common.Address   // Account address that this private key is bound to
+	PrivateKey *ecies.PrivateKey // private viewing key
+	PublicKey  []byte            // public viewing key in bytes to share with enclave
+	SignedKey  []byte            // public viewing key signed by the Account's private key
+}
 
 // GenerateAndSignViewingKey takes an account wallet, it generate a viewing key and signs the key with the acc's private key
-func GenerateAndSignViewingKey(wal wallet.Wallet) (*rpcclientlib.ViewingKey, error) {
+func GenerateAndSignViewingKey(wal wallet.Wallet) (*ViewingKey, error) {
 	// generate an ECDSA key pair to encrypt sensitive communications with the obscuro enclave
 	vk, err := crypto.GenerateKey()
 	if err != nil {
@@ -38,7 +45,7 @@ func GenerateAndSignViewingKey(wal wallet.Wallet) (*rpcclientlib.ViewingKey, err
 	}
 
 	accAddress := wal.Address()
-	return &rpcclientlib.ViewingKey{
+	return &ViewingKey{
 		Account:    &accAddress,
 		PrivateKey: viewingPrivateKeyECIES,
 		PublicKey:  viewingPubKeyBytes,

--- a/integration/common/viewkey/viewkey.go
+++ b/integration/common/viewkey/viewkey.go
@@ -16,18 +16,12 @@ import (
 
 // This package contains viewing key utils for testing and simulations
 
-// GenerateAndRegisterViewingKey takes a wallet and the client that will be used for that wallet's transactions.
-//
-//	It sets up a viewing key for that client (without using a wallet extension) with the following steps:
-//	1. generate a "viewing" keypair
-//	2. simulates signing the key with metamask
-//	3. sets the private key on the client (to decrypt enclave responses)
-//	4. registers the public viewing key with the enclave (to encrypt enclave responses)
-func GenerateAndRegisterViewingKey(cli *rpcclientlib.ViewingKeyClient, wal wallet.Wallet) error {
+// GenerateAndSignViewingKey takes an account wallet, it generate a viewing key and signs the key with the acc's private key
+func GenerateAndSignViewingKey(wal wallet.Wallet) (*rpcclientlib.ViewingKey, error) {
 	// generate an ECDSA key pair to encrypt sensitive communications with the obscuro enclave
 	vk, err := crypto.GenerateKey()
 	if err != nil {
-		return fmt.Errorf("failed to generate viewing key for RPC client: %w", err)
+		return nil, fmt.Errorf("failed to generate viewing key for RPC client: %w", err)
 	}
 
 	// get key in ECIES format
@@ -36,23 +30,20 @@ func GenerateAndRegisterViewingKey(cli *rpcclientlib.ViewingKeyClient, wal walle
 	// encode public key as bytes
 	viewingPubKeyBytes := crypto.CompressPubkey(&vk.PublicKey)
 
-	// set key pair on the RPC client
-	cli.SetViewingKey(viewingPrivateKeyECIES, wal.Address(), viewingPubKeyBytes)
-
 	// sign hex-encoded public key string with the wallet's private key
 	viewingKeyHex := hex.EncodeToString(viewingPubKeyBytes)
 	signature, err := signViewingKey(viewingKeyHex, wal.PrivateKey())
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	// submit the signed public key to the enclave so it can encrypt sensitive responses
-	err = cli.RegisterViewingKey(signature, wal.Address())
-	if err != nil {
-		return err
-	}
-
-	return nil
+	accAddress := wal.Address()
+	return &rpcclientlib.ViewingKey{
+		Account:    &accAddress,
+		PrivateKey: viewingPrivateKeyECIES,
+		PublicKey:  viewingPubKeyBytes,
+		SignedKey:  signature,
+	}, nil
 }
 
 // signViewingKey takes a public key bytes as hex and the private key for a wallet, it simulates the back-and-forth to

--- a/integration/simulation/network/inmemory.go
+++ b/integration/simulation/network/inmemory.go
@@ -63,7 +63,7 @@ func (n *basicNetworkOfInMemoryNodes) Create(params *params.SimParams, stats *st
 			miner,
 			params.Wallets,
 		)
-		obscuroClient := p2p.NewInMemoryViewingKeyClient(agg)
+		obscuroClient := p2p.NewInMemObscuroClient(agg)
 
 		// and connect them to each other
 		miner.AddClient(agg)

--- a/integration/simulation/network/obscuro_node_utils.go
+++ b/integration/simulation/network/obscuro_node_utils.go
@@ -9,8 +9,6 @@ import (
 	"github.com/obscuronet/go-obscuro/go/host"
 	"github.com/obscuronet/go-obscuro/go/wallet"
 
-	"github.com/obscuronet/go-obscuro/integration/common/viewkey"
-
 	"github.com/obscuronet/go-obscuro/go/common/log"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -159,7 +157,7 @@ func startStandaloneObscuroNodes(params *params.SimParams, stats *stats.Stats, g
 func createInMemoryClientsForWallet(nodes []host.MockHost, wal wallet.Wallet) []rpcclientlib.Client {
 	clients := make([]rpcclientlib.Client, len(nodes))
 	for i, node := range nodes {
-		vk, err := viewkey.GenerateAndSignViewingKey(wal)
+		vk, err := rpcclientlib.GenerateAndSignViewingKey(wal)
 		if err != nil {
 			panic(err)
 		}
@@ -174,7 +172,7 @@ func createInMemoryClientsForWallet(nodes []host.MockHost, wal wallet.Wallet) []
 func createRPCClientsForWallet(nodeRPCAddresses []string, wal wallet.Wallet) []rpcclientlib.Client {
 	clients := make([]rpcclientlib.Client, len(nodeRPCAddresses))
 	for i, addr := range nodeRPCAddresses {
-		vk, err := viewkey.GenerateAndSignViewingKey(wal)
+		vk, err := rpcclientlib.GenerateAndSignViewingKey(wal)
 		if err != nil {
 			panic(err)
 		}

--- a/integration/simulation/p2p/in_mem_obscuro_client.go
+++ b/integration/simulation/p2p/in_mem_obscuro_client.go
@@ -56,11 +56,11 @@ func NewInMemObscuroClient(nodeHost host.Host) rpcclientlib.Client {
 
 func NewInMemoryEncRPCClient(host host.Host, viewingKey *rpcclientlib.ViewingKey) *rpcclientlib.EncRPCClient {
 	inMemClient := NewInMemObscuroClient(host)
-	vkClient, err := rpcclientlib.NewEncRPCClient(inMemClient, viewingKey)
+	encClient, err := rpcclientlib.NewEncRPCClient(inMemClient, viewingKey)
 	if err != nil {
 		panic(err)
 	}
-	return vkClient
+	return encClient
 }
 
 // Call bypasses RPC, and invokes methods on the node directly.

--- a/integration/simulation/p2p/in_mem_obscuro_client.go
+++ b/integration/simulation/p2p/in_mem_obscuro_client.go
@@ -54,9 +54,9 @@ func NewInMemObscuroClient(nodeHost host.Host) rpcclientlib.Client {
 	}
 }
 
-func NewInMemoryViewingKeyClient(host host.Host) *rpcclientlib.ViewingKeyClient {
+func NewInMemoryEncRPCClient(host host.Host, viewingKey *rpcclientlib.ViewingKey) *rpcclientlib.EncRPCClient {
 	inMemClient := NewInMemObscuroClient(host)
-	vkClient, err := rpcclientlib.NewViewingKeyClient(inMemClient)
+	vkClient, err := rpcclientlib.NewEncRPCClient(inMemClient, viewingKey)
 	if err != nil {
 		panic(err)
 	}

--- a/integration/walletextension/wallet_extension_test.go
+++ b/integration/walletextension/wallet_extension_test.go
@@ -543,7 +543,7 @@ func createObscuroNetwork(t *testing.T) {
 		GasPrice: common.Big0,
 		Data:     erc20contract.L2BytecodeWithDefaultSupply("TST"),
 	}
-	generateAndSubmitViewingKey(t, walletExtensionAddr, walletExtensionAddr, txWallet.PrivateKey())
+	generateAndSubmitViewingKey(t, walletExtensionAddr, txWallet.Address().String(), txWallet.PrivateKey())
 	txBinaryHex, err := formatTxForSubmission(txWallet, &deployContractTx)
 	if err != nil {
 		panic(fmt.Sprintf("failed to create test Obscuro network. Cause: %s", err))

--- a/tools/networkmanager/inject_txs.go
+++ b/tools/networkmanager/inject_txs.go
@@ -34,7 +34,7 @@ func InjectTransactions(cfg Config, args []string) {
 		panic(fmt.Sprintf("could not create L1 client. Cause: %s", err))
 	}
 	println("Connecting to Obscuro node...")
-	l2Client, err := rpcclientlib.NewViewingKeyNetworkClient(cfg.obscuroClientAddress)
+	l2Client, err := rpcclientlib.NewNetworkClient(cfg.obscuroClientAddress)
 	if err != nil {
 		panic(err)
 	}
@@ -87,28 +87,28 @@ func createWalletRPCClients(wallets *params.SimWallets, obscuroNodeAddr string) 
 	clients := make(map[string][]rpcclientlib.Client)
 
 	for _, w := range wallets.SimObsWallets {
-		client, err := rpcclientlib.NewViewingKeyNetworkClient(obscuroNodeAddr)
+		vk, err := viewkey.GenerateAndSignViewingKey(w)
+		if err != nil {
+			panic(err)
+		}
+		client, err := rpcclientlib.NewEncNetworkClient(obscuroNodeAddr, vk)
 		if err != nil {
 			panic(err)
 		}
 
-		err = viewkey.GenerateAndRegisterViewingKey(client, w)
-		if err != nil {
-			panic(err)
-		}
 		clients[w.Address().String()] = []rpcclientlib.Client{client}
 	}
 	for _, t := range wallets.Tokens {
 		w := t.L2Owner
-		client, err := rpcclientlib.NewViewingKeyNetworkClient(obscuroNodeAddr)
+		vk, err := viewkey.GenerateAndSignViewingKey(w)
+		if err != nil {
+			panic(err)
+		}
+		client, err := rpcclientlib.NewEncNetworkClient(obscuroNodeAddr, vk)
 		if err != nil {
 			panic(err)
 		}
 
-		err = viewkey.GenerateAndRegisterViewingKey(client, w)
-		if err != nil {
-			panic(err)
-		}
 		clients[w.Address().String()] = []rpcclientlib.Client{client}
 	}
 

--- a/tools/networkmanager/inject_txs.go
+++ b/tools/networkmanager/inject_txs.go
@@ -7,8 +7,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/obscuronet/go-obscuro/integration/common/viewkey"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/obscuronet/go-obscuro/integration/simulation/network"
 
@@ -87,7 +85,7 @@ func createWalletRPCClients(wallets *params.SimWallets, obscuroNodeAddr string) 
 	clients := make(map[string][]rpcclientlib.Client)
 
 	for _, w := range wallets.SimObsWallets {
-		vk, err := viewkey.GenerateAndSignViewingKey(w)
+		vk, err := rpcclientlib.GenerateAndSignViewingKey(w)
 		if err != nil {
 			panic(err)
 		}
@@ -100,7 +98,7 @@ func createWalletRPCClients(wallets *params.SimWallets, obscuroNodeAddr string) 
 	}
 	for _, t := range wallets.Tokens {
 		w := t.L2Owner
-		vk, err := viewkey.GenerateAndSignViewingKey(w)
+		vk, err := rpcclientlib.GenerateAndSignViewingKey(w)
 		if err != nil {
 			panic(err)
 		}

--- a/tools/walletextension/multi_acc_helper.go
+++ b/tools/walletextension/multi_acc_helper.go
@@ -48,6 +48,9 @@ func suggestAccountClient(req *rpcRequest, accClients map[common.Address]*rpccli
 		}
 	}
 
+	// todo: add other mechanisms for determining the correct account to use. E.g. we may want to start caching and
+	// 	 	recent transaction hashes for accounts so that receipt lookups know which acc to use
+
 	return nil
 }
 

--- a/tools/walletextension/multi_acc_helper.go
+++ b/tools/walletextension/multi_acc_helper.go
@@ -167,3 +167,18 @@ func proxyRequest(rpcReq *rpcRequest, rpcResp interface{}, accClients map[common
 
 	return err
 }
+
+func executeCall(client *rpcclientlib.EncRPCClient, req *rpcRequest, resp *interface{}) error {
+	var err error
+	if req.method == rpcclientlib.RPCCall {
+		// RPCCall is a sensitive method that requires a viewing key lookup but the 'from' field is not mandatory in geth
+		//	and is often not included from metamask etc. So we ensure it is populated here.
+		account := client.Account()
+		req.params, err = setCallFromFieldIfMissing(req.params, *account)
+		if err != nil {
+			return err
+		}
+	}
+
+	return client.Call(resp, req.method, req.params...)
+}

--- a/tools/walletextension/multi_acc_helper.go
+++ b/tools/walletextension/multi_acc_helper.go
@@ -1,0 +1,136 @@
+package walletextension
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/obscuronet/go-obscuro/go/rpcclientlib"
+)
+
+const (
+	reqJSONKeyFrom      = "from"
+	reqJSONKeyData      = "data"
+	ethCallPaddedArgLen = 64
+	ethCallAddrPadding  = "000000000000000000000000"
+)
+
+// multi_acc_helper provides a single location for code that helps wallet extension in determining the appropriate account
+//	to use to send a request when multiple are registered
+
+// suggestAccountClient works through various methods to try and guess which available client to use for a request, returns nil if none found
+func suggestAccountClient(req *rpcRequest, accClients map[common.Address]*rpcclientlib.EncRPCClient) *rpcclientlib.EncRPCClient {
+	if len(accClients) == 1 {
+		for _, client := range accClients {
+			// return the first (and only) client
+			return client
+		}
+	}
+
+	paramsMap, err := parseParams(req.params)
+	if err != nil {
+		// no further info to deduce calling client
+		return nil
+	}
+
+	// check if request params had a "from" address and if we had a client for that address
+	fromClient, found := checkForFromField(paramsMap, accClients)
+	if found {
+		return fromClient
+	}
+
+	if req.method == rpcclientlib.RPCCall {
+		// Otherwise, we search the `data` field for an address matching a registered viewing key.
+		addr, err := searchDataFieldForAccount(paramsMap, accClients)
+		if err == nil {
+			return accClients[*addr]
+		}
+	}
+
+	return nil
+}
+
+func checkForFromField(paramsMap map[string]interface{}, accClients map[common.Address]*rpcclientlib.EncRPCClient) (*rpcclientlib.EncRPCClient, bool) {
+	fromVal, found := paramsMap[reqJSONKeyFrom]
+	if !found {
+		return nil, false
+	}
+
+	fromStr, ok := fromVal.(string)
+	if !ok {
+		return nil, false
+	}
+
+	fromAddr := common.HexToAddress(fromStr)
+	client, found := accClients[fromAddr]
+	return client, found
+}
+
+// Extracts the arguments from the request's `data` field. If any of them, after removing padding, match the viewing
+// key address, we return that address. Otherwise, we return nil.
+func searchDataFieldForAccount(callParams map[string]interface{}, accClients map[common.Address]*rpcclientlib.EncRPCClient) (*common.Address, error) {
+	// We ensure that the `data` field is present.
+	data := callParams[reqJSONKeyData]
+	if data == nil {
+		return nil, fmt.Errorf("eth_call request did not have its `data` field set")
+	}
+	dataString, ok := data.(string)
+	if !ok {
+		return nil, fmt.Errorf("eth_call request's `data` field was not of the expected type `string`")
+	}
+
+	// We check that the data field is long enough before removing the leading "0x" (1 bytes/2 chars) and the method ID
+	// (4 bytes/8 chars).
+	if len(dataString) < 10 {
+		return nil, nil //nolint:nilnil
+	}
+	dataString = dataString[10:]
+
+	// We split up the arguments in the `data` field.
+	var dataArgs []string
+	for i := 0; i < len(dataString); i += ethCallPaddedArgLen {
+		if i+ethCallPaddedArgLen > len(dataString) {
+			break
+		}
+		dataArgs = append(dataArgs, dataString[i:i+ethCallPaddedArgLen])
+	}
+
+	// We iterate over the arguments, looking for an argument that matches a viewing key address
+	for _, dataArg := range dataArgs {
+		// If the argument doesn't have the correct padding, it's not an address.
+		if !strings.HasPrefix(dataArg, ethCallAddrPadding) {
+			continue
+		}
+
+		maybeAddress := common.HexToAddress(dataArg[len(ethCallAddrPadding):])
+		if _, ok := accClients[maybeAddress]; ok {
+			return &maybeAddress, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no known account found in data bytes")
+}
+
+// Many eth RPC requests provide params as first argument in a json map with similar fields (e.g. a `from` field)
+func parseParams(args []interface{}) (map[string]interface{}, error) {
+	if len(args) == 0 {
+		return nil, fmt.Errorf("no params found to unmarshal")
+	}
+
+	// only interested in trying first arg
+	params, ok := args[0].(map[string]interface{})
+	if !ok {
+		callParamsJSON, ok := args[0].([]byte)
+		if !ok {
+			return nil, fmt.Errorf("first arg was not a byte array")
+		}
+
+		err := json.Unmarshal(callParamsJSON, &params)
+		if err != nil {
+			return nil, fmt.Errorf("first arg couldn't be unmarshalled into a params map")
+		}
+	}
+
+	return params, nil
+}

--- a/tools/walletextension/multi_acc_helper.go
+++ b/tools/walletextension/multi_acc_helper.go
@@ -144,7 +144,7 @@ func parseParams(args []interface{}) (map[string]interface{}, error) {
 // proxyRequest will try to identify the correct EncRPCClient to proxy the request to the Obscuro node, or it will attempt
 //
 //	the request with all clients until it succeeds
-func proxyRequest(rpcReq *rpcRequest, rpcResp interface{}, accClients map[common.Address]*rpcclientlib.EncRPCClient) error {
+func proxyRequest(rpcReq *rpcRequest, rpcResp *interface{}, accClients map[common.Address]*rpcclientlib.EncRPCClient) error {
 	// for obscuro RPC requests it is important we know the sender account for the viewing key encryption/decryption
 	suggestedClient := suggestAccountClient(rpcReq, accClients)
 
@@ -152,12 +152,12 @@ func proxyRequest(rpcReq *rpcRequest, rpcResp interface{}, accClients map[common
 	if suggestedClient != nil {
 		// todo: if we have a suggested client, should we still loop through the other clients if it fails?
 		// 		The call data guessing won't often be wrong but there could be edge-cases there
-		err = executeCall(suggestedClient, rpcReq, &rpcResp)
+		err = executeCall(suggestedClient, rpcReq, rpcResp)
 	} else {
 		// we attempt the request with every client until we have a successful execution
 		log.Info("appropriate client not found, attempting request with up to %d clients", len(accClients))
 		for _, client := range accClients {
-			err = executeCall(client, rpcReq, &rpcResp)
+			err = executeCall(client, rpcReq, rpcResp)
 			if err == nil || errors.Is(err, rpcclientlib.ErrNilResponse) {
 				// request didn't fail, we don't need to continue trying the other clients
 				break

--- a/tools/walletextension/multi_acc_helper_test.go
+++ b/tools/walletextension/multi_acc_helper_test.go
@@ -1,11 +1,10 @@
-package rpcclientlib
+package walletextension
 
 import (
 	"testing"
 
-	"github.com/ethereum/go-ethereum/crypto/ecies"
-
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/obscuronet/go-obscuro/go/rpcclientlib"
 )
 
 const (
@@ -19,7 +18,7 @@ const (
 var (
 	viewingKeyAddressOne = common.HexToAddress("0x" + viewingKeyAddressHex)
 	viewingKeyAddressTwo = common.HexToAddress("0x71C7656EC7ab88b098defB751B7401B5f6d8976D") // Not in the data field.
-	viewingKeyMap        = map[common.Address]*ecies.PrivateKey{
+	accClients           = map[common.Address]*rpcclientlib.EncRPCClient{
 		viewingKeyAddressOne: nil,
 		viewingKeyAddressTwo: nil,
 	}
@@ -27,7 +26,7 @@ var (
 
 func TestCanSearchDataFieldForFrom(t *testing.T) {
 	callParams := map[string]interface{}{"data": dataFieldPrefix + otherAddressHexPadded + viewingKeyAddressHexPadded}
-	address, err := searchDataFieldForFrom(callParams, viewingKeyMap)
+	address, err := searchDataFieldForAccount(callParams, accClients)
 	if err != nil {
 		t.Fatalf("did not expect an error but got %s", err)
 	}
@@ -39,7 +38,7 @@ func TestCanSearchDataFieldForFrom(t *testing.T) {
 func TestCanSearchDataFieldWhenHasUnexpectedLength(t *testing.T) {
 	incorrectLengthArg := "arg2xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" // Only 31 bytes.
 	callParams := map[string]interface{}{"data": dataFieldPrefix + otherAddressHexPadded + viewingKeyAddressHexPadded + incorrectLengthArg}
-	address, err := searchDataFieldForFrom(callParams, viewingKeyMap)
+	address, err := searchDataFieldForAccount(callParams, accClients)
 	if err != nil {
 		t.Fatalf("did not expect an error but got %s", err)
 	}
@@ -49,7 +48,7 @@ func TestCanSearchDataFieldWhenHasUnexpectedLength(t *testing.T) {
 }
 
 func TestErrorsWhenDataFieldIsMissing(t *testing.T) {
-	_, err := searchDataFieldForFrom(make(map[string]interface{}), viewingKeyMap)
+	_, err := searchDataFieldForAccount(make(map[string]interface{}), accClients)
 
 	if err == nil {
 		t.Fatal("`data` field was missing but not error was thrown")
@@ -58,7 +57,7 @@ func TestErrorsWhenDataFieldIsMissing(t *testing.T) {
 
 func TestGracefulWhenDataFieldTooShort(t *testing.T) {
 	callParams := map[string]interface{}{"data": "tooshort"}
-	address, err := searchDataFieldForFrom(callParams, viewingKeyMap)
+	address, err := searchDataFieldForAccount(callParams, accClients)
 	if err != nil {
 		t.Fatalf("did not expect an error but got %s", err)
 	}

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -218,7 +218,6 @@ func (we *WalletExtension) handleHTTPEthJSON(resp http.ResponseWriter, req *http
 	}
 }
 
-//
 func executeCall(client *rpcclientlib.EncRPCClient, req *rpcRequest, resp *interface{}) error {
 	return client.Call(resp, req.method, req.params...)
 }

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -203,21 +203,6 @@ func (we *WalletExtension) handleHTTPEthJSON(resp http.ResponseWriter, req *http
 	}
 }
 
-func executeCall(client *rpcclientlib.EncRPCClient, req *rpcRequest, resp *interface{}) error {
-	var err error
-	if req.method == rpcclientlib.RPCCall {
-		// RPCCall is a sensitive method that requires a viewing key lookup but the 'from' field is not mandatory in geth
-		//	and is often not included from metamask etc. So we ensure it is populated here.
-		account := client.Account()
-		req.params, err = setCallFromFieldIfMissing(req.params, *account)
-		if err != nil {
-			return err
-		}
-	}
-
-	return client.Call(resp, req.method, req.params...)
-}
-
 func parseRequest(body []byte) (*rpcRequest, error) {
 	// We unmarshal the JSON request
 	var reqJSONMap map[string]json.RawMessage

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -162,7 +162,7 @@ func (we *WalletExtension) handleHTTPEthJSON(resp http.ResponseWriter, req *http
 
 	var rpcResp interface{}
 	// proxyRequest will find the correct client to proxy the request (or try them all if appropriate)
-	err = proxyRequest(rpcReq, rpcResp, we.accountClients)
+	err = proxyRequest(rpcReq, &rpcResp, we.accountClients)
 
 	if err != nil {
 		// if err was for a nil response then we will return an RPC result of null to the caller (this is a valid "not-found" response for some methods)


### PR DESCRIPTION
### Why is this change needed?

- Pre-requisite for the go-obs client
- (hopefully) makes the RPC client logic layers easier to reason about
- The EncRPCClient introduced here is used in *both* the wallet extension and the AuthClient that's coming.

This change also moves the multi-acc fuzzy stuff out of the core client and just into wallet extension now for cleanliness.

### What changes were made as part of this PR:

- Add viewing key type per Tudor's suggestion to wrap account with viewing key and signature
- Rename ViewingKeyClient -> EncRPCClient, a VK-encrypting/decrypting client which is bound to a single account for its lifespan
- rework wallet extension to use a map of acc addresses -> EncRPCClients, with logic to pick the right one or retry them all

Note: this change means we will round-robin all registered clients when it's not obvious which to use, we should monitor and optimise this over time.

Note2: as Joel pointed out this means we find and cast the params map twice (in wallet ext to deduce the correct client, in EncRPCClient to make sure the 'from' is set)

### What are the key areas to look at

EncRPCClient, WalletExtension


### :rotating_light: Definition of Done :rotating_light:
- [ ] Merged into dev-testnet 
- [ ] Passes tests on dev-testnet
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated
