### PR TITLE
WE tests: More tidying. Retrieves nonce via wallet extension, not directly via clients

### DIFF
--- a/integration/simulation/simulation.go
+++ b/integration/simulation/simulation.go
@@ -27,7 +27,11 @@ import (
 	"github.com/obscuronet/go-obscuro/integration/simulation/stats"
 )
 
-const initialBalance = 5000
+const (
+	initialBalance       = 5000
+	allocObsWallets      = 750000000000000 // The amount the faucet allocates to each Obscuro wallet.
+	receiptTimeoutMillis = 30000           // The timeout in millis to wait for a receipt for a transaction.
+)
 
 // Simulation represents all the data required to inject transactions on a network
 type Simulation struct {

--- a/integration/simulation/transaction_injector.go
+++ b/integration/simulation/transaction_injector.go
@@ -39,14 +39,11 @@ import (
 )
 
 const (
-	nonceTimeoutMillis   = 30000 // The timeout in millis to wait for an updated nonce for a wallet.
-	receiptTimeoutMillis = 30000 // The timeout in millis to wait for a receipt for a transaction.
+	nonceTimeoutMillis = 30000 // The timeout in millis to wait for an updated nonce for a wallet.
 
 	// EnclavePublicKeyHex is the public key of the enclave.
 	// TODO - Retrieve this key from the management contract instead.
 	EnclavePublicKeyHex = "034d3b7e63a8bcd532ee3d1d6ecad9d67fca7821981a044551f0f0cbec74d0bc5e"
-
-	allocObsWallets = 750000000000000 // The amount the faucet allocates to each Obscuro wallet.
 )
 
 // TransactionInjector is a structure that generates, issues and tracks transactions

--- a/integration/walletextension/wallet_extension_test.go
+++ b/integration/walletextension/wallet_extension_test.go
@@ -74,6 +74,7 @@ var (
 		NodeRPCHTTPAddress:      fmt.Sprintf("%s:%d", network.Localhost, nodeRPCHTTPPort),
 		NodeRPCWebsocketAddress: fmt.Sprintf("%s:%d", network.Localhost, nodeRPCWSPort),
 	}
+	
 	dummyAccountAddress = common.HexToAddress("0x8D97689C9818892B700e27F316cc3E41e17fBeb9")
 	deployERC20Tx       = types.LegacyTx{
 		Gas:      1025_000_000,

--- a/integration/walletextension/wallet_extension_test.go
+++ b/integration/walletextension/wallet_extension_test.go
@@ -74,7 +74,7 @@ var (
 		NodeRPCHTTPAddress:      fmt.Sprintf("%s:%d", network.Localhost, nodeRPCHTTPPort),
 		NodeRPCWebsocketAddress: fmt.Sprintf("%s:%d", network.Localhost, nodeRPCWSPort),
 	}
-	
+
 	dummyAccountAddress = common.HexToAddress("0x8D97689C9818892B700e27F316cc3E41e17fBeb9")
 	deployERC20Tx       = types.LegacyTx{
 		Gas:      1025_000_000,


### PR DESCRIPTION
### Why is this change needed?

More clearing of the way to enable setting of a gas price in the WE tests.

### What changes were made as part of this PR:

Functional.

- WE tests now retrieve nonce via wallet extension, rather than going directly via clients (which is not what we're trying to test here)
- Some more clean-up

### What are the key areas to look at

- ...


### :rotating_light: Definition of Done :rotating_light:
- [ ] Deployed into dev-testnet 
- [ ] Passes tests on dev-testnet
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated
