### PR TITLE
Correct hoc/poc addresses in doc site reference

### DIFF
--- a/docs/testnet/essentials.md
+++ b/docs/testnet/essentials.md
@@ -35,11 +35,11 @@ Please contact us in the discord if you'd like some tokens to test with these co
 Hocus (HOC):
 
 ```
-0x9802F661d17c65527D7ABB59DAAD5439cb125a67
+0xf3a8bd422097bFdd9B3519Eaeb533393a1c561aC
 ```
 
 Pocus (POC):
 
 ```
-0xf3a8bd422097bFdd9B3519Eaeb533393a1c561aC
+0x9802F661d17c65527D7ABB59DAAD5439cb125a67
 ```


### PR DESCRIPTION
### Why is this change needed?

- HOC/POC were the wrong way round. The correct addresses can be confirmed in `bridge.go` and in the L2 contract deployment logs in the testnet deployment github actions.

### What changes were made as part of this PR:

- swap the addresses


### :rotating_light: Definition of Done :rotating_light:
- [ ] Deployed into dev-testnet 
- [ ] Passes tests on dev-testnet
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated
