### PR TITLE
Prints entire receipt for transactions.

### DIFF
--- a/go/enclave/evm/evm_facade.go
+++ b/go/enclave/evm/evm_facade.go
@@ -34,14 +34,17 @@ func ExecuteTransactions(txs []*common.L2Tx, s *state.StateDB, header *common.He
 			continue
 		}
 		result[t.Hash()] = r
+		receiptJSON, err := r.MarshalJSON()
 		if r.Status == types.ReceiptStatusFailed {
-			common.ErrorTXExecution(t.Hash(),
-				"Unsuccessful (status != 1) To: %s Gas: %d Data: %x",
-				t.To().Hex(),
-				t.Gas(),
-				t.Data())
+			if err != nil {
+				common.ErrorTXExecution(t.Hash(), "Unsuccessful (status != 1) (but could not print receipt as JSON)")
+			}
+			common.ErrorTXExecution(t.Hash(), "Unsuccessful (status != 1). Receipt: %s", string(receiptJSON))
 		} else {
-			common.LogTXExecution(t.Hash(), "Successfully executed. Address: %s", r.ContractAddress.Hex())
+			if err != nil {
+				common.TraceTXExecution(t.Hash(), "Successfully executed (but could not print receipt as JSON)")
+			}
+			common.TraceTXExecution(t.Hash(), "Successfully executed. Receipt: %s", string(receiptJSON))
 		}
 	}
 	s.Finalise(true)

--- a/go/enclave/evm/evm_facade.go
+++ b/go/enclave/evm/evm_facade.go
@@ -38,13 +38,15 @@ func ExecuteTransactions(txs []*common.L2Tx, s *state.StateDB, header *common.He
 		if r.Status == types.ReceiptStatusFailed {
 			if err != nil {
 				common.ErrorTXExecution(t.Hash(), "Unsuccessful (status != 1) (but could not print receipt as JSON)")
+			} else {
+				common.ErrorTXExecution(t.Hash(), "Unsuccessful (status != 1). Receipt: %s", string(receiptJSON))
 			}
-			common.ErrorTXExecution(t.Hash(), "Unsuccessful (status != 1). Receipt: %s", string(receiptJSON))
 		} else {
 			if err != nil {
 				common.TraceTXExecution(t.Hash(), "Successfully executed (but could not print receipt as JSON)")
+			} else {
+				common.TraceTXExecution(t.Hash(), "Successfully executed. Receipt: %s", string(receiptJSON))
 			}
-			common.TraceTXExecution(t.Hash(), "Successfully executed. Receipt: %s", string(receiptJSON))
 		}
 	}
 	s.Finalise(true)

--- a/go/enclave/evm/evm_facade.go
+++ b/go/enclave/evm/evm_facade.go
@@ -34,20 +34,7 @@ func ExecuteTransactions(txs []*common.L2Tx, s *state.StateDB, header *common.He
 			continue
 		}
 		result[t.Hash()] = r
-		receiptJSON, err := r.MarshalJSON()
-		if r.Status == types.ReceiptStatusFailed {
-			if err != nil {
-				common.ErrorTXExecution(t.Hash(), "Unsuccessful (status != 1) (but could not print receipt as JSON)")
-			} else {
-				common.ErrorTXExecution(t.Hash(), "Unsuccessful (status != 1). Receipt: %s", string(receiptJSON))
-			}
-		} else {
-			if err != nil {
-				common.TraceTXExecution(t.Hash(), "Successfully executed (but could not print receipt as JSON)")
-			} else {
-				common.TraceTXExecution(t.Hash(), "Successfully executed. Receipt: %s", string(receiptJSON))
-			}
-		}
+		logReceipt(err, r, t)
 	}
 	s.Finalise(true)
 	return result
@@ -69,6 +56,23 @@ func executeTransaction(s *state.StateDB, cc *params.ChainConfig, chain *Obscuro
 	}
 
 	return receipt, nil
+}
+
+func logReceipt(r *types.Receipt) {
+	receiptJSON, err := r.MarshalJSON()
+	if err != nil {
+		if r.Status == types.ReceiptStatusFailed {
+			common.ErrorTXExecution(r.TxHash, "Unsuccessful (status != 1) (but could not print receipt as JSON)")
+		} else {
+			common.TraceTXExecution(r.TxHash, "Successfully executed (but could not print receipt as JSON)")
+		}
+	}
+	
+	if r.Status == types.ReceiptStatusFailed {
+		common.ErrorTXExecution(r.TxHash, "Unsuccessful (status != 1). Receipt: %s", string(receiptJSON))
+	} else {
+		common.TraceTXExecution(r.TxHash, "Successfully executed. Receipt: %s", string(receiptJSON))
+	}
 }
 
 // ExecuteOffChainCall - executes the "data" command against the "to" smart contract

--- a/go/enclave/evm/evm_facade.go
+++ b/go/enclave/evm/evm_facade.go
@@ -34,7 +34,7 @@ func ExecuteTransactions(txs []*common.L2Tx, s *state.StateDB, header *common.He
 			continue
 		}
 		result[t.Hash()] = r
-		logReceipt(err, r, t)
+		logReceipt(r)
 	}
 	s.Finalise(true)
 	return result
@@ -67,7 +67,7 @@ func logReceipt(r *types.Receipt) {
 			common.TraceTXExecution(r.TxHash, "Successfully executed (but could not print receipt as JSON)")
 		}
 	}
-	
+
 	if r.Status == types.ReceiptStatusFailed {
 		common.ErrorTXExecution(r.TxHash, "Unsuccessful (status != 1). Receipt: %s", string(receiptJSON))
 	} else {


### PR DESCRIPTION
### Why is this change needed?

Currently, we are selective in terms of what information we print from a transaction's receipt. It would be more useful to print everything.

### What changes were made as part of this PR:

Functional.

- Prints all non-nil fields in each receipt

One nice thing is that the JSON formatting filters out empty fields. So for regular transactions, you get:

```
Unsuccessful (status != 1). Receipt: {"root":"0x","status":"0x0","cumulativeGasUsed":"0x61b3","logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","logs":null,"transactionHash":"0x598cf088adde0b34ddf2b79d16f73650a353c7057a096de67bb63a84b586f1de","contractAddress":"0x0000000000000000000000000000000000000000","gasUsed":"0x61b3","blockHash":"0xa16cefb2ce673bd200858aa25df4d4564f1869e53f49e80f0f6c413ea8229e44","blockNumber":"0x9","transactionIndex":"0x0"}
```

But for contract deployment transactions, we have:

```
Successfully executed. Receipt: {"type":"0x2","root":"0x","status":"0x1","cumulativeGasUsed":"0x14b2d5","logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000020000000000000000000800000000000000000000010010000200000000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000020000200000000000040000000000000000000000000000000000000000020000000","logs":[{"address":"0x9802f661d17c65527d7abb59daad5439cb125a67","topics":["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef","0x0000000000000000000000000000000000000000000000000000000000000000","0x000000000000000000000000987e0a0692475bcc5f13d97e700bb43c1913effe"],"data":"0x00000000000000000000000000000002f050fe938943acc45f65568000000000","blockNumber":"0x6","transactionHash":"0x857e41be3c1afbf1ff651c0973126e5f8faf536cde1312e350997e5d94a3c9a9","transactionIndex":"0x0","blockHash":"0x99e8d208f67db9ca6a8e02ff8aa989efb3df3b8f5438ec19757489b4f1db3d54","logIndex":"0x0","removed":false}],"transactionHash":"0x857e41be3c1afbf1ff651c0973126e5f8faf536cde1312e350997e5d94a3c9a9","contractAddress":"0x9802f661d17c65527d7abb59daad5439cb125a67","gasUsed":"0x14b2d5","blockHash":"0x99e8d208f67db9ca6a8e02ff8aa989efb3df3b8f5438ec19757489b4f1db3d54","blockNumber":"0x6","transactionIndex":"0x0"}
```

### What are the key areas to look at

- ...


### :rotating_light: Definition of Done :rotating_light:
- [ ] Deployed into dev-testnet 
- [ ] Passes tests on dev-testnet
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated
