### PR TITLE
Separate retry package for re-use

### DIFF
--- a/go/common/retry/README.md
+++ b/go/common/retry/README.md
@@ -1,0 +1,7 @@
+Util package for retrying, functions and tools for situations where we are retrying/polling for a change.
+
+Based around a 'RetryStrategy' interface that allows different approaches such as:
+- retry X times
+- retry for X seconds
+- retry for 2 minutes but backing off
+

--- a/go/common/retry/retry.go
+++ b/go/common/retry/retry.go
@@ -1,0 +1,26 @@
+package retry
+
+import (
+	"fmt"
+	"time"
+)
+
+func Do(fn func() error, retryStrat RetryStrategy) error {
+	// Reset tells the strategy we are about to start making attempts (it might reset attempts counter/record start time)
+	retryStrat.Reset()
+
+	for {
+		// attempt to execute the function
+		err := fn()
+		if err == nil {
+			// success
+			return nil
+		}
+
+		if retryStrat.Done() {
+			return fmt.Errorf("%s - latest error: %w", retryStrat.Summary(), err)
+		}
+
+		time.Sleep(retryStrat.NextRetryInterval())
+	}
+}

--- a/go/common/retry/retry.go
+++ b/go/common/retry/retry.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-func Do(fn func() error, retryStrat RetryStrategy) error {
+func Do(fn func() error, retryStrat Strategy) error {
 	// Reset tells the strategy we are about to start making attempts (it might reset attempts counter/record start time)
 	retryStrat.Reset()
 

--- a/go/common/retry/retry_strategy.go
+++ b/go/common/retry/retry_strategy.go
@@ -5,8 +5,8 @@ import (
 	"time"
 )
 
-// RetryStrategy interface allows for flexible strategies for retrying/polling functions, the usage should be:
-type RetryStrategy interface {
+// Strategy interface allows for flexible strategies for retrying/polling functions, the usage should be:
+type Strategy interface {
 	// NextRetryInterval calls can be considered as marking the completion of an attempt
 	NextRetryInterval() time.Duration // returns the duration to sleep before making the next attempt (may not be fixed, e.g. if strategy is to back-off)
 	Done() bool                       // returns true when caller should stop retrying

--- a/go/common/retry/retry_strategy.go
+++ b/go/common/retry/retry_strategy.go
@@ -1,13 +1,13 @@
-package clientutil
+package retry
 
 import (
 	"fmt"
 	"time"
 )
 
-// retryStrategy interface allows for flexible strategies for retrying/polling functions
-type retryStrategy interface {
-	// WaitInterval calls can be considered as marking the completion of an attempt
+// RetryStrategy interface allows for flexible strategies for retrying/polling functions, the usage should be:
+type RetryStrategy interface {
+	// NextRetryInterval calls can be considered as marking the completion of an attempt
 	NextRetryInterval() time.Duration // returns the duration to sleep before making the next attempt (may not be fixed, e.g. if strategy is to back-off)
 	Done() bool                       // returns true when caller should stop retrying
 	Summary() string                  // message to summarise usage (i.e. number of retries, time take, if it failed and why, e.g. "timed out after 120 seconds (8 attempts)"

--- a/go/common/retry/retry_test.go
+++ b/go/common/retry/retry_test.go
@@ -1,0 +1,41 @@
+package retry
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestDoWithTimeoutStrategy_SuccessAfterRetries(t *testing.T) {
+	var count int
+	testFunc := func() error {
+		count = count + 1
+		fmt.Printf("c: %d\n", count)
+		if count < 3 {
+			return fmt.Errorf("attempt number %d", count)
+		}
+		return nil
+	}
+	err := Do(testFunc, NewTimeoutStrategy(1*time.Second, 100*time.Millisecond))
+	if err != nil {
+		assert.Fail(t, "Expected function to succeed before timeout but failed", err)
+	}
+
+	assert.Equal(t, 3, count, "expected function to be called 3 times before succeeding")
+}
+
+func TestDoWithTimeoutStrategy_FailAfterTimeout(t *testing.T) {
+	var count int
+	testFunc := func() error {
+		count = count + 1
+		fmt.Printf("c: %d\n", count)
+		return fmt.Errorf("attempt number %d", count)
+	}
+	err := Do(testFunc, NewTimeoutStrategy(600*time.Millisecond, 100*time.Millisecond))
+	if err == nil {
+		assert.Fail(t, "expected failure from timeout but no err received")
+	}
+
+	assert.Greater(t, count, 5, "expected function to be called at least 5 times before timing out")
+}

--- a/go/common/retry/retry_test.go
+++ b/go/common/retry/retry_test.go
@@ -2,9 +2,10 @@ package retry
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDoWithTimeoutStrategy_SuccessAfterRetries(t *testing.T) {

--- a/go/obsclient/clientutil/clientutil.go
+++ b/go/obsclient/clientutil/clientutil.go
@@ -3,6 +3,7 @@ package clientutil
 import (
 	"context"
 	"fmt"
+	"github.com/obscuronet/go-obscuro/go/common/retry"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -13,11 +14,11 @@ import (
 var defaultTimeoutInterval = 1 * time.Second
 
 func AwaitTransactionReceipt(ctx context.Context, client *obsclient.AuthObsClient, txHash common.Hash, timeout time.Duration) (*types.Receipt, error) {
-	timeoutStrategy := NewTimeoutStrategy(timeout, defaultTimeoutInterval)
+	timeoutStrategy := retry.NewTimeoutStrategy(timeout, defaultTimeoutInterval)
 	return AwaitTransactionReceiptWithRetryStrategy(ctx, client, txHash, timeoutStrategy)
 }
 
-func AwaitTransactionReceiptWithRetryStrategy(ctx context.Context, client *obsclient.AuthObsClient, txHash common.Hash, retryStrategy retryStrategy) (*types.Receipt, error) {
+func AwaitTransactionReceiptWithRetryStrategy(ctx context.Context, client *obsclient.AuthObsClient, txHash common.Hash, retryStrategy retry.RetryStrategy) (*types.Receipt, error) {
 	retryStrategy.Reset()
 	for {
 		select {

--- a/go/obsclient/clientutil/clientutil.go
+++ b/go/obsclient/clientutil/clientutil.go
@@ -3,8 +3,9 @@ package clientutil
 import (
 	"context"
 	"fmt"
-	"github.com/obscuronet/go-obscuro/go/common/retry"
 	"time"
+
+	"github.com/obscuronet/go-obscuro/go/common/retry"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -18,7 +19,7 @@ func AwaitTransactionReceipt(ctx context.Context, client *obsclient.AuthObsClien
 	return AwaitTransactionReceiptWithRetryStrategy(ctx, client, txHash, timeoutStrategy)
 }
 
-func AwaitTransactionReceiptWithRetryStrategy(ctx context.Context, client *obsclient.AuthObsClient, txHash common.Hash, retryStrategy retry.RetryStrategy) (*types.Receipt, error) {
+func AwaitTransactionReceiptWithRetryStrategy(ctx context.Context, client *obsclient.AuthObsClient, txHash common.Hash, retryStrategy retry.Strategy) (*types.Receipt, error) {
 	retryStrategy.Reset()
 	for {
 		select {

--- a/tools/contractdeployer/contract_deployer.go
+++ b/tools/contractdeployer/contract_deployer.go
@@ -4,10 +4,11 @@ package contractdeployer
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/obscuronet/go-obscuro/go/common/retry"
 	"math/big"
 	"strconv"
 	"time"
+
+	"github.com/obscuronet/go-obscuro/go/common/retry"
 
 	"github.com/obscuronet/go-obscuro/contracts/managementcontract"
 	"github.com/obscuronet/go-obscuro/integration/erc20contract"

--- a/tools/contractdeployer/main/main.go
+++ b/tools/contractdeployer/main/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"math/big"
 	"time"
 
 	"github.com/obscuronet/go-obscuro/go/common/log"
@@ -10,7 +11,20 @@ import (
 
 func main() {
 	log.SetLogLevel(log.DisabledLevel)
-	config := contractdeployer.ParseConfig()
+	//config := contractdeployer.ParseConfig()
+	config := &contractdeployer.Config{
+		NodeHost:       "obscuronode-0-testnet-17.uksouth.cloudapp.azure.com",
+		NodePort:       13000,
+		IsL1Deployment: false,
+		PrivateKey:     "4bfe14725e685901c062ccd4e220c61cf9c189897b6c78bd18d7f51291b2b8f8",
+		ChainID:        big.NewInt(777),
+		ContractName:   "L2ERC20",
+		ConstructorParams: []string{
+			"Matt",
+			"MAT",
+			"1000000000000000000000000000000",
+		},
+	}
 	contractAddr, err := contractdeployer.Deploy(config)
 	if err != nil {
 		// the contract deployer's output is to be consumed by other applications

--- a/tools/contractdeployer/main/main.go
+++ b/tools/contractdeployer/main/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"math/big"
 	"time"
 
 	"github.com/obscuronet/go-obscuro/go/common/log"
@@ -11,20 +10,7 @@ import (
 
 func main() {
 	log.SetLogLevel(log.DisabledLevel)
-	// config := contractdeployer.ParseConfig()
-	config := &contractdeployer.Config{
-		NodeHost:       "obscuronode-0-testnet-17.uksouth.cloudapp.azure.com",
-		NodePort:       13000,
-		IsL1Deployment: false,
-		PrivateKey:     "4bfe14725e685901c062ccd4e220c61cf9c189897b6c78bd18d7f51291b2b8f8",
-		ChainID:        big.NewInt(777),
-		ContractName:   "L2ERC20",
-		ConstructorParams: []string{
-			"Matt",
-			"MAT",
-			"1000000000000000000000000000000",
-		},
-	}
+	config := contractdeployer.ParseConfig()
 	contractAddr, err := contractdeployer.Deploy(config)
 	if err != nil {
 		// the contract deployer's output is to be consumed by other applications

--- a/tools/contractdeployer/main/main.go
+++ b/tools/contractdeployer/main/main.go
@@ -11,7 +11,7 @@ import (
 
 func main() {
 	log.SetLogLevel(log.DisabledLevel)
-	//config := contractdeployer.ParseConfig()
+	// config := contractdeployer.ParseConfig()
 	config := &contractdeployer.Config{
 		NodeHost:       "obscuronode-0-testnet-17.uksouth.cloudapp.azure.com",
 		NodePort:       13000,


### PR DESCRIPTION
### Why is this change needed?

- The retry mechanism is more widely useful than just in the obsclient utils
- The contract deployer can use it as Tudor suggested in review yesterday
- I'd like to use it in particular in the node code where we need to retry connections to the L1 client (and I'll merge the backoff mechanism into it too)

### What changes were made as part of this PR:

- Move the retry mechanism to a small `retry` package in common
- Add a `retry.Do()` that takes a function which errors for generic retry behaviour
- Update contract deployer to use retry.Do() for the deployment

I've run the contract deployer against testnet to verify multiple attempts are made before it succeeds and outputs the contract address.

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
