### PR TITLE
Assert for initialized pointer in rpc client Call

### DIFF
--- a/go/rpcclientlib/encrypted_client.go
+++ b/go/rpcclientlib/encrypted_client.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
+	"reflect"
 
 	"github.com/ethereum/go-ethereum/crypto"
 
@@ -52,6 +53,19 @@ func NewEncRPCClient(client Client, viewingKey *ViewingKey) (*EncRPCClient, erro
 // then decrypts the response before returning.
 // The result must be a pointer so that package json can unmarshal into it. You can also pass nil, in which case the result is ignored.
 func (c *EncRPCClient) Call(result interface{}, method string, args ...interface{}) error {
+	// result MUST be an initialized pointer else call won't be able to return it
+	if result != nil {
+		// todo: replace these panics with an error for invalid usage (same behaviour as json.Unmarshal())
+		if reflect.ValueOf(result).Kind() != reflect.Ptr {
+			// we panic if result is not a pointer, this is a coding mistake and we want to fail fast during development
+			panic("result MUST be a pointer else Call cannot populate it")
+		}
+		if reflect.ValueOf(result).IsNil() {
+			// we panic if result is a nil pointer, cannot unmarshall json to it. Pointer must be initialized.
+			// if you see this then the calling code probably used: `var resObj *ResType` instead of: `var resObj ResType`
+			panic("result pointer must be initialized else Call cannot populate it")
+		}
+	}
 	if !isSensitive(method) {
 		// for non-sensitive methods or when viewing keys are disabled we just delegate directly to the geth RPC client
 		return c.obscuroClient.Call(result, method, args...)

--- a/go/rpcclientlib/encrypted_client.go
+++ b/go/rpcclientlib/encrypted_client.go
@@ -4,8 +4,9 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
-	"github.com/ethereum/go-ethereum/crypto"
 	"reflect"
+
+	"github.com/ethereum/go-ethereum/crypto"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto/ecies"

--- a/go/rpcclientlib/encrypted_client.go
+++ b/go/rpcclientlib/encrypted_client.go
@@ -4,9 +4,8 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
-	"reflect"
-
 	"github.com/ethereum/go-ethereum/crypto"
+	"reflect"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto/ecies"
@@ -53,19 +52,7 @@ func NewEncRPCClient(client Client, viewingKey *ViewingKey) (*EncRPCClient, erro
 // then decrypts the response before returning.
 // The result must be a pointer so that package json can unmarshal into it. You can also pass nil, in which case the result is ignored.
 func (c *EncRPCClient) Call(result interface{}, method string, args ...interface{}) error {
-	// result MUST be an initialized pointer else call won't be able to return it
-	if result != nil {
-		// todo: replace these panics with an error for invalid usage (same behaviour as json.Unmarshal())
-		if reflect.ValueOf(result).Kind() != reflect.Ptr {
-			// we panic if result is not a pointer, this is a coding mistake and we want to fail fast during development
-			panic("result MUST be a pointer else Call cannot populate it")
-		}
-		if reflect.ValueOf(result).IsNil() {
-			// we panic if result is a nil pointer, cannot unmarshall json to it. Pointer must be initialized.
-			// if you see this then the calling code probably used: `var resObj *ResType` instead of: `var resObj ResType`
-			panic("result pointer must be initialized else Call cannot populate it")
-		}
-	}
+	assertResultIsPointer(result)
 	if !isSensitive(method) {
 		// for non-sensitive methods or when viewing keys are disabled we just delegate directly to the geth RPC client
 		return c.obscuroClient.Call(result, method, args...)
@@ -199,4 +186,20 @@ func isSensitive(method interface{}) bool {
 		}
 	}
 	return false
+}
+
+func assertResultIsPointer(result interface{}) {
+	// result MUST be an initialized pointer else call won't be able to return it
+	if result != nil {
+		// todo: replace these panics with an error for invalid usage (same behaviour as json.Unmarshal())
+		if reflect.ValueOf(result).Kind() != reflect.Ptr {
+			// we panic if result is not a pointer, this is a coding mistake and we want to fail fast during development
+			panic("result MUST be a pointer else Call cannot populate it")
+		}
+		if reflect.ValueOf(result).IsNil() {
+			// we panic if result is a nil pointer, cannot unmarshall json to it. Pointer must be initialized.
+			// if you see this then the calling code probably used: `var resObj *ResType` instead of: `var resObj ResType`
+			panic("result pointer must be initialized else Call cannot populate it")
+		}
+	}
 }


### PR DESCRIPTION
### Why is this change needed?

- common cause of confusing errors during development is not giving the correct result pointer to encRPCClient.Call()

### What changes were made as part of this PR:

- perform assert on the result to make sure:
1. It is a pointer
2. It is initialized


### :rotating_light: Definition of Done :rotating_light:
- [ ] Deployed into dev-testnet 
- [ ] Passes tests on dev-testnet
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated
