### PR TITLE
Fixes nil point except

### DIFF
--- a/tools/walletextension/multi_acc_helper.go
+++ b/tools/walletextension/multi_acc_helper.go
@@ -46,7 +46,7 @@ func suggestAccountClient(req *rpcRequest, accClients map[common.Address]*rpc.En
 	if req.method == rpc.RPCCall {
 		// Otherwise, we search the `data` field for an address matching a registered viewing key.
 		addr, err := searchDataFieldForAccount(paramsMap, accClients)
-		if err == nil {
+		if err == nil && addr != nil {
 			return accClients[*addr]
 		}
 	}

--- a/tools/walletextension/multi_acc_helper.go
+++ b/tools/walletextension/multi_acc_helper.go
@@ -46,7 +46,7 @@ func suggestAccountClient(req *rpcRequest, accClients map[common.Address]*rpc.En
 	if req.method == rpc.RPCCall {
 		// Otherwise, we search the `data` field for an address matching a registered viewing key.
 		addr, err := searchDataFieldForAccount(paramsMap, accClients)
-		if err == nil && addr != nil {
+		if err == nil {
 			return accClients[*addr]
 		}
 	}
@@ -89,7 +89,7 @@ func searchDataFieldForAccount(callParams map[string]interface{}, accClients map
 	// We check that the data field is long enough before removing the leading "0x" (1 bytes/2 chars) and the method ID
 	// (4 bytes/8 chars).
 	if len(dataString) < 10 {
-		return nil, nil //nolint:nilnil
+		return nil, fmt.Errorf("data field is not long enough - no known account found in data bytes")
 	}
 	dataString = dataString[10:]
 

--- a/tools/walletextension/multi_acc_helper_test.go
+++ b/tools/walletextension/multi_acc_helper_test.go
@@ -58,8 +58,8 @@ func TestErrorsWhenDataFieldIsMissing(t *testing.T) {
 func TestGracefulWhenDataFieldTooShort(t *testing.T) {
 	callParams := map[string]interface{}{"data": "tooshort"}
 	address, err := searchDataFieldForAccount(callParams, accClients)
-	if err != nil {
-		t.Fatalf("did not expect an error but got %s", err)
+	if err == nil {
+		t.Fatal("expected an error but got none")
 	}
 	if address != nil {
 		t.Fatal("`data` field was too short but address was found anyway")

--- a/tools/walletextension/multi_acc_helper_test.go
+++ b/tools/walletextension/multi_acc_helper_test.go
@@ -55,7 +55,7 @@ func TestErrorsWhenDataFieldIsMissing(t *testing.T) {
 	}
 }
 
-func TestGracefulWhenDataFieldTooShort(t *testing.T) {
+func TestDataFieldTooShort(t *testing.T) {
 	callParams := map[string]interface{}{"data": "tooshort"}
 	address, err := searchDataFieldForAccount(callParams, accClients)
 	if err == nil {


### PR DESCRIPTION
### Why is this change needed?

- Found when working on https://github.com/obscuronet/obscuro-internal/issues/911
- If the `acc` is nil, then the wallet blows up with nil point exception
- Found when runnign the following curl cmd and pointing at testnet
```
curl --location --request POST 'http://127.0.0.1:3001' \
--header 'Content-Type: application/json' \
--data-raw '{
    "jsonrpc":"2.0",
    "method":"eth_call",
    "params":[{
        "from": "0x38a47fe0c945900d2b29db7edae05178cdba3d15",
        "to": null,
        "gas": "null",
        "gasPrice": "null",
        "value": "0x3635c9adc5dea00000",
        "data": ""
    }, "latest"],
    "id":1
}'
```



### :rotating_light: Definition of Done :rotating_light:
- [ ] Deployed into dev-testnet 
- [ ] Passes tests on dev-testnet
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated
