### PR TITLE
Add context support to EncClient

### DIFF
--- a/go/rpcclientlib/client.go
+++ b/go/rpcclientlib/client.go
@@ -1,6 +1,7 @@
 package rpcclientlib
 
 import (
+	"context"
 	"errors"
 )
 
@@ -34,6 +35,8 @@ var ErrNilResponse = errors.New("nil response received from Obscuro node")
 type Client interface {
 	// Call executes the named method via RPC. (Returns `ErrNilResponse` on nil response from Node, this is used as "not found" for some method calls)
 	Call(result interface{}, method string, args ...interface{}) error
+	// CallContext If the context is canceled before the call has successfully returned, CallContext returns immediately.
+	CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error
 	// Stop closes the client.
 	Stop()
 }

--- a/go/rpcclientlib/encrypted_client.go
+++ b/go/rpcclientlib/encrypted_client.go
@@ -52,7 +52,7 @@ func NewEncRPCClient(client Client, viewingKey *ViewingKey) (*EncRPCClient, erro
 
 // Call handles JSON rpc requests without a context - see CallContext for details
 func (c *EncRPCClient) Call(result interface{}, method string, args ...interface{}) error {
-	return c.CallContext(nil, result, method, args...)
+	return c.CallContext(nil, result, method, args...) //nolint:staticcheck
 }
 
 // CallContext is the main logic to execute JSON-RPC requests, the context can be nil.
@@ -107,9 +107,8 @@ func (c *EncRPCClient) CallContext(ctx context.Context, result interface{}, meth
 func (c *EncRPCClient) executeRPCCall(ctx context.Context, result interface{}, method string, args ...interface{}) error {
 	if ctx == nil {
 		return c.obscuroClient.Call(result, method, args...)
-	} else {
-		return c.obscuroClient.CallContext(ctx, result, method, args...)
 	}
+	return c.obscuroClient.CallContext(ctx, result, method, args...)
 }
 
 func (c *EncRPCClient) Stop() {

--- a/go/rpcclientlib/network_client.go
+++ b/go/rpcclientlib/network_client.go
@@ -41,8 +41,7 @@ func NewNetworkClient(address string) (Client, error) {
 	}, nil
 }
 
-// Call handles JSON rpc requests - if the method is sensitive it will encrypt the args before sending the request and
-// then decrypts the response before returning.
+// Call handles JSON rpc requests, delegating to the geth RPC client
 // The result must be a pointer so that package json can unmarshal into it. You can also pass nil, in which case the result is ignored.
 func (c *networkClient) Call(result interface{}, method string, args ...interface{}) error {
 	return c.rpcClient.Call(&result, method, args...)

--- a/go/rpcclientlib/network_client.go
+++ b/go/rpcclientlib/network_client.go
@@ -1,6 +1,7 @@
 package rpcclientlib
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/rpc"
@@ -45,6 +46,10 @@ func NewNetworkClient(address string) (Client, error) {
 // The result must be a pointer so that package json can unmarshal into it. You can also pass nil, in which case the result is ignored.
 func (c *networkClient) Call(result interface{}, method string, args ...interface{}) error {
 	return c.rpcClient.Call(&result, method, args...)
+}
+
+func (c *networkClient) CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error {
+	return c.rpcClient.CallContext(ctx, result, method, args...)
 }
 
 func (c *networkClient) Stop() {

--- a/integration/simulation/p2p/in_mem_obscuro_client.go
+++ b/integration/simulation/p2p/in_mem_obscuro_client.go
@@ -1,3 +1,4 @@
+//nolint:contextcheck
 package p2p
 
 import (

--- a/integration/simulation/p2p/in_mem_obscuro_client.go
+++ b/integration/simulation/p2p/in_mem_obscuro_client.go
@@ -114,6 +114,11 @@ func (c *inMemObscuroClient) Call(result interface{}, method string, args ...int
 	}
 }
 
+// CallContext not currently supported by in-memory obscuro client, the context will be ignored.
+func (c *inMemObscuroClient) CallContext(_ context.Context, result interface{}, method string, args ...interface{}) error {
+	return c.Call(result, method, args...)
+}
+
 func (c *inMemObscuroClient) sendRawTransaction(args []interface{}) error {
 	encBytes, err := getEncryptedBytes(args, rpcclientlib.RPCSendRawTransaction)
 	if err != nil {


### PR DESCRIPTION
### Why is this change needed?

- we want our Go ObscuroClient to support contexts like the geth client does, so we need to add support on the EncClient for it

### What changes were made as part of this PR:

- add CallContext methods through the rpc clients (not used by anything yet)

### What are the key areas to look at
- is the EncClient implementation clear with its `internalCall()`? I wanted to re-use the Call() logic, maybe there's a neater way


### :rotating_light: Definition of Done :rotating_light:
- [ ] Deployed into dev-testnet 
- [ ] Passes tests on dev-testnet
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated
