### PR TITLE
Removes Docker image build from CI.

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -20,12 +20,6 @@ jobs:
         with:
           go-version: 1.17.8
 
-      - name: Set up Docker
-        uses: docker/setup-buildx-action@v1
-
-      - name: Build Docker images
-        run:  docker build -t obscuro_enclave -f dockerfiles/enclave.Dockerfile .
-
       # Makes sure the artifacts are built correctly
       - name: Build
         run: go build -v ./...


### PR DESCRIPTION
### Why is this change needed?

We no longer run tests using the Docker image in CI

### What changes were made as part of this PR:

Functional.

- Removes the set up of Docker and the Docker image build

### What are the key areas to look at

- ...


### :rotating_light: Definition of Done :rotating_light:
- [ ] Deployed into dev-testnet 
- [ ] Passes tests on dev-testnet
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated
