### PR TITLE
Avoids race condition in Geth shutdown.

### DIFF
--- a/integration/gethnetwork/geth_network.go
+++ b/integration/gethnetwork/geth_network.go
@@ -269,7 +269,7 @@ func createAndStartMiners(network GethNetwork, dataDirs []string) {
 
 	if errors != nil {
 		network.StopNodes()
-		panic(fmt.Errorf("could not start Geth node. Causes: %s", strings.Join(errors, "; ")))
+		panic(fmt.Errorf("could not start one or more Geth nodes. Causes: %s", strings.Join(errors, "; ")))
 	}
 }
 

--- a/integration/gethnetwork/geth_network.go
+++ b/integration/gethnetwork/geth_network.go
@@ -216,7 +216,7 @@ func NewGethNetwork(portStart int, websocketPortStart int, gethBinaryPath string
 	network.genesisFilePath = genesisFilePath
 
 	// We start the miners.
-	createAndStartMiners(dataDirs, network)
+	createAndStartMiners(network, dataDirs)
 
 	// We retrieve the enode address for each node.
 	enodeAddrs := make([]string, len(network.dataDirs))
@@ -246,7 +246,7 @@ func NewGethNetwork(portStart int, websocketPortStart int, gethBinaryPath string
 	return &network
 }
 
-func createAndStartMiners(dataDirs []string, network GethNetwork) {
+func createAndStartMiners(network GethNetwork, dataDirs []string) {
 	var wg sync.WaitGroup
 	errors := make([]string, len(dataDirs))
 

--- a/integration/gethnetwork/geth_network.go
+++ b/integration/gethnetwork/geth_network.go
@@ -267,7 +267,7 @@ func createAndStartMiners(network GethNetwork, dataDirs []string) {
 	}
 	wg.Wait()
 
-	if errors != nil {
+	if len(errors) > 0 {
 		network.StopNodes()
 		panic(fmt.Errorf("could not start one or more Geth nodes. Causes: %s", strings.Join(errors, "; ")))
 	}

--- a/integration/gethnetwork/geth_network.go
+++ b/integration/gethnetwork/geth_network.go
@@ -216,14 +216,7 @@ func NewGethNetwork(portStart int, websocketPortStart int, gethBinaryPath string
 	network.genesisFilePath = genesisFilePath
 
 	// We start the miners.
-	for idx, dataDir := range dataDirs {
-		wg.Add(1)
-		go func(idx int, dataDir string) {
-			defer wg.Done()
-			network.createMiner(dataDir, idx)
-		}(idx, dataDir)
-	}
-	wg.Wait()
+	createAndStartMiners(dataDirs, network)
 
 	// We retrieve the enode address for each node.
 	enodeAddrs := make([]string, len(network.dataDirs))
@@ -251,6 +244,32 @@ func NewGethNetwork(portStart int, websocketPortStart int, gethBinaryPath string
 	wg.Wait()
 
 	return &network
+}
+
+func createAndStartMiners(dataDirs []string, network GethNetwork) {
+	var wg sync.WaitGroup
+	var errors error
+
+	// We need to wait for all the miner-creation goroutines to return before shutting down the nodes if there were any
+	// errors. Otherwise, there's a possible race condition whereby if the creation of one node fails, we start
+	// shutting down the nodes from that goroutine, but new nodes are being spun up on other goroutines, and these are
+	// missed by the shutdown process.
+	for idx, dataDir := range dataDirs {
+		wg.Add(1)
+		go func(idx int, dataDir string) {
+			defer wg.Done()
+			err := network.createAndStartMiner(dataDir, idx)
+			if err != nil {
+				errors = fmt.Errorf("%w;%s", errors, err.Error())
+			}
+		}(idx, dataDir)
+	}
+	wg.Wait()
+
+	if errors != nil {
+		network.StopNodes()
+		panic(fmt.Errorf("could not start Geth node. Causes: %w", errors))
+	}
 }
 
 // IssueCommand sends the command via RPC to the nodeIdx'th node in the network.
@@ -295,12 +314,12 @@ func (network *GethNetwork) StopNodes() {
 }
 
 // Initialises and starts a miner.
-func (network *GethNetwork) createMiner(dataDir string, idx int) {
+func (network *GethNetwork) createAndStartMiner(dataDir string, idx int) error {
 	// We delete the leftover IPC file from the previous run, if it exists.
 	_ = os.Remove(path.Join(dataDir, ipcFileName))
 	// The node must create its initial config based on the network's genesis file before it can be started.
 	network.initNode(dataDir)
-	network.startMiner(dataDir, idx)
+	return network.startMiner(dataDir, idx)
 }
 
 // Creates an account for a Geth node.
@@ -353,7 +372,7 @@ func (network *GethNetwork) initNode(dataDirPath string) {
 }
 
 // Starts a Geth miner.
-func (network *GethNetwork) startMiner(dataDirPath string, idx int) {
+func (network *GethNetwork) startMiner(dataDirPath string, idx int) error {
 	webSocketPort := network.wsStartPort + idx
 	port := network.commStartPort + idx
 	httpPort := network.commStartPort + 25 + idx
@@ -372,13 +391,13 @@ func (network *GethNetwork) startMiner(dataDirPath string, idx int) {
 	cmd.Stderr = network.logNodeID(idx)
 
 	if err := cmd.Start(); err != nil {
-		network.StopNodes() // We stop any nodes started so far.
-		panic(fmt.Errorf("could not start Geth node. Cause: %w", err))
+		return err
 	}
+
 	network.nodesProcs[idx] = cmd.Process
 	network.WebSocketPorts[idx] = uint(webSocketPort)
-
 	fmt.Printf("Geth node %d on network %d started on ports %d (WebSocket) and %d (HTTP).\n", idx, network.id, webSocketPort, httpPort)
+	return nil
 }
 
 // logNodeID prepends the nodeID to the log entries


### PR DESCRIPTION
### Why is this change needed?

There was a race condition in the Geth start-up code (I think).

We needed to wait for all the miner-creation goroutines to return before shutting down the nodes if there were any errors. Otherwise, there's a possible race condition whereby if the creation of one node fails, we start shutting down the nodes from that goroutine, but new nodes are being spun up on other goroutines, and these are missed by the shutdown process.

### What changes were made as part of this PR:

Refactoring.

- Avoids race condition

### What are the key areas to look at

- ...


### :rotating_light: Definition of Done :rotating_light:
- [ ] Deployed into dev-testnet 
- [ ] Passes tests on dev-testnet
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated
