### PR TITLE
Prints message to indicate when a Geth node is stopping, to detect unstopped Geth nodes

### DIFF
--- a/integration/datagenerator/common.go
+++ b/integration/datagenerator/common.go
@@ -30,7 +30,7 @@ func RandomAddress() gethcommon.Address {
 }
 
 func randomUInt64() uint64 {
-	val, err := rand.Int(rand.Reader, big.NewInt(int64(math.MaxInt64)))
+	val, err := rand.Int(rand.Reader, big.NewInt(math.MaxInt64))
 	if err != nil {
 		panic(err)
 	}

--- a/integration/gethnetwork/geth_network.go
+++ b/integration/gethnetwork/geth_network.go
@@ -2,9 +2,12 @@ package gethnetwork
 
 import (
 	"bufio"
+	"crypto/rand"
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
+	"math/big"
 	"net"
 	"os"
 	"os/exec"
@@ -117,6 +120,7 @@ type GethNetwork struct {
 	commStartPort    int
 	wsStartPort      int
 	blockTimeSecs    int
+	id               int64 // A random ID used to identify the network in logging.
 }
 
 // NewGethNetwork returns an Ethereum network with numNodes nodes using the provided Geth binary and allows for prefunding addresses.
@@ -163,6 +167,11 @@ func NewGethNetwork(portStart int, websocketPortStart int, gethBinaryPath string
 		panic(err)
 	}
 
+	networkID, err := rand.Int(rand.Reader, big.NewInt(math.MaxInt64))
+	if err != nil {
+		panic(err)
+	}
+
 	network := GethNetwork{
 		gethBinaryPath:   gethBinaryPath,
 		dataDirs:         dataDirs,
@@ -174,6 +183,7 @@ func NewGethNetwork(portStart int, websocketPortStart int, gethBinaryPath string
 		commStartPort:    portStart,
 		wsStartPort:      websocketPortStart,
 		blockTimeSecs:    blockTimeSecs,
+		id:               networkID.Int64(),
 	}
 
 	// We create an account for each node.
@@ -263,7 +273,7 @@ func (network *GethNetwork) IssueCommand(nodeIdx int, command string) string {
 // StopNodes kills the Geth node processes.
 func (network *GethNetwork) StopNodes() {
 	var wg sync.WaitGroup
-	for _, process := range network.nodesProcs {
+	for idx, process := range network.nodesProcs {
 		if process != nil {
 			wg.Add(1)
 			go func(process *os.Process) {
@@ -275,6 +285,8 @@ func (network *GethNetwork) StopNodes() {
 				_, err = process.Wait()
 				if err != nil {
 					log.Error("geth node was killed successfully but did not exit: %s", err)
+				} else {
+					fmt.Printf("Geth node %d on network %d stopped.\n", network.id, idx)
 				}
 			}(process)
 		}
@@ -366,7 +378,7 @@ func (network *GethNetwork) startMiner(dataDirPath string, idx int) {
 	network.nodesProcs[idx] = cmd.Process
 	network.WebSocketPorts[idx] = uint(webSocketPort)
 
-	fmt.Printf("Geth node %d started on ports %d (WebSocket) and %d (HTTP)\n", idx, webSocketPort, httpPort)
+	fmt.Printf("Geth node %d on network %d started on ports %d (WebSocket) and %d (HTTP).\n", idx, network.id, webSocketPort, httpPort)
 }
 
 // logNodeID prepends the nodeID to the log entries

--- a/integration/gethnetwork/geth_network.go
+++ b/integration/gethnetwork/geth_network.go
@@ -286,7 +286,7 @@ func (network *GethNetwork) StopNodes() {
 				if err != nil {
 					log.Error("geth node was killed successfully but did not exit: %s", err)
 				} else {
-					fmt.Printf("Geth node %d on network %d stopped.\n", network.id, idx)
+					fmt.Printf("Geth node %d on network %d stopped.\n", idx, network.id)
 				}
 			}(process)
 		}

--- a/integration/simulation/network/geth_utils.go
+++ b/integration/simulation/network/geth_utils.go
@@ -84,7 +84,9 @@ func StopGethNetwork(clients []ethadapter.EthClient, netw *gethnetwork.GethNetwo
 		}
 	}
 	// Stop the nodes second
-	netw.StopNodes()
+	if netw != nil { // If network creation failed, we may be attempting to tear down the Geth network before it even exists.
+		netw.StopNodes()
+	}
 }
 
 // DeployContract todo -this should live somewhere else


### PR DESCRIPTION
### Why is this change needed?

We have had issues on CI that appear to be related to Geth nodes not being stopped correctly.

### What changes were made as part of this PR:

Functional.

- Print out message when Geth nodes are stopped, to identify missing, unstopped nodes

### What are the key areas to look at

- ...


### :rotating_light: Definition of Done :rotating_light:
- [ ] Deployed into dev-testnet 
- [ ] Passes tests on dev-testnet
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated
