### PR TITLE
identify nonce-req failure in walext

### DIFF
--- a/integration/walletextension/wallet_extension_test.go
+++ b/integration/walletextension/wallet_extension_test.go
@@ -536,7 +536,7 @@ func sendTransactionAndAwaitConfirmation(txWallet wallet.Wallet, tx types.Legacy
 	nonceJSON := makeEthJSONReqAsJSON(rpcclientlib.RPCNonce, []interface{}{txWallet.Address().Hex(), latestBlock})
 	nonceString, ok := nonceJSON[walletextension.RespJSONKeyResult].(string)
 	if !ok {
-		panic(fmt.Errorf("retrieved nonce was not of type string"))
+		panic(fmt.Errorf("retrieved nonce was not of type string, resp: %s", nonceJSON))
 	}
 	nonce, err := hexutil.DecodeUint64(nonceString)
 	if err != nil {

--- a/integration/walletextension/wallet_extension_test.go
+++ b/integration/walletextension/wallet_extension_test.go
@@ -536,8 +536,11 @@ func sendTransactionAndAwaitConfirmation(txWallet wallet.Wallet, tx types.Legacy
 	nonceJSON := makeEthJSONReqAsJSON(rpcclientlib.RPCNonce, []interface{}{txWallet.Address().Hex(), latestBlock})
 	nonceString, ok := nonceJSON[walletextension.RespJSONKeyResult].(string)
 	if !ok {
-		nonceJson, _ := json.Marshal(nonceJSON)
-		panic(fmt.Errorf("retrieved nonce was not of type string, resp: %s", nonceJson))
+		respJSON, err := json.Marshal(nonceJSON)
+		if err != nil {
+			respJSON = []byte(fmt.Sprintf("can't read response as json, cause: %s response: %v", err, nonceJSON))
+		}
+		panic(fmt.Errorf("retrieved nonce was not of type string, resp: %s", respJSON))
 	}
 	nonce, err := hexutil.DecodeUint64(nonceString)
 	if err != nil {

--- a/integration/walletextension/wallet_extension_test.go
+++ b/integration/walletextension/wallet_extension_test.go
@@ -536,7 +536,8 @@ func sendTransactionAndAwaitConfirmation(txWallet wallet.Wallet, tx types.Legacy
 	nonceJSON := makeEthJSONReqAsJSON(rpcclientlib.RPCNonce, []interface{}{txWallet.Address().Hex(), latestBlock})
 	nonceString, ok := nonceJSON[walletextension.RespJSONKeyResult].(string)
 	if !ok {
-		panic(fmt.Errorf("retrieved nonce was not of type string, resp: %s", nonceJSON))
+		nonceJson, _ := json.Marshal(nonceJSON)
+		panic(fmt.Errorf("retrieved nonce was not of type string, resp: %s", nonceJson))
 	}
 	nonce, err := hexutil.DecodeUint64(nonceString)
 	if err != nil {


### PR DESCRIPTION
### Why is this change needed?

- we are seeing Wallet Extension failures on CI and need more info, suspect an error is being returned and not logged

### What changes were made as part of this PR:

- log the repsonse json for failed nonce request

### :rotating_light: Definition of Done :rotating_light:
- [ ] Deployed into dev-testnet 
- [ ] Passes tests on dev-testnet
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated
