### PR TITLE
Fixes node shutdown.

### DIFF
--- a/go/host/node/node.go
+++ b/go/host/node/node.go
@@ -300,12 +300,17 @@ func (a *Node) Stop() {
 		common.ErrorWithID(a.shortID, "failed to stop enclave RPC client. Cause: %s", err)
 	}
 	if a.rpcServer != nil {
-		a.rpcServer.Stop()
+		// We cannot stop the RPC server synchronously. This is because the host itself is being stopped by an RPC
+		// call, so there is a deadlock. The RPC server is waiting for all connections to close, but a single
+		// connection remains open, waiting for the RPC server to close.
+		go a.rpcServer.Stop()
 	}
 
 	// Leave some time for all processing to finish before exiting the main loop.
 	time.Sleep(time.Second)
 	a.exitNodeCh <- true
+
+	common.LogWithID(a.shortID, "Node shut down successfully.")
 }
 
 func (a *Node) ConnectToEthNode(node ethadapter.EthClient) {

--- a/go/host/rpc/clientrpc/rpc_server.go
+++ b/go/host/rpc/clientrpc/rpc_server.go
@@ -53,9 +53,8 @@ func (s *serverImpl) Start() {
 }
 
 func (s *serverImpl) Stop() {
-	s.node.Server().Stop()
-	go func() {
-		// TODO - Investigate why this never returns.
-		_ = s.node.Close()
-	}()
+	err := s.node.Close()
+	if err != nil {
+		log.Panic("could not stop node client server. Cause: %s", err)
+	}
 }

--- a/go/host/rpc/clientrpc/rpc_server.go
+++ b/go/host/rpc/clientrpc/rpc_server.go
@@ -57,5 +57,4 @@ func (s *serverImpl) Stop() {
 	if err != nil {
 		log.Panic("could not stop node client server. Cause: %s", err)
 	}
-	println("jjj server closed inside")
 }

--- a/go/host/rpc/clientrpc/rpc_server.go
+++ b/go/host/rpc/clientrpc/rpc_server.go
@@ -57,4 +57,5 @@ func (s *serverImpl) Stop() {
 	if err != nil {
 		log.Panic("could not stop node client server. Cause: %s", err)
 	}
+	println("jjj server closed inside")
 }

--- a/integration/gethnetwork/geth_network.go
+++ b/integration/gethnetwork/geth_network.go
@@ -276,7 +276,7 @@ func (network *GethNetwork) StopNodes() {
 	for idx, process := range network.nodesProcs {
 		if process != nil {
 			wg.Add(1)
-			go func(process *os.Process) {
+			go func(process *os.Process, nodeNumber int) {
 				defer wg.Done()
 				err := process.Kill()
 				if err != nil {
@@ -286,9 +286,9 @@ func (network *GethNetwork) StopNodes() {
 				if err != nil {
 					log.Error("geth node was killed successfully but did not exit: %s", err)
 				} else {
-					fmt.Printf("Geth node %d on network %d stopped.\n", idx, network.id)
+					fmt.Printf("Geth node %d on network %d stopped.\n", nodeNumber, network.id)
 				}
-			}(process)
+			}(process, idx)
 		}
 	}
 	wg.Wait()

--- a/integration/simulation/network/azureenclave.go
+++ b/integration/simulation/network/azureenclave.go
@@ -28,6 +28,7 @@ type networkWithAzureEnclaves struct {
 	obscuroClients  []rpcclientlib.Client
 	azureEnclaveIps []string
 
+	hostRPCAddresses []string
 	enclaveAddresses []string
 }
 
@@ -70,8 +71,9 @@ func (n *networkWithAzureEnclaves) Create(params *params.SimParams, stats *stats
 		n.enclaveAddresses[i] = fmt.Sprintf("%s:%d", Localhost, params.StartPort+DefaultEnclaveOffset+i)
 	}
 
-	obscuroClients, walletClients := startStandaloneObscuroNodes(params, stats, n.gethClients, n.enclaveAddresses)
+	obscuroClients, walletClients, hostRPCAddresses := startStandaloneObscuroNodes(params, stats, n.gethClients, n.enclaveAddresses)
 	n.obscuroClients = obscuroClients
+	n.hostRPCAddresses = hostRPCAddresses
 
 	return &RPCHandles{
 		EthClients:                    n.gethClients,
@@ -84,4 +86,5 @@ func (n *networkWithAzureEnclaves) TearDown() {
 	// First stop the obscuro nodes
 	StopObscuroNodes(n.obscuroClients)
 	StopGethNetwork(n.gethClients, n.gethNetwork)
+	CheckHostRPCServersStopped(n.hostRPCAddresses)
 }

--- a/integration/simulation/network/dockerenclave.go
+++ b/integration/simulation/network/dockerenclave.go
@@ -31,7 +31,9 @@ const (
 // creates Obscuro nodes with their own enclave servers that communicate with peers via sockets, wires them up, and populates the network objects
 type basicNetworkOfNodesWithDockerEnclave struct {
 	obscuroClients   []rpcclientlib.Client
+	hostRPCAddresses []string
 	enclaveAddresses []string
+
 	// Geth
 	gethNetwork *gethnetwork.GethNetwork
 	gethClients []ethadapter.EthClient
@@ -78,8 +80,9 @@ func (n *basicNetworkOfNodesWithDockerEnclave) Create(params *params.SimParams, 
 	}
 
 	// Start the standalone obscuro nodes connected to the enclaves and to the geth nodes
-	obscuroClients, walletClients := startStandaloneObscuroNodes(params, stats, n.gethClients, n.enclaveAddresses)
+	obscuroClients, walletClients, hostRPCAddresses := startStandaloneObscuroNodes(params, stats, n.gethClients, n.enclaveAddresses)
 	n.obscuroClients = obscuroClients
+	n.hostRPCAddresses = hostRPCAddresses
 
 	return &RPCHandles{
 		EthClients:                    n.gethClients,
@@ -94,6 +97,7 @@ func (n *basicNetworkOfNodesWithDockerEnclave) TearDown() {
 
 	StopGethNetwork(n.gethClients, n.gethNetwork)
 	terminateDockerContainers(n.ctx, n.client, n.containerIDs, n.containerStreams)
+	CheckHostRPCServersStopped(n.hostRPCAddresses)
 }
 
 func (n *basicNetworkOfNodesWithDockerEnclave) setupAndCheckDocker() error {

--- a/integration/simulation/network/geth_network.go
+++ b/integration/simulation/network/geth_network.go
@@ -52,6 +52,6 @@ func (n *networkInMemGeth) Create(params *params.SimParams, stats *stats.Stats) 
 func (n *networkInMemGeth) TearDown() {
 	// Stop the Obscuro nodes first
 	StopObscuroNodes(n.obscuroClients)
-	// Stop the Geth nodes next
+	// Stop geth last
 	StopGethNetwork(n.gethClients, n.gethNetwork)
 }

--- a/integration/simulation/network/geth_network.go
+++ b/integration/simulation/network/geth_network.go
@@ -52,6 +52,7 @@ func (n *networkInMemGeth) Create(params *params.SimParams, stats *stats.Stats) 
 func (n *networkInMemGeth) TearDown() {
 	// Stop the Obscuro nodes first
 	StopObscuroNodes(n.obscuroClients)
+	
 	// Stop geth last
 	StopGethNetwork(n.gethClients, n.gethNetwork)
 }

--- a/integration/simulation/network/geth_network.go
+++ b/integration/simulation/network/geth_network.go
@@ -50,9 +50,8 @@ func (n *networkInMemGeth) Create(params *params.SimParams, stats *stats.Stats) 
 }
 
 func (n *networkInMemGeth) TearDown() {
-	// Stop the obscuro nodes first
+	// Stop the Obscuro nodes first
 	StopObscuroNodes(n.obscuroClients)
-
-	// Stop geth last
+	// Stop the Geth nodes next
 	StopGethNetwork(n.gethClients, n.gethNetwork)
 }

--- a/integration/simulation/network/geth_network.go
+++ b/integration/simulation/network/geth_network.go
@@ -50,9 +50,9 @@ func (n *networkInMemGeth) Create(params *params.SimParams, stats *stats.Stats) 
 }
 
 func (n *networkInMemGeth) TearDown() {
-	// Stop the Obscuro nodes first
+	// Stop the obscuro nodes first
 	StopObscuroNodes(n.obscuroClients)
-	
+
 	// Stop geth last
 	StopGethNetwork(n.gethClients, n.gethNetwork)
 }

--- a/integration/simulation/network/obscuro_node_utils.go
+++ b/integration/simulation/network/obscuro_node_utils.go
@@ -218,18 +218,22 @@ func StopObscuroNodes(clients []rpcclientlib.Client) {
 			defer wg.Done()
 			err := c.Call(nil, rpcclientlib.RPCStopHost)
 			if err != nil {
-				log.Error("Failed to stop client %s", err)
+				log.Error("Failed to stop Obscuro node. Cause: %s", err)
 			}
 			c.Stop()
 		}(client)
 	}
+
 	if waitTimeout(&wg, 10*time.Second) {
-		log.Error("Timed out waiting for the obscuro nodes to stop")
+		panic("Timed out waiting for the Obscuro nodes to stop")
 	} else {
 		log.Info("Obscuro nodes stopped")
 	}
-	// Wait a bit for the nodes to shut down.
-	time.Sleep(2 * time.Second)
+
+	// Wait a bit longer for the node's RPC servers to exit, since we cannot stop the RPC server synchronously. This is
+	// because the host itself is being stopped by an RPC call, so there is a deadlock. The RPC server is waiting for
+	// all connections to close, but a single connection remains open, waiting for the RPC server to close.
+	time.Sleep(5 * time.Second)
 }
 
 // waitTimeout waits for the waitgroup for the specified max timeout.

--- a/integration/simulation/network/obscuro_node_utils.go
+++ b/integration/simulation/network/obscuro_node_utils.go
@@ -3,6 +3,7 @@ package network
 import (
 	"fmt"
 	"math/big"
+	"net"
 	"sync"
 	"time"
 
@@ -83,7 +84,7 @@ func setupInMemWalletClients(params *params.SimParams, obscuroNodes []host.MockH
 }
 
 // todo: this method is quite heavy, should refactor to separate out the creation of the nodes, starting of the nodes, setup of the RPC clients etc.
-func startStandaloneObscuroNodes(params *params.SimParams, stats *stats.Stats, gethClients []ethadapter.EthClient, enclaveAddresses []string) ([]rpcclientlib.Client, map[string][]rpcclientlib.Client) {
+func startStandaloneObscuroNodes(params *params.SimParams, stats *stats.Stats, gethClients []ethadapter.EthClient, enclaveAddresses []string) ([]rpcclientlib.Client, map[string][]rpcclientlib.Client, []string) {
 	// handle to the obscuro clients
 	nodeRPCAddresses := make([]string, params.NumberOfNodes)
 	obscuroClients := make([]rpcclientlib.Client, params.NumberOfNodes)
@@ -150,7 +151,7 @@ func startStandaloneObscuroNodes(params *params.SimParams, stats *stats.Stats, g
 		walletClients[w.Address().String()] = createRPCClientsForWallet(nodeRPCAddresses, w)
 	}
 
-	return obscuroClients, walletClients
+	return obscuroClients, walletClients, nodeRPCAddresses
 }
 
 // createRPCClientsForWallet takes a wallet and sets up a client for it for every node
@@ -210,6 +211,7 @@ func startRemoteEnclaveServers(startAt int, params *params.SimParams, stats *sta
 	}
 }
 
+// StopObscuroNodes stops the Obscuro nodes and their RPC clients.
 func StopObscuroNodes(clients []rpcclientlib.Client) {
 	var wg sync.WaitGroup
 	for _, client := range clients {
@@ -229,11 +231,26 @@ func StopObscuroNodes(clients []rpcclientlib.Client) {
 	} else {
 		log.Info("Obscuro nodes stopped")
 	}
+}
 
-	// Wait a bit longer for the node's RPC servers to exit, since we cannot stop the RPC server synchronously. This is
-	// because the host itself is being stopped by an RPC call, so there is a deadlock. The RPC server is waiting for
-	// all connections to close, but a single connection remains open, waiting for the RPC server to close.
-	time.Sleep(5 * time.Second)
+// CheckHostRPCServersStopped checks whether the hosts' RPC server addresses have been freed up.
+func CheckHostRPCServersStopped(hostRPCAddresses []string) {
+	var wg sync.WaitGroup
+	for _, hostRPCAddress := range hostRPCAddresses {
+		// We cannot stop the RPC server synchronously. This is because the host itself is being stopped by an RPC
+		// call, so there is a deadlock. The RPC server is waiting for all connections to close, but a single
+		// connection remains open, waiting for the RPC server to close. Instead, we check whether the RPC port
+		// becomes free.
+		for !isAddressAvailable(hostRPCAddress) {
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+
+	if waitTimeout(&wg, 10*time.Second) {
+		panic("Timed out waiting for the Obscuro host RPC addresses to become available")
+	} else {
+		log.Info("Obscuro host RPC addresses freed")
+	}
 }
 
 // waitTimeout waits for the waitgroup for the specified max timeout.
@@ -250,4 +267,15 @@ func waitTimeout(wg *sync.WaitGroup, timeout time.Duration) bool {
 	case <-time.After(timeout):
 		return true // timed out
 	}
+}
+
+func isAddressAvailable(address string) bool {
+	ln, err := net.Listen("tcp", address)
+	if err != nil {
+		return false
+	}
+	if ln != nil {
+		_ = ln.Close()
+	}
+	return true
 }

--- a/integration/simulation/network/socket.go
+++ b/integration/simulation/network/socket.go
@@ -19,6 +19,7 @@ import (
 // creates Obscuro nodes with their own enclave servers that communicate with peers via sockets, wires them up, and populates the network objects
 type networkOfSocketNodes struct {
 	obscuroClients   []rpcclientlib.Client
+	hostRPCAddresses []string
 	enclaveAddresses []string
 
 	// geth
@@ -53,8 +54,9 @@ func (n *networkOfSocketNodes) Create(params *params.SimParams, stats *stats.Sta
 		n.enclaveAddresses[i] = fmt.Sprintf("%s:%d", Localhost, params.StartPort+DefaultEnclaveOffset+i)
 	}
 
-	obscuroClients, walletClients := startStandaloneObscuroNodes(params, stats, n.gethClients, n.enclaveAddresses)
+	obscuroClients, walletClients, hostRPCAddresses := startStandaloneObscuroNodes(params, stats, n.gethClients, n.enclaveAddresses)
 	n.obscuroClients = obscuroClients
+	n.hostRPCAddresses = hostRPCAddresses
 
 	return &RPCHandles{
 		EthClients:                    n.gethClients,
@@ -67,4 +69,5 @@ func (n *networkOfSocketNodes) TearDown() {
 	// Stop the Obscuro nodes first (each host will attempt to shut down its enclave as part of shutdown).
 	StopObscuroNodes(n.obscuroClients)
 	StopGethNetwork(n.gethClients, n.gethNetwork)
+	CheckHostRPCServersStopped(n.hostRPCAddresses)
 }


### PR DESCRIPTION
### Why is this change needed?

Previously, we had to perform the node RPC server shutdown in a goroutine, and we weren't sure why.

### What changes were made as part of this PR:

Functional.

- Adds explanatory comment explaining why using a goroutine is required
- Waits for host RPC ports to free up, to ensure the RPC server has actually stopped
- Panics instead of logging an error if the ports aren't freed, to highlight issues in the future

### What are the key areas to look at

- ...


### :rotating_light: Definition of Done :rotating_light:
- [ ] Deployed into dev-testnet 
- [ ] Passes tests on dev-testnet
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated
