### PR TITLE
Puts the Docker and Geth sims behind an environment variable.

### DIFF
--- a/integration/simulation/simulation_docker_test.go
+++ b/integration/simulation/simulation_docker_test.go
@@ -1,6 +1,7 @@
 package simulation
 
 import (
+	"os"
 	"testing"
 	"time"
 
@@ -9,11 +10,16 @@ import (
 	"github.com/obscuronet/go-obscuro/integration/simulation/params"
 )
 
+const dockerTestEnv = "DOCKER_TEST_ENABLED"
+
 // This test creates a network of L2 nodes, then injects transactions, and finally checks the resulting output blockchain
 // The L2 nodes communicate with each other via sockets, and with their enclave servers via RPC.
 // All nodes live in the same process, the enclaves run in individual Docker containers, and the Ethereum nodes are mocked out.
 // $> docker rm $(docker stop $(docker ps -a -q --filter ancestor=obscuro_enclave --format="{{.ID}}") will stop and remove all images
 func TestDockerNodesMonteCarloSimulation(t *testing.T) {
+	if os.Getenv(dockerTestEnv) == "" {
+		t.Skipf("set the variable to run this test: `%s=true`", dockerTestEnv)
+	}
 	setupSimTestLog("docker")
 
 	numberOfNodes := 5

--- a/integration/simulation/simulation_geth_in_mem_test.go
+++ b/integration/simulation/simulation_geth_in_mem_test.go
@@ -1,6 +1,7 @@
 package simulation
 
 import (
+	"os"
 	"testing"
 	"time"
 
@@ -10,8 +11,13 @@ import (
 	"github.com/obscuronet/go-obscuro/integration/simulation/params"
 )
 
+const gethTestEnv = "GETH_TEST_ENABLED"
+
 // TestGethSimulation runs the simulation against a private geth network using Clique (PoA)
 func TestGethSimulation(t *testing.T) {
+	if os.Getenv(gethTestEnv) == "" {
+		t.Skipf("set the variable to run this test: `%s=true`", gethTestEnv)
+	}
 	setupSimTestLog("geth-in-mem")
 
 	numberOfNodes := 5


### PR DESCRIPTION
### Why is this change needed?

The CI times are very long. A large contributor is the large number of simulations we run.

Since we now have the test-obscuro tests and a running testnet, we no longer need as many sims to gain assurance that everything is working fine.

### What changes were made as part of this PR:

Functional.

- Moves the Docker and Geth sims behind an environment flag

### What are the key areas to look at

- ...


### :rotating_light: Definition of Done :rotating_light:
- [ ] Deployed into dev-testnet 
- [ ] Passes tests on dev-testnet
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated
