### PR TITLE
Adds gas price to wallet extension test transactions.

### DIFF
--- a/integration/gethnetwork/geth_network.go
+++ b/integration/gethnetwork/geth_network.go
@@ -422,7 +422,7 @@ func ensurePortsAreAvailable(startPort int, websocketStartPort int, numberNodes 
 
 	if len(unavailablePorts) > 0 {
 		list, _ := json.Marshal(unavailablePorts)
-		return fmt.Errorf("could not run geth network because test ports are unavailable for use - the following ports were unavailable: %s", list)
+		return fmt.Errorf("could not run geth network because the following ports were unavailable: %s", list)
 	}
 	return nil
 }

--- a/integration/gethnetwork/geth_network.go
+++ b/integration/gethnetwork/geth_network.go
@@ -430,7 +430,7 @@ func ensurePortsAreAvailable(startPort int, websocketStartPort int, numberNodes 
 func isPortAvailable(port int) bool {
 	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
 	if err != nil {
-		fmt.Printf("Listen port %d. Err: %s. ", port, err)
+		log.Error("Listen port %d. Err: %s. ", port, err)
 	}
 	if ln != nil {
 		_ = ln.Close()

--- a/integration/simulation/simulation.go
+++ b/integration/simulation/simulation.go
@@ -116,7 +116,6 @@ func (s *Simulation) prefundObscuroAccounts() {
 			Value:    big.NewInt(allocObsWallets),
 			Gas:      uint64(1_000_000),
 			GasPrice: gethcommon.Big1,
-			Data:     nil,
 			To:       &destAddr,
 		}
 		signedTx, err := faucetWallet.SignTransaction(tx)

--- a/integration/walletextension/wallet_extension_test.go
+++ b/integration/walletextension/wallet_extension_test.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/obscuronet/go-obscuro/go/enclave/rollupchain"
+
 	"github.com/obscuronet/go-obscuro/go/enclave/rpc"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -60,6 +62,8 @@ const (
 	// Returned by the EVM to indicate a zero result.
 	zeroResult  = "0x0000000000000000000000000000000000000000000000000000000000000000"
 	zeroBalance = "0x0"
+
+	faucetAlloc = 750000000000000 // The amount the faucet allocates to each Obscuro wallet.
 )
 
 var (
@@ -78,7 +82,7 @@ var (
 	dummyAccountAddress = common.HexToAddress("0x8D97689C9818892B700e27F316cc3E41e17fBeb9")
 	deployERC20Tx       = types.LegacyTx{
 		Gas:      1025_000_000,
-		GasPrice: common.Big0,
+		GasPrice: common.Big1,
 		Data:     erc20contract.L2BytecodeWithDefaultSupply("TST"),
 	}
 )
@@ -271,6 +275,7 @@ func TestCanSubmitTxAndGetTxReceiptAndTxAfterSubmittingViewingKey(t *testing.T) 
 	_, privateKey := registerPrivateKey(t)
 
 	txWallet := wallet.NewInMemoryWalletFromPK(big.NewInt(integration.ObscuroChainID), privateKey)
+	fundAccount(txWallet.Address())
 	signedTx, err := txWallet.SignTransaction(&deployERC20Tx)
 	if err != nil {
 		panic(fmt.Errorf("could not sign transaction. Cause: %w", err))
@@ -514,7 +519,8 @@ func createObscuroNetwork(t *testing.T) {
 
 	// Set up the ERC20 wallet.
 	erc20Wallet := wallets.Tokens[bridge.OBX].L2Owner
-	generateAndSubmitViewingKey(walletExtensionAddr, erc20Wallet.PrivateKey())
+	generateAndSubmitViewingKey(erc20Wallet.Address().Hex(), erc20Wallet.PrivateKey())
+	fundAccount(erc20Wallet.Address())
 
 	sendTransactionAndAwaitConfirmation(erc20Wallet, deployERC20Tx)
 }
@@ -586,6 +592,28 @@ func signAndSerialiseTransaction(wallet wallet.Wallet, tx types.TxData) string {
 	}
 
 	return txBinaryHex
+}
+
+// Funds the account from the faucet account.
+func fundAccount(dest common.Address) {
+	// We create the faucet wallet.
+	faucetPrivKey, err := crypto.HexToECDSA(rollupchain.FaucetPrivateKeyHex)
+	if err != nil {
+		panic("could not initialise faucet private key")
+	}
+	faucetWallet := wallet.NewInMemoryWalletFromPK(big.NewInt(integration.ObscuroChainID), faucetPrivKey)
+
+	// We generate a viewing key for the faucet.
+	generateAndSubmitViewingKey(faucetWallet.Address().Hex(), faucetPrivKey)
+
+	// We submit the transaction and await confirmation.
+	tx := types.LegacyTx{
+		Value:    big.NewInt(faucetAlloc),
+		Gas:      uint64(1_000_000),
+		GasPrice: common.Big1,
+		To:       &dest,
+	}
+	sendTransactionAndAwaitConfirmation(faucetWallet, tx)
 }
 
 func setupWalletTestLog(testName string) {

--- a/tools/contractdeployer/contract_deployer.go
+++ b/tools/contractdeployer/contract_deployer.go
@@ -181,7 +181,6 @@ func (cd *contractDeployer) prefundAccount() error {
 		Value:    big.NewInt(prealloc),
 		Gas:      uint64(1_000_000),
 		GasPrice: common.Big1,
-		Data:     nil,
 		To:       &destAddr,
 	}
 	_, err = signAndSendTxWithReceipt(cd.faucetWallet, cd.faucetClient, tx)


### PR DESCRIPTION
### Why is this change needed?

Before we can enable a mandatory minimum gas price, the wallet extension tests have to support prefunding of accounts.

### What changes were made as part of this PR:

Functional.

- Prefunds accounts in wallet extension tests

### What are the key areas to look at

- ...


### :rotating_light: Definition of Done :rotating_light:
- [ ] Deployed into dev-testnet 
- [ ] Passes tests on dev-testnet
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated
