### PR TITLE
Logs re-registered viewing keys.

### DIFF
--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/obscuronet/go-obscuro/go/common/log"
@@ -482,7 +483,26 @@ func (we *WalletExtension) loadViewingKeys() map[common.Address]*rpc.ViewingKey 
 		viewingKeys[account] = &viewingKey
 	}
 
+	logReRegisteredViewingKeys(viewingKeys)
+
 	return viewingKeys
+}
+
+// Logs and prints the accounts for which we are re-registering viewing keys.
+func logReRegisteredViewingKeys(viewingKeys map[common.Address]*rpc.ViewingKey) {
+	if len(viewingKeys) == 0 {
+		return
+	}
+
+	var accounts []string
+	for account, _ := range viewingKeys {
+		accounts = append(accounts, account.Hex())
+	}
+
+	msg := fmt.Sprintf("Re-registering persisted viewing keys for the following addresses: %s",
+		strings.Join(accounts, ", "))
+	log.Error(msg)
+	fmt.Println(msg)
 }
 
 // Logs the error message and sends it as an HTTP error.

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -494,14 +494,14 @@ func logReRegisteredViewingKeys(viewingKeys map[common.Address]*rpc.ViewingKey) 
 		return
 	}
 
-	var accounts []string
-	for account, _ := range viewingKeys {
+	var accounts []string //nolint:prealloc
+	for account := range viewingKeys {
 		accounts = append(accounts, account.Hex())
 	}
 
 	msg := fmt.Sprintf("Re-registering persisted viewing keys for the following addresses: %s",
 		strings.Join(accounts, ", "))
-	log.Error(msg)
+	log.Info(msg)
 	fmt.Println(msg)
 }
 


### PR DESCRIPTION
### Why is this change needed?

To make it clear to the user that keys are being re-registered.

### What changes were made as part of this PR:

Functional.

- Prints information about re-registered keys

### What are the key areas to look at

- ...


### :rotating_light: Definition of Done :rotating_light:
- [ ] Deployed into dev-testnet 
- [ ] Passes tests on dev-testnet
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated
