### PR TITLE
fix dev testnet to use correct image

### DIFF
--- a/.github/workflows/manual-deploy-dev-testnet.yml
+++ b/.github/workflows/manual-deploy-dev-testnet.yml
@@ -229,6 +229,7 @@ jobs:
                --pocerc20addr=${{needs.build-l2.outputs.pocErc20Addr}} \
                --pkaddr=${{ secrets[matrix.node_pk_addr] }} \
                --pkstring=${{ secrets[matrix.node_pk_str] }} \
+               --dev_testnet=true \
                --p2p_public_address=dev-obscuronode-${{ matrix.host_id }}-testnet-${{ GITHUB.RUN_NUMBER }}.uksouth.cloudapp.azure.com:10000'
 
 

--- a/testnet/docker-compose.dev-testnet.yml
+++ b/testnet/docker-compose.dev-testnet.yml
@@ -1,0 +1,83 @@
+# This compose requires SGX capable CPU
+
+version: "3.9"
+networks:
+  default:
+    name: node_network
+services:
+  host:
+    networks:
+      - default
+    ports:
+      - "13000:13000"
+      - "13001:13001"
+      - "6061:6061"
+      - "10000:10000"
+    environment:
+      MGMTCONTRACTADDR: some_address
+      PKSTRING: some_string
+      L1HOST: some_host
+      L1PORT: some_port
+      HOSTID: some_address
+      ISGENESIS: some_bool
+      PROFILERENABLED: some_bool
+      P2PPUBLICADDRESS: some_string
+    image: testnetobscuronet.azurecr.io/obscuronet/dev_obscuro_host:latest
+    entrypoint: [
+      "/home/go-obscuro/go/host/main/main",
+      "--l1NodeHost=$L1HOST",
+      "--l1NodePort=$L1PORT",
+      "--id=$HOSTID",
+      "--enclaveRPCAddress=enclave:11000",
+      "--rollupContractAddress=$MGMTCONTRACTADDR",
+      "--privateKey=$PKSTRING",
+      "--clientRPCHost=0.0.0.0",
+      "--isGenesis=$ISGENESIS",
+      "--logLevel=debug",
+      "--profilerEnabled=$PROFILERENABLED",
+      "--p2pPublicAddress=$P2PPUBLICADDRESS"
+    ]
+
+  enclave:
+    privileged: true
+    volumes:
+      - /dev/sgx:/dev/sgx
+    networks:
+      - default
+    ports:
+      - "6060:6060"
+    environment:
+      MGMTCONTRACTADDR: some_address
+      HOCERC20ADDR: some_address
+      POCERC20ADDR: some_address
+      HOSTID: some_address
+      OE_SIMULATION: 0
+      PROFILERENABLED: some_bool
+      P2PPUBLICADDRESS: some_string
+    image: testnetobscuronet.azurecr.io/obscuronet/dev_obscuro_enclave:latest
+    entrypoint: [
+                 "ego", "run", "/home/obscuro/go-obscuro/go/enclave/main/main",
+                 "--hostID=$HOSTID",
+                 "--address=:11000",
+                 "--managementContractAddress=$MGMTCONTRACTADDR",
+                 "--erc20ContractAddresses=$HOCERC20ADDR,$POCERC20ADDR",
+                 "--hostAddress=host:10000",
+                 "--willAttest",
+                 "--useInMemoryDB=false",
+                 "--edgelessDBHost=edgelessdb",
+                 "--profilerEnabled=$PROFILERENABLED",
+                 "--hostAddress=$P2PPUBLICADDRESS"
+    ]
+
+  edgelessdb:
+    privileged: true
+    volumes:
+      - /dev/sgx:/dev/sgx
+    networks:
+      - default
+    environment:
+      EDG_EDB_CERT_DNS: edgelessdb
+    ports:
+      - "3306:3306"
+      - "8080:8080"
+    image: ghcr.io/edgelesssys/edgelessdb-sgx-1gb:latest

--- a/testnet/start-obscuro-node.sh
+++ b/testnet/start-obscuro-node.sh
@@ -120,17 +120,17 @@ then
   exit 0
 fi
 
-if ${sgx_enabled} ;
-then
-  echo "Starting enclave with enabled SGX and host..."
-  docker compose up enclave host edgelessdb -d
-  exit 0
-fi
-
 if ${dev_testnet} ;
 then
   echo "Starting enclave and host with dev testnet images..."
   docker compose -f docker-compose.dev-testnet.yml up enclave host edgelessdb -d
+  exit 0
+fi
+
+if ${sgx_enabled} ;
+then
+  echo "Starting enclave with enabled SGX and host..."
+  docker compose up enclave host edgelessdb -d
   exit 0
 fi
 

--- a/testnet/start-obscuro-node.sh
+++ b/testnet/start-obscuro-node.sh
@@ -42,6 +42,8 @@ help_and_exit() {
     echo ""
     echo "  debug_enclave      *Optional* Dev mode, with a dlv debugger remote attach on port 2345"
     echo ""
+    echo "  dev_testnet        *Optional* Uses dev images for dev testnet"
+    echo ""
     echo ""
     echo ""
     exit 1  # Exit with error explicitly
@@ -59,6 +61,7 @@ is_genesis=false
 profiler_enabled=false
 p2p_public_address="127.0.0.1:10000"
 debug_enclave=false
+dev_testnet=false
 pk_address=0x0654D8B60033144D567f25bF41baC1FB0D60F23B
 pk_string=8ead642ca80dadb0f346a66cd6aa13e08a8ac7b5c6f7578d4bac96f5db01ac99
 
@@ -83,6 +86,7 @@ do
             --profiler_enabled)         profiler_enabled=${value} ;;
             --p2p_public_address)       p2p_public_address=${value} ;;
             --debug_enclave)            debug_enclave=${value} ;;
+            --dev_testnet)              dev_testnet=${value} ;;
 
             --help)                     help_and_exit ;;
             *)
@@ -120,8 +124,16 @@ if ${sgx_enabled} ;
 then
   echo "Starting enclave with enabled SGX and host..."
   docker compose up enclave host edgelessdb -d
-else
-  echo "Starting enclave with DISABLED SGX and host..."
-  docker compose -f docker-compose.non-sgx.yml up enclave host -d
+  exit 0
 fi
+
+if ${dev_testnet} ;
+then
+  echo "Starting enclave and host with dev testnet images..."
+  docker compose -f docker-compose.dev-testnet.yml up enclave host edgelessdb -d
+  exit 0
+fi
+
+echo "Starting enclave with DISABLED SGX and host..."
+docker compose -f docker-compose.non-sgx.yml up enclave host -d
 


### PR DESCRIPTION
### Why is this change needed?

- Fixed the deployment pipeline to use the correct dev image

### What changes were made as part of this PR:

- docker-compose and bash script



### :rotating_light: Definition of Done :rotating_light:
- [ ] Deployed into dev-testnet 
- [ ] Passes tests on dev-testnet
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated
