### PR TITLE
Triggers the faucet deployemnt

### DIFF
--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -176,7 +176,7 @@ jobs:
                --p2p_public_address=obscuronode-${{ matrix.host_id }}-testnet-${{ GITHUB.RUN_NUMBER }}.uksouth.cloudapp.azure.com:10000'
 
 
-  update:
+  update-loadbalancer:
     needs: deploy
     runs-on: ubuntu-latest
     steps:
@@ -201,7 +201,7 @@ jobs:
               --resource-group Testnet \
               --lb-name testnet-loadbalancer
 
-  setup:
+  deploy-l2-contracts:
     needs: deploy
     runs-on: ubuntu-latest
     steps:
@@ -212,3 +212,13 @@ jobs:
         shell: bash
         run: |
           ./testnet/testnet-deploy-l2-contracts.sh --l2host=obscuronode-0-testnet-${{ GITHUB.RUN_NUMBER }}.uksouth.cloudapp.azure.com
+
+  deploy-faucet:
+    runs-on: ubuntu-latest
+    needs:
+      - update-loadbalancer
+      - deploy-l2-contracts
+    steps:
+      - name: 'Trigger Faucet deployment workflow'
+        run: |
+          curl -XPOST -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" -H "Accept:application/vnd.github" -H "Content-Type:application/json" https://api.github.com/repos/obscuronet/faucet/actions/workflows/manual-deploy-testnet-faucet.yml/dispatches --data '{"ref": "main" }'


### PR DESCRIPTION
### Why is this change needed?

- https://github.com/obscuronet/obscuro-internal/issues/910
- Deploying testnet triggers the faucet deployment

### What changes were made as part of this PR:

- adds a new step to the end of the l2 deployment



### :rotating_light: Definition of Done :rotating_light:
- [ ] Deployed into dev-testnet 
- [ ] Passes tests on dev-testnet
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated
