### PR TITLE
Fix bug in contract deployer for guessing game arg

### DIFF
--- a/tools/contractdeployer/contract_deployer.go
+++ b/tools/contractdeployer/contract_deployer.go
@@ -250,7 +250,7 @@ func getContractCode(cfg *Config) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		address := common.BytesToAddress(common.Hex2Bytes(cfg.ConstructorParams[1]))
+		address := common.HexToAddress(cfg.ConstructorParams[1])
 
 		return guessinggame.Bytecode(uint8(size), address)
 


### PR DESCRIPTION
### Why is this change needed?

The contract deployer is deploying guessing game with an erc20 address of 0x00...000, igoring the arg.

Was able to verify with the debugger that the code converting from hex string to erc20 was outputting the zero address.

### What changes were made as part of this PR:

- fix that conversion


### :rotating_light: Definition of Done :rotating_light:
- [ ] Deployed into dev-testnet 
- [ ] Passes tests on dev-testnet
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated
