### PR TITLE
Add obscuro client for Go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,13 +18,13 @@ require (
 	github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416
 	github.com/rs/zerolog v1.26.1
 	github.com/status-im/keycard-go v0.0.0-20190316090335-8537d3370df4
-	github.com/stretchr/testify v1.7.1
+	github.com/stretchr/testify v1.8.0
 	github.com/tidwall/gjson v1.11.0
 	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	google.golang.org/grpc v1.45.0
 	google.golang.org/protobuf v1.28.0
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -80,6 +80,7 @@ require (
 	github.com/rs/cors v1.7.0 // indirect
 	github.com/shirou/gopsutil v3.21.4-0.20210419000835-c7a38de76ee5+incompatible // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
+	github.com/stretchr/objx v0.4.0 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -590,6 +590,8 @@ github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271/go.mod h1:AZpEONHx3
 github.com/streadway/handy v0.0.0-20190108123426-d5acb3125c2a/go.mod h1:qNTQ5P5JnDBl6z3cMAg/SywNDC5ABu5ApDIw6lUbRmI=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0 h1:M2gUjqZET1qApGOWNSnZ49BAIMX4F/1plDv3+l31EJ4=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/testify v1.2.0/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
@@ -598,6 +600,8 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 h1:epCh84lMvA70Z7CTTCmYQn2CKbY8j86K7/FAIr141uY=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
 github.com/tidwall/gjson v1.11.0 h1:C16pk7tQNiH6VlCrtIXL1w8GaOsi1X3W8KDkE1BuYd4=
@@ -953,6 +957,8 @@ gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/go/ethadapter/obscuro_rpc_client.go
+++ b/go/ethadapter/obscuro_rpc_client.go
@@ -26,6 +26,8 @@ var ErrReceiptNotFound = errors.New("receipt not found, received nil response")
 
 // obscuroWalletRPCClient implements the EthClient interface, it's bound to a single wallet (viewing key and address)
 //
+// todo: remove this client, it is deprecated, use obsclient.AuthObsClient instead.
+//
 // Note: Why does this exist (why use a geth-focused interface for our obscuro interactions)?
 // - We have code (like deploying contracts) that we want to run against both L1 and L2, useful to be able to treat them the same
 // - Maintaining this interface helps ensure we remain closely compatible with eth usability

--- a/go/obsclient/README.md
+++ b/go/obsclient/README.md
@@ -6,7 +6,7 @@ It aims to provide all the same methods that the geth ethclient provides for com
 
 There are two clients, `ObsClient` and `AuthObsClient`
 
-`ObsClient` just requires a NodeClient and provides access to general Obscuro functionality that doesn't require viewing keys.
+`ObsClient` just requires a Client and provides access to general Obscuro functionality that doesn't require viewing keys.
 
-`AuthObsClient` requires a NodeClient, an account and a Viewing Key with signature. It provides full Obscuro functionality,
-authenticating with the node and encrypting/decrypting sensitive requests.
+`AuthObsClient` requires a EncRPCClient, which is an RPC client with an account and a signed Viewing Key for authentication.
+It provides full Obscuro functionality, authenticating with the node and encrypting/decrypting sensitive requests.

--- a/go/obsclient/README.md
+++ b/go/obsclient/README.md
@@ -1,0 +1,12 @@
+This package is analogous to the ethclient package in go-ethereum.
+
+It provides a higher level, standard way to interact with an Obscuro network programmatically.
+
+It aims to provide all the same methods that the geth ethclient provides for compatibility/familiarity, as well as obscuro-specific methods.
+
+There are two clients, `ObsClient` and `AuthObsClient`
+
+`Client` just requires a NodeClient and provides access to general Obscuro functionality that doesn't require viewing keys.
+
+`AuthObsClient` requires a NodeClient, an account and a Viewing Key with signature. It provides full Obscuro functionality,
+authenticating with the node and encrypting/decrypting sensitive requests.

--- a/go/obsclient/README.md
+++ b/go/obsclient/README.md
@@ -6,7 +6,7 @@ It aims to provide all the same methods that the geth ethclient provides for com
 
 There are two clients, `ObsClient` and `AuthObsClient`
 
-`Client` just requires a NodeClient and provides access to general Obscuro functionality that doesn't require viewing keys.
+`ObsClient` just requires a NodeClient and provides access to general Obscuro functionality that doesn't require viewing keys.
 
 `AuthObsClient` requires a NodeClient, an account and a Viewing Key with signature. It provides full Obscuro functionality,
 authenticating with the node and encrypting/decrypting sensitive requests.

--- a/go/obsclient/authclient.go
+++ b/go/obsclient/authclient.go
@@ -2,8 +2,9 @@ package obsclient
 
 import (
 	"context"
-	"github.com/obscuronet/go-obscuro/go/wallet"
 	"math/big"
+
+	"github.com/obscuronet/go-obscuro/go/wallet"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
@@ -33,7 +34,8 @@ func NewAuthObsClient(client *rpcclientlib.EncRPCClient) *AuthObsClient {
 }
 
 // DialWithAuth will generate and sign a viewing key for given wallet, then initiate a connection with the RPC node and
-//   register the viewing key
+//
+//	register the viewing key
 func DialWithAuth(rpcurl string, wal wallet.Wallet) (*AuthObsClient, error) {
 	viewingKey, err := rpcclientlib.GenerateAndSignViewingKey(wal)
 	if err != nil {

--- a/go/obsclient/authclient.go
+++ b/go/obsclient/authclient.go
@@ -2,16 +2,17 @@ package obsclient
 
 import (
 	"context"
+	"math/big"
+
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/obscuronet/go-obscuro/go/rpcclientlib"
-	"math/big"
 )
 
-// AuthObsClient extends the functionality of the ObsClient for all methods that require encryption when communicating with
-//	the enclave
+// AuthObsClient extends the functionality of the ObsClient for all methods that require encryption when communicating
+//	with the enclave
 type AuthObsClient struct {
 	ObsClient
 	c rpcclientlib.Client
@@ -75,46 +76,3 @@ func (ac *AuthObsClient) CallContract(ctx context.Context, msg ethereum.CallMsg,
 func (ac *AuthObsClient) SendTransaction(ctx context.Context, signedTx *types.Transaction) error {
 	return ac.c.CallContext(ctx, nil, rpcclientlib.RPCSendRawTransaction, encodeTx(signedTx))
 }
-
-//func Dial(rawurl string) (*Client, error) {
-//func DialContext(ctx context.Context, rawurl string) (*Client, error) {
-//func NewClient(c *rpc.Client) *Client {
-//func (ec *Client) Close() {
-//func (ec *Client) ChainID(ctx context.Context) (*big.Int, error) {
-//func (ec *Client) BlockByHash(ctx context.Context, hash common.Hash) (*types.Block, error) {
-//func (ec *Client) BlockByNumber(ctx context.Context, number *big.Int) (*types.Block, error) {
-//func (ec *Client) BlockNumber(ctx context.Context) (uint64, error) {
-//func (ec *Client) getBlock(ctx context.Context, method string, args ...interface{}) (*types.Block, error) {
-//func (ec *Client) HeaderByHash(ctx context.Context, hash common.Hash) (*types.Header, error) {
-//func (ec *Client) HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error) {
-//func (tx *rpcTransaction) UnmarshalJSON(msg []byte) error {
-//func (ec *Client) TransactionByHash(ctx context.Context, hash common.Hash) (tx *types.Transaction, isPending bool, err error) {
-//func (ec *Client) TransactionSender(ctx context.Context, tx *types.Transaction, block common.Hash, index uint) (common.Address, error) {
-//func (ec *Client) TransactionCount(ctx context.Context, blockHash common.Hash) (uint, error) {
-//func (ec *Client) TransactionInBlock(ctx context.Context, blockHash common.Hash, index uint) (*types.Transaction, error) {
-//func (ec *Client) TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {
-//func (ec *Client) SyncProgress(ctx context.Context) (*ethereum.SyncProgress, error) {
-//func (ec *Client) SubscribeNewHead(ctx context.Context, ch chan<- *types.Header) (ethereum.Subscription, error) {
-//func (ec *Client) NetworkID(ctx context.Context) (*big.Int, error) {
-//func (ec *Client) BalanceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (*big.Int, error) {
-//func (ec *Client) StorageAt(ctx context.Context, account common.Address, key common.Hash, blockNumber *big.Int) ([]byte, error) {
-//func (ec *Client) CodeAt(ctx context.Context, account common.Address, blockNumber *big.Int) ([]byte, error) {
-//func (ec *Client) NonceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (uint64, error) {
-//func (ec *Client) FilterLogs(ctx context.Context, q ethereum.FilterQuery) ([]types.Log, error) {
-//func (ec *Client) SubscribeFilterLogs(ctx context.Context, q ethereum.FilterQuery, ch chan<- types.Log) (ethereum.Subscription, error) {
-//func toFilterArg(q ethereum.FilterQuery) (interface{}, error) {
-//func (ec *Client) PendingBalanceAt(ctx context.Context, account common.Address) (*big.Int, error) {
-//func (ec *Client) PendingStorageAt(ctx context.Context, account common.Address, key common.Hash) ([]byte, error) {
-//func (ec *Client) PendingCodeAt(ctx context.Context, account common.Address) ([]byte, error) {
-//func (ec *Client) PendingNonceAt(ctx context.Context, account common.Address) (uint64, error) {
-//func (ec *Client) PendingTransactionCount(ctx context.Context) (uint, error) {
-//func (ec *Client) CallContract(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
-//func (ec *Client) CallContractAtHash(ctx context.Context, msg ethereum.CallMsg, blockHash common.Hash) ([]byte, error) {
-//func (ec *Client) PendingCallContract(ctx context.Context, msg ethereum.CallMsg) ([]byte, error) {
-//func (ec *Client) SuggestGasPrice(ctx context.Context) (*big.Int, error) {
-//func (ec *Client) SuggestGasTipCap(ctx context.Context) (*big.Int, error) {
-//func (ec *Client) EstimateGas(ctx context.Context, msg ethereum.CallMsg) (uint64, error) {
-//func (ec *Client) SendTransaction(ctx context.Context, tx *types.Transaction) error {
-//func toBlockNumArg(number *big.Int) string {
-//func toCallArg(msg ethereum.CallMsg) interface{} {
-//func (p *rpcProgress) toSyncProgress() *ethereum.SyncProgress {

--- a/go/obsclient/authclient.go
+++ b/go/obsclient/authclient.go
@@ -12,6 +12,7 @@ import (
 )
 
 // AuthObsClient extends the functionality of the ObsClient for all methods that require encryption when communicating
+//
 //	with the enclave
 type AuthObsClient struct {
 	ObsClient
@@ -19,7 +20,8 @@ type AuthObsClient struct {
 }
 
 // NewAuthObsClient constructs an AuthObsClient for sensitive communication with an enclave.
-// 	It requires an EncRPCClient specifically even though the AuthObsClient uses a Client interface in its struct because
+//
+//	It requires an EncRPCClient specifically even though the AuthObsClient uses a Client interface in its struct because
 //	the Client interface makes testing easy but an EncRPCClient is required for the actual encrypted communication
 func NewAuthObsClient(client *rpcclientlib.EncRPCClient) *AuthObsClient {
 	return &AuthObsClient{

--- a/go/obsclient/authclient.go
+++ b/go/obsclient/authclient.go
@@ -11,9 +11,7 @@ import (
 	"github.com/obscuronet/go-obscuro/go/rpcclientlib"
 )
 
-// AuthObsClient extends the functionality of the ObsClient for all methods that require encryption when communicating
-//
-//	with the enclave
+// AuthObsClient extends the functionality of the ObsClient for all methods that require encryption when communicating with the enclave
 type AuthObsClient struct {
 	ObsClient
 	c rpcclientlib.Client

--- a/go/obsclient/authclient.go
+++ b/go/obsclient/authclient.go
@@ -1,0 +1,120 @@
+package obsclient
+
+import (
+	"context"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/obscuronet/go-obscuro/go/rpcclientlib"
+	"math/big"
+)
+
+// AuthObsClient extends the functionality of the ObsClient for all methods that require encryption when communicating with
+//	the enclave
+type AuthObsClient struct {
+	ObsClient
+	c rpcclientlib.Client
+}
+
+// NewAuthObsClient constructs an AuthObsClient for sensitive communication with an enclave.
+// 	It requires an EncRPCClient specifically even though the AuthObsClient uses a Client interface in its struct because
+//	the Client interface makes testing easy but an EncRPCClient is required for the actual encrypted communication
+func NewAuthObsClient(client *rpcclientlib.EncRPCClient) *AuthObsClient {
+	return &AuthObsClient{
+		ObsClient: ObsClient{
+			c: client,
+		},
+		c: client,
+	}
+}
+
+func (ac *AuthObsClient) Close() {
+	ac.c.Stop()
+	ac.ObsClient.Close()
+}
+
+// TransactionByHash returns transaction (if found), isPending (always false currently as we don't search the mempool), error
+func (ac *AuthObsClient) TransactionByHash(ctx context.Context, hash common.Hash) (*types.Transaction, bool, error) {
+	var tx types.Transaction
+	err := ac.c.CallContext(ctx, &tx, rpcclientlib.RPCGetTransactionByHash, hash.Hex())
+	// todo: revisit isPending result value, included for ethclient equivalence but hardcoded currently
+	return &tx, false, err
+}
+
+func (ac *AuthObsClient) TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {
+	var receipt types.Receipt
+	err := ac.c.CallContext(ctx, &receipt, rpcclientlib.RPCGetTxReceipt, txHash)
+	return &receipt, err
+}
+
+func (ac *AuthObsClient) NonceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (uint64, error) {
+	var result hexutil.Uint64
+	err := ac.c.CallContext(ctx, &result, rpcclientlib.RPCNonce, account, toBlockNumArg(blockNumber))
+	return uint64(result), err
+}
+
+// Contract Calling
+
+// CallContract executes a message call transaction, which is directly executed in the VM
+// of the node, but never mined into the blockchain.
+//
+// blockNumber selects the block height at which the call runs. It can be nil, in which
+// case the code is taken from the latest known block. Note that state from very old
+// blocks might not be available.
+func (ac *AuthObsClient) CallContract(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+	var hex string
+	err := ac.c.CallContext(ctx, &hex, rpcclientlib.RPCCall, toCallArg(msg), toBlockNumArg(blockNumber))
+	return []byte(hex), err
+}
+
+// SendTransaction injects a signed transaction into the pending pool for execution.
+//
+// If the transaction was a contract creation use the TransactionReceipt method to get the
+// contract address after the transaction has been mined.
+func (ac *AuthObsClient) SendTransaction(ctx context.Context, signedTx *types.Transaction) error {
+	return ac.c.CallContext(ctx, nil, rpcclientlib.RPCSendRawTransaction, encodeTx(signedTx))
+}
+
+//func Dial(rawurl string) (*Client, error) {
+//func DialContext(ctx context.Context, rawurl string) (*Client, error) {
+//func NewClient(c *rpc.Client) *Client {
+//func (ec *Client) Close() {
+//func (ec *Client) ChainID(ctx context.Context) (*big.Int, error) {
+//func (ec *Client) BlockByHash(ctx context.Context, hash common.Hash) (*types.Block, error) {
+//func (ec *Client) BlockByNumber(ctx context.Context, number *big.Int) (*types.Block, error) {
+//func (ec *Client) BlockNumber(ctx context.Context) (uint64, error) {
+//func (ec *Client) getBlock(ctx context.Context, method string, args ...interface{}) (*types.Block, error) {
+//func (ec *Client) HeaderByHash(ctx context.Context, hash common.Hash) (*types.Header, error) {
+//func (ec *Client) HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error) {
+//func (tx *rpcTransaction) UnmarshalJSON(msg []byte) error {
+//func (ec *Client) TransactionByHash(ctx context.Context, hash common.Hash) (tx *types.Transaction, isPending bool, err error) {
+//func (ec *Client) TransactionSender(ctx context.Context, tx *types.Transaction, block common.Hash, index uint) (common.Address, error) {
+//func (ec *Client) TransactionCount(ctx context.Context, blockHash common.Hash) (uint, error) {
+//func (ec *Client) TransactionInBlock(ctx context.Context, blockHash common.Hash, index uint) (*types.Transaction, error) {
+//func (ec *Client) TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {
+//func (ec *Client) SyncProgress(ctx context.Context) (*ethereum.SyncProgress, error) {
+//func (ec *Client) SubscribeNewHead(ctx context.Context, ch chan<- *types.Header) (ethereum.Subscription, error) {
+//func (ec *Client) NetworkID(ctx context.Context) (*big.Int, error) {
+//func (ec *Client) BalanceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (*big.Int, error) {
+//func (ec *Client) StorageAt(ctx context.Context, account common.Address, key common.Hash, blockNumber *big.Int) ([]byte, error) {
+//func (ec *Client) CodeAt(ctx context.Context, account common.Address, blockNumber *big.Int) ([]byte, error) {
+//func (ec *Client) NonceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (uint64, error) {
+//func (ec *Client) FilterLogs(ctx context.Context, q ethereum.FilterQuery) ([]types.Log, error) {
+//func (ec *Client) SubscribeFilterLogs(ctx context.Context, q ethereum.FilterQuery, ch chan<- types.Log) (ethereum.Subscription, error) {
+//func toFilterArg(q ethereum.FilterQuery) (interface{}, error) {
+//func (ec *Client) PendingBalanceAt(ctx context.Context, account common.Address) (*big.Int, error) {
+//func (ec *Client) PendingStorageAt(ctx context.Context, account common.Address, key common.Hash) ([]byte, error) {
+//func (ec *Client) PendingCodeAt(ctx context.Context, account common.Address) ([]byte, error) {
+//func (ec *Client) PendingNonceAt(ctx context.Context, account common.Address) (uint64, error) {
+//func (ec *Client) PendingTransactionCount(ctx context.Context) (uint, error) {
+//func (ec *Client) CallContract(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+//func (ec *Client) CallContractAtHash(ctx context.Context, msg ethereum.CallMsg, blockHash common.Hash) ([]byte, error) {
+//func (ec *Client) PendingCallContract(ctx context.Context, msg ethereum.CallMsg) ([]byte, error) {
+//func (ec *Client) SuggestGasPrice(ctx context.Context) (*big.Int, error) {
+//func (ec *Client) SuggestGasTipCap(ctx context.Context) (*big.Int, error) {
+//func (ec *Client) EstimateGas(ctx context.Context, msg ethereum.CallMsg) (uint64, error) {
+//func (ec *Client) SendTransaction(ctx context.Context, tx *types.Transaction) error {
+//func toBlockNumArg(number *big.Int) string {
+//func toCallArg(msg ethereum.CallMsg) interface{} {
+//func (p *rpcProgress) toSyncProgress() *ethereum.SyncProgress {

--- a/go/obsclient/authclient.go
+++ b/go/obsclient/authclient.go
@@ -2,6 +2,7 @@ package obsclient
 
 import (
 	"context"
+	"github.com/obscuronet/go-obscuro/go/wallet"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum"
@@ -12,67 +13,65 @@ import (
 )
 
 // AuthObsClient extends the functionality of the ObsClient for all methods that require encryption when communicating with the enclave
+// It is created with an EncRPCClient rather than basic RPC client so encryption/decryption is supported
+//
+// The methods in this client are analogous to the methods in geth's EthClient and should behave the same unless noted otherwise.
 type AuthObsClient struct {
 	ObsClient
-	c rpcclientlib.Client
 }
 
 // NewAuthObsClient constructs an AuthObsClient for sensitive communication with an enclave.
 //
-//	It requires an EncRPCClient specifically even though the AuthObsClient uses a Client interface in its struct because
-//	the Client interface makes testing easy but an EncRPCClient is required for the actual encrypted communication
+// It requires an EncRPCClient specifically even though the AuthObsClient uses a Client interface in its struct because
+// the Client interface makes testing easy but an EncRPCClient is required for the actual encrypted communication
 func NewAuthObsClient(client *rpcclientlib.EncRPCClient) *AuthObsClient {
 	return &AuthObsClient{
 		ObsClient: ObsClient{
-			c: client,
+			RPCClient: client,
 		},
-		c: client,
 	}
 }
 
-func (ac *AuthObsClient) Close() {
-	ac.c.Stop()
-	ac.ObsClient.Close()
+// DialWithAuth will generate and sign a viewing key for given wallet, then initiate a connection with the RPC node and
+//   register the viewing key
+func DialWithAuth(rpcurl string, wal wallet.Wallet) (*AuthObsClient, error) {
+	viewingKey, err := rpcclientlib.GenerateAndSignViewingKey(wal)
+	if err != nil {
+		return nil, err
+	}
+	encClient, err := rpcclientlib.NewEncNetworkClient(rpcurl, viewingKey)
+	if err != nil {
+		return nil, err
+	}
+	return NewAuthObsClient(encClient), nil
 }
 
 // TransactionByHash returns transaction (if found), isPending (always false currently as we don't search the mempool), error
 func (ac *AuthObsClient) TransactionByHash(ctx context.Context, hash common.Hash) (*types.Transaction, bool, error) {
 	var tx types.Transaction
-	err := ac.c.CallContext(ctx, &tx, rpcclientlib.RPCGetTransactionByHash, hash.Hex())
+	err := ac.RPCClient.CallContext(ctx, &tx, rpcclientlib.RPCGetTransactionByHash, hash.Hex())
 	// todo: revisit isPending result value, included for ethclient equivalence but hardcoded currently
 	return &tx, false, err
 }
 
 func (ac *AuthObsClient) TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {
 	var receipt types.Receipt
-	err := ac.c.CallContext(ctx, &receipt, rpcclientlib.RPCGetTxReceipt, txHash)
+	err := ac.RPCClient.CallContext(ctx, &receipt, rpcclientlib.RPCGetTxReceipt, txHash)
 	return &receipt, err
 }
 
 func (ac *AuthObsClient) NonceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (uint64, error) {
 	var result hexutil.Uint64
-	err := ac.c.CallContext(ctx, &result, rpcclientlib.RPCNonce, account, toBlockNumArg(blockNumber))
+	err := ac.RPCClient.CallContext(ctx, &result, rpcclientlib.RPCNonce, account, toBlockNumArg(blockNumber))
 	return uint64(result), err
 }
 
-// Contract Calling
-
-// CallContract executes a message call transaction, which is directly executed in the VM
-// of the node, but never mined into the blockchain.
-//
-// blockNumber selects the block height at which the call runs. It can be nil, in which
-// case the code is taken from the latest known block. Note that state from very old
-// blocks might not be available.
 func (ac *AuthObsClient) CallContract(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
 	var hex string
-	err := ac.c.CallContext(ctx, &hex, rpcclientlib.RPCCall, toCallArg(msg), toBlockNumArg(blockNumber))
+	err := ac.RPCClient.CallContext(ctx, &hex, rpcclientlib.RPCCall, toCallArg(msg), toBlockNumArg(blockNumber))
 	return []byte(hex), err
 }
 
-// SendTransaction injects a signed transaction into the pending pool for execution.
-//
-// If the transaction was a contract creation use the TransactionReceipt method to get the
-// contract address after the transaction has been mined.
 func (ac *AuthObsClient) SendTransaction(ctx context.Context, signedTx *types.Transaction) error {
-	return ac.c.CallContext(ctx, nil, rpcclientlib.RPCSendRawTransaction, encodeTx(signedTx))
+	return ac.RPCClient.CallContext(ctx, nil, rpcclientlib.RPCSendRawTransaction, encodeTx(signedTx))
 }

--- a/go/obsclient/authclient_test.go
+++ b/go/obsclient/authclient_test.go
@@ -1,0 +1,49 @@
+package obsclient
+
+import (
+	"context"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/obscuronet/go-obscuro/go/rpcclientlib"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"testing"
+)
+
+var (
+	// since the RPC client is mocked out in these tests we are never testing the context and we just use this
+	testCtx = context.TODO()
+	testAcc = common.BytesToAddress(common.Hex2Bytes("0000000000000000000000000000000000000abc"))
+)
+
+func TestNonceAt_ConvertsNilBlockNumberToLatest(t *testing.T) {
+	mockRpc, authClient := createAuthClientWithMockRPCClient()
+
+	// expect mock to be called once with the nonce request, it should have translated nil blockNumber to "latest" string
+	mockRpc.On(
+		"CallContext",
+		testCtx, mock.AnythingOfType("*hexutil.Uint64"), rpcclientlib.RPCNonce, []interface{}{testAcc, "latest"},
+	).Return(nil).Run(func(args mock.Arguments) {
+		res := args.Get(1).(*hexutil.Uint64)
+		// set the result pointer in the RPC client
+		*res = 2
+	})
+
+	nonce, err := authClient.NonceAt(testCtx, testAcc, nil)
+
+	// assert mock called as expected
+	mockRpc.AssertExpectations(t)
+	// assert no error
+	assert.Nil(t, err)
+	// assert nonce returned correctly
+	assert.Equal(t, uint64(2), nonce)
+}
+
+func createAuthClientWithMockRPCClient() (*rpcClientMock, *AuthObsClient) {
+	mockRpc := new(rpcClientMock)
+	authClient := &AuthObsClient{
+		ObsClient: ObsClient{c: mockRpc},
+		c:         mockRpc,
+	}
+	return mockRpc, authClient
+}

--- a/go/obsclient/authclient_test.go
+++ b/go/obsclient/authclient_test.go
@@ -46,8 +46,7 @@ func TestNonceAt_ConvertsNilBlockNumberToLatest(t *testing.T) {
 func createAuthClientWithMockRPCClient() (*rpcClientMock, *AuthObsClient) {
 	mockRPC := new(rpcClientMock)
 	authClient := &AuthObsClient{
-		ObsClient: ObsClient{c: mockRPC},
-		c:         mockRPC,
+		ObsClient: ObsClient{RPCClient: mockRPC},
 	}
 	return mockRPC, authClient
 }

--- a/go/obsclient/encoding.go
+++ b/go/obsclient/encoding.go
@@ -1,11 +1,12 @@
 package obsclient
 
 import (
+	"math/big"
+
 	"github.com/ethereum/go-ethereum"
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/obscuronet/go-obscuro/go/common"
-	"math/big"
 )
 
 // utils for converting to RPC message format - mostly ported from geth client

--- a/go/obsclient/encoding.go
+++ b/go/obsclient/encoding.go
@@ -1,0 +1,55 @@
+package obsclient
+
+import (
+	"github.com/ethereum/go-ethereum"
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/obscuronet/go-obscuro/go/common"
+	"math/big"
+)
+
+// utils for converting to RPC message format - mostly ported from geth client
+
+// Formats a transaction for sending to the enclave
+func encodeTx(tx *common.L2Tx) string {
+	txBinary, err := tx.MarshalBinary()
+	if err != nil {
+		panic(err)
+	}
+
+	// We convert the transaction binary to the form expected for sending transactions via RPC.
+	txBinaryHex := gethcommon.Bytes2Hex(txBinary)
+
+	return "0x" + txBinaryHex
+}
+
+func toCallArg(msg ethereum.CallMsg) interface{} {
+	arg := map[string]interface{}{
+		"from": msg.From,
+		"to":   msg.To,
+	}
+	if len(msg.Data) > 0 {
+		arg["data"] = hexutil.Bytes(msg.Data)
+	}
+	if msg.Value != nil {
+		arg["value"] = (*hexutil.Big)(msg.Value)
+	}
+	if msg.Gas != 0 {
+		arg["gas"] = hexutil.Uint64(msg.Gas)
+	}
+	if msg.GasPrice != nil {
+		arg["gasPrice"] = (*hexutil.Big)(msg.GasPrice)
+	}
+	return arg
+}
+
+func toBlockNumArg(number *big.Int) string {
+	if number == nil {
+		return "latest"
+	}
+	pending := big.NewInt(-1)
+	if number.Cmp(pending) == 0 {
+		return "pending"
+	}
+	return hexutil.EncodeBig(number)
+}

--- a/go/obsclient/obsclient.go
+++ b/go/obsclient/obsclient.go
@@ -19,10 +19,10 @@ func Dial(rawurl string) (*ObsClient, error) {
 	if err != nil {
 		return nil, err
 	}
-	return NewClient(rc), nil
+	return NewObsClient(rc), nil
 }
 
-func NewClient(c rpcclientlib.Client) *ObsClient {
+func NewObsClient(c rpcclientlib.Client) *ObsClient {
 	return &ObsClient{c}
 }
 

--- a/go/obsclient/obsclient.go
+++ b/go/obsclient/obsclient.go
@@ -1,9 +1,10 @@
 package obsclient
 
 import (
+	"math/big"
+
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/obscuronet/go-obscuro/go/rpcclientlib"
-	"math/big"
 )
 
 // ObsClient requires an RPC Client and provides access to general Obscuro functionality that doesn't require viewing keys.

--- a/go/obsclient/obsclient.go
+++ b/go/obsclient/obsclient.go
@@ -35,7 +35,7 @@ func (oc *ObsClient) Close() {
 // ChainID retrieves the current chain ID for transaction replay protection.
 func (oc *ObsClient) ChainID() (*big.Int, error) {
 	var result hexutil.Big
-	err := oc.RPCClient.Call(&result, "eth_chainId")
+	err := oc.RPCClient.Call(&result, rpcclientlib.RPCChainID)
 	if err != nil {
 		return nil, err
 	}

--- a/go/obsclient/obsclient.go
+++ b/go/obsclient/obsclient.go
@@ -1,0 +1,40 @@
+package obsclient
+
+import (
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/obscuronet/go-obscuro/go/rpcclientlib"
+	"math/big"
+)
+
+// ObsClient requires an RPC Client and provides access to general Obscuro functionality that doesn't require viewing keys.
+type ObsClient struct {
+	c rpcclientlib.Client
+}
+
+func Dial(rawurl string) (*ObsClient, error) {
+	rc, err := rpcclientlib.NewNetworkClient(rawurl)
+	if err != nil {
+		return nil, err
+	}
+	return NewClient(rc), nil
+}
+
+func NewClient(c rpcclientlib.Client) *ObsClient {
+	return &ObsClient{c}
+}
+
+func (oc *ObsClient) Close() {
+	oc.c.Stop()
+}
+
+// Blockchain Access
+
+// ChainID retrieves the current chain ID for transaction replay protection.
+func (oc *ObsClient) ChainID() (*big.Int, error) {
+	var result hexutil.Big
+	err := oc.c.Call(&result, "eth_chainId")
+	if err != nil {
+		return nil, err
+	}
+	return (*big.Int)(&result), err
+}

--- a/go/obsclient/obsclient.go
+++ b/go/obsclient/obsclient.go
@@ -8,8 +8,10 @@ import (
 )
 
 // ObsClient requires an RPC Client and provides access to general Obscuro functionality that doesn't require viewing keys.
+//
+// The methods in this client are analogous to the methods in geth's EthClient and should behave the same unless noted otherwise.
 type ObsClient struct {
-	c rpcclientlib.Client
+	RPCClient rpcclientlib.Client
 }
 
 func Dial(rawurl string) (*ObsClient, error) {
@@ -25,7 +27,7 @@ func NewClient(c rpcclientlib.Client) *ObsClient {
 }
 
 func (oc *ObsClient) Close() {
-	oc.c.Stop()
+	oc.RPCClient.Stop()
 }
 
 // Blockchain Access
@@ -33,7 +35,7 @@ func (oc *ObsClient) Close() {
 // ChainID retrieves the current chain ID for transaction replay protection.
 func (oc *ObsClient) ChainID() (*big.Int, error) {
 	var result hexutil.Big
-	err := oc.c.Call(&result, "eth_chainId")
+	err := oc.RPCClient.Call(&result, "eth_chainId")
 	if err != nil {
 		return nil, err
 	}

--- a/go/obsclient/test_util.go
+++ b/go/obsclient/test_util.go
@@ -1,0 +1,23 @@
+package obsclient
+
+import (
+	"context"
+	"github.com/stretchr/testify/mock"
+)
+
+// this mock lets us simulate responses from the RPC client, so we can verify the obsclient usage and response handling
+type rpcClientMock struct {
+	mock.Mock
+}
+
+func (m *rpcClientMock) Call(result interface{}, method string, args ...interface{}) error {
+	arguments := m.Called(result, method, args)
+	return arguments.Error(0)
+}
+func (m *rpcClientMock) CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error {
+	arguments := m.Called(ctx, result, method, args)
+	return arguments.Error(0)
+}
+func (m *rpcClientMock) Stop() {
+	m.Called()
+}

--- a/go/obsclient/test_util.go
+++ b/go/obsclient/test_util.go
@@ -2,6 +2,7 @@ package obsclient
 
 import (
 	"context"
+
 	"github.com/stretchr/testify/mock"
 )
 
@@ -14,10 +15,12 @@ func (m *rpcClientMock) Call(result interface{}, method string, args ...interfac
 	arguments := m.Called(result, method, args)
 	return arguments.Error(0)
 }
+
 func (m *rpcClientMock) CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error {
 	arguments := m.Called(ctx, result, method, args)
 	return arguments.Error(0)
 }
+
 func (m *rpcClientMock) Stop() {
 	m.Called()
 }

--- a/integration/common/utils.go
+++ b/integration/common/utils.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/obscuronet/go-obscuro/go/obsclient"
 	"math/big"
 	"math/rand"
 	"sync"
 	"time"
+
+	"github.com/obscuronet/go-obscuro/go/obsclient"
 
 	"github.com/obscuronet/go-obscuro/go/wallet"
 
@@ -110,7 +111,7 @@ func PrefundWallets(ctx context.Context, faucetWallet wallet.Wallet, faucetClien
 		wg.Add(1)
 		go func(txHash gethcommon.Hash) {
 			defer wg.Done()
-			err := AwaitReceipt(nil, faucetClient, txHash)
+			err := AwaitReceipt(ctx, faucetClient, txHash)
 			if err != nil {
 				panic(fmt.Sprintf("faucet transfer transaction failed. Cause: %s", err))
 			}

--- a/integration/common/utils.go
+++ b/integration/common/utils.go
@@ -1,8 +1,10 @@
 package common
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"github.com/obscuronet/go-obscuro/go/obsclient"
 	"math/big"
 	"math/rand"
 	"sync"
@@ -37,11 +39,10 @@ func RndBtwTime(min time.Duration, max time.Duration) time.Duration {
 
 // AwaitReceipt blocks until the receipt for the transaction with the given hash has been received. Errors if the
 // transaction is unsuccessful or times out.
-func AwaitReceipt(client rpcclientlib.Client, txHash gethcommon.Hash) error {
-	var receipt types.Receipt
+func AwaitReceipt(ctx context.Context, client *obsclient.AuthObsClient, txHash gethcommon.Hash) error {
 	counter := 0
 	for {
-		err := client.Call(&receipt, rpcclientlib.RPCGetTxReceipt, txHash)
+		receipt, err := client.TransactionReceipt(ctx, txHash)
 		if err != nil {
 			if !errors.Is(err, rpcclientlib.ErrNilResponse) {
 				return err
@@ -78,7 +79,7 @@ func EncodeTx(tx *common.L2Tx) string {
 
 // PrefundWallets sends an amount `alloc` from the faucet wallet to each listed wallet.
 // The transactions are sent with sequential nonces, starting with `startingNonce`.
-func PrefundWallets(faucetWallet wallet.Wallet, faucetClient rpcclientlib.Client, startingNonce uint64, wallets []wallet.Wallet, alloc *big.Int) {
+func PrefundWallets(ctx context.Context, faucetWallet wallet.Wallet, faucetClient *obsclient.AuthObsClient, startingNonce uint64, wallets []wallet.Wallet, alloc *big.Int) {
 	// We send the transactions serially, so that we can precompute the nonces.
 	txHashes := make([]gethcommon.Hash, len(wallets))
 	for idx, w := range wallets {
@@ -95,7 +96,7 @@ func PrefundWallets(faucetWallet wallet.Wallet, faucetClient rpcclientlib.Client
 			panic(err)
 		}
 
-		err = faucetClient.Call(nil, rpcclientlib.RPCSendRawTransaction, EncodeTx(signedTx))
+		err = faucetClient.SendTransaction(ctx, signedTx)
 		if err != nil {
 			panic(fmt.Sprintf("could not transfer from faucet. Cause: %s", err))
 		}
@@ -109,7 +110,7 @@ func PrefundWallets(faucetWallet wallet.Wallet, faucetClient rpcclientlib.Client
 		wg.Add(1)
 		go func(txHash gethcommon.Hash) {
 			defer wg.Done()
-			err := AwaitReceipt(faucetClient, txHash)
+			err := AwaitReceipt(nil, faucetClient, txHash)
 			if err != nil {
 				panic(fmt.Sprintf("faucet transfer transaction failed. Cause: %s", err))
 			}

--- a/integration/contractdeployer/contract_deployer_test.go
+++ b/integration/contractdeployer/contract_deployer_test.go
@@ -75,7 +75,7 @@ func TestFaucetSendsFundsOnlyIfNeeded(t *testing.T) {
 	contractDeployerWallet := getWallet(contractDeployerPrivateKeyHex)
 	// We send more than enough to the contract deployer, to make sure prefunding won't be needed.
 	excessivePrealloc := big.NewInt(contractdeployer.Prealloc * 3)
-	testcommon.PrefundWallets(faucetWallet, faucetClient, 0, []wallet.Wallet{contractDeployerWallet}, excessivePrealloc)
+	testcommon.PrefundWallets(nil, faucetWallet, faucetClient, 0, []wallet.Wallet{contractDeployerWallet}, excessivePrealloc)
 
 	// We check the faucet's balance before and after the deployment. Since the contract deployer has already been sent
 	// sufficient funds, the faucet should have been to dispense any more, leaving its balance unchanged.

--- a/integration/contractdeployer/contract_deployer_test.go
+++ b/integration/contractdeployer/contract_deployer_test.go
@@ -1,10 +1,13 @@
 package contractdeployer
 
 import (
+	"context"
 	"fmt"
 	"math/big"
 	"testing"
 	"time"
+
+	"github.com/obscuronet/go-obscuro/go/obsclient"
 
 	testcommon "github.com/obscuronet/go-obscuro/integration/common"
 
@@ -75,7 +78,7 @@ func TestFaucetSendsFundsOnlyIfNeeded(t *testing.T) {
 	contractDeployerWallet := getWallet(contractDeployerPrivateKeyHex)
 	// We send more than enough to the contract deployer, to make sure prefunding won't be needed.
 	excessivePrealloc := big.NewInt(contractdeployer.Prealloc * 3)
-	testcommon.PrefundWallets(nil, faucetWallet, faucetClient, 0, []wallet.Wallet{contractDeployerWallet}, excessivePrealloc)
+	testcommon.PrefundWallets(context.Background(), faucetWallet, obsclient.NewAuthObsClient(faucetClient), 0, []wallet.Wallet{contractDeployerWallet}, excessivePrealloc)
 
 	// We check the faucet's balance before and after the deployment. Since the contract deployer has already been sent
 	// sufficient funds, the faucet should have been to dispense any more, leaving its balance unchanged.

--- a/integration/simulation/network/azureenclave.go
+++ b/integration/simulation/network/azureenclave.go
@@ -76,9 +76,9 @@ func (n *networkWithAzureEnclaves) Create(params *params.SimParams, stats *stats
 	n.hostRPCAddresses = hostRPCAddresses
 
 	return &RPCHandles{
-		EthClients:                    n.gethClients,
-		ObscuroClients:                n.obscuroClients,
-		VirtualWalletExtensionClients: walletClients,
+		EthClients:     n.gethClients,
+		ObscuroClients: n.obscuroClients,
+		AuthObsClients: walletClients,
 	}, nil
 }
 

--- a/integration/simulation/network/dockerenclave.go
+++ b/integration/simulation/network/dockerenclave.go
@@ -85,9 +85,9 @@ func (n *basicNetworkOfNodesWithDockerEnclave) Create(params *params.SimParams, 
 	n.hostRPCAddresses = hostRPCAddresses
 
 	return &RPCHandles{
-		EthClients:                    n.gethClients,
-		ObscuroClients:                obscuroClients,
-		VirtualWalletExtensionClients: walletClients,
+		EthClients:     n.gethClients,
+		ObscuroClients: obscuroClients,
+		AuthObsClients: walletClients,
 	}, nil
 }
 

--- a/integration/simulation/network/geth_network.go
+++ b/integration/simulation/network/geth_network.go
@@ -4,6 +4,7 @@ import (
 	"github.com/obscuronet/go-obscuro/go/ethadapter"
 	"github.com/obscuronet/go-obscuro/go/ethadapter/erc20contractlib"
 	"github.com/obscuronet/go-obscuro/go/ethadapter/mgmtcontractlib"
+	"github.com/obscuronet/go-obscuro/go/obsclient"
 	"github.com/obscuronet/go-obscuro/go/rpcclientlib"
 	"github.com/obscuronet/go-obscuro/integration/gethnetwork"
 	"github.com/obscuronet/go-obscuro/integration/simulation/params"
@@ -39,7 +40,7 @@ func (n *networkInMemGeth) Create(params *params.SimParams, stats *stats.Stats) 
 	params.ERC20ContractLib = erc20contractlib.NewERC20ContractLib(params.MgmtContractAddr, params.ObxErc20Address, params.EthErc20Address)
 
 	// Start the obscuro nodes and return the handles
-	var walletClients map[string][]rpcclientlib.Client
+	var walletClients map[string][]*obsclient.AuthObsClient
 	n.obscuroClients, walletClients = startInMemoryObscuroNodes(params, stats, n.gethNetwork.GenesisJSON, n.gethClients)
 
 	return &RPCHandles{

--- a/integration/simulation/network/geth_network.go
+++ b/integration/simulation/network/geth_network.go
@@ -44,9 +44,9 @@ func (n *networkInMemGeth) Create(params *params.SimParams, stats *stats.Stats) 
 	n.obscuroClients, walletClients = startInMemoryObscuroNodes(params, stats, n.gethNetwork.GenesisJSON, n.gethClients)
 
 	return &RPCHandles{
-		EthClients:                    n.gethClients,
-		ObscuroClients:                n.obscuroClients,
-		VirtualWalletExtensionClients: walletClients,
+		EthClients:     n.gethClients,
+		ObscuroClients: n.obscuroClients,
+		AuthObsClients: walletClients,
 	}, nil
 }
 

--- a/integration/simulation/network/inmemory.go
+++ b/integration/simulation/network/inmemory.go
@@ -102,9 +102,9 @@ func (n *basicNetworkOfInMemoryNodes) Create(params *params.SimParams, stats *st
 	walletClients := setupInMemWalletClients(params, obscuroNodes)
 
 	return &RPCHandles{
-		EthClients:                    l1Clients,
-		ObscuroClients:                n.obscuroClients,
-		VirtualWalletExtensionClients: walletClients,
+		EthClients:     l1Clients,
+		ObscuroClients: n.obscuroClients,
+		AuthObsClients: walletClients,
 	}, nil
 }
 

--- a/integration/simulation/network/network.go
+++ b/integration/simulation/network/network.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"github.com/obscuronet/go-obscuro/go/rpcclientlib"
 	"math/rand"
 
 	"github.com/obscuronet/go-obscuro/go/obsclient"
@@ -8,7 +9,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/obscuronet/go-obscuro/go/ethadapter"
-	"github.com/obscuronet/go-obscuro/go/rpcclientlib"
 	"github.com/obscuronet/go-obscuro/go/wallet"
 	"github.com/obscuronet/go-obscuro/integration/simulation/params"
 	"github.com/obscuronet/go-obscuro/integration/simulation/stats"
@@ -39,26 +39,22 @@ type RPCHandles struct {
 	//	to mimic user acc interaction via a wallet extension
 	// map of owner addresses to RPC clients for that owner (one per L2 node)
 	// todo: simplify this with a client per node when we have clients that can support multiple wallets
-	VirtualWalletExtensionClients map[string][]*obsclient.AuthObsClient
+	AuthObsClients map[string][]*obsclient.AuthObsClient
 }
 
 func (n *RPCHandles) RndEthClient() ethadapter.EthClient {
 	return n.EthClients[rand.Intn(len(n.EthClients))] //nolint:gosec
 }
 
-func (n *RPCHandles) RndObscuroClient() rpcclientlib.Client {
-	return n.ObscuroClients[rand.Intn(len(n.ObscuroClients))] //nolint:gosec
-}
-
 // ObscuroWalletRndClient fetches an RPC client connected to a random L2 node for a given wallet
 func (n *RPCHandles) ObscuroWalletRndClient(wallet wallet.Wallet) *obsclient.AuthObsClient {
 	addr := wallet.Address().String()
-	clients := n.VirtualWalletExtensionClients[addr]
+	clients := n.AuthObsClients[addr]
 	return clients[rand.Intn(len(clients))] //nolint:gosec
 }
 
 // ObscuroWalletClient fetches a client for a given wallet address, for a specific node
 func (n *RPCHandles) ObscuroWalletClient(walletAddress common.Address, nodeIdx int) *obsclient.AuthObsClient {
-	clients := n.VirtualWalletExtensionClients[walletAddress.String()]
+	clients := n.AuthObsClients[walletAddress.String()]
 	return clients[nodeIdx]
 }

--- a/integration/simulation/network/network.go
+++ b/integration/simulation/network/network.go
@@ -1,8 +1,9 @@
 package network
 
 import (
-	"github.com/obscuronet/go-obscuro/go/obsclient"
 	"math/rand"
+
+	"github.com/obscuronet/go-obscuro/go/obsclient"
 
 	"github.com/ethereum/go-ethereum/common"
 

--- a/integration/simulation/network/network.go
+++ b/integration/simulation/network/network.go
@@ -1,8 +1,9 @@
 package network
 
 import (
-	"github.com/obscuronet/go-obscuro/go/rpcclientlib"
 	"math/rand"
+
+	"github.com/obscuronet/go-obscuro/go/rpcclientlib"
 
 	"github.com/obscuronet/go-obscuro/go/obsclient"
 

--- a/integration/simulation/network/network.go
+++ b/integration/simulation/network/network.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"github.com/obscuronet/go-obscuro/go/obsclient"
 	"math/rand"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -37,7 +38,7 @@ type RPCHandles struct {
 	//	to mimic user acc interaction via a wallet extension
 	// map of owner addresses to RPC clients for that owner (one per L2 node)
 	// todo: simplify this with a client per node when we have clients that can support multiple wallets
-	VirtualWalletExtensionClients map[string][]rpcclientlib.Client
+	VirtualWalletExtensionClients map[string][]*obsclient.AuthObsClient
 }
 
 func (n *RPCHandles) RndEthClient() ethadapter.EthClient {
@@ -49,14 +50,14 @@ func (n *RPCHandles) RndObscuroClient() rpcclientlib.Client {
 }
 
 // ObscuroWalletRndClient fetches an RPC client connected to a random L2 node for a given wallet
-func (n *RPCHandles) ObscuroWalletRndClient(wallet wallet.Wallet) rpcclientlib.Client {
+func (n *RPCHandles) ObscuroWalletRndClient(wallet wallet.Wallet) *obsclient.AuthObsClient {
 	addr := wallet.Address().String()
 	clients := n.VirtualWalletExtensionClients[addr]
 	return clients[rand.Intn(len(clients))] //nolint:gosec
 }
 
 // ObscuroWalletClient fetches a client for a given wallet address, for a specific node
-func (n *RPCHandles) ObscuroWalletClient(walletAddress common.Address, nodeIdx int) rpcclientlib.Client {
+func (n *RPCHandles) ObscuroWalletClient(walletAddress common.Address, nodeIdx int) *obsclient.AuthObsClient {
 	clients := n.VirtualWalletExtensionClients[walletAddress.String()]
 	return clients[nodeIdx]
 }

--- a/integration/simulation/network/obscuro_node_utils.go
+++ b/integration/simulation/network/obscuro_node_utils.go
@@ -2,11 +2,12 @@ package network
 
 import (
 	"fmt"
-	"github.com/obscuronet/go-obscuro/go/obsclient"
 	"math/big"
 	"net"
 	"sync"
 	"time"
+
+	"github.com/obscuronet/go-obscuro/go/obsclient"
 
 	"github.com/obscuronet/go-obscuro/go/host"
 	"github.com/obscuronet/go-obscuro/go/wallet"
@@ -86,7 +87,8 @@ func setupInMemWalletClients(params *params.SimParams, obscuroNodes []host.MockH
 
 // todo: this method is quite heavy, should refactor to separate out the creation of the nodes, starting of the nodes, setup of the RPC clients etc.
 func startStandaloneObscuroNodes(
-	params *params.SimParams, stats *stats.Stats, gethClients []ethadapter.EthClient, enclaveAddresses []string) ([]rpcclientlib.Client, map[string][]*obsclient.AuthObsClient, []string) {
+	params *params.SimParams, stats *stats.Stats, gethClients []ethadapter.EthClient, enclaveAddresses []string,
+) ([]rpcclientlib.Client, map[string][]*obsclient.AuthObsClient, []string) {
 	// handle to the obscuro clients
 	nodeRPCAddresses := make([]string, params.NumberOfNodes)
 	obscuroClients := make([]rpcclientlib.Client, params.NumberOfNodes)

--- a/integration/simulation/network/socket.go
+++ b/integration/simulation/network/socket.go
@@ -59,9 +59,9 @@ func (n *networkOfSocketNodes) Create(params *params.SimParams, stats *stats.Sta
 	n.hostRPCAddresses = hostRPCAddresses
 
 	return &RPCHandles{
-		EthClients:                    n.gethClients,
-		ObscuroClients:                n.obscuroClients,
-		VirtualWalletExtensionClients: walletClients,
+		EthClients:     n.gethClients,
+		ObscuroClients: n.obscuroClients,
+		AuthObsClients: walletClients,
 	}, nil
 }
 

--- a/integration/simulation/transaction_injector.go
+++ b/integration/simulation/transaction_injector.go
@@ -1,14 +1,12 @@
 package simulation
 
 import (
+	"context"
 	"fmt"
 	"math/big"
 	"math/rand"
 	"sync/atomic"
 	"time"
-
-	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/obscuronet/go-obscuro/integration/simulation/network"
 
@@ -27,7 +25,6 @@ import (
 	"github.com/obscuronet/go-obscuro/integration/simulation/params"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
-	"github.com/obscuronet/go-obscuro/go/rpcclientlib"
 	"github.com/obscuronet/go-obscuro/integration"
 
 	"github.com/ethereum/go-ethereum/core/types"
@@ -74,6 +71,9 @@ type TransactionInjector struct {
 
 	// The number of transactions of each type to issue, or 0 for unlimited transactions
 	txsToIssue int
+
+	// context for the transaction injector so in-flight requests can be cancelled gracefully
+	ctx context.Context
 }
 
 // NewTransactionInjector returns a transaction manager with a given number of obsWallets
@@ -110,6 +110,7 @@ func NewTransactionInjector(
 		TxTracker:        newCounter(),
 		enclavePublicKey: enclavePublicKeyEcies,
 		txsToIssue:       txsToIssue,
+		ctx:              context.Background(), // for now we create a new context here, should allow it to be passed in
 	}
 }
 
@@ -173,7 +174,7 @@ func (ti *TransactionInjector) issueRandomTransfers() {
 
 		ti.stats.Transfer()
 
-		err = ti.rpcHandles.ObscuroWalletRndClient(fromWallet).Call(nil, rpcclientlib.RPCSendRawTransaction, testcommon.EncodeTx(signedTx))
+		err = ti.rpcHandles.ObscuroWalletRndClient(fromWallet).SendTransaction(ti.ctx, signedTx)
 		if err != nil {
 			log.Info("Failed to issue transfer via RPC. Cause: %s", err)
 			continue
@@ -235,7 +236,7 @@ func (ti *TransactionInjector) issueRandomWithdrawals() {
 			common.ShortAddress(obsWallet.Address()),
 		)
 
-		err = ti.rpcHandles.ObscuroWalletRndClient(obsWallet).Call(nil, rpcclientlib.RPCSendRawTransaction, testcommon.EncodeTx(signedTx))
+		err = ti.rpcHandles.ObscuroWalletRndClient(obsWallet).SendTransaction(ti.ctx, signedTx)
 		if err != nil {
 			log.Info("Failed to issue withdrawal via RPC. Cause: %s", err)
 			continue
@@ -262,7 +263,7 @@ func (ti *TransactionInjector) issueInvalidL2Txs() {
 
 		signedTx := ti.createInvalidSignage(tx, fromWallet)
 
-		err := ti.rpcHandles.ObscuroWalletRndClient(fromWallet).Call(nil, rpcclientlib.RPCSendRawTransaction, testcommon.EncodeTx(signedTx))
+		err := ti.rpcHandles.ObscuroWalletRndClient(fromWallet).SendTransaction(ti.ctx, signedTx)
 		if err != nil {
 			log.Info("Failed to issue withdrawal via RPC. Cause: %s", err)
 		}
@@ -295,12 +296,12 @@ func (ti *TransactionInjector) rndEthWallet() wallet.Wallet {
 
 func (ti *TransactionInjector) newObscuroTransferTx(from wallet.Wallet, dest gethcommon.Address, amount uint64) types.TxData {
 	data := erc20contractlib.CreateTransferTxData(dest, amount)
-	return ti.newTx(data, NextNonce(ti.rpcHandles, from))
+	return ti.newTx(data, NextNonce(ti.ctx, ti.rpcHandles, from))
 }
 
 func (ti *TransactionInjector) newObscuroWithdrawalTx(from wallet.Wallet, amount uint64) types.TxData {
 	transferERC20data := erc20contractlib.CreateTransferTxData(bridge.BridgeAddress, amount)
-	return ti.newTx(transferERC20data, NextNonce(ti.rpcHandles, from))
+	return ti.newTx(transferERC20data, NextNonce(ti.ctx, ti.rpcHandles, from))
 }
 
 func (ti *TransactionInjector) newCustomObscuroWithdrawalTx(amount uint64) types.TxData {
@@ -325,25 +326,15 @@ func (ti *TransactionInjector) newTx(data []byte, nonce uint64) types.TxData {
 	}
 }
 
-func readNonce(cl rpcclientlib.Client, a gethcommon.Address) uint64 {
-	var result hexutil.Uint64
-	err := cl.Call(&result, rpcclientlib.RPCNonce, a, rpc.BlockNumberOrHash{})
-	if err != nil {
-		panic(err)
-	}
-	nonce, err := hexutil.DecodeUint64(result.String())
-	if err != nil {
-		panic(err)
-	}
-	return nonce
-}
-
-func NextNonce(clients *network.RPCHandles, w wallet.Wallet) uint64 {
+func NextNonce(ctx context.Context, clients *network.RPCHandles, w wallet.Wallet) uint64 {
 	counter := 0
 
 	// only returns the nonce when the previous transaction was recorded
 	for {
-		remoteNonce := readNonce(clients.ObscuroWalletRndClient(w), w.Address())
+		remoteNonce, err := clients.ObscuroWalletRndClient(w).NonceAt(ctx, w.Address(), nil)
+		if err != nil {
+			panic(err)
+		}
 		localNonce := w.GetNonce()
 		if remoteNonce == localNonce {
 			return w.GetNonceAndIncrement()

--- a/integration/simulation/utils.go
+++ b/integration/simulation/utils.go
@@ -3,10 +3,11 @@ package simulation
 import (
 	"context"
 	"fmt"
-	"github.com/ethereum/go-ethereum"
-	"github.com/obscuronet/go-obscuro/go/obsclient"
 	"math/big"
 	"time"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/obscuronet/go-obscuro/go/obsclient"
 
 	"github.com/obscuronet/go-obscuro/integration/common/testlog"
 

--- a/integration/simulation/utils.go
+++ b/integration/simulation/utils.go
@@ -1,19 +1,18 @@
 package simulation
 
 import (
+	"context"
 	"fmt"
+	"github.com/ethereum/go-ethereum"
+	"github.com/obscuronet/go-obscuro/go/obsclient"
 	"math/big"
-	"strings"
 	"time"
-
-	"github.com/obscuronet/go-obscuro/go/enclave/rpc"
 
 	"github.com/obscuronet/go-obscuro/integration/common/testlog"
 
 	testcommon "github.com/obscuronet/go-obscuro/integration/common"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/obscuronet/go-obscuro/go/common"
 	"github.com/obscuronet/go-obscuro/go/ethadapter/erc20contractlib"
@@ -88,51 +87,23 @@ func getRollupHeader(client rpcclientlib.Client, hash gethcommon.Hash) *common.H
 	return result
 }
 
-// Uses the client to retrieve the transaction with the matching hash.
-func getTransaction(client rpcclientlib.Client, txHash gethcommon.Hash) *types.Transaction {
-	var tx types.Transaction
-	err := client.Call(&tx, rpcclientlib.RPCGetTransactionByHash, txHash.Hex())
-	if err != nil {
-		panic(fmt.Errorf("simulation failed due to failed %s RPC call. Cause: %w", rpcclientlib.RPCGetTransactionByHash, err))
-	}
-
-	return &tx
-}
-
-// Returns the transaction receipt for the given transaction hash.
-func getTransactionReceipt(client rpcclientlib.Client, txHash gethcommon.Hash) *types.Receipt {
-	var rec types.Receipt
-	err := client.Call(&rec, rpcclientlib.RPCGetTxReceipt, txHash.Hex())
-	if err != nil {
-		panic(fmt.Errorf("simulation failed due to failed %s RPC call. Cause: %w", rpcclientlib.RPCGetTxReceipt, err))
-	}
-	return &rec
-}
-
 // Uses the client to retrieve the balance of the wallet with the given address.
-func balance(client rpcclientlib.Client, address gethcommon.Address, l2ContractAddress *gethcommon.Address) uint64 {
-	method := rpcclientlib.RPCCall
+func balance(ctx context.Context, client *obsclient.AuthObsClient, address gethcommon.Address, l2ContractAddress *gethcommon.Address) uint64 {
 	balanceData := erc20contractlib.CreateBalanceOfData(address)
-	convertedData := (hexutil.Bytes)(balanceData)
 
-	params := map[string]interface{}{
-		rpc.CallFieldFrom: address.Hex(),
-		rpc.CallFieldTo:   l2ContractAddress.Hex(),
-		rpc.CallFieldData: convertedData,
+	callMsg := ethereum.CallMsg{
+		From: address,
+		To:   l2ContractAddress,
+		Data: balanceData,
 	}
 
-	var response string
-	err := client.Call(&response, method, params)
+	response, err := client.CallContract(ctx, callMsg, nil)
 	if err != nil {
-		panic(fmt.Errorf("simulation failed due to failed %s RPC call. Cause: %w", method, err))
+		panic(fmt.Errorf("simulation failed due to failed RPC call. Cause: %w", err))
 	}
-	if !strings.HasPrefix(response, "0x") {
-		panic(fmt.Errorf("expected hex formatted balance string but was: %s", response))
-	}
-
 	b := new(big.Int)
 	// remove the "0x" prefix (we already confirmed it is present), convert the remaining hex value (base 16) to a balance number
-	b.SetString(response[2:], 16)
+	b.SetString(string(response)[2:], 16)
 	return b.Uint64()
 }
 

--- a/integration/simulation/validate_chain.go
+++ b/integration/simulation/validate_chain.go
@@ -1,6 +1,7 @@
 package simulation
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"testing"
@@ -223,7 +224,7 @@ func checkBlockchainOfObscuroNode(t *testing.T, rpcHandles *network.RPCHandles, 
 		t.Errorf("Node %d: L2 to L1 Efficiency is %f. Expected:%f", nodeAddr, efficiency, s.Params.L2ToL1EfficiencyThreshold)
 	}
 
-	notFoundTransfers, notFoundWithdrawals := FindNotIncludedL2Txs(nodeIdx, rpcHandles, s.TxInjector)
+	notFoundTransfers, notFoundWithdrawals := FindNotIncludedL2Txs(nil, nodeIdx, rpcHandles, s.TxInjector)
 	if notFoundTransfers > 0 {
 		t.Errorf("Node %d: %d out of %d Transfer Txs not found in the enclave",
 			nodeAddr, notFoundTransfers, len(s.TxInjector.TxTracker.TransferL2Transactions))
@@ -233,7 +234,7 @@ func checkBlockchainOfObscuroNode(t *testing.T, rpcHandles *network.RPCHandles, 
 			nodeAddr, notFoundWithdrawals, len(s.TxInjector.TxTracker.WithdrawalL2Transactions))
 	}
 
-	checkTransactionReceipts(nodeIdx, rpcHandles, s.TxInjector)
+	checkTransactionReceipts(s.ctx, nodeIdx, rpcHandles, s.TxInjector)
 
 	totalSuccessfullyWithdrawn, numberOfWithdrawalRequests := extractWithdrawals(t, nodeClient, nodeAddr)
 
@@ -265,7 +266,8 @@ func checkBlockchainOfObscuroNode(t *testing.T, rpcHandles *network.RPCHandles, 
 	totalAmountInSystem := s.Stats.TotalDepositedAmount - totalSuccessfullyWithdrawn
 	total := uint64(0)
 	for _, wallet := range s.Params.Wallets.SimObsWallets {
-		total += balance(rpcHandles.ObscuroWalletClient(wallet.Address(), nodeIdx), wallet.Address(), s.Params.Wallets.Tokens[bridge.HOC].L2ContractAddress)
+		client := rpcHandles.ObscuroWalletClient(wallet.Address(), nodeIdx)
+		total += balance(s.ctx, client, wallet.Address(), s.Params.Wallets.Tokens[bridge.HOC].L2ContractAddress)
 	}
 
 	if total != totalAmountInSystem {
@@ -278,13 +280,17 @@ func checkBlockchainOfObscuroNode(t *testing.T, rpcHandles *network.RPCHandles, 
 }
 
 // FindNotIncludedL2Txs returns the number of transfers and withdrawals that were injected but are not present in the L2 blockchain.
-func FindNotIncludedL2Txs(nodeIdx int, rpcHandles *network.RPCHandles, txInjector *TransactionInjector) (int, int) {
+func FindNotIncludedL2Txs(ctx context.Context, nodeIdx int, rpcHandles *network.RPCHandles, txInjector *TransactionInjector) (int, int) {
 	transfers, withdrawals := txInjector.TxTracker.GetL2Transactions()
 	notFoundTransfers := 0
 	for _, tx := range transfers {
 		sender := getSender(tx)
 		// because of viewing key encryption we need to get the RPC client for this specific node for the wallet that sent the transaction
-		if l2tx := getTransaction(rpcHandles.ObscuroWalletClient(sender, nodeIdx), tx.Hash()); l2tx == nil {
+		l2tx, _, err := rpcHandles.ObscuroWalletClient(sender, nodeIdx).TransactionByHash(ctx, tx.Hash())
+		if err != nil {
+			panic(err)
+		}
+		if l2tx == nil {
 			notFoundTransfers++
 		}
 	}
@@ -293,7 +299,11 @@ func FindNotIncludedL2Txs(nodeIdx int, rpcHandles *network.RPCHandles, txInjecto
 	for _, tx := range withdrawals {
 		sender := getSender(tx)
 		// because of viewing key encryption we need to get the RPC client for this specific node for the wallet that sent the transaction
-		if l2tx := getTransaction(rpcHandles.ObscuroWalletClient(sender, nodeIdx), tx.Hash()); l2tx == nil {
+		l2tx, _, err := rpcHandles.ObscuroWalletClient(sender, nodeIdx).TransactionByHash(ctx, tx.Hash())
+		if err != nil {
+			panic(err)
+		}
+		if l2tx == nil {
 			notFoundWithdrawals++
 		}
 	}
@@ -310,13 +320,16 @@ func getSender(tx *common.L2Tx) gethcommon.Address {
 }
 
 // Checks that there is a receipt available for each L2 transaction.
-func checkTransactionReceipts(nodeIdx int, rpcHandles *network.RPCHandles, txInjector *TransactionInjector) {
+func checkTransactionReceipts(ctx context.Context, nodeIdx int, rpcHandles *network.RPCHandles, txInjector *TransactionInjector) {
 	l2Txs := append(txInjector.TxTracker.TransferL2Transactions, txInjector.TxTracker.WithdrawalL2Transactions...)
 
 	for _, tx := range l2Txs {
 		sender := getSender(tx)
 		// We check that there is a receipt available for each transaction
-		rec := getTransactionReceipt(rpcHandles.ObscuroWalletClient(sender, nodeIdx), tx.Hash())
+		rec, err := rpcHandles.ObscuroWalletClient(sender, nodeIdx).TransactionReceipt(ctx, tx.Hash())
+		if err != nil {
+			panic(err)
+		}
 		if rec.Status == types.ReceiptStatusFailed {
 			log.Info("Transaction %s has failed.", tx.Hash().Hex())
 		}

--- a/integration/simulation/validate_chain.go
+++ b/integration/simulation/validate_chain.go
@@ -224,7 +224,7 @@ func checkBlockchainOfObscuroNode(t *testing.T, rpcHandles *network.RPCHandles, 
 		t.Errorf("Node %d: L2 to L1 Efficiency is %f. Expected:%f", nodeAddr, efficiency, s.Params.L2ToL1EfficiencyThreshold)
 	}
 
-	notFoundTransfers, notFoundWithdrawals := FindNotIncludedL2Txs(nil, nodeIdx, rpcHandles, s.TxInjector)
+	notFoundTransfers, notFoundWithdrawals := FindNotIncludedL2Txs(s.ctx, nodeIdx, rpcHandles, s.TxInjector)
 	if notFoundTransfers > 0 {
 		t.Errorf("Node %d: %d out of %d Transfer Txs not found in the enclave",
 			nodeAddr, notFoundTransfers, len(s.TxInjector.TxTracker.TransferL2Transactions))

--- a/tools/networkmanager/inject_txs.go
+++ b/tools/networkmanager/inject_txs.go
@@ -1,7 +1,9 @@
 package networkmanager
 
 import (
+	"context"
 	"fmt"
+	"github.com/obscuronet/go-obscuro/go/obsclient"
 	"math/big"
 	"os"
 	"strconv"
@@ -26,6 +28,7 @@ import (
 )
 
 func InjectTransactions(cfg Config, args []string) {
+	ctx := context.Background()
 	println("Connecting to L1 node...")
 	l1Client, err := ethadapter.NewEthClient(cfg.l1NodeHost, cfg.l1NodeWebsocketPort, cfg.l1RPCTimeout, common.HexToAddress("0x0"))
 	if err != nil {
@@ -75,14 +78,14 @@ func InjectTransactions(cfg Config, args []string) {
 	))
 
 	checkDepositsSuccessful(txInjector, l1Client, simStats, erc20ContractLib, mgmtContractLib, startBlock)
-	checkL2TxsSuccessful(rpcHandles, txInjector)
+	checkL2TxsSuccessful(ctx, rpcHandles, txInjector)
 
 	os.Exit(0)
 }
 
 // createWalletRPCClients creates map of wallet address to list of wallet clients (of length 1 because we have 1 node)
-func createWalletRPCClients(wallets *params.SimWallets, obscuroNodeAddr string) map[string][]rpcclientlib.Client {
-	clients := make(map[string][]rpcclientlib.Client)
+func createWalletRPCClients(wallets *params.SimWallets, obscuroNodeAddr string) map[string][]*obsclient.AuthObsClient {
+	clients := make(map[string][]*obsclient.AuthObsClient)
 
 	for _, w := range wallets.SimObsWallets {
 		vk, err := rpcclientlib.GenerateAndSignViewingKey(w)
@@ -93,8 +96,9 @@ func createWalletRPCClients(wallets *params.SimWallets, obscuroNodeAddr string) 
 		if err != nil {
 			panic(err)
 		}
+		authClient := obsclient.NewAuthObsClient(client)
 
-		clients[w.Address().String()] = []rpcclientlib.Client{client}
+		clients[w.Address().String()] = []*obsclient.AuthObsClient{authClient}
 	}
 	for _, t := range wallets.Tokens {
 		w := t.L2Owner
@@ -106,8 +110,9 @@ func createWalletRPCClients(wallets *params.SimWallets, obscuroNodeAddr string) 
 		if err != nil {
 			panic(err)
 		}
+		authClient := obsclient.NewAuthObsClient(client)
 
-		clients[w.Address().String()] = []rpcclientlib.Client{client}
+		clients[w.Address().String()] = []*obsclient.AuthObsClient{authClient}
 	}
 
 	return clients
@@ -183,10 +188,10 @@ func checkDepositsSuccessful(txInjector *simulation.TransactionInjector, l1Clien
 	}
 }
 
-func checkL2TxsSuccessful(rpcHandles *network.RPCHandles, txInjector *simulation.TransactionInjector) {
+func checkL2TxsSuccessful(ctx context.Context, rpcHandles *network.RPCHandles, txInjector *simulation.TransactionInjector) {
 	injectedTransfers := len(txInjector.TxTracker.TransferL2Transactions)
 	injectedWithdrawals := len(txInjector.TxTracker.WithdrawalL2Transactions)
-	notFoundTransfers, notFoundWithdrawals := simulation.FindNotIncludedL2Txs(0, rpcHandles, txInjector)
+	notFoundTransfers, notFoundWithdrawals := simulation.FindNotIncludedL2Txs(ctx, 0, rpcHandles, txInjector)
 
 	if notFoundTransfers != 0 {
 		println(fmt.Sprintf("Injected %d transfers into the L2 but %d were missing.", injectedTransfers, notFoundTransfers))

--- a/tools/networkmanager/inject_txs.go
+++ b/tools/networkmanager/inject_txs.go
@@ -53,9 +53,9 @@ func InjectTransactions(cfg Config, args []string) {
 	walletClients := createWalletRPCClients(wallets, cfg.obscuroClientAddress)
 
 	rpcHandles := &network.RPCHandles{
-		EthClients:                    []ethadapter.EthClient{l1Client},
-		ObscuroClients:                []rpcclientlib.Client{l2Client},
-		VirtualWalletExtensionClients: walletClients,
+		EthClients:     []ethadapter.EthClient{l1Client},
+		ObscuroClients: []rpcclientlib.Client{l2Client},
+		AuthObsClients: walletClients,
 	}
 
 	txInjector := simulation.NewTransactionInjector(

--- a/tools/networkmanager/inject_txs.go
+++ b/tools/networkmanager/inject_txs.go
@@ -3,11 +3,12 @@ package networkmanager
 import (
 	"context"
 	"fmt"
-	"github.com/obscuronet/go-obscuro/go/obsclient"
 	"math/big"
 	"os"
 	"strconv"
 	"time"
+
+	"github.com/obscuronet/go-obscuro/go/obsclient"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/obscuronet/go-obscuro/integration/simulation/network"


### PR DESCRIPTION
### Why is this change needed?

- We want a high-level Go client, analogous to the EthClient
- We want the sim-tests to use this client

### What changes were made as part of this PR:

- Add an ObsClient and an AuthObsClient, ObsClient is for unencrypted requests and AuthObsClient is bound to a single wallet, has a registered viewing key and provides the encrypted requests
- Wire these clients into the simulation tests to get confidence in them and avoid duplication
- These clients should eventually support all relevant methods from the EthClient and more, but for now just the bare minimum to get the tests passing and structure in place

### What are the key areas to look at
- The /obsclient package
- The naming of these things, I went for ObsClient because of EthClient but not wedded to it at all


### :rotating_light: Definition of Done :rotating_light:
- [ ] Deployed into dev-testnet 
- [ ] Passes tests on dev-testnet
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated
