### PR TITLE
Retry L1 transaction broadcast

### DIFF
--- a/go/host/node/node.go
+++ b/go/host/node/node.go
@@ -983,7 +983,7 @@ func (a *Node) checkBlockForSecretResponse(block *types.Block) bool {
 }
 
 // We retry calling `funcToRetry`, with a pause in between that starts at one second and doubles on each retry.
-// This is equal to 9 seconds for 3 retries, and 63 seconds for 7 retries.
+// This is equal to 7 seconds for 3 retries, and 63 seconds for 7 retries.
 func retryWithBackoff(retries int, funcToRetry func() error) error {
 	pause := time.Second
 	var err error

--- a/go/host/node/node.go
+++ b/go/host/node/node.go
@@ -40,8 +40,10 @@ const (
 	apiNamespaceNetwork     = "net"
 	apiNamespaceTest        = "test"
 
-	l1TxTriesRollup = 3 // The number of times we try broadcasting the rollup transaction to the L1.
-	l1TxTriesSecret = 7 // The number of times we try sending secret initialisation, request or response transactions to the L1.
+	// Attempts to broadcast the rollup transaction to the L1. Worst-case, equates to 7 seconds, plus time per request.
+	l1TxTriesRollup = 3
+	// Attempts to send secret initialisation, request or response transactions to the L1. Worst-case, equates to 63 seconds, plus time per request.
+	l1TxTriesSecret = 7
 )
 
 // Node is an implementation of host.Host.

--- a/go/host/node/node.go
+++ b/go/host/node/node.go
@@ -599,7 +599,11 @@ func (a *Node) signAndBroadcastTx(tx types.TxData, retries int) error {
 	}
 
 	funcBroadcastTx := func() error { return a.ethClient.SendTransaction(signedTx) }
-	return retryWithBackoff(retries, funcBroadcastTx)
+	err = retryWithBackoff(retries, funcBroadcastTx)
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("broadcasting L1 transaction failed after %d retries. Cause: %w", retries, err)
 }
 
 // This method implements the procedure by which a node obtains the secret

--- a/go/host/node/node.go
+++ b/go/host/node/node.go
@@ -597,15 +597,19 @@ func (a *Node) broadcastL1Tx(tx types.TxData, retries int) error {
 		return err
 	}
 
-	// todo - joel - use retries
+	err = nil
+	for i := 0; ; i++ {
+		// We've performed all the retries, so we return the (possibly nil) error.
+		if i >= retries {
+			return err
+		}
 
-	// TODO Add retries, with fewer retries for rollups. Escalate an error if all retries fail.
-	err = a.ethClient.SendTransaction(signedTx)
-	if err != nil {
-		return err
+		err = a.ethClient.SendTransaction(signedTx)
+		if err == nil {
+			// If the transaction sent successfully, we break out.
+			return nil
+		}
 	}
-
-	return nil
 }
 
 // This method implements the procedure by which a node obtains the secret


### PR DESCRIPTION
### Why is this change needed?

Currently, we do not retry broadcasting transactions to the L1 from the host. We error out after the first failure. This is not resilient.

### What changes were made as part of this PR:

Functional.

- Sets timeout for all L1 client requests
- Adds retries for L1 transaction broadcast

### What are the key areas to look at

- ...


### :rotating_light: Definition of Done :rotating_light:
- [ ] Deployed into dev-testnet 
- [ ] Passes tests on dev-testnet
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated
