### PR TITLE
force trace level until config implementned

### DIFF
--- a/go/enclave/enclaverunner/enclave_runner.go
+++ b/go/enclave/enclaverunner/enclave_runner.go
@@ -6,6 +6,8 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/rs/zerolog"
+
 	gethlog "github.com/ethereum/go-ethereum/log"
 
 	"github.com/obscuronet/go-obscuro/go/common/log"
@@ -26,7 +28,10 @@ func RunEnclave(config config.EnclaveConfig) {
 	mgmtContractLib := mgmtcontractlib.NewMgmtContractLib(&contractAddr)
 	erc20ContractLib := erc20contractlib.NewERC20ContractLib(&contractAddr, config.ERC20ContractAddresses...)
 
-	log.SetLogLevel(log.ParseLevel(config.LogLevel))
+	// todo temporary
+	// log.SetLogLevel(log.ParseLevel(config.LogLevel))
+	log.SetLogLevel(zerolog.TraceLevel)
+
 	if config.LogPath != "" {
 		setLogs(config.LogPath)
 	}

--- a/go/host/hostrunner/host_runner.go
+++ b/go/host/hostrunner/host_runner.go
@@ -6,6 +6,8 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/rs/zerolog"
+
 	"github.com/obscuronet/go-obscuro/go/host/node"
 
 	"github.com/obscuronet/go-obscuro/go/host/rpc/enclaverpc"
@@ -27,7 +29,9 @@ import (
 func RunHost(config config.HostConfig) {
 	mgmtContractLib := mgmtcontractlib.NewMgmtContractLib(&config.RollupContractAddress)
 
-	log.SetLogLevel(log.ParseLevel(config.LogLevel))
+	// todo temporary
+	// log.SetLogLevel(log.ParseLevel(config.LogLevel))
+	log.SetLogLevel(zerolog.TraceLevel)
 
 	if config.LogPath != "" {
 		setLogs(config.LogPath)


### PR DESCRIPTION
### Why is this change needed?

investigate crashing testnet

### What changes were made as part of this PR:

- functional
- force log level to trace until the config plumbing is in place

### What are the key areas to look at

- ...


### :rotating_light: Definition of Done :rotating_light:
- [ ] Deployed into dev-testnet 
- [ ] Passes tests on dev-testnet
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated
