### PR TITLE
Returns checksummed address in wallet extension.

### DIFF
--- a/tools/walletextension/static/index.html
+++ b/tools/walletextension/static/index.html
@@ -4,6 +4,7 @@
 <head>
     <title>Obscuro | Generate viewing key</title>
     <link rel="icon" type="favicon-32x32" sizes="32x32" href="favicon-32x32.png">
+    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/web3@latest/dist/web3.min.js"></script>
     <script type="text/javascript" src="javascript.js"></script>
     <link rel="stylesheet" href="style.css">
 </head>

--- a/tools/walletextension/static/javascript.js
+++ b/tools/walletextension/static/javascript.js
@@ -64,8 +64,10 @@ const initialize = () => {
                 body: JSON.stringify(signedViewingKeyJson)
             }
         );
+
+        let checksummedAccount = Web3.utils.toChecksumAddress(account);
         if (submitViewingKeyResp.ok) {
-            statusArea.innerText = `Account: ${account}\nViewing key: ${viewingKey}\nSigned bytes: ${signature}`
+            statusArea.innerText = `Account: ${checksummedAccount}\nViewing key: ${viewingKey}\nSigned bytes: ${signature}`
         } else {
             statusArea.innerText = "Failed to submit viewing key to enclave."
         }


### PR DESCRIPTION
### Why is this change needed?

We should display public-facing addresses in this format, so that people don't accidentally make mistakes in them (e.g. when copy-and-pasting them to us to dispense funds).

### What changes were made as part of this PR:

Functional.

- Displays account in checksummed form in wallet extension

### What are the key areas to look at

- ...


### :rotating_light: Definition of Done :rotating_light:
- [ ] Deployed into dev-testnet 
- [ ] Passes tests on dev-testnet
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated
