### PR TITLE
Only send funds to contract deployer if needed. Extend contract deployer tests.

### DIFF
--- a/go/ethadapter/geth_rpc_client.go
+++ b/go/ethadapter/geth_rpc_client.go
@@ -170,7 +170,7 @@ func (e *gethRPCClient) EthClient() *ethclient.Client {
 	return e.client
 }
 
-func (e *gethRPCClient) GetBalance(_ gethcommon.Address) (big.Int, error) {
+func (e *gethRPCClient) BalanceAt(gethcommon.Address, *big.Int) (*big.Int, error) {
 	panic("not implemented")
 }
 

--- a/go/ethadapter/geth_rpc_client.go
+++ b/go/ethadapter/geth_rpc_client.go
@@ -170,6 +170,10 @@ func (e *gethRPCClient) EthClient() *ethclient.Client {
 	return e.client
 }
 
+func (e *gethRPCClient) GetBalance(_ gethcommon.Address) (big.Int, error) {
+	panic("not implemented")
+}
+
 func (e *gethRPCClient) Stop() {
 	e.client.Close()
 }

--- a/go/ethadapter/interface.go
+++ b/go/ethadapter/interface.go
@@ -15,12 +15,12 @@ import (
 // EthClient defines the interface for RPC communications with the ethereum nodes
 // TODO Some of these methods are composed calls that should be decoupled in the future (ie: BlocksBetween or IsBlockAncestor)
 type EthClient interface {
-	BlockByHash(id gethcommon.Hash) (*types.Block, error)            // retrieves a block given a hash
-	BlockByNumber(n *big.Int) (*types.Block, error)                  // retrieves a block given a number - returns head block if n is nil
-	SendTransaction(signedTx *types.Transaction) error               // issues an ethereum transaction (expects signed tx)
-	TransactionReceipt(hash gethcommon.Hash) (*types.Receipt, error) // fetches the ethereum transaction receipt
-	Nonce(address gethcommon.Address) (uint64, error)                // fetches the account nonce to use in the next transaction
-	GetBalance(address gethcommon.Address) (big.Int, error)          // fetches the balance of the account
+	BlockByHash(id gethcommon.Hash) (*types.Block, error)                         // retrieves a block given a hash
+	BlockByNumber(n *big.Int) (*types.Block, error)                               // retrieves a block given a number - returns head block if n is nil
+	SendTransaction(signedTx *types.Transaction) error                            // issues an ethereum transaction (expects signed tx)
+	TransactionReceipt(hash gethcommon.Hash) (*types.Receipt, error)              // fetches the ethereum transaction receipt
+	Nonce(address gethcommon.Address) (uint64, error)                             // fetches the account nonce to use in the next transaction
+	BalanceAt(account gethcommon.Address, blockNumber *big.Int) (*big.Int, error) // fetches the balance of the account
 
 	Info() Info                                                         // retrieves the node Info
 	FetchHeadBlock() *types.Block                                       // retrieves the block at head height

--- a/go/ethadapter/interface.go
+++ b/go/ethadapter/interface.go
@@ -20,6 +20,7 @@ type EthClient interface {
 	SendTransaction(signedTx *types.Transaction) error               // issues an ethereum transaction (expects signed tx)
 	TransactionReceipt(hash gethcommon.Hash) (*types.Receipt, error) // fetches the ethereum transaction receipt
 	Nonce(address gethcommon.Address) (uint64, error)                // fetches the account nonce to use in the next transaction
+	GetBalance(address gethcommon.Address) (big.Int, error)          // fetches the balance of the account
 
 	Info() Info                                                         // retrieves the node Info
 	FetchHeadBlock() *types.Block                                       // retrieves the block at head height

--- a/go/ethadapter/obscuro_rpc_client.go
+++ b/go/ethadapter/obscuro_rpc_client.go
@@ -18,6 +18,10 @@ import (
 	"github.com/obscuronet/go-obscuro/go/wallet"
 )
 
+const (
+	latestBlock = "latest"
+)
+
 var ErrReceiptNotFound = errors.New("receipt not found, received nil response")
 
 // obscuroWalletRPCClient implements the EthClient interface, it's bound to a single wallet (viewing key and address)
@@ -79,9 +83,20 @@ func (c *obscuroWalletRPCClient) TransactionReceipt(hash gethcommon.Hash) (*type
 func (c *obscuroWalletRPCClient) Nonce(address gethcommon.Address) (uint64, error) {
 	var result hexutil.Uint64
 	bl := rpc.LatestBlockNumber
-	// todo take the block number as an argument
+	// todo take the block number as an argument, rather than hardcoding latest
 	err := c.client.Call(&result, rpcclientlib.RPCNonce, address, rpc.BlockNumberOrHash{BlockNumber: &bl})
 	return uint64(result), err
+}
+
+func (c *obscuroWalletRPCClient) GetBalance(address gethcommon.Address) (big.Int, error) {
+	var result string
+	// todo take the block number as an argument, rather than hardcoding latest
+	err := c.client.Call(&result, rpcclientlib.RPCGetBalance, address.Hex(), latestBlock)
+	if err != nil {
+		return *gethcommon.Big0, err
+	}
+	balance, err := hexutil.DecodeBig(result)
+	return *balance, err
 }
 
 func (c *obscuroWalletRPCClient) Info() Info {

--- a/go/ethadapter/obscuro_rpc_client.go
+++ b/go/ethadapter/obscuro_rpc_client.go
@@ -88,15 +88,15 @@ func (c *obscuroWalletRPCClient) Nonce(address gethcommon.Address) (uint64, erro
 	return uint64(result), err
 }
 
-func (c *obscuroWalletRPCClient) GetBalance(address gethcommon.Address) (big.Int, error) {
+func (c *obscuroWalletRPCClient) BalanceAt(account gethcommon.Address, _ *big.Int) (*big.Int, error) {
 	var result string
 	// todo take the block number as an argument, rather than hardcoding latest
-	err := c.client.Call(&result, rpcclientlib.RPCGetBalance, address.Hex(), latestBlock)
+	err := c.client.Call(&result, rpcclientlib.RPCGetBalance, account.Hex(), latestBlock)
 	if err != nil {
-		return *gethcommon.Big0, err
+		return gethcommon.Big0, err
 	}
 	balance, err := hexutil.DecodeBig(result)
-	return *balance, err
+	return balance, err
 }
 
 func (c *obscuroWalletRPCClient) Info() Info {

--- a/go/rpcclientlib/client.go
+++ b/go/rpcclientlib/client.go
@@ -9,6 +9,7 @@ const (
 	RPCCall                    = "eth_call"
 	RPCChainID                 = "eth_chainId"
 	RPCGetBalance              = "eth_getBalance"
+	RPCGetCode                 = "eth_getCode"
 	RPCGetTransactionByHash    = "eth_getTransactionByHash"
 	RPCNonce                   = "eth_getTransactionCount"
 	RPCGetTxReceipt            = "eth_getTransactionReceipt"

--- a/integration/common/utils.go
+++ b/integration/common/utils.go
@@ -43,11 +43,11 @@ func AwaitReceipt(client rpcclientlib.Client, txHash gethcommon.Hash) error {
 				return err
 			}
 
-			counter++
+			counter += 100
 			if counter > receiptTimeoutMillis {
 				return fmt.Errorf("could not retrieve transaction after timeout")
 			}
-			time.Sleep(time.Millisecond)
+			time.Sleep(100 * time.Millisecond)
 			continue
 		}
 

--- a/integration/contractdeployer/contract_deployer_test.go
+++ b/integration/contractdeployer/contract_deployer_test.go
@@ -85,6 +85,8 @@ func TestFaucetSendsFundsOnlyIfNeeded(t *testing.T) {
 	// We send more than enough to the contract deployer, to make sure prefunding won't be needed.
 	prefundContractDeployer(faucetWallet, faucetClient, contractdeployer.Prealloc*3)
 
+	// We check the faucet's balance before and after the deployment. Since the contract deployer has already been sent
+	// sufficient funds, the faucet should have been to dispense any more, leaving its balance unchanged.
 	var faucetInitialBalance string
 	err := faucetClient.Call(&faucetInitialBalance, rpcclientlib.RPCGetBalance, faucetWallet.Address().Hex(), latestBlock)
 	if err != nil {

--- a/integration/contractdeployer/contract_deployer_test.go
+++ b/integration/contractdeployer/contract_deployer_test.go
@@ -7,9 +7,7 @@ import (
 	"time"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/obscuronet/go-obscuro/go/common"
 	"github.com/obscuronet/go-obscuro/go/enclave/rollupchain"
 	testcommon "github.com/obscuronet/go-obscuro/integration/common"
 
@@ -49,6 +47,8 @@ var (
 
 func TestCanDeployGuessingGameContract(t *testing.T) {
 	createObscuroNetwork(t)
+	// This sleep is required to ensure the initial rollup exists, and thus contract deployer can check its balance.
+	time.Sleep(2 * time.Second)
 	contractAddr, err := contractdeployer.Deploy(config)
 	if err != nil {
 		panic(err)
@@ -57,16 +57,8 @@ func TestCanDeployGuessingGameContract(t *testing.T) {
 	contractDeployerWallet := getWallet(contractDeployerPrivateKeyHex)
 	contractDeployerClient := getClient(contractDeployerWallet)
 
-	// TODO - Once the bug around use of "latest" with `eth_getCode` is fixed, use "latest" instead of rollup number.
-	var rollupHeader *common.Header
-	err = contractDeployerClient.Call(&rollupHeader, rpcclientlib.RPCGetCurrentRollupHead)
-	if err != nil {
-		panic(err)
-	}
-	rollupNumber := hexutil.EncodeBig(rollupHeader.Number)
-
 	var deployedCode string
-	err = contractDeployerClient.Call(&deployedCode, rpcclientlib.RPCGetCode, contractAddr, rollupNumber)
+	err = contractDeployerClient.Call(&deployedCode, rpcclientlib.RPCGetCode, contractAddr, latestBlock)
 	if err != nil {
 		panic(err)
 	}

--- a/integration/contractdeployer/contract_deployer_test.go
+++ b/integration/contractdeployer/contract_deployer_test.go
@@ -2,8 +2,20 @@ package contractdeployer
 
 import (
 	"fmt"
+	"math/big"
 	"testing"
 	"time"
+
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/obscuronet/go-obscuro/go/common"
+	"github.com/obscuronet/go-obscuro/go/enclave/rollupchain"
+	testcommon "github.com/obscuronet/go-obscuro/integration/common"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/obscuronet/go-obscuro/go/rpcclientlib"
+	"github.com/obscuronet/go-obscuro/go/wallet"
 
 	"github.com/obscuronet/go-obscuro/tools/contractdeployer"
 
@@ -15,25 +27,95 @@ import (
 )
 
 const (
-	contractDeployerPrivateKey = "4bfe14725e685901c062ccd4e220c61cf9c189897b6c78bd18d7f51291b2b8f8"
-	guessingGameParamOne       = "100"
-	guessingGameParamTwo       = "0xf3a8bd422097bFdd9B3519Eaeb533393a1c561aC"
+	contractDeployerPrivateKeyHex = "4bfe14725e685901c062ccd4e220c61cf9c189897b6c78bd18d7f51291b2b8f8"
+	guessingGameParamOne          = "100"
+	guessingGameParamTwo          = "0xf3a8bd422097bFdd9B3519Eaeb533393a1c561aC"
+	latestBlock                   = "latest"
+	emptyCode                     = "0x"
+)
+
+var (
+	config = &contractdeployer.Config{
+		NodeHost:          network.Localhost,
+		NodePort:          integration.StartPortContractDeployerTest + network.DefaultHostRPCHTTPOffset,
+		IsL1Deployment:    false,
+		PrivateKey:        contractDeployerPrivateKeyHex,
+		ChainID:           big.NewInt(integration.ObscuroChainID),
+		ContractName:      contractdeployer.GuessingGameContract,
+		ConstructorParams: []string{guessingGameParamOne, guessingGameParamTwo},
+	}
+	nodeAddress = fmt.Sprintf("%s:%d", config.NodeHost, config.NodePort)
 )
 
 func TestCanDeployGuessingGameContract(t *testing.T) {
 	createObscuroNetwork(t)
-
-	config := contractdeployer.DefaultConfig()
-	config.NodeHost = network.Localhost
-	config.NodePort = integration.StartPortContractDeployerTest + network.DefaultHostRPCHTTPOffset
-	config.PrivateKey = contractDeployerPrivateKey
-	config.ContractName = contractdeployer.GuessingGameContract
-	config.ConstructorParams = []string{guessingGameParamOne, guessingGameParamTwo}
-
-	err := contractdeployer.Deploy(config)
+	contractAddr, err := contractdeployer.Deploy(config)
 	if err != nil {
 		panic(err)
 	}
+
+	contractDeployerWallet := getWallet(contractDeployerPrivateKeyHex)
+	contractDeployerClient := getClient(contractDeployerWallet)
+
+	// TODO - Once the bug around use of "latest" with `eth_getCode` is fixed, use "latest" instead of rollup number.
+	var rollupHeader *common.Header
+	err = contractDeployerClient.Call(&rollupHeader, rpcclientlib.RPCGetCurrentRollupHead)
+	if err != nil {
+		panic(err)
+	}
+	rollupNumber := hexutil.EncodeBig(rollupHeader.Number)
+
+	var deployedCode string
+	err = contractDeployerClient.Call(&deployedCode, rpcclientlib.RPCGetCode, contractAddr, rollupNumber)
+	if err != nil {
+		panic(err)
+	}
+
+	if deployedCode == emptyCode {
+		t.Fatal("contract was deployed but could not get code")
+	}
+}
+
+func TestFaucetSendsFundsOnlyIfNeeded(t *testing.T) {
+	createObscuroNetwork(t)
+
+	faucetWallet := getWallet(rollupchain.FaucetPrivateKeyHex)
+	faucetClient := getClient(faucetWallet)
+
+	// We send more than enough to the contract deployer, to make sure prefunding won't be needed.
+	prefundContractDeployer(faucetWallet, faucetClient, contractdeployer.Prealloc*3)
+
+	var faucetInitialBalance string
+	err := faucetClient.Call(&faucetInitialBalance, rpcclientlib.RPCGetBalance, faucetWallet.Address().Hex(), latestBlock)
+	if err != nil {
+		panic(err)
+	}
+
+	_, err = contractdeployer.Deploy(config)
+	if err != nil {
+		panic(err)
+	}
+
+	var faucetBalanceAfterDeploy string
+	// We create a new faucet client because deploying the contract will have overwritten the faucet's viewing key on the node.
+	faucetClient = getClient(faucetWallet)
+	err = faucetClient.Call(&faucetBalanceAfterDeploy, rpcclientlib.RPCGetBalance, faucetWallet.Address().Hex(), latestBlock)
+	if err != nil {
+		panic(err)
+	}
+
+	if faucetInitialBalance != faucetBalanceAfterDeploy {
+		t.Fatal("contract deployment allocated extra funds to contract deployer, despite sufficient funds")
+	}
+}
+
+func getWallet(privateKeyHex string) wallet.Wallet {
+	faucetPrivKey, err := crypto.HexToECDSA(privateKeyHex)
+	if err != nil {
+		panic("could not initialise faucet private key")
+	}
+	faucetWallet := wallet.NewInMemoryWalletFromPK(config.ChainID, faucetPrivKey)
+	return faucetWallet
 }
 
 // Creates a single-node Obscuro network for testing.
@@ -56,5 +138,50 @@ func createObscuroNetwork(t *testing.T) {
 	_, err := obscuroNetwork.Create(&simParams, simStats)
 	if err != nil {
 		panic(fmt.Sprintf("failed to create test Obscuro network. Cause: %s", err))
+	}
+}
+
+// Returns a viewing-key client with a registered viewing key.
+func getClient(wallet wallet.Wallet) *rpcclientlib.EncRPCClient {
+	viewingKey, err := rpcclientlib.GenerateAndSignViewingKey(wallet)
+	if err != nil {
+		panic(err)
+	}
+	client, err := rpcclientlib.NewEncNetworkClient(nodeAddress, viewingKey)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
+// Prefunds the contract deployer with the given amount.
+func prefundContractDeployer(faucetWallet wallet.Wallet, faucetClient *rpcclientlib.EncRPCClient, prealloc int64) {
+	contractDeployerPrivKey, err := crypto.HexToECDSA(contractDeployerPrivateKeyHex)
+	if err != nil {
+		panic("could not initialise contract deployer private key")
+	}
+	contractDeployerWallet := wallet.NewInMemoryWalletFromPK(config.ChainID, contractDeployerPrivKey)
+
+	contractDeployerAddr := contractDeployerWallet.Address()
+	tx := &types.LegacyTx{
+		Nonce:    0, // We can assume this is the first transaction for the new wallet.
+		Value:    big.NewInt(prealloc),
+		Gas:      uint64(1_000_000),
+		GasPrice: gethcommon.Big1,
+		To:       &contractDeployerAddr,
+	}
+	signedTx, err := faucetWallet.SignTransaction(tx)
+	if err != nil {
+		panic(err)
+	}
+
+	err = faucetClient.Call(nil, rpcclientlib.RPCSendRawTransaction, testcommon.EncodeTx(signedTx))
+	if err != nil {
+		panic(err)
+	}
+
+	err = testcommon.AwaitReceipt(faucetClient, signedTx.Hash())
+	if err != nil {
+		panic(err)
 	}
 }

--- a/integration/ethereummock/node.go
+++ b/integration/ethereummock/node.go
@@ -136,6 +136,10 @@ func (m *Node) IsBlockAncestor(block *types.Block, proof common.L1RootHash) bool
 	return m.Resolver.IsBlockAncestor(block, proof)
 }
 
+func (m *Node) GetBalance(_ gethcommon.Address) (big.Int, error) {
+	panic("not implemented")
+}
+
 // Start runs an infinite loop that listens to the two block producing channels and processes them.
 // it outputs the winning blocks to the roundWinnerCh channel
 func (m *Node) Start() {

--- a/integration/ethereummock/node.go
+++ b/integration/ethereummock/node.go
@@ -136,7 +136,7 @@ func (m *Node) IsBlockAncestor(block *types.Block, proof common.L1RootHash) bool
 	return m.Resolver.IsBlockAncestor(block, proof)
 }
 
-func (m *Node) GetBalance(_ gethcommon.Address) (big.Int, error) {
+func (m *Node) BalanceAt(gethcommon.Address, *big.Int) (*big.Int, error) {
 	panic("not implemented")
 }
 

--- a/integration/simulation/simulation_in_mem_test.go
+++ b/integration/simulation/simulation_in_mem_test.go
@@ -15,7 +15,7 @@ import (
 // Running it long enough with various parameters will test many corner cases without having to explicitly write individual tests for them.
 // The unit of time is the "AvgBlockDuration" - which is the average time between L1 blocks, which are the carriers of rollups.
 // Everything else is reported to this value. This number has to be adjusted in conjunction with the number of nodes. If it's too low,
-// the CPU usage will be very high during the simulation which might result in inconclusive results.
+// the CPU usage will be very high during the simulation which might give inconclusive results.
 func TestInMemoryMonteCarloSimulation(t *testing.T) {
 	setupSimTestLog("in-mem")
 

--- a/integration/simulation/transaction_injector.go
+++ b/integration/simulation/transaction_injector.go
@@ -173,7 +173,7 @@ func (ti *TransactionInjector) issueRandomTransfers() {
 
 		ti.stats.Transfer()
 
-		err = ti.rpcHandles.ObscuroWalletRndClient(fromWallet).Call(nil, rpcclientlib.RPCSendRawTransaction, encodeTx(signedTx))
+		err = ti.rpcHandles.ObscuroWalletRndClient(fromWallet).Call(nil, rpcclientlib.RPCSendRawTransaction, testcommon.EncodeTx(signedTx))
 		if err != nil {
 			log.Info("Failed to issue transfer via RPC. Cause: %s", err)
 			continue
@@ -235,7 +235,7 @@ func (ti *TransactionInjector) issueRandomWithdrawals() {
 			common.ShortAddress(obsWallet.Address()),
 		)
 
-		err = ti.rpcHandles.ObscuroWalletRndClient(obsWallet).Call(nil, rpcclientlib.RPCSendRawTransaction, encodeTx(signedTx))
+		err = ti.rpcHandles.ObscuroWalletRndClient(obsWallet).Call(nil, rpcclientlib.RPCSendRawTransaction, testcommon.EncodeTx(signedTx))
 		if err != nil {
 			log.Info("Failed to issue withdrawal via RPC. Cause: %s", err)
 			continue
@@ -262,7 +262,7 @@ func (ti *TransactionInjector) issueInvalidL2Txs() {
 
 		signedTx := ti.createInvalidSignage(tx, fromWallet)
 
-		err := ti.rpcHandles.ObscuroWalletRndClient(fromWallet).Call(nil, rpcclientlib.RPCSendRawTransaction, encodeTx(signedTx))
+		err := ti.rpcHandles.ObscuroWalletRndClient(fromWallet).Call(nil, rpcclientlib.RPCSendRawTransaction, testcommon.EncodeTx(signedTx))
 		if err != nil {
 			log.Info("Failed to issue withdrawal via RPC. Cause: %s", err)
 		}
@@ -359,19 +359,6 @@ func NextNonce(clients *network.RPCHandles, w wallet.Wallet) uint64 {
 		}
 		time.Sleep(time.Millisecond)
 	}
-}
-
-// Formats a transaction for sending to the enclave
-func encodeTx(tx *common.L2Tx) string {
-	txBinary, err := tx.MarshalBinary()
-	if err != nil {
-		panic(err)
-	}
-
-	// We convert the transaction binary to the form expected for sending transactions via RPC.
-	txBinaryHex := gethcommon.Bytes2Hex(txBinary)
-
-	return "0x" + txBinaryHex
 }
 
 // Indicates whether to keep issuing transactions, or halt.

--- a/tools/contractdeployer/contract_deployer.go
+++ b/tools/contractdeployer/contract_deployer.go
@@ -33,7 +33,7 @@ const (
 const (
 	timeoutWait   = 80 * time.Second
 	retryInterval = 2 * time.Second
-	prealloc      = 2_050_000_000_000_000_000 // The amount preallocated to the contract deployer wallet.
+	Prealloc      = 2_050_000_000_000_000_000 // The amount preallocated to the contract deployer wallet.
 )
 
 type contractDeployer struct {
@@ -44,10 +44,11 @@ type contractDeployer struct {
 	contractCode []byte
 }
 
-func Deploy(config *Config) error {
+// Deploy deploys the contract specified in the config, and returns its address.
+func Deploy(config *Config) (string, error) {
 	deployer, err := newContractDeployer(config)
 	if err != nil {
-		return err
+		return "", err
 	}
 	return deployer.run(config.IsL1Deployment)
 }
@@ -95,18 +96,18 @@ func newContractDeployer(config *Config) (*contractDeployer, error) {
 	return deployer, nil
 }
 
-func (cd *contractDeployer) run(isL1Deployment bool) error {
+func (cd *contractDeployer) run(isL1Deployment bool) (string, error) {
 	// On the L2, we need to prefund the contract deployer account.
 	if !isL1Deployment {
 		err := cd.prefundAccount()
 		if err != nil {
-			return fmt.Errorf("unable to prefund contract deployer account. Cause: %w", err)
+			return "", fmt.Errorf("unable to prefund contract deployer account. Cause: %w", err)
 		}
 	}
 
 	nonce, err := cd.client.Nonce(cd.wallet.Address())
 	if err != nil {
-		return fmt.Errorf("failed to fetch wallet nonce: %w", err)
+		return "", fmt.Errorf("failed to fetch wallet nonce: %w", err)
 	}
 	cd.wallet.SetNonce(nonce)
 
@@ -119,10 +120,10 @@ func (cd *contractDeployer) run(isL1Deployment bool) error {
 
 	contractAddr, err := signAndSendTxWithReceipt(cd.wallet, cd.client, &deployContractTx)
 	if err != nil {
-		return err
+		return "", err
 	}
 	if contractAddr == nil {
-		return fmt.Errorf("transaction was successful but could not retrieve address for deployed contract")
+		return "", fmt.Errorf("transaction was successful but could not retrieve address for deployed contract")
 	}
 
 	// print the contract address, to be read if necessary by the caller (important: this must be the last message output by the script)
@@ -130,7 +131,7 @@ func (cd *contractDeployer) run(isL1Deployment bool) error {
 
 	// this is a safety sleep to make sure the output is printed
 	time.Sleep(5 * time.Second)
-	return nil
+	return contractAddr.Hex(), nil
 }
 
 func setupWallet(cfg *Config) (wallet.Wallet, error) {
@@ -181,7 +182,7 @@ func (cd *contractDeployer) prefundAccount() error {
 	destAddr := cd.wallet.Address()
 	tx := &types.LegacyTx{
 		Nonce:    nonce,
-		Value:    big.NewInt(prealloc),
+		Value:    big.NewInt(Prealloc),
 		Gas:      uint64(1_000_000),
 		GasPrice: common.Big1,
 		To:       &destAddr,

--- a/tools/contractdeployer/contract_deployer.go
+++ b/tools/contractdeployer/contract_deployer.go
@@ -174,6 +174,15 @@ func setupClient(cfg *Config, wal wallet.Wallet) (ethadapter.EthClient, error) {
 }
 
 func (cd *contractDeployer) prefundAccount() error {
+	balance, err := cd.client.GetBalance(cd.wallet.Address())
+	if err != nil {
+		return fmt.Errorf("failed to fetch contract deployer balance. Cause: %w", err)
+	}
+	// We do not send more funds if the contract deployer already has enough.
+	if balance.Cmp(big.NewInt(Prealloc)) == 1 {
+		return nil
+	}
+
 	nonce, err := cd.faucetClient.Nonce(cd.faucetWallet.Address())
 	if err != nil {
 		return fmt.Errorf("failed to fetch faucet nonce. Cause: %w", err)

--- a/tools/contractdeployer/contract_deployer.go
+++ b/tools/contractdeployer/contract_deployer.go
@@ -44,7 +44,7 @@ type contractDeployer struct {
 	contractCode []byte
 }
 
-// Deploy deploys the contract specified in the config, and returns its address.
+// Deploy deploys the contract specified in the config, and returns its deployed address.
 func Deploy(config *Config) (string, error) {
 	deployer, err := newContractDeployer(config)
 	if err != nil {

--- a/tools/contractdeployer/contract_deployer.go
+++ b/tools/contractdeployer/contract_deployer.go
@@ -126,9 +126,6 @@ func (cd *contractDeployer) run(isL1Deployment bool) (string, error) {
 		return "", fmt.Errorf("transaction was successful but could not retrieve address for deployed contract")
 	}
 
-	// print the contract address, to be read if necessary by the caller (important: this must be the last message output by the script)
-	fmt.Print(contractAddr.Hex())
-
 	// this is a safety sleep to make sure the output is printed
 	time.Sleep(5 * time.Second)
 	return contractAddr.Hex(), nil

--- a/tools/contractdeployer/contract_deployer.go
+++ b/tools/contractdeployer/contract_deployer.go
@@ -171,7 +171,7 @@ func setupClient(cfg *Config, wal wallet.Wallet) (ethadapter.EthClient, error) {
 }
 
 func (cd *contractDeployer) prefundAccount() error {
-	balance, err := cd.client.GetBalance(cd.wallet.Address())
+	balance, err := cd.client.BalanceAt(cd.wallet.Address(), nil)
 	if err != nil {
 		return fmt.Errorf("failed to fetch contract deployer balance. Cause: %w", err)
 	}

--- a/tools/contractdeployer/main/main.go
+++ b/tools/contractdeployer/main/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/obscuronet/go-obscuro/go/common/log"
 	"github.com/obscuronet/go-obscuro/tools/contractdeployer"
 )
@@ -8,11 +10,13 @@ import (
 func main() {
 	log.SetLogLevel(log.DisabledLevel)
 	config := contractdeployer.ParseConfig()
-	_, err := contractdeployer.Deploy(config)
+	contractAddr, err := contractdeployer.Deploy(config)
 	if err != nil {
 		// the contract deployer's output is to be consumed by other applications
 		// in case of a failure bump the log level and panic
 		log.SetLogLevel(log.TraceLevel)
 		log.Panic("%s", err)
 	}
+	// print the contract address, to be read if necessary by the caller (important: this must be the last message output by the script)
+	fmt.Print(contractAddr)
 }

--- a/tools/contractdeployer/main/main.go
+++ b/tools/contractdeployer/main/main.go
@@ -8,7 +8,7 @@ import (
 func main() {
 	log.SetLogLevel(log.DisabledLevel)
 	config := contractdeployer.ParseConfig()
-	err := contractdeployer.Deploy(config)
+	_, err := contractdeployer.Deploy(config)
 	if err != nil {
 		// the contract deployer's output is to be consumed by other applications
 		// in case of a failure bump the log level and panic


### PR DESCRIPTION
### Why is this change needed?

The contract deployer is sent funds every time the deployer is run, even if they already have lots of funds (e.g. due to previous failed contract deploy attempts). This can drain the faucet.

### What changes were made as part of this PR:

Functional.

- Contract deployer is only given new funds if needed
- Adds integration test of the above
- Extends original contract deployer integration test to actually check contract is deployed

### What are the key areas to look at

- ...


### :rotating_light: Definition of Done :rotating_light:
- [ ] Deployed into dev-testnet 
- [ ] Passes tests on dev-testnet
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated
