### PR TITLE
Rename JAM/OBX and ETH erc20s to be HOC/POC

### DIFF
--- a/.github/workflows/manual-deploy-dev-testnet.yml
+++ b/.github/workflows/manual-deploy-dev-testnet.yml
@@ -65,8 +65,8 @@ jobs:
     # Map a step output to a job output
     outputs:
       mgmtContractAddr: ${{ steps.deployContracts.outputs.mgmtContractAddr }}
-      obxErc20Addr: ${{ steps.deployContracts.outputs.obxErc20Addr }}
-      ethErc20Addr: ${{ steps.deployContracts.outputs.ethErc20Addr }}
+      hocErc20Addr: ${{ steps.deployContracts.outputs.hocErc20Addr }}
+      pocErc20Addr: ${{ steps.deployContracts.outputs.pocErc20Addr }}
     steps:
       - uses: actions/checkout@v3
 
@@ -96,12 +96,12 @@ jobs:
           ./testnet/testnet-deploy-contracts.sh --l1host=${{ github.event.inputs.L1HOST }} --pkstring=${{ secrets.GETHNETWORK_PREFUNDED_PKSTR_WORKER }}
           source ./testnet/.env
           echo "MGMTCONTRACTADDR=$MGMTCONTRACTADDR" >> $GITHUB_ENV
-          echo "JAMERC20ADDR=$JAMERC20ADDR" >> $GITHUB_ENV
-          echo "ETHERC20ADDR=$ETHERC20ADDR" >> $GITHUB_ENV
-          echo "Contracts deployed to $MGMTCONTRACTADDR and $JAMERC20ADDR and $ETHERC20ADDR"
+          echo "HOCERC20ADDR=$HOCERC20ADDR" >> $GITHUB_ENV
+          echo "POCERC20ADDR=$POCERC20ADDR" >> $GITHUB_ENV
+          echo "Contracts deployed to $MGMTCONTRACTADDR and $HOCERC20ADDR and $POCERC20ADDR"
           echo "::set-output name=mgmtContractAddr::$MGMTCONTRACTADDR"
-          echo "::set-output name=obxErc20Addr::$JAMERC20ADDR"   
-          echo "::set-output name=ethErc20Addr::$ETHERC20ADDR"    
+          echo "::set-output name=hocErc20Addr::$HOCERC20ADDR"   
+          echo "::set-output name=pocErc20Addr::$POCERC20ADDR"    
 
       # This will fail some deletions due to resource dependencies ( ie. you must first delete the vm before deleting the disk)
       - name: 'Delete deployed VMs'
@@ -225,8 +225,8 @@ jobs:
                --host_id=${{ matrix.host_addr }} \
                --l1host=${{ github.event.inputs.L1HOST }} \
                --mgmtcontractaddr=${{needs.build-l2.outputs.mgmtContractAddr}} \
-               --obxerc20addr=${{needs.build-l2.outputs.obxErc20Addr}} \
-               --etherc20addr=${{needs.build-l2.outputs.ethErc20Addr}} \
+               --hocerc20addr=${{needs.build-l2.outputs.hocErc20Addr}} \
+               --pocerc20addr=${{needs.build-l2.outputs.pocErc20Addr}} \
                --pkaddr=${{ secrets[matrix.node_pk_addr] }} \
                --pkstring=${{ secrets[matrix.node_pk_str] }} \
                --p2p_public_address=dev-obscuronode-${{ matrix.host_id }}-testnet-${{ GITHUB.RUN_NUMBER }}.uksouth.cloudapp.azure.com:10000'

--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -23,8 +23,8 @@ jobs:
     # Map a step output to a job output
     outputs:
       mgmtContractAddr: ${{ steps.deployContracts.outputs.mgmtContractAddr }}
-      obxErc20Addr: ${{ steps.deployContracts.outputs.obxErc20Addr }}
-      ethErc20Addr: ${{ steps.deployContracts.outputs.ethErc20Addr }}
+      hocErc20Addr: ${{ steps.deployContracts.outputs.hocErc20Addr }}
+      pocErc20Addr: ${{ steps.deployContracts.outputs.pocErc20Addr }}
     steps:
       - uses: actions/checkout@v2
 
@@ -54,12 +54,12 @@ jobs:
           ./testnet/testnet-deploy-contracts.sh --l1host=${{ github.event.inputs.L1HOST }} --pkstring=${{ secrets.GETHNETWORK_PREFUNDED_PKSTR_WORKER }}
           source ./testnet/.env
           echo "MGMTCONTRACTADDR=$MGMTCONTRACTADDR" >> $GITHUB_ENV
-          echo "JAMERC20ADDR=$JAMERC20ADDR" >> $GITHUB_ENV
-          echo "ETHERC20ADDR=$ETHERC20ADDR" >> $GITHUB_ENV
-          echo "Contracts deployed to $MGMTCONTRACTADDR and $JAMERC20ADDR and $ETHERC20ADDR"
+          echo "HOCERC20ADDR=$HOCERC20ADDR" >> $GITHUB_ENV
+          echo "POCERC20ADDR=$POCERC20ADDR" >> $GITHUB_ENV
+          echo "Contracts deployed to $MGMTCONTRACTADDR and $HOCERC20ADDR and $POCERC20ADDR"
           echo "::set-output name=mgmtContractAddr::$MGMTCONTRACTADDR"
-          echo "::set-output name=obxErc20Addr::$JAMERC20ADDR"   
-          echo "::set-output name=ethErc20Addr::$ETHERC20ADDR"    
+          echo "::set-output name=hocErc20Addr::$HOCERC20ADDR"   
+          echo "::set-output name=pocErc20Addr::$POCERC20ADDR"    
 
       # This will fail some deletions due to resource dependencies ( ie. you must first delete the vm before deleting the disk)
       - name: 'Delete deployed VMs'
@@ -182,8 +182,8 @@ jobs:
                --host_id=${{ matrix.host_addr }} \
                --l1host=${{ github.event.inputs.L1HOST }} \
                --mgmtcontractaddr=${{needs.build.outputs.mgmtContractAddr}} \
-               --obxerc20addr=${{needs.build.outputs.obxErc20Addr}} \
-               --etherc20addr=${{needs.build.outputs.ethErc20Addr}} \
+               --hocerc20addr=${{needs.build.outputs.hocErc20Addr}} \
+               --pocerc20addr=${{needs.build.outputs.pocErc20Addr}} \
                --pkaddr=${{ secrets[matrix.node_pk_addr] }} \
                --pkstring=${{ secrets[matrix.node_pk_str] }} \
                --p2p_public_address=obscuronode-${{ matrix.host_id }}-testnet-${{ GITHUB.RUN_NUMBER }}.uksouth.cloudapp.azure.com:10000'

--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ only a single Obscuro node is started, it must be set as a genesis node.
 ```
 ./testnet-local-gethnetwork.sh --pkaddresses=0x13E23Ca74DE0206C56ebaE8D51b5622EFF1E9944,0x0654D8B60033144D567f25bF41baC1FB0D60F23B
 ./testnet-deploy-contracts.sh --l1host=gethnetwork --pkstring=f52e5418e349dccdda29b6ac8b0abe6576bb7713886aa85abea6181ba731f9bb
-./start-obscuro-node.sh --sgx_enabled=false --host_id=0x0000000000000000000000000000000000000001 --l1host=gethnetwork --mgmtcontractaddr=0xeDa66Cc53bd2f26896f6Ba6b736B1Ca325DE04eF --obxerc20addr=0xC0370e0b5C1A41D447BDdA655079A1B977C71aA9 --etherc20addr=0x51D43a3Ca257584E770B6188232b199E76B022A2 --is_genesis=true
+./start-obscuro-node.sh --sgx_enabled=false --host_id=0x0000000000000000000000000000000000000001 --l1host=gethnetwork --mgmtcontractaddr=0xeDa66Cc53bd2f26896f6Ba6b736B1Ca325DE04eF --hocerc20addr=0xC0370e0b5C1A41D447BDdA655079A1B977C71aA9 --pocerc20addr=0x51D43a3Ca257584E770B6188232b199E76B022A2 --is_genesis=true
 ./testnet-deploy-l2-contracts.sh --l2host=testnet-host-1 
 ```
 

--- a/go/enclave/bridge/bridge.go
+++ b/go/enclave/bridge/bridge.go
@@ -34,19 +34,19 @@ import (
 type ERC20 string
 
 const (
-	OBX ERC20 = "OBX"
-	ETH ERC20 = "ETH"
+	HOC ERC20 = "HOC"
+	POC ERC20 = "POC"
 )
 
-var WOBXOwner, _ = crypto.HexToECDSA("6e384a07a01263518a09a5424c7b6bbfc3604ba7d93f47e3a455cbdd7f9f0682")
+var HOCOwner, _ = crypto.HexToECDSA("6e384a07a01263518a09a5424c7b6bbfc3604ba7d93f47e3a455cbdd7f9f0682")
 
-// WOBXContract X- address of the deployed "obx" erc20 on the L2
-var WOBXContract = gethcommon.BytesToAddress(gethcommon.Hex2Bytes("f3a8bd422097bFdd9B3519Eaeb533393a1c561aC"))
+// HOCContract X- address of the deployed "hocus" erc20 on the L2
+var HOCContract = gethcommon.BytesToAddress(gethcommon.Hex2Bytes("f3a8bd422097bFdd9B3519Eaeb533393a1c561aC"))
 
-var WETHOwner, _ = crypto.HexToECDSA("4bfe14725e685901c062ccd4e220c61cf9c189897b6c78bd18d7f51291b2b8f8")
+var POCOwner, _ = crypto.HexToECDSA("4bfe14725e685901c062ccd4e220c61cf9c189897b6c78bd18d7f51291b2b8f8")
 
-// WETHContract - address of the deployed "eth" erc20 on the L2
-var WETHContract = gethcommon.BytesToAddress(gethcommon.Hex2Bytes("9802F661d17c65527D7ABB59DAAD5439cb125a67"))
+// POCContract - address of the deployed "pocus" erc20 on the L2
+var POCContract = gethcommon.BytesToAddress(gethcommon.Hex2Bytes("9802F661d17c65527D7ABB59DAAD5439cb125a67"))
 
 // BridgeAddress - address of the virtual bridge
 var BridgeAddress = gethcommon.BytesToAddress(gethcommon.Hex2Bytes("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"))
@@ -79,8 +79,8 @@ type Bridge struct {
 }
 
 func New(
-	obxAddress *gethcommon.Address,
-	ethAddress *gethcommon.Address,
+	hocAddress *gethcommon.Address,
+	pocAddress *gethcommon.Address,
 	mgmtContractLib mgmtcontractlib.MgmtContractLib,
 	erc20ContractLib erc20contractlib.ERC20ContractLib,
 	nodeID uint64,
@@ -90,18 +90,18 @@ func New(
 ) *Bridge {
 	tokens := make(map[ERC20]*ERC20Mapping, 0)
 
-	tokens[OBX] = &ERC20Mapping{
-		Name:      OBX,
-		L1Address: obxAddress,
-		Owner:     wallet.NewInMemoryWalletFromPK(big.NewInt(obscuroChainID), WOBXOwner),
-		L2Address: &WOBXContract,
+	tokens[HOC] = &ERC20Mapping{
+		Name:      HOC,
+		L1Address: hocAddress,
+		Owner:     wallet.NewInMemoryWalletFromPK(big.NewInt(obscuroChainID), HOCOwner),
+		L2Address: &HOCContract,
 	}
 
-	tokens[ETH] = &ERC20Mapping{
-		Name:      ETH,
-		L1Address: ethAddress,
-		Owner:     wallet.NewInMemoryWalletFromPK(big.NewInt(obscuroChainID), WETHOwner),
-		L2Address: &WETHContract,
+	tokens[POC] = &ERC20Mapping{
+		Name:      POC,
+		L1Address: pocAddress,
+		Owner:     wallet.NewInMemoryWalletFromPK(big.NewInt(obscuroChainID), POCOwner),
+		L2Address: &POCContract,
 	}
 
 	return &Bridge{

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -84,8 +84,8 @@ func NewEnclave(
 	collector StatsCollector,
 ) common.Enclave {
 	if len(config.ERC20ContractAddresses) < 2 {
-		log.Panic("failed to initialise enclave. At least two ERC20 contract addresses are required - the OBX " +
-			"ERC20 address and the ETH ERC20 address")
+		log.Panic("failed to initialise enclave. At least two ERC20 contract addresses are required - the HOC " +
+			"ERC20 address and the POC ERC20 address")
 	}
 
 	// todo - add the delay: N hashes

--- a/integration/simulation/network/inmemory.go
+++ b/integration/simulation/network/inmemory.go
@@ -39,9 +39,9 @@ func (n *basicNetworkOfInMemoryNodes) Create(params *params.SimParams, stats *st
 
 	// Invent some addresses to assign as the L1 erc20 contracts
 	dummyOBXAddress := common.HexToAddress("AA")
-	params.Wallets.Tokens[bridge.OBX].L1ContractAddress = &dummyOBXAddress
+	params.Wallets.Tokens[bridge.HOC].L1ContractAddress = &dummyOBXAddress
 	dummyETHAddress := common.HexToAddress("BB")
-	params.Wallets.Tokens[bridge.ETH].L1ContractAddress = &dummyETHAddress
+	params.Wallets.Tokens[bridge.POC].L1ContractAddress = &dummyETHAddress
 
 	for i := 0; i < params.NumberOfNodes; i++ {
 		isGenesis := i == 0

--- a/integration/simulation/params/wallet_utils.go
+++ b/integration/simulation/params/wallet_utils.go
@@ -66,17 +66,17 @@ func NewSimWallets(nrSimWallets int, nNodes int, ethereumChainID int64, obscuroC
 	l2FaucetWallet := wallet.NewInMemoryWalletFromPK(big.NewInt(obscuroChainID), l2FaucetPrivKey)
 
 	// create the L1 addresses of the two tokens, and connect them to the hardcoded addresses from the enclave
-	obx := SimToken{
-		Name:              bridge.OBX,
+	hoc := SimToken{
+		Name:              bridge.HOC,
 		L1Owner:           datagenerator.RandomWallet(ethereumChainID),
-		L2Owner:           wallet.NewInMemoryWalletFromPK(big.NewInt(obscuroChainID), bridge.WOBXOwner),
-		L2ContractAddress: &bridge.WOBXContract,
+		L2Owner:           wallet.NewInMemoryWalletFromPK(big.NewInt(obscuroChainID), bridge.HOCOwner),
+		L2ContractAddress: &bridge.HOCContract,
 	}
-	eth := SimToken{
-		Name:              bridge.ETH,
+	poc := SimToken{
+		Name:              bridge.POC,
 		L1Owner:           datagenerator.RandomWallet(ethereumChainID),
-		L2Owner:           wallet.NewInMemoryWalletFromPK(big.NewInt(obscuroChainID), bridge.WETHOwner),
-		L2ContractAddress: &bridge.WETHContract,
+		L2Owner:           wallet.NewInMemoryWalletFromPK(big.NewInt(obscuroChainID), bridge.POCOwner),
+		L2ContractAddress: &bridge.POCContract,
 	}
 
 	return &SimWallets{
@@ -86,8 +86,8 @@ func NewSimWallets(nrSimWallets int, nNodes int, ethereumChainID int64, obscuroC
 		SimObsWallets:  simObsWallets,
 		L2FaucetWallet: l2FaucetWallet,
 		Tokens: map[bridge.ERC20]*SimToken{
-			bridge.OBX: &obx,
-			bridge.ETH: &eth,
+			bridge.HOC: &hoc,
+			bridge.POC: &poc,
 		},
 	}
 }
@@ -102,8 +102,8 @@ func (w *SimWallets) AllEthWallets() []wallet.Wallet {
 
 func (w *SimWallets) AllEthAddresses() []*common.Address {
 	addresses := make([]*common.Address, 0)
-	addresses = append(addresses, w.Tokens[bridge.OBX].L1ContractAddress)
-	addresses = append(addresses, w.Tokens[bridge.ETH].L1ContractAddress)
+	addresses = append(addresses, w.Tokens[bridge.HOC].L1ContractAddress)
+	addresses = append(addresses, w.Tokens[bridge.POC].L1ContractAddress)
 	return addresses
 }
 

--- a/integration/simulation/simulation.go
+++ b/integration/simulation/simulation.go
@@ -51,7 +51,7 @@ func (s *Simulation) Start() {
 	time.Sleep(1 * time.Second)
 
 	s.prefundObscuroAccounts() // Prefund every L2 wallet
-	s.deployObscuroERC20s()    // Deploy the Obscuro OBX and ETH ERC20 contracts
+	s.deployObscuroERC20s()    // Deploy the Obscuro HOC and POC ERC20 contracts
 	s.prefundL1Accounts()      // Prefund every L1 wallet
 
 	timer := time.Now()
@@ -110,7 +110,7 @@ func (s *Simulation) prefundObscuroAccounts() {
 
 // This deploys an ERC20 contract on Obscuro, which is used for token arithmetic.
 func (s *Simulation) deployObscuroERC20s() {
-	tokens := []bridge.ERC20{bridge.OBX, bridge.ETH}
+	tokens := []bridge.ERC20{bridge.HOC, bridge.POC}
 
 	wg := sync.WaitGroup{}
 	for _, token := range tokens {
@@ -152,7 +152,7 @@ func (s *Simulation) prefundL1Accounts() {
 		txData := &ethadapter.L1DepositTx{
 			Amount:        initialBalance,
 			To:            s.Params.MgmtContractAddr,
-			TokenContract: s.Params.Wallets.Tokens[bridge.OBX].L1ContractAddress,
+			TokenContract: s.Params.Wallets.Tokens[bridge.HOC].L1ContractAddress,
 			Sender:        &addr,
 		}
 		tx := s.Params.ERC20ContractLib.CreateDepositTx(txData, w.GetNonceAndIncrement())

--- a/integration/simulation/transaction_injector.go
+++ b/integration/simulation/transaction_injector.go
@@ -195,7 +195,7 @@ func (ti *TransactionInjector) issueRandomDeposits() {
 		txData := &ethadapter.L1DepositTx{
 			Amount:        v,
 			To:            ti.mgmtContractAddr,
-			TokenContract: ti.wallets.Tokens[bridge.OBX].L1ContractAddress,
+			TokenContract: ti.wallets.Tokens[bridge.HOC].L1ContractAddress,
 			Sender:        &addr,
 		}
 		tx := ti.erc20ContractLib.CreateDepositTx(txData, ethWallet.GetNonceAndIncrement())
@@ -321,7 +321,7 @@ func (ti *TransactionInjector) newTx(data []byte, nonce uint64) types.TxData {
 		Gas:      uint64(1_000_000),
 		GasPrice: gethcommon.Big1,
 		Data:     data,
-		To:       ti.wallets.Tokens[bridge.OBX].L2ContractAddress,
+		To:       ti.wallets.Tokens[bridge.HOC].L2ContractAddress,
 	}
 }
 

--- a/integration/simulation/validate_chain.go
+++ b/integration/simulation/validate_chain.go
@@ -265,7 +265,7 @@ func checkBlockchainOfObscuroNode(t *testing.T, rpcHandles *network.RPCHandles, 
 	totalAmountInSystem := s.Stats.TotalDepositedAmount - totalSuccessfullyWithdrawn
 	total := uint64(0)
 	for _, wallet := range s.Params.Wallets.SimObsWallets {
-		total += balance(rpcHandles.ObscuroWalletClient(wallet.Address(), nodeIdx), wallet.Address(), s.Params.Wallets.Tokens[bridge.OBX].L2ContractAddress)
+		total += balance(rpcHandles.ObscuroWalletClient(wallet.Address(), nodeIdx), wallet.Address(), s.Params.Wallets.Tokens[bridge.HOC].L2ContractAddress)
 	}
 
 	if total != totalAmountInSystem {

--- a/integration/walletextension/wallet_extension_test.go
+++ b/integration/walletextension/wallet_extension_test.go
@@ -160,7 +160,7 @@ func TestCannotCallWithoutSubmittingViewingKey(t *testing.T) {
 	// deposit any funds in the ERC20 contract.
 	transferTxBytes := erc20contractlib.CreateTransferTxData(accountAddress, 0)
 	reqParams := map[string]interface{}{
-		reqJSONKeyTo:   bridge.WOBXContract,
+		reqJSONKeyTo:   bridge.HOCContract,
 		reqJSONKeyFrom: accountAddress.String(),
 		reqJSONKeyData: "0x" + common.Bytes2Hex(transferTxBytes),
 	}
@@ -185,7 +185,7 @@ func TestCanCallAfterSubmittingViewingKey(t *testing.T) {
 	balanceData := erc20contractlib.CreateBalanceOfData(accountAddress)
 	convertedData := (hexutil.Bytes)(balanceData)
 	reqParams := map[string]interface{}{
-		reqJSONKeyTo:   bridge.WOBXContract.Hex(),
+		reqJSONKeyTo:   bridge.HOCContract.Hex(),
 		reqJSONKeyFrom: accountAddress.String(),
 		reqJSONKeyData: convertedData,
 	}
@@ -209,7 +209,7 @@ func TestCanCallWithoutSettingFromField(t *testing.T) {
 	balanceData := erc20contractlib.CreateBalanceOfData(accountAddress)
 	convertedData := (hexutil.Bytes)(balanceData)
 	reqParams := map[string]interface{}{
-		reqJSONKeyTo:   bridge.WOBXContract,
+		reqJSONKeyTo:   bridge.HOCContract,
 		reqJSONKeyData: convertedData,
 	}
 
@@ -232,7 +232,7 @@ func TestCannotCallForAnotherAddressAfterSubmittingViewingKey(t *testing.T) {
 	balanceData := erc20contractlib.CreateBalanceOfData(dummyAccountAddress)
 	convertedData := (hexutil.Bytes)(balanceData)
 	reqParams := map[string]interface{}{
-		reqJSONKeyTo: bridge.WOBXContract,
+		reqJSONKeyTo: bridge.HOCContract,
 		// We send the request from a different address than the one we created a viewing key for.
 		reqJSONKeyFrom: dummyAccountAddress.Hex(),
 		reqJSONKeyData: convertedData,
@@ -518,7 +518,7 @@ func createObscuroNetwork(t *testing.T) {
 	}
 
 	// Set up the ERC20 wallet.
-	erc20Wallet := wallets.Tokens[bridge.OBX].L2Owner
+	erc20Wallet := wallets.Tokens[bridge.HOC].L2Owner
 	generateAndSubmitViewingKey(erc20Wallet.Address().Hex(), erc20Wallet.PrivateKey())
 	fundAccount(erc20Wallet.Address())
 

--- a/testnet/docker-compose.debug.yml
+++ b/testnet/docker-compose.debug.yml
@@ -44,8 +44,8 @@ services:
       - "2345:2345"
     environment:
       MGMTCONTRACTADDR: some_address
-      JAMERC20ADDR: some_address
-      ETHERC20ADDR: some_address
+      HOCERC20ADDR: some_address
+      POCERC20ADDR: some_address
       HOSTID: some_address
       PROFILERENABLED: some_bool
       P2PPUBLICADDRESS: some_string
@@ -64,7 +64,7 @@ services:
       "--useInMemoryDB=false",
       "--sqliteDBPath=/data/sqlite.db",
       "--managementContractAddress=$MGMTCONTRACTADDR",
-      "--erc20ContractAddresses=$JAMERC20ADDR,$ETHERC20ADDR",
+      "--erc20ContractAddresses=$HOCERC20ADDR,$POCERC20ADDR",
       "--hostAddress=host:10000",
       "--profilerEnabled=$PROFILERENABLED",
       "--hostAddress=$P2PPUBLICADDRESS"

--- a/testnet/docker-compose.non-sgx.yml
+++ b/testnet/docker-compose.non-sgx.yml
@@ -43,8 +43,8 @@ services:
       - "6060:6060"
     environment:
       MGMTCONTRACTADDR: some_address
-      JAMERC20ADDR: some_address
-      ETHERC20ADDR: some_address
+      HOCERC20ADDR: some_address
+      POCERC20ADDR: some_address
       HOSTID: some_address
       PROFILERENABLED: some_bool
       P2PPUBLICADDRESS: some_string
@@ -56,7 +56,7 @@ services:
                  "--useInMemoryDB=false",
                  "--sqliteDBPath=/data/sqlite.db",
                  "--managementContractAddress=$MGMTCONTRACTADDR",
-                 "--erc20ContractAddresses=$JAMERC20ADDR,$ETHERC20ADDR",
+                 "--erc20ContractAddresses=$HOCERC20ADDR,$POCERC20ADDR",
                  "--hostAddress=host:10000",
                  "--profilerEnabled=$PROFILERENABLED",
                  "--hostAddress=$P2PPUBLICADDRESS"

--- a/testnet/docker-compose.yml
+++ b/testnet/docker-compose.yml
@@ -48,8 +48,8 @@ services:
       - "6060:6060"
     environment:
       MGMTCONTRACTADDR: some_address
-      JAMERC20ADDR: some_address
-      ETHERC20ADDR: some_address
+      HOCERC20ADDR: some_address
+      POCERC20ADDR: some_address
       HOSTID: some_address
       OE_SIMULATION: 0
       PROFILERENABLED: some_bool
@@ -60,7 +60,7 @@ services:
                  "--hostID=$HOSTID",
                  "--address=:11000",
                  "--managementContractAddress=$MGMTCONTRACTADDR",
-                 "--erc20ContractAddresses=$JAMERC20ADDR,$ETHERC20ADDR",
+                 "--erc20ContractAddresses=$HOCERC20ADDR,$POCERC20ADDR",
                  "--hostAddress=host:10000",
                  "--willAttest",
                  "--useInMemoryDB=false",

--- a/testnet/start-obscuro-node.sh
+++ b/testnet/start-obscuro-node.sh
@@ -11,10 +11,10 @@ help_and_exit() {
     echo ""
     echo "Usage: "
     echo "   ex: (run locally)"
-    echo "      -  $(basename "${0}") --sgx_enabled=false --host_id=0x0000000000000000000000000000000000000001 --l1host=gethnetwork --mgmtcontractaddr=0xeDa66Cc53bd2f26896f6Ba6b736B1Ca325DE04eF --obxerc20addr=0xC0370e0b5C1A41D447BDdA655079A1B977C71aA9 --etherc20addr=0x51D43a3Ca257584E770B6188232b199E76B022A2 --is_genesis=true"
+    echo "      -  $(basename "${0}") --sgx_enabled=false --host_id=0x0000000000000000000000000000000000000001 --l1host=gethnetwork --mgmtcontractaddr=0xeDa66Cc53bd2f26896f6Ba6b736B1Ca325DE04eF --hocerc20addr=0xC0370e0b5C1A41D447BDdA655079A1B977C71aA9 --pocerc20addr=0x51D43a3Ca257584E770B6188232b199E76B022A2 --is_genesis=true"
     echo ""
     echo "   ex: (run connect external)"
-    echo "      -  $(basename "${0}") --sgx_enabled=true --host_id=0x0000000000000000000000000000000000000001 --l1host=testnet-gethnetwork-18.uksouth.azurecontainer.io --mgmtcontractaddr=0xeDa66Cc53bd2f26896f6Ba6b736B1Ca325DE04eF --obxerc20addr=0xC0370e0b5C1A41D447BDdA655079A1B977C71aA9 --etherc20addr=0x51D43a3Ca257584E770B6188232b199E76B022A2"
+    echo "      -  $(basename "${0}") --sgx_enabled=true --host_id=0x0000000000000000000000000000000000000001 --l1host=testnet-gethnetwork-18.uksouth.azurecontainer.io --mgmtcontractaddr=0xeDa66Cc53bd2f26896f6Ba6b736B1Ca325DE04eF --hocerc20addr=0xC0370e0b5C1A41D447BDdA655079A1B977C71aA9 --pocerc20addr=0x51D43a3Ca257584E770B6188232b199E76B022A2"
     echo ""
     echo "  host_id            *Required* Set the node ID"
     echo ""
@@ -22,9 +22,9 @@ help_and_exit() {
     echo ""
     echo "  mgmtcontractaddr   *Required* Set the management contract address"
     echo ""
-    echo "  obxerc20addr       *Required* Set the erc20 contract address for OBX"
+    echo "  hocerc20addr       *Required* Set the erc20 contract address for HOC"
     echo ""
-    echo "  etherc20addr       *Required* Set the erc20 contract address for ETH"
+    echo "  pocerc20addr       *Required* Set the erc20 contract address for POC"
     echo ""
     echo "  sgx_enabled        *Required* Set the execution to run with sgx enabled"
     echo ""
@@ -74,8 +74,8 @@ do
             --l1port)                   l1_port=${value} ;;
             --host_id)                  host_id=${value} ;;
             --mgmtcontractaddr)         mgmt_contract_addr=${value} ;;
-            --obxerc20addr)             obx_erc20_addr=${value} ;;
-            --etherc20addr)             eth_erc20_addr=${value} ;;
+            --hocerc20addr)             hoc_erc20_addr=${value} ;;
+            --pocerc20addr)             poc_erc20_addr=${value} ;;
             --pkaddress)                pk_address=${value} ;;
             --pkstring)                 pk_string=${value} ;;
             --sgx_enabled)              sgx_enabled=${value} ;;
@@ -89,7 +89,7 @@ do
     esac
 done
 
-if [[ -z ${l1_host:-} || -z ${host_id:-} || -z ${mgmt_contract_addr:-} || -z ${obx_erc20_addr:-} || -z ${eth_erc20_addr:-} || -z ${sgx_enabled:-} ]];
+if [[ -z ${l1_host:-} || -z ${host_id:-} || -z ${mgmt_contract_addr:-} || -z ${hoc_erc20_addr:-} || -z ${poc_erc20_addr:-} || -z ${sgx_enabled:-} ]];
 then
     help_and_exit
 fi
@@ -100,8 +100,8 @@ echo "PKSTRING=${pk_string}" > "${testnet_path}/.env"
 echo "PKADDR=${pk_address}" >> "${testnet_path}/.env"
 echo "HOSTID=${host_id}"  >> "${testnet_path}/.env"
 echo "MGMTCONTRACTADDR=${mgmt_contract_addr}"  >> "${testnet_path}/.env"
-echo "JAMERC20ADDR=${obx_erc20_addr}"  >> "${testnet_path}/.env"
-echo "ETHERC20ADDR=${eth_erc20_addr}"  >> "${testnet_path}/.env"
+echo "HOCERC20ADDR=${hoc_erc20_addr}"  >> "${testnet_path}/.env"
+echo "POCERC20ADDR=${poc_erc20_addr}"  >> "${testnet_path}/.env"
 echo "L1HOST=${l1_host}" >> "${testnet_path}/.env"
 echo "L1PORT=${l1_port}" >> "${testnet_path}/.env"
 echo "ISGENESIS=${is_genesis}" >> "${testnet_path}/.env"

--- a/testnet/testnet-deploy-contracts.sh
+++ b/testnet/testnet-deploy-contracts.sh
@@ -73,9 +73,9 @@ mgmtContractAddr=$(docker logs --tail 1 mgmtcontractdeployer)
 echo "MGMTCONTRACTADDR=${mgmtContractAddr}" > "${testnet_path}/.env"
 echo ""
 
-# deploy JAM ERC20 contract
-echo "Deploying JAM ERC20 contract to L1 network"
-docker run --name=jamerc20deployer \
+# deploy Hocus ERC20 contract
+echo "Deploying Hocus ERC20 contract to L1 network"
+docker run --name=hocerc20deployer \
     --network=node_network \
     --entrypoint /home/go-obscuro/tools/contractdeployer/main/main \
      "${docker_image}" \
@@ -84,15 +84,15 @@ docker run --name=jamerc20deployer \
     --l1Deployment \
     --contractName="L1ERC20" \
     --privateKey=${pkstring}\
-    --constructorParams="JAM,JAM,1000000000000000000000000000000"
+    --constructorParams="Hocus,HOC,1000000000000000000000000000000"
 # storing the contract address to the .env file
-jamErc20Addr=$(docker logs --tail 1 jamerc20deployer)
-echo "JAMERC20ADDR=${jamErc20Addr}" >> "${testnet_path}/.env"
+hocErc20Addr=$(docker logs --tail 1 hocerc20deployer)
+echo "HOCERC20ADDR=${hocErc20Addr}" >> "${testnet_path}/.env"
 echo ""
 
-# deploy ETH ERC20 contract
-echo "Deploying ETH ERC20 contract to L1 network"
-docker run --name=etherc20deployer \
+# deploy Pocus ERC20 contract
+echo "Deploying Pocus ERC20 contract to L1 network"
+docker run --name=pocerc20deployer \
     --network=node_network \
     --entrypoint /home/go-obscuro/tools/contractdeployer/main/main \
      "${docker_image}" \
@@ -101,8 +101,8 @@ docker run --name=etherc20deployer \
     --l1Deployment \
     --contractName="L1ERC20" \
     --privateKey=${pkstring}\
-    --constructorParams="ETH,ETH,1000000000000000000000000000000"
+    --constructorParams="Pocus,POC,1000000000000000000000000000000"
 # storing the contract address to the .env file
-ethErc20Addr=$(docker logs --tail 1 etherc20deployer)
-echo "ETHERC20ADDR=${ethErc20Addr}" >> "${testnet_path}/.env"
+pocErc20Addr=$(docker logs --tail 1 pocerc20deployer)
+echo "POCERC20ADDR=${pocErc20Addr}" >> "${testnet_path}/.env"
 echo ""

--- a/testnet/testnet-deploy-l2-contracts.sh
+++ b/testnet/testnet-deploy-l2-contracts.sh
@@ -10,9 +10,9 @@ help_and_exit() {
     echo ""
     echo "  l2host             *Required* Set the l2 host address"
     echo ""
-    echo "  jampkstring        *Optional* Set the pkstring to deploy JAM contract"
+    echo "  hocpkstring        *Optional* Set the pkstring to deploy HOC contract"
     echo ""
-    echo "  ethpkstring        *Optional* Set the pkstring to deploy ETH contract"
+    echo "  pocpkstring        *Optional* Set the pkstring to deploy POC contract"
     echo ""
     echo "  l2port             *Optional* Set the l2 port. Defaults to 10000"
     echo ""
@@ -32,9 +32,9 @@ testnet_path="${start_path}"
 # Define defaults
 l2port=13000
 # todo: get rid of these defaults and require them to be passed in, using github secrets for testnet values (requires bridge.go changes)
-jampkstring="6e384a07a01263518a09a5424c7b6bbfc3604ba7d93f47e3a455cbdd7f9f0682"
-ethpkstring="4bfe14725e685901c062ccd4e220c61cf9c189897b6c78bd18d7f51291b2b8f8"
-jamerc20address="0xf3a8bd422097bFdd9B3519Eaeb533393a1c561aC"
+hocpkstring="6e384a07a01263518a09a5424c7b6bbfc3604ba7d93f47e3a455cbdd7f9f0682"
+pocpkstring="4bfe14725e685901c062ccd4e220c61cf9c189897b6c78bd18d7f51291b2b8f8"
+hocerc20address="0xf3a8bd422097bFdd9B3519Eaeb533393a1c561aC"
 docker_image="testnetobscuronet.azurecr.io/obscuronet/obscuro_contractdeployer:latest"
 
 # Fetch options
@@ -46,8 +46,8 @@ do
     case "$key" in
             --l2host)                   l2host=${value} ;;
             --l2port)                   l2port=${value} ;;
-            --jampkstring)              jampkstring=${value} ;;
-            --ethpkstring)              ethpkstring=${value} ;;
+            --hocpkstring)              hocpkstring=${value} ;;
+            --pocpkstring)              pocpkstring=${value} ;;
             --docker_image)             docker_image=${value} ;;
             --help)                     help_and_exit ;;
             *)
@@ -55,35 +55,35 @@ do
 done
 
 # ensure required fields
-if [[ -z ${l2host:-} || -z ${jampkstring:-} || -z ${ethpkstring:-}  ]];
+if [[ -z ${l2host:-} || -z ${hocpkstring:-} || -z ${pocpkstring:-}  ]];
 then
     help_and_exit
 fi
 
 # deploy contracts to the obscuro network
-echo "Deploying JAM ERC20 contract to the obscuro network..."
+echo "Deploying HOC ERC20 contract to the obscuro network..."
 docker network create --driver bridge node_network || true
-docker run --name=jamL2deployer \
+docker run --name=hocL2deployer \
     --network=node_network \
     --entrypoint /home/go-obscuro/tools/contractdeployer/main/main \
      "${docker_image}" \
     --nodeHost=${l2host} \
     --nodePort=${l2port} \
     --contractName="L2ERC20" \
-    --privateKey=${jampkstring}\
-    --constructorParams="JAM,JAM,1000000000000000000000000000000"
+    --privateKey=${hocpkstring}\
+    --constructorParams="Hocus,HOC,1000000000000000000000000000000"
 echo ""
 
-echo "Deploying ETH ERC20 contract to the obscuro network..."
-docker run --name=ethL2deployer \
+echo "Deploying POC ERC20 contract to the obscuro network..."
+docker run --name=pocL2deployer \
     --network=node_network \
     --entrypoint /home/go-obscuro/tools/contractdeployer/main/main \
      "${docker_image}" \
     --nodeHost=${l2host} \
     --nodePort=${l2port} \
     --contractName="L2ERC20" \
-    --privateKey=${ethpkstring}\
-    --constructorParams="ETH,ETH,1000000000000000000000000000000"
+    --privateKey=${pocpkstring}\
+    --constructorParams="Pocus,POC,1000000000000000000000000000000"
 echo ""
 
 echo "Deploying Guessing game contract to the obscuro network..."
@@ -94,6 +94,6 @@ docker run --name=guessingGameL2deployer \
     --nodeHost=${l2host} \
     --nodePort=${l2port} \
     --contractName="GUESS" \
-    --privateKey=${ethpkstring}\
-    --constructorParams="100,${jamerc20address}"
+    --privateKey=${pocpkstring}\
+    --constructorParams="100,${hocerc20address}"
 echo ""


### PR DESCRIPTION
### Why is this change needed?

- There has been confusion between OBX erc20 and OBX native, using a dummy ETH erc20 could be confusing, etc.
- By calling the tokens Hocus (HOC) and Pocus (POC) we make it clear they are just for playing and remove ambiguity

### What changes were made as part of this PR:

**refactor**
- find/replace all the references and usages of OBX/JAM and ETH erc20 contracts
- mainly in the bridge code and in the scripts that set up our testnets

### What are the key areas to look at
- the bridge/testnet scripts


### :rotating_light: Definition of Done :rotating_light:
- [ ] Deployed into dev-testnet 
- [ ] Passes tests on dev-testnet
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated
