### PR TITLE
Store logs for each block to not have to recalculate them

### DIFF
--- a/go/enclave/core/types.go
+++ b/go/enclave/core/types.go
@@ -4,7 +4,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-// BlockState - Represents the state after an L1 Block was processed.
+// BlockState pairs a block with its corresponding rollup.
 type BlockState struct {
 	Block          common.Hash
 	HeadRollup     common.Hash

--- a/go/enclave/db/interfaces.go
+++ b/go/enclave/db/interfaces.go
@@ -3,6 +3,7 @@ package db
 import (
 	"crypto/ecdsa"
 
+	"github.com/google/uuid"
 	"github.com/obscuronet/go-obscuro/go/enclave/crypto"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
@@ -52,9 +53,9 @@ type RollupResolver interface {
 }
 
 type BlockStateStorage interface {
-	// FetchBlockState returns the head rollup found in the block
-	FetchBlockState(blockHash common.L1RootHash) (*core.BlockState, bool)
-	// FetchHeadState returns the head rollup. Returns nil if nothing recorded yet
+	// FetchBlockState returns the block state and logs for the given block. Returns nil if the block hasn't been stored.
+	FetchBlockState(blockHash common.L1RootHash) (*core.BlockState, map[uuid.UUID][]*types.Log, bool)
+	// FetchHeadState returns the head block state. Returns nil if nothing recorded yet
 	FetchHeadState() *core.BlockState
 	// SaveNewHead save the rollup-block mapping
 	SaveNewHead(state *core.BlockState, rollup *core.Rollup, receipts []*types.Receipt)

--- a/go/enclave/db/interfaces.go
+++ b/go/enclave/db/interfaces.go
@@ -58,7 +58,7 @@ type BlockStateStorage interface {
 	// FetchHeadState returns the head block state. Returns nil if nothing recorded yet
 	FetchHeadState() *core.BlockState
 	// SaveNewHead save the rollup-block mapping
-	SaveNewHead(state *core.BlockState, rollup *core.Rollup, receipts []*types.Receipt)
+	SaveNewHead(state *core.BlockState, rollup *core.Rollup, receipts []*types.Receipt, logs map[uuid.UUID][]*types.Log)
 	// CreateStateDB create a database that can be used to execute transactions
 	CreateStateDB(hash common.L2RootHash) *state.StateDB
 	// EmptyStateDB create the original empty StateDB

--- a/go/enclave/db/interfaces.go
+++ b/go/enclave/db/interfaces.go
@@ -53,7 +53,7 @@ type RollupResolver interface {
 }
 
 type BlockStateStorage interface {
-	// FetchBlockState returns the block state and logs for the given block. Returns nil if the block hasn't been stored.
+	// FetchBlockState returns the block state and logs for the given block, and a boolean indicating if the block was found.
 	FetchBlockState(blockHash common.L1RootHash) (*core.BlockState, map[uuid.UUID][]*types.Log, bool)
 	// FetchHeadState returns the head block state. Returns nil if nothing recorded yet
 	FetchHeadState() *core.BlockState

--- a/go/enclave/db/rawdb/accessors_chain.go
+++ b/go/enclave/db/rawdb/accessors_chain.go
@@ -183,6 +183,7 @@ func ReadBlockState(kv ethdb.KeyValueReader, hash gethcommon.Hash) *core.BlockSt
 }
 
 func WriteBlockLogs(db ethdb.KeyValueWriter, blockHash gethcommon.Hash, logs map[uuid.UUID][]*types.Log) {
+	// We use gobs instead of RLP here, because RLP cannot handle maps.
 	buffer := new(bytes.Buffer)
 	encoder := gob.NewEncoder(buffer)
 	if err := encoder.Encode(logs); err != nil {
@@ -201,12 +202,12 @@ func ReadBlockLogs(kv ethdb.KeyValueReader, blockHash gethcommon.Hash) map[uuid.
 	}
 
 	decoder := gob.NewDecoder(bytes.NewBuffer(data))
-	var logsRLP map[uuid.UUID][]*types.Log
-	if err := decoder.Decode(&logsRLP); err != nil {
+	var logs map[uuid.UUID][]*types.Log
+	if err := decoder.Decode(&logs); err != nil {
 		log.Panic("could not decode logs. Cause: %s", err)
 	}
 
-	return map[uuid.UUID][]*types.Log{} // todo - joel - return proper value
+	return logs
 }
 
 // ReadCanonicalHash retrieves the hash assigned to a canonical block number.

--- a/go/enclave/db/rawdb/accessors_chain.go
+++ b/go/enclave/db/rawdb/accessors_chain.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"encoding/binary"
 
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/google/uuid"
+
 	"github.com/status-im/keycard-go/hexutils"
 
 	"github.com/obscuronet/go-obscuro/go/common/log"
@@ -176,6 +179,11 @@ func ReadBlockState(kv ethdb.KeyValueReader, hash gethcommon.Hash) *core.BlockSt
 		log.Panic("could not decode block state. Cause: %s", err)
 	}
 	return bs
+}
+
+func ReadBlockLogs(kv ethdb.KeyValueReader, hash gethcommon.Hash) map[uuid.UUID][]*types.Log {
+	// todo - joel - write this logic
+	return nil
 }
 
 // ReadCanonicalHash retrieves the hash assigned to a canonical block number.

--- a/go/enclave/db/rawdb/accessors_chain.go
+++ b/go/enclave/db/rawdb/accessors_chain.go
@@ -181,9 +181,26 @@ func ReadBlockState(kv ethdb.KeyValueReader, hash gethcommon.Hash) *core.BlockSt
 	return bs
 }
 
+func WriteBlockLogs(db ethdb.KeyValueWriter, blockHash gethcommon.Hash, logs map[uuid.UUID][]*types.Log) {
+	bytes, err := rlp.EncodeToBytes(logs)
+	if err != nil {
+		log.Panic("could not encode logs. Cause: %s", err)
+	}
+	if err := db.Put(logsKey(blockHash), bytes); err != nil {
+		log.Panic("could not put logs in DB. Cause: %s", err)
+	}
+}
+
 func ReadBlockLogs(kv ethdb.KeyValueReader, hash gethcommon.Hash) map[uuid.UUID][]*types.Log {
-	// todo - joel - write this logic
-	return nil
+	data, _ := kv.Get(logsKey(hash))
+	if data == nil {
+		return nil
+	}
+	var logs map[uuid.UUID][]*types.Log
+	if err := rlp.Decode(bytes.NewReader(data), logs); err != nil {
+		log.Panic("could not decode block state. Cause: %s", err)
+	}
+	return logs
 }
 
 // ReadCanonicalHash retrieves the hash assigned to a canonical block number.

--- a/go/enclave/db/rawdb/schema.go
+++ b/go/enclave/db/rawdb/schema.go
@@ -52,10 +52,12 @@ func rollupBodyKey(number uint64, hash common.Hash) []byte {
 	return append(append(rollupBodyPrefix, encodeRollupNumber(number)...), hash.Bytes()...)
 }
 
+// blockStateKey = blockStatePrefix + hash
 func blockStateKey(hash common.Hash) []byte {
 	return append(blockStatePrefix, hash.Bytes()...)
 }
 
+// logsKey = logsPrefix + hash
 func logsKey(hash common.Hash) []byte {
 	return append(logsPrefix, hash.Bytes()...)
 }

--- a/go/enclave/db/rawdb/schema.go
+++ b/go/enclave/db/rawdb/schema.go
@@ -13,10 +13,11 @@ var (
 
 	genesisRollupHash        = []byte("GenesisRollupHash")
 	rollupHeaderPrefix       = []byte("oh")          // rollupHeaderPrefix + num (uint64 big endian) + hash -> header
-	headerHashSuffix         = []byte("on")          // headerPrefix + num (uint64 big endian) + headerHashSuffix -> hash
+	headerHashSuffix         = []byte("on")          // rollupHeaderPrefix + num (uint64 big endian) + headerHashSuffix -> hash
 	rollupBodyPrefix         = []byte("ob")          // rollupBodyPrefix + num (uint64 big endian) + hash -> rollup body
-	rollupHeaderNumberPrefix = []byte("oH")          // headerNumberPrefix + hash -> num (uint64 big endian)
-	blockStatePrefix         = []byte("obs")         // headerNumberPrefix + hash -> num (uint64 big endian)
+	rollupHeaderNumberPrefix = []byte("oH")          // rollupHeaderNumberPrefix + hash -> num (uint64 big endian)
+	blockStatePrefix         = []byte("obs")         // blockStatePrefix + hash -> num (uint64 big endian)
+	logsPrefix               = []byte("olg")         // logsPrefix + hash -> block logs
 	rollupReceiptsPrefix     = []byte("or")          // rollupReceiptsPrefix + num (uint64 big endian) + hash -> block receipts
 	txLookupPrefix           = []byte("ol")          // txLookupPrefix + hash -> transaction/receipt lookup metadata
 	bloomBitsPrefix          = []byte("oB")          // bloomBitsPrefix + bit (uint16 big endian) + section (uint64 big endian) + hash -> bloom bits
@@ -53,6 +54,10 @@ func rollupBodyKey(number uint64, hash common.Hash) []byte {
 
 func blockStateKey(hash common.Hash) []byte {
 	return append(blockStatePrefix, hash.Bytes()...)
+}
+
+func logsKey(hash common.Hash) []byte {
+	return append(logsPrefix, hash.Bytes()...)
 }
 
 // rollupReceiptsKey = rollupReceiptsPrefix + num (uint64 big endian) + hash

--- a/go/enclave/db/storage.go
+++ b/go/enclave/db/storage.go
@@ -225,7 +225,7 @@ func (s *storageImpl) FetchBlockState(hash common.L1RootHash) (*core.BlockState,
 	return nil, nil, false
 }
 
-func (s *storageImpl) SaveNewHead(state *core.BlockState, rollup *core.Rollup, receipts []*types.Receipt) {
+func (s *storageImpl) SaveNewHead(state *core.BlockState, rollup *core.Rollup, receipts []*types.Receipt, logs map[uuid.UUID][]*types.Log) {
 	batch := s.db.NewBatch()
 
 	if state.FoundNewRollup {
@@ -238,6 +238,8 @@ func (s *storageImpl) SaveNewHead(state *core.BlockState, rollup *core.Rollup, r
 	}
 
 	obscurorawdb.WriteBlockState(batch, state)
+	obscurorawdb.WriteBlockLogs(batch, state.Block, logs)
+
 	rawdb.WriteHeadHeaderHash(batch, state.Block)
 
 	if err := batch.Write(); err != nil {

--- a/go/enclave/db/storage.go
+++ b/go/enclave/db/storage.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/google/uuid"
+
 	"github.com/obscuronet/go-obscuro/go/enclave/crypto"
 
 	"github.com/obscuronet/go-obscuro/go/common/log"
@@ -213,12 +215,14 @@ func (s *storageImpl) Proof(r *core.Rollup) *types.Block {
 	return v
 }
 
-func (s *storageImpl) FetchBlockState(hash common.L1RootHash) (*core.BlockState, bool) {
+func (s *storageImpl) FetchBlockState(hash common.L1RootHash) (*core.BlockState, map[uuid.UUID][]*types.Log, bool) {
 	bs := obscurorawdb.ReadBlockState(s.db, hash)
-	if bs != nil {
-		return bs, true
+	logs := obscurorawdb.ReadBlockLogs(s.db, hash)
+	// We expect both the block state and the logs to be stored. If one isn't, we return neither.
+	if bs != nil && logs != nil {
+		return bs, logs, true
 	}
-	return nil, false
+	return nil, nil, false
 }
 
 func (s *storageImpl) SaveNewHead(state *core.BlockState, rollup *core.Rollup, receipts []*types.Receipt) {

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -212,7 +212,6 @@ func (rc *RollupChain) updateState(b *types.Block) (*obscurocore.BlockState, map
 	// To calculate the state after the current block, we need the state after the parent.
 	// If this point is reached, there is a parent state guaranteed, because the genesis is handled above
 	parentState, parentLogs, parentFound := rc.storage.FetchBlockState(b.ParentHash())
-
 	if !parentFound {
 		// go back and calculate the Root of the Parent
 		parent, found := rc.storage.FetchBlock(b.ParentHash())


### PR DESCRIPTION
### Why is this change needed?

Currently, we recalculate the logs for the entire chain each time we get a new block. This isn't sustainable.

### What changes were made as part of this PR:

Refactoring.

- Pushes the logs for each block to the DB
- Retrieves the logs for each block from the DB

### What are the key areas to look at

- ...


### :rotating_light: Definition of Done :rotating_light:
- [ ] Deployed into dev-testnet 
- [ ] Passes tests on dev-testnet
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated
