### PR TITLE
Remove address param from AuthClient's NonceAt and BalanceAt

### DIFF
--- a/go/obsclient/authclient.go
+++ b/go/obsclient/authclient.go
@@ -19,7 +19,7 @@ import (
 // The methods in this client are analogous to the methods in geth's EthClient and should behave the same unless noted otherwise.
 type AuthObsClient struct {
 	ObsClient
-	Account *common.Address
+	account common.Address
 }
 
 // NewAuthObsClient constructs an AuthObsClient for sensitive communication with an enclave.
@@ -29,9 +29,9 @@ type AuthObsClient struct {
 func NewAuthObsClient(client *rpc.EncRPCClient) *AuthObsClient {
 	return &AuthObsClient{
 		ObsClient: ObsClient{
-			RPCClient: client,
+			rpcClient: client,
 		},
-		Account: client.Account(),
+		account: *client.Account(),
 	}
 }
 
@@ -53,14 +53,14 @@ func DialWithAuth(rpcurl string, wal wallet.Wallet) (*AuthObsClient, error) {
 // TransactionByHash returns transaction (if found), isPending (always false currently as we don't search the mempool), error
 func (ac *AuthObsClient) TransactionByHash(ctx context.Context, hash common.Hash) (*types.Transaction, bool, error) {
 	var tx types.Transaction
-	err := ac.RPCClient.CallContext(ctx, &tx, rpc.RPCGetTransactionByHash, hash.Hex())
+	err := ac.rpcClient.CallContext(ctx, &tx, rpc.RPCGetTransactionByHash, hash.Hex())
 	// todo: revisit isPending result value, included for ethclient equivalence but hardcoded currently
 	return &tx, false, err
 }
 
 func (ac *AuthObsClient) TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {
 	var receipt types.Receipt
-	err := ac.RPCClient.CallContext(ctx, &receipt, rpc.RPCGetTxReceipt, txHash)
+	err := ac.rpcClient.CallContext(ctx, &receipt, rpc.RPCGetTxReceipt, txHash)
 	return &receipt, err
 }
 
@@ -68,25 +68,25 @@ func (ac *AuthObsClient) TransactionReceipt(ctx context.Context, txHash common.H
 // nonce cannot be requested for other accounts)
 func (ac *AuthObsClient) NonceAt(ctx context.Context, blockNumber *big.Int) (uint64, error) {
 	var result hexutil.Uint64
-	err := ac.RPCClient.CallContext(ctx, &result, rpc.RPCNonce, ac.Account.Hex(), toBlockNumArg(blockNumber))
+	err := ac.rpcClient.CallContext(ctx, &result, rpc.RPCNonce, ac.account, toBlockNumArg(blockNumber))
 	return uint64(result), err
 }
 
 func (ac *AuthObsClient) CallContract(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
 	var hex string
-	err := ac.RPCClient.CallContext(ctx, &hex, rpc.RPCCall, toCallArg(msg), toBlockNumArg(blockNumber))
+	err := ac.rpcClient.CallContext(ctx, &hex, rpc.RPCCall, toCallArg(msg), toBlockNumArg(blockNumber))
 	return []byte(hex), err
 }
 
 func (ac *AuthObsClient) SendTransaction(ctx context.Context, signedTx *types.Transaction) error {
-	return ac.RPCClient.CallContext(ctx, nil, rpc.RPCSendRawTransaction, encodeTx(signedTx))
+	return ac.rpcClient.CallContext(ctx, nil, rpc.RPCSendRawTransaction, encodeTx(signedTx))
 }
 
 // BalanceAt retrieves the native balance for the account registered on this client (due to obscuro privacy restrictions,
 // balance cannot be requested for other accounts)
 func (ac *AuthObsClient) BalanceAt(ctx context.Context, blockNumber *big.Int) (*big.Int, error) {
 	var result string
-	err := ac.RPCClient.CallContext(ctx, &result, rpc.RPCGetBalance, ac.Account.Hex(), toBlockNumArg(blockNumber))
+	err := ac.rpcClient.CallContext(ctx, &result, rpc.RPCGetBalance, ac.account, toBlockNumArg(blockNumber))
 	if err != nil {
 		return big.NewInt(0), err
 	}

--- a/go/obsclient/authclient_test.go
+++ b/go/obsclient/authclient_test.go
@@ -33,7 +33,7 @@ func TestNonceAt_ConvertsNilBlockNumberToLatest(t *testing.T) {
 		*res = 2
 	})
 
-	nonce, err := authClient.NonceAt(testCtx, testAcc, nil)
+	nonce, err := authClient.NonceAt(testCtx, nil)
 
 	// assert mock called as expected
 	mockRPC.AssertExpectations(t)
@@ -46,7 +46,8 @@ func TestNonceAt_ConvertsNilBlockNumberToLatest(t *testing.T) {
 func createAuthClientWithMockRPCClient() (*rpcClientMock, *AuthObsClient) {
 	mockRPC := new(rpcClientMock)
 	authClient := &AuthObsClient{
-		ObsClient: ObsClient{RPCClient: mockRPC},
+		ObsClient: *NewObsClient(mockRPC),
+		account:   testAcc,
 	}
 	return mockRPC, authClient
 }

--- a/go/obsclient/obsclient.go
+++ b/go/obsclient/obsclient.go
@@ -11,7 +11,7 @@ import (
 //
 // The methods in this client are analogous to the methods in geth's EthClient and should behave the same unless noted otherwise.
 type ObsClient struct {
-	RPCClient rpc.Client
+	rpcClient rpc.Client
 }
 
 func Dial(rawurl string) (*ObsClient, error) {
@@ -27,7 +27,7 @@ func NewObsClient(c rpc.Client) *ObsClient {
 }
 
 func (oc *ObsClient) Close() {
-	oc.RPCClient.Stop()
+	oc.rpcClient.Stop()
 }
 
 // Blockchain Access
@@ -35,7 +35,7 @@ func (oc *ObsClient) Close() {
 // ChainID retrieves the current chain ID for transaction replay protection.
 func (oc *ObsClient) ChainID() (*big.Int, error) {
 	var result hexutil.Big
-	err := oc.RPCClient.Call(&result, rpc.RPCChainID)
+	err := oc.rpcClient.Call(&result, rpc.RPCChainID)
 	if err != nil {
 		return nil, err
 	}

--- a/integration/simulation/transaction_injector.go
+++ b/integration/simulation/transaction_injector.go
@@ -331,7 +331,7 @@ func NextNonce(ctx context.Context, clients *network.RPCHandles, w wallet.Wallet
 
 	// only returns the nonce when the previous transaction was recorded
 	for {
-		remoteNonce, err := clients.ObscuroWalletRndClient(w).NonceAt(ctx, w.Address(), nil)
+		remoteNonce, err := clients.ObscuroWalletRndClient(w).NonceAt(ctx, nil)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
### Why is this change needed?

- Per Joel's suggestion it makes this client a bit more coherent. The client is bound to a single account, it should populate the address in requests (and not allow addresses to be passed in that can never be successful).

### What changes were made as part of this PR:

- store account on AuthObsClient
- remove address from NonceAt method
- add BalanceAt method, also without an address field

### What are the key areas to look at
- My main concern was wondering if we'd ever support Nonce/Balance lookups for contracts from other accounts? In which case we'd need that option. But I think current design means we won't be able to do that (contract devs would need to expose it through methods if they wanted to, and that could be permissioned)


### :rotating_light: Definition of Done :rotating_light:
- [ ] Deployed into dev-testnet 
- [ ] Passes tests on dev-testnet
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated
