### PR TITLE
Removes ConnectToEthNode test method.

### DIFF
--- a/go/host/interfaces.go
+++ b/go/host/interfaces.go
@@ -5,7 +5,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/obscuronet/go-obscuro/go/common"
 	"github.com/obscuronet/go-obscuro/go/config"
-	"github.com/obscuronet/go-obscuro/go/ethadapter"
 	"github.com/obscuronet/go-obscuro/go/host/db"
 )
 
@@ -38,8 +37,6 @@ type MockHost interface {
 	MockedNewHead(b common.EncodedBlock, p common.EncodedBlock)
 	// MockedNewFork receives the notification of a new fork.
 	MockedNewFork(b []common.EncodedBlock)
-	// ConnectToEthNode connects the Aggregator to the Ethereum node.
-	ConnectToEthNode(node ethadapter.EthClient)
 }
 
 // P2P is the layer responsible for sending and receiving messages to Obscuro network peers.

--- a/go/host/node/node.go
+++ b/go/host/node/node.go
@@ -336,10 +336,6 @@ func (a *Node) Stop() {
 	common.LogWithID(a.shortID, "Node shut down successfully.")
 }
 
-func (a *Node) ConnectToEthNode(node ethadapter.EthClient) {
-	a.ethClient = node
-}
-
 // Waits for enclave to be available, printing a wait message every two seconds.
 func (a *Node) waitForEnclave() {
 	counter := 0

--- a/integration/simulation/network/network_utils.go
+++ b/integration/simulation/network/network_utils.go
@@ -96,13 +96,12 @@ func createInMemObscuroNode(
 		hostConfig,
 		stats,
 		obscuroInMemNetwork,
-		nil,
+		ethClient,
 		enclaveClient,
 		ethWallet,
 		mgmtContractLib,
 	)
 	obscuroInMemNetwork.CurrentNode = node
-	node.ConnectToEthNode(ethClient)
 	return node
 }
 
@@ -143,18 +142,15 @@ func createSocketObscuroNode(
 	// create a socket obscuro node
 	nodeP2p := p2p.NewSocketP2PLayer(hostConfig)
 
-	node := node.NewHost(
+	return node.NewHost(
 		hostConfig,
 		stats,
 		nodeP2p,
-		nil,
+		ethClient,
 		enclaveClient,
 		ethWallet,
 		mgmtContractLib,
 	)
-
-	node.ConnectToEthNode(ethClient)
-	return node
 }
 
 func defaultMockEthNodeCfg(nrNodes int, avgBlockDuration time.Duration) ethereum_mock.MiningConfig {

--- a/integration/simulation/network/network_utils.go
+++ b/integration/simulation/network/network_utils.go
@@ -89,7 +89,7 @@ func createInMemObscuroNode(
 	enclaveClient := enclave.NewEnclave(enclaveConfig, mgmtContractLib, stableTokenContractLib, stats)
 
 	// create an in memory obscuro node
-	node := node.NewHost(
+	inMemNode := node.NewHost(
 		hostConfig,
 		stats,
 		mockP2P,
@@ -98,8 +98,8 @@ func createInMemObscuroNode(
 		ethWallet,
 		mgmtContractLib,
 	)
-	mockP2P.CurrentNode = node
-	return node
+	mockP2P.CurrentNode = inMemNode
+	return inMemNode
 }
 
 func createSocketObscuroNode(


### PR DESCRIPTION
### Why is this change needed?

Removes an unnecessary host method that's only used in tests.

### What changes were made as part of this PR:

Refactoring.

- Removes the `ConnectToEthNode` method

### What are the key areas to look at

- ...


### :rotating_light: Definition of Done :rotating_light:
- [ ] Deployed into dev-testnet 
- [ ] Passes tests on dev-testnet
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated
