### PR TITLE
Clarifies logic if a node starts processing blocks too early.

### DIFF
--- a/go/host/node/node.go
+++ b/go/host/node/node.go
@@ -449,19 +449,20 @@ func (a *Node) processBlocks(blocks []common.EncodedBlock, interrupt *int32) err
 	}
 
 	// Nodes can start before the genesis was published, and it makes no sense to enter the protocol.
-	if result.ProducedRollup.Header != nil {
-		encodedRollup, err := common.EncodeRollup(result.ProducedRollup.ToRollup())
-		if err != nil {
-			return fmt.Errorf("could not encode rollup. Cause: %w", err)
-		}
-		err = a.p2p.BroadcastRollup(encodedRollup)
-		if err != nil {
-			return fmt.Errorf("could not broadcast rollup. Cause: %w", err)
-		}
-
-		common.ScheduleInterrupt(a.config.GossipRoundDuration, interrupt, a.handleRoundWinner(result))
+	if result.ProducedRollup.Header == nil {
+		return nil
 	}
 
+	encodedRollup, err := common.EncodeRollup(result.ProducedRollup.ToRollup())
+	if err != nil {
+		return fmt.Errorf("could not encode rollup. Cause: %w", err)
+	}
+	err = a.p2p.BroadcastRollup(encodedRollup)
+	if err != nil {
+		return fmt.Errorf("could not broadcast rollup. Cause: %w", err)
+	}
+
+	common.ScheduleInterrupt(a.config.GossipRoundDuration, interrupt, a.handleRoundWinner(result))
 	return nil
 }
 

--- a/go/host/node/node.go
+++ b/go/host/node/node.go
@@ -424,20 +424,22 @@ func (a *Node) processBlocks(blocks []common.EncodedBlock, interrupt *int32) err
 	var result common.BlockSubmissionResponse
 	for _, block := range blocks {
 		// For the genesis block the parent is nil
-		if block != nil {
-			decoded, err := block.DecodeBlock()
-			if err != nil {
-				return err
-			}
-			a.processBlock(decoded)
-
-			// submit each block to the enclave for ingestion plus validation
-			result, err = a.enclaveClient.SubmitBlock(*decoded)
-			if err != nil {
-				return err
-			}
-			a.storeBlockProcessingResult(result)
+		if block == nil {
+			continue
 		}
+
+		decoded, err := block.DecodeBlock()
+		if err != nil {
+			return err
+		}
+		a.processBlock(decoded)
+
+		// submit each block to the enclave for ingestion plus validation
+		result, err = a.enclaveClient.SubmitBlock(*decoded)
+		if err != nil {
+			return err
+		}
+		a.storeBlockProcessingResult(result)
 	}
 
 	if !result.IngestedBlock {


### PR DESCRIPTION
### Why is this change needed?

The new approach is clearer.

### What changes were made as part of this PR:

- Provide a high level list of the changes made

### What are the key areas to look at

- Describe the key areas for a reviewer to look at 

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
