### PR TITLE
set log level to trace

### DIFF
--- a/go/common/log/log.go
+++ b/go/common/log/log.go
@@ -10,7 +10,7 @@ import (
 // setups some defaults like timestamp precision and logger
 func init() { //nolint:gochecknoinits
 	zerolog.TimeFieldFormat = time.RFC3339Nano
-	zerolog.SetGlobalLevel(DebugLevel)
+	zerolog.SetGlobalLevel(TraceLevel)
 	logger = zerolog.New(zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: time.StampMilli, NoColor: true}).With().Timestamp().Logger()
 }
 


### PR DESCRIPTION
### Why is this change needed?

to be able to investigate issues on the testnet

### What changes were made as part of this PR:

Functional PR

- hardcode the log level to trace. 

Note: this is temporary until the logging framework is sorted

### What are the key areas to look at


### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
