### PR TITLE
minor wording fixes

### DIFF
--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -400,7 +400,7 @@ func (e *enclaveImpl) GetTransactionReceipt(encryptedParams common.EncryptedPara
 	}
 	txReceiptBytes, err := txReceipt.MarshalJSON()
 	if err != nil {
-		return nil, fmt.Errorf("could not marshall transaction receipt to JSON in eth_getTransactionReceipt request. Cause: %w", err)
+		return nil, fmt.Errorf("could not marshal transaction receipt to JSON in eth_getTransactionReceipt request. Cause: %w", err)
 	}
 
 	encryptedTxReceipt, err := e.rpcEncryptionManager.EncryptWithViewingKey(viewingKeyAddress, txReceiptBytes)

--- a/go/enclave/rpc/rpc_utils.go
+++ b/go/enclave/rpc/rpc_utils.go
@@ -41,7 +41,7 @@ func ExtractTx(sendRawTxParams []byte) (*common.L2Tx, error) {
 	tx := &common.L2Tx{}
 	err := tx.UnmarshalBinary(txBytes)
 	if err != nil {
-		return nil, fmt.Errorf("could not unmarshall transaction from bytes. Cause: %w", err)
+		return nil, fmt.Errorf("could not unmarshal transaction from bytes. Cause: %w", err)
 	}
 
 	return tx, nil

--- a/integration/gethnetwork/geth_network_test.go
+++ b/integration/gethnetwork/geth_network_test.go
@@ -89,7 +89,7 @@ func TestGethTransactionCanBeSubmitted(t *testing.T) {
 	// check the transaction has expected values
 	issuedTx := map[string]interface{}{}
 	if err = yaml.Unmarshal([]byte(issuedTxStr), issuedTx); err != nil {
-		t.Fatalf("unable to unmarshall getTransaction response to YAML. Cause: %s.\nsendTransaction response was: %s\ngetTransaction response was %s", err, txHash, issuedTxStr)
+		t.Fatalf("unable to unmarshal getTransaction response to YAML. Cause: %s.\nsendTransaction response was: %s\ngetTransaction response was %s", err, txHash, issuedTxStr)
 	}
 
 	if issuedTx["value"].(int) != 1000000000000000 ||

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -5,7 +5,7 @@
 ### What changes were made as part of this PR:
 
 - list of changes
-- Is this a functional or refactoring PR ( it needs to be one or the other)
+- Is this a functional or refactoring PR (it needs to be one or the other)
 
 ### What are the key areas to look at
 
@@ -13,6 +13,6 @@
 
 
 ### :rotating_light: Definition of Done :rotating_light:
-- [ ] Merged into dev-testnet 
+- [ ] Deployed into dev-testnet 
 - [ ] Passes tests on dev-testnet
 - [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -204,7 +204,7 @@ func (we *WalletExtension) handleHTTPEthJSON(resp http.ResponseWriter, req *http
 }
 
 func parseRequest(body []byte) (*rpcRequest, error) {
-	// We unmarshall the JSON request
+	// We unmarshal the JSON request
 	var reqJSONMap map[string]json.RawMessage
 	err := json.Unmarshal(body, &reqJSONMap)
 	if err != nil {


### PR DESCRIPTION
### Why is this change needed?

Just some spelling/wordings that keep catching my eye

### What changes were made as part of this PR:

- change PR placeholder to be deploy into dev-testnet instead of merge, think that's what is meant by it
- marshal has single "l" (it was mostly me misspelling them in first place 😳)

### What are the key areas to look at

- typos


### :rotating_light: Definition of Done :rotating_light:
- [ ] Merged into dev-testnet 
- [ ] Passes tests on dev-testnet
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated
