### PR TITLE
fix erc20 deployer supply arg

### DIFF
--- a/integration/erc20contract/contract.go
+++ b/integration/erc20contract/contract.go
@@ -11,16 +11,16 @@ import (
 )
 
 func L2BytecodeWithDefaultSupply(tokenName string) []byte {
-	return L2Bytecode(tokenName, "1000000000000000000000000000000000000000")
+	return L2Bytecode(tokenName, tokenName, "1000000000000000000000000000000000000000")
 }
 
-func L2Bytecode(tokenName string, initialSupply string) []byte {
+func L2Bytecode(tokenName string, tokenSymbol string, initialSupply string) []byte {
 	parsed, err := ObsERC20.ObsERC20MetaData.GetAbi()
 	if err != nil {
 		panic(err)
 	}
 	supply, _ := big.NewInt(0).SetString(initialSupply, 10)
-	input, err := parsed.Pack("", tokenName, tokenName, supply)
+	input, err := parsed.Pack("", tokenName, tokenSymbol, supply)
 	if err != nil {
 		panic(err)
 	}
@@ -29,16 +29,16 @@ func L2Bytecode(tokenName string, initialSupply string) []byte {
 }
 
 func L1BytecodeWithDefaultSupply(tokenName string) []byte {
-	return L1Bytecode(tokenName, "1000000000000000000000000000000000000000")
+	return L1Bytecode(tokenName, tokenName, "1000000000000000000000000000000000000000")
 }
 
-func L1Bytecode(tokenName string, initialSupply string) []byte {
+func L1Bytecode(tokenName string, tokenSymbol string, initialSupply string) []byte {
 	parsed, err := EthERC20.EthERC20MetaData.GetAbi()
 	if err != nil {
 		panic(err)
 	}
 	supply, _ := big.NewInt(0).SetString(initialSupply, 10)
-	input, err := parsed.Pack("", tokenName, tokenName, supply)
+	input, err := parsed.Pack("", tokenName, tokenSymbol, supply)
 	if err != nil {
 		panic(err)
 	}

--- a/integration/erc20contract/contract.go
+++ b/integration/erc20contract/contract.go
@@ -13,6 +13,7 @@ import (
 func L2BytecodeWithDefaultSupply(tokenName string) []byte {
 	return L2Bytecode(tokenName, "1000000000000000000000000000000000000000")
 }
+
 func L2Bytecode(tokenName string, initialSupply string) []byte {
 	parsed, err := ObsERC20.ObsERC20MetaData.GetAbi()
 	if err != nil {
@@ -30,6 +31,7 @@ func L2Bytecode(tokenName string, initialSupply string) []byte {
 func L1BytecodeWithDefaultSupply(tokenName string) []byte {
 	return L1Bytecode(tokenName, "1000000000000000000000000000000000000000")
 }
+
 func L1Bytecode(tokenName string, initialSupply string) []byte {
 	parsed, err := EthERC20.EthERC20MetaData.GetAbi()
 	if err != nil {

--- a/integration/erc20contract/contract.go
+++ b/integration/erc20contract/contract.go
@@ -10,21 +10,16 @@ import (
 	"github.com/obscuronet/go-obscuro/integration/erc20contract/generated/ObsERC20"
 )
 
-func ObsBytecode(tokenName string, initialSupply *big.Int) ([]byte, error) {
-	parsed, err := ObsERC20.ObsERC20MetaData.GetAbi()
-	if err != nil {
-		return nil, err
-	}
-	return parsed.Pack("", tokenName, tokenName, initialSupply)
-}
-
 func L2BytecodeWithDefaultSupply(tokenName string) []byte {
+	return L2Bytecode(tokenName, "1000000000000000000000000000000000000000")
+}
+func L2Bytecode(tokenName string, initialSupply string) []byte {
 	parsed, err := ObsERC20.ObsERC20MetaData.GetAbi()
 	if err != nil {
 		panic(err)
 	}
-	initialSupply, _ := big.NewInt(0).SetString("1000000000000000000000000000000000000000", 10)
-	input, err := parsed.Pack("", tokenName, tokenName, initialSupply)
+	supply, _ := big.NewInt(0).SetString(initialSupply, 10)
+	input, err := parsed.Pack("", tokenName, tokenName, supply)
 	if err != nil {
 		panic(err)
 	}
@@ -33,12 +28,15 @@ func L2BytecodeWithDefaultSupply(tokenName string) []byte {
 }
 
 func L1BytecodeWithDefaultSupply(tokenName string) []byte {
+	return L1Bytecode(tokenName, "1000000000000000000000000000000000000000")
+}
+func L1Bytecode(tokenName string, initialSupply string) []byte {
 	parsed, err := EthERC20.EthERC20MetaData.GetAbi()
 	if err != nil {
 		panic(err)
 	}
-	initialSupply, _ := big.NewInt(0).SetString("1000000000000000000000000000000000000000", 10)
-	input, err := parsed.Pack("", tokenName, tokenName, initialSupply)
+	supply, _ := big.NewInt(0).SetString(initialSupply, 10)
+	input, err := parsed.Pack("", tokenName, tokenName, supply)
 	if err != nil {
 		panic(err)
 	}

--- a/testnet/testnet-deploy-contracts.sh
+++ b/testnet/testnet-deploy-contracts.sh
@@ -84,7 +84,7 @@ docker run --name=jamerc20deployer \
     --l1Deployment \
     --contractName="L1ERC20" \
     --privateKey=${pkstring}\
-    --constructorParams="JAM,JAM,1000000000000000000000"
+    --constructorParams="JAM,JAM,1000000000000000000000000000000"
 # storing the contract address to the .env file
 jamErc20Addr=$(docker logs --tail 1 jamerc20deployer)
 echo "JAMERC20ADDR=${jamErc20Addr}" >> "${testnet_path}/.env"
@@ -101,7 +101,7 @@ docker run --name=etherc20deployer \
     --l1Deployment \
     --contractName="L1ERC20" \
     --privateKey=${pkstring}\
-    --constructorParams="ETH,ETH,1000000000000000000000"
+    --constructorParams="ETH,ETH,1000000000000000000000000000000"
 # storing the contract address to the .env file
 ethErc20Addr=$(docker logs --tail 1 etherc20deployer)
 echo "ETHERC20ADDR=${ethErc20Addr}" >> "${testnet_path}/.env"

--- a/testnet/testnet-deploy-l2-contracts.sh
+++ b/testnet/testnet-deploy-l2-contracts.sh
@@ -71,7 +71,7 @@ docker run --name=jamL2deployer \
     --nodePort=${l2port} \
     --contractName="L2ERC20" \
     --privateKey=${jampkstring}\
-    --constructorParams="JAM,JAM,1000000000000000000000"
+    --constructorParams="JAM,JAM,1000000000000000000000000000000"
 echo ""
 
 echo "Deploying ETH ERC20 contract to the obscuro network..."
@@ -83,7 +83,7 @@ docker run --name=ethL2deployer \
     --nodePort=${l2port} \
     --contractName="L2ERC20" \
     --privateKey=${ethpkstring}\
-    --constructorParams="ETH,ETH,1000000000000000000000"
+    --constructorParams="ETH,ETH,1000000000000000000000000000000"
 echo ""
 
 echo "Deploying Guessing game contract to the obscuro network..."

--- a/tools/contractdeployer/contract_deployer.go
+++ b/tools/contractdeployer/contract_deployer.go
@@ -235,13 +235,15 @@ func getContractCode(cfg *Config) ([]byte, error) {
 
 	case l2Erc20Contract:
 		tokenName := cfg.ConstructorParams[0]
-		supply := cfg.ConstructorParams[1]
-		return erc20contract.L2Bytecode(tokenName, supply), nil
+		tokenSymbol := cfg.ConstructorParams[1]
+		supply := cfg.ConstructorParams[2]
+		return erc20contract.L2Bytecode(tokenName, tokenSymbol, supply), nil
 
 	case l1Erc20Contract:
 		tokenName := cfg.ConstructorParams[0]
-		supply := cfg.ConstructorParams[1]
-		return erc20contract.L1Bytecode(tokenName, supply), nil
+		tokenSymbol := cfg.ConstructorParams[1]
+		supply := cfg.ConstructorParams[2]
+		return erc20contract.L1Bytecode(tokenName, tokenSymbol, supply), nil
 
 	case GuessingGameContract:
 		size, err := strconv.Atoi(cfg.ConstructorParams[0])

--- a/tools/contractdeployer/contract_deployer.go
+++ b/tools/contractdeployer/contract_deployer.go
@@ -235,11 +235,13 @@ func getContractCode(cfg *Config) ([]byte, error) {
 
 	case l2Erc20Contract:
 		tokenName := cfg.ConstructorParams[0]
-		return erc20contract.L2BytecodeWithDefaultSupply(tokenName), nil
+		supply := cfg.ConstructorParams[1]
+		return erc20contract.L2Bytecode(tokenName, supply), nil
 
 	case l1Erc20Contract:
 		tokenName := cfg.ConstructorParams[0]
-		return erc20contract.L1BytecodeWithDefaultSupply(tokenName), nil
+		supply := cfg.ConstructorParams[1]
+		return erc20contract.L1Bytecode(tokenName, supply), nil
 
 	case GuessingGameContract:
 		size, err := strconv.Atoi(cfg.ConstructorParams[0])


### PR DESCRIPTION
### Why is this change needed?

- there was a bug, the supply parameter in scripts was being ignored during erc20 deployment
- also the supply is too small when we've got 18 decimal places

### What changes were made as part of this PR:

- respect the supply args in contract
- increase supply

### :rotating_light: Definition of Done :rotating_light:
- [ ] Deployed into dev-testnet 
- [ ] Passes tests on dev-testnet
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated
