### PR TITLE
Waits for host shutdown, instead of spinning off goroutine.

### DIFF
--- a/go/host/node/node.go
+++ b/go/host/node/node.go
@@ -299,12 +299,8 @@ func (a *Node) Stop() {
 	if err := a.enclaveClient.StopClient(); err != nil {
 		common.ErrorWithID(a.shortID, "failed to stop enclave RPC client. Cause: %s", err)
 	}
-
 	if a.rpcServer != nil {
-		// TODO - The RPC server does not return from stopping. Investigate.
-		go func() {
-			_ = a.rpcServer.Stop()
-		}()
+		a.rpcServer.Stop()
 	}
 
 	// Leave some time for all processing to finish before exiting the main loop.

--- a/go/host/node/node.go
+++ b/go/host/node/node.go
@@ -293,18 +293,18 @@ func (a *Node) Stop() {
 	if err := a.p2p.StopListening(); err != nil {
 		common.ErrorWithID(a.shortID, "failed to close transaction P2P listener cleanly: %s", err)
 	}
-
 	if err := a.enclaveClient.Stop(); err != nil {
 		common.ErrorWithID(a.shortID, "could not stop enclave server. Cause: %s", err)
 	}
-
 	if err := a.enclaveClient.StopClient(); err != nil {
 		common.ErrorWithID(a.shortID, "failed to stop enclave RPC client. Cause: %s", err)
 	}
 
 	if a.rpcServer != nil {
 		// TODO - The RPC server does not return from stopping. Investigate.
-		go a.rpcServer.Stop()
+		go func() {
+			_ = a.rpcServer.Stop()
+		}()
 	}
 
 	// Leave some time for all processing to finish before exiting the main loop.

--- a/go/host/node/node.go
+++ b/go/host/node/node.go
@@ -293,6 +293,7 @@ func (a *Node) Stop() {
 	if err := a.p2p.StopListening(); err != nil {
 		common.ErrorWithID(a.shortID, "failed to close transaction P2P listener cleanly: %s", err)
 	}
+
 	if err := a.enclaveClient.Stop(); err != nil {
 		common.ErrorWithID(a.shortID, "could not stop enclave server. Cause: %s", err)
 	}
@@ -300,10 +301,10 @@ func (a *Node) Stop() {
 	if err := a.enclaveClient.StopClient(); err != nil {
 		common.ErrorWithID(a.shortID, "failed to stop enclave RPC client. Cause: %s", err)
 	}
+
 	if a.rpcServer != nil {
-		if err := a.rpcServer.Stop(); err != nil {
-			common.ErrorWithID(a.shortID, "could not stop client RPC server. Cause: %s", err)
-		}
+		// TODO - The RPC server does not return from stopping. Investigate.
+		go a.rpcServer.Stop()
 	}
 
 	// Leave some time for all processing to finish before exiting the main loop.

--- a/go/host/rpc/clientapi/client_api_obscurotest.go
+++ b/go/host/rpc/clientapi/client_api_obscurotest.go
@@ -42,5 +42,5 @@ func (api *TestAPI) GetRollupHeader(hash gethcommon.Hash) *common.Header {
 // StopHost gracefully stops the host.
 // TODO - Investigate how to authenticate this and other sensitive methods in production (Geth uses JWT).
 func (api *TestAPI) StopHost() {
-	go api.host.Stop()
+	api.host.Stop()
 }

--- a/go/host/rpc/clientrpc/rpc_server.go
+++ b/go/host/rpc/clientrpc/rpc_server.go
@@ -14,7 +14,7 @@ const (
 // Server is the layer responsible for handling RPC requests from Obscuro client applications.
 type Server interface {
 	Start()
-	Stop() error
+	Stop()
 }
 
 // An implementation of `host.Server` that reuses the Geth `node` package for client communication.
@@ -52,6 +52,10 @@ func (s *serverImpl) Start() {
 	}
 }
 
-func (s *serverImpl) Stop() error {
-	return s.node.Close()
+func (s *serverImpl) Stop() {
+	s.node.Server().Stop()
+	go func() {
+		// TODO - Investigate why this never returns.
+		_ = s.node.Close()
+	}()
 }

--- a/integration/simulation/network/obscuro_node_utils.go
+++ b/integration/simulation/network/obscuro_node_utils.go
@@ -223,7 +223,7 @@ func StopObscuroNodes(clients []rpcclientlib.Client) {
 			c.Stop()
 		}(client)
 	}
-	if waitTimeout(&wg, 2*time.Second) {
+	if waitTimeout(&wg, 10*time.Second) {
 		log.Error("Timed out waiting for the obscuro nodes to stop")
 	} else {
 		log.Info("Obscuro nodes stopped")


### PR DESCRIPTION
### Why is this change needed?

It's clear from CI that hosts are often not being shut down properly.

### What changes were made as part of this PR:

Functional.

- Previously, host shutdown was run on an unawaited goroutine, so shutdown would end as soon as the process exited

### What are the key areas to look at

- ...


### :rotating_light: Definition of Done :rotating_light:
- [ ] Deployed into dev-testnet 
- [ ] Passes tests on dev-testnet
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated
