### PR TITLE
bumps the tx execution to info

### DIFF
--- a/go/common/logging.go
+++ b/go/common/logging.go
@@ -49,12 +49,6 @@ func LogTXExecution(txHash common.Hash, msg string, args ...interface{}) {
 	log.Info(txExecPattern, txHash.Hex(), formattedMsg)
 }
 
-// DebugTXExecution - logs at DEBUG level with the tx hash prepended
-func DebugTXExecution(txHash common.Hash, msg string, args ...interface{}) {
-	formattedMsg := fmt.Sprintf(msg, args...)
-	log.Debug(txExecPattern, txHash.Hex(), formattedMsg)
-}
-
 // TraceTXExecution - logs at Trace level with the tx hash prepended
 func TraceTXExecution(txHash common.Hash, msg string, args ...interface{}) {
 	formattedMsg := fmt.Sprintf(msg, args...)

--- a/go/common/logging.go
+++ b/go/common/logging.go
@@ -49,6 +49,12 @@ func LogTXExecution(txHash common.Hash, msg string, args ...interface{}) {
 	log.Info(txExecPattern, txHash.Hex(), formattedMsg)
 }
 
+// DebugTXExecution - logs at DEBUG level with the tx hash prepended
+func DebugTXExecution(txHash common.Hash, msg string, args ...interface{}) {
+	formattedMsg := fmt.Sprintf(msg, args...)
+	log.Debug(txExecPattern, txHash.Hex(), formattedMsg)
+}
+
 // TraceTXExecution - logs at Trace level with the tx hash prepended
 func TraceTXExecution(txHash common.Hash, msg string, args ...interface{}) {
 	formattedMsg := fmt.Sprintf(msg, args...)

--- a/go/enclave/evm/evm_facade.go
+++ b/go/enclave/evm/evm_facade.go
@@ -36,15 +36,12 @@ func ExecuteTransactions(txs []*common.L2Tx, s *state.StateDB, header *common.He
 		result[t.Hash()] = r
 		if r.Status == types.ReceiptStatusFailed {
 			common.ErrorTXExecution(t.Hash(),
-				"Unsuccessful (status != 1)."+
-					"\n To: %s"+
-					"\n Data: %x"+
-					"\n Gas: %d",
+				"Unsuccessful (status != 1) To: %s Gas: %d Data: %x",
 				t.To().Hex(),
-				t.Data(),
-				t.Gas())
+				t.Gas(),
+				t.Data())
 		} else {
-			common.TraceTXExecution(t.Hash(), "Successfully executed. Address: %s", r.ContractAddress.Hex())
+			common.LogTXExecution(t.Hash(), "Successfully executed. Address: %s", r.ContractAddress.Hex())
 		}
 	}
 	s.Finalise(true)


### PR DESCRIPTION
### Why is this change needed?

- Log correctly executed txs

### What changes were made as part of this PR:

- tx log


### :rotating_light: Definition of Done :rotating_light:
- [ ] Deployed into dev-testnet 
- [ ] Passes tests on dev-testnet
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated
