### PR TITLE
Removes host method only used by tests

### DIFF
--- a/go/host/interfaces.go
+++ b/go/host/interfaces.go
@@ -31,8 +31,6 @@ type Host interface {
 type MockHost interface {
 	Host
 
-	// TODO - Remove this method.
-	P2P() P2P
 	// MockedNewHead receives the notification of new blocks.
 	// TODO - Remove this method.
 	MockedNewHead(b common.EncodedBlock, p common.EncodedBlock)

--- a/go/host/node/node.go
+++ b/go/host/node/node.go
@@ -258,10 +258,6 @@ func (a *Node) EnclaveClient() common.Enclave {
 	return a.enclaveClient
 }
 
-func (a *Node) P2P() host.P2P {
-	return a.p2p
-}
-
 func (a *Node) MockedNewHead(b common.EncodedBlock, p common.EncodedBlock) {
 	if atomic.LoadInt32(a.stopNodeInterrupt) == 1 {
 		return

--- a/integration/simulation/network/inmemory.go
+++ b/integration/simulation/network/inmemory.go
@@ -55,7 +55,7 @@ func (n *basicNetworkOfInMemoryNodes) Create(params *params.SimParams, stats *st
 			isGenesis,
 			params.MgmtContractLib,
 			params.ERC20ContractLib,
-			params.AvgNetworkLatency,
+			params.AvgGossipPeriod,
 			stats,
 			false,
 			nil,

--- a/integration/simulation/network/inmemory.go
+++ b/integration/simulation/network/inmemory.go
@@ -36,6 +36,7 @@ func (n *basicNetworkOfInMemoryNodes) Create(params *params.SimParams, stats *st
 	n.ethNodes = make([]*ethereum_mock.Node, params.NumberOfNodes)
 	obscuroNodes := make([]host.MockHost, params.NumberOfNodes)
 	n.obscuroClients = make([]rpcclientlib.Client, params.NumberOfNodes)
+	p2pLayers := make([]*p2p.MockP2P, params.NumberOfNodes)
 
 	// Invent some addresses to assign as the L1 erc20 contracts
 	dummyOBXAddress := common.HexToAddress("AA")
@@ -43,16 +44,12 @@ func (n *basicNetworkOfInMemoryNodes) Create(params *params.SimParams, stats *st
 	dummyETHAddress := common.HexToAddress("BB")
 	params.Wallets.Tokens[bridge.POC].L1ContractAddress = &dummyETHAddress
 
-	p2pLayers := make([]*p2p.MockP2P, params.NumberOfNodes)
-	for i := 0; i < params.NumberOfNodes; i++ {
-		p2pLayers[i] = p2p.NewMockP2P(params.AvgBlockDuration, params.AvgGossipPeriod)
-	}
-
 	for i := 0; i < params.NumberOfNodes; i++ {
 		isGenesis := i == 0
 
 		// create the in memory l1 and l2 node
 		miner := createMockEthNode(int64(i), params.NumberOfNodes, params.AvgBlockDuration, params.AvgNetworkLatency, stats)
+		p2pLayers[i] = p2p.NewMockP2P(params.AvgBlockDuration, params.AvgGossipPeriod)
 		agg := createInMemObscuroNode(
 			int64(i),
 			isGenesis,

--- a/integration/simulation/network/inmemory.go
+++ b/integration/simulation/network/inmemory.go
@@ -49,7 +49,7 @@ func (n *basicNetworkOfInMemoryNodes) Create(params *params.SimParams, stats *st
 
 		// create the in memory l1 and l2 node
 		miner := createMockEthNode(int64(i), params.NumberOfNodes, params.AvgBlockDuration, params.AvgNetworkLatency, stats)
-		p2pLayers[i] = p2p.NewMockP2P(params.AvgBlockDuration, params.AvgGossipPeriod)
+		p2pLayers[i] = p2p.NewMockP2P(params.AvgBlockDuration, params.AvgNetworkLatency)
 		agg := createInMemObscuroNode(
 			int64(i),
 			isGenesis,

--- a/integration/simulation/network/network_utils.go
+++ b/integration/simulation/network/network_utils.go
@@ -60,17 +60,14 @@ func createInMemObscuroNode(
 	mgmtContractLib mgmtcontractlib.MgmtContractLib,
 	stableTokenContractLib erc20contractlib.ERC20ContractLib,
 	avgGossipPeriod time.Duration,
-	avgBlockDuration time.Duration,
-	avgNetworkLatency time.Duration,
 	stats *stats.Stats,
 	validateBlocks bool,
 	genesisJSON []byte,
 	ethWallet wallet.Wallet,
 	ethClient ethadapter.EthClient,
 	wallets *params.SimWallets,
+	mockP2P *simp2p.MockP2P,
 ) host.MockHost {
-	obscuroInMemNetwork := simp2p.NewMockP2P(avgBlockDuration, avgNetworkLatency)
-
 	hostConfig := config.HostConfig{
 		ID:                  gethcommon.BigToAddress(big.NewInt(id)),
 		IsGenesis:           isGenesis,
@@ -95,13 +92,13 @@ func createInMemObscuroNode(
 	node := node.NewHost(
 		hostConfig,
 		stats,
-		obscuroInMemNetwork,
+		mockP2P,
 		nil,
 		enclaveClient,
 		ethWallet,
 		mgmtContractLib,
 	)
-	obscuroInMemNetwork.CurrentNode = node
+	mockP2P.CurrentNode = node
 	node.ConnectToEthNode(ethClient)
 	return node
 }

--- a/integration/simulation/network/obscuro_node_utils.go
+++ b/integration/simulation/network/obscuro_node_utils.go
@@ -39,7 +39,7 @@ func startInMemoryObscuroNodes(params *params.SimParams, stats *stats.Stats, gen
 			isGenesis,
 			params.MgmtContractLib,
 			params.ERC20ContractLib,
-			params.AvgNetworkLatency,
+			params.AvgGossipPeriod,
 			stats,
 			true,
 			genesisJSON,

--- a/integration/simulation/network/obscuro_node_utils.go
+++ b/integration/simulation/network/obscuro_node_utils.go
@@ -32,7 +32,7 @@ func startInMemoryObscuroNodes(params *params.SimParams, stats *stats.Stats, gen
 	p2pLayers := make([]*p2p.MockP2P, params.NumberOfNodes)
 	for i := 0; i < params.NumberOfNodes; i++ {
 		isGenesis := i == 0
-		p2pLayers[i] = p2p.NewMockP2P(params.AvgBlockDuration, params.AvgGossipPeriod)
+		p2pLayers[i] = p2p.NewMockP2P(params.AvgBlockDuration, params.AvgNetworkLatency)
 
 		obscuroNodes[i] = createInMemObscuroNode(
 			int64(i),

--- a/integration/simulation/network/obscuro_node_utils.go
+++ b/integration/simulation/network/obscuro_node_utils.go
@@ -27,15 +27,13 @@ import (
 )
 
 func startInMemoryObscuroNodes(params *params.SimParams, stats *stats.Stats, genesisJSON []byte, l1Clients []ethadapter.EthClient) ([]rpcclientlib.Client, map[string][]*obsclient.AuthObsClient) {
-	p2pLayers := make([]*p2p.MockP2P, params.NumberOfNodes)
-	for i := 0; i < params.NumberOfNodes; i++ {
-		p2pLayers[i] = p2p.NewMockP2P(params.AvgBlockDuration, params.AvgGossipPeriod)
-	}
-
 	// Create the in memory obscuro nodes, each connect each to a geth node
 	obscuroNodes := make([]host.MockHost, params.NumberOfNodes)
+	p2pLayers := make([]*p2p.MockP2P, params.NumberOfNodes)
 	for i := 0; i < params.NumberOfNodes; i++ {
 		isGenesis := i == 0
+		p2pLayers[i] = p2p.NewMockP2P(params.AvgBlockDuration, params.AvgGossipPeriod)
+
 		obscuroNodes[i] = createInMemObscuroNode(
 			int64(i),
 			isGenesis,


### PR DESCRIPTION
### Why is this change needed?

We have a `MockHost` interface that is implemented by the host, and exposes methods required by the in-memory integration tests. Where possible, we should be removing these methods, so that we're testing the "real" host API.

### What changes were made as part of this PR:

Refactoring.

- Removes the `MockHost.P2P` method

### What are the key areas to look at

- ...


### :rotating_light: Definition of Done :rotating_light:
- [ ] Deployed into dev-testnet 
- [ ] Passes tests on dev-testnet
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated
