### PR TITLE
Add a repository dispatch on a merged PR

### DIFF
--- a/.github/workflows/on-merged-pr.yml
+++ b/.github/workflows/on-merged-pr.yml
@@ -1,0 +1,15 @@
+name: Close and merge PR
+# Notifies via a repository dispatch event of a closed and merged PR
+
+on:
+  pull_request:
+    types: [ closed ]
+
+jobs:
+  merge_job:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Trigger obscuro-test local testnet tun'
+        run: |
+          curl -XPOST -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" -H "Accept:application/vnd.github" -H "Content-Type:application/json" https://api.github.com/repos/obscuronet/obscuro-test/actions/workflows/local_tests.yml/dispatches --data '{"pr_number": "${{ github.event.number }}" }'


### PR DESCRIPTION
### Why is this change needed?

- Adds a hooked on merged PRs to main to run local testnet tests (early detection of failures)

### What changes were made as part of this PR:

- Addition of a new workflow action file 

### What are the key areas to look at

- The newly added file

