### PR TITLE
Update default RPC ports to use WS

### DIFF
--- a/.github/workflows/manual-deploy-obscuroscan.yml
+++ b/.github/workflows/manual-deploy-obscuroscan.yml
@@ -63,7 +63,7 @@ jobs:
           name: testnet-obscuroscan
           location: 'uksouth'
           restart-policy: 'Never'
-          command-line: ./tools/obscuroscan/main/main --rpcServerAddress testnet.obscu.ro:13000 --address 0.0.0.0:80
+          command-line: ./tools/obscuroscan/main/main --rpcServerAddress testnet.obscu.ro:13001 --address 0.0.0.0:80
           ports: '80'
           cpu: 2
           memory: 2

--- a/testnet/testnet-deploy-l2-contracts.sh
+++ b/testnet/testnet-deploy-l2-contracts.sh
@@ -30,7 +30,7 @@ start_path="$(cd "$(dirname "${0}")" && pwd)"
 testnet_path="${start_path}"
 
 # Define defaults
-l2port=13000
+l2port=13001
 # todo: get rid of these defaults and require them to be passed in, using github secrets for testnet values (requires bridge.go changes)
 hocpkstring="6e384a07a01263518a09a5424c7b6bbfc3604ba7d93f47e3a455cbdd7f9f0682"
 pocpkstring="4bfe14725e685901c062ccd4e220c61cf9c189897b6c78bd18d7f51291b2b8f8"

--- a/tools/azuredeployer/networkdeployer/README.md
+++ b/tools/azuredeployer/networkdeployer/README.md
@@ -26,6 +26,6 @@ network.
   * The enclave logs can be viewed using `docker logs <container-id>`
   * The Geth network logs are found under `~/go-obscuro/integration/.build/geth/<run-id>/node_logs.txt`
 
-* The first Obscuro host can be connected to remotely on port `13000`
+* The first Obscuro host can be connected to remotely via WS on port `13001`
   * This repo contains a tool under `tools/obscuroclient/` that can be used to connect remotely to the running 
     Obscuro host and retrieve the current block head height

--- a/tools/azuredeployer/networkdeployer/run.sh
+++ b/tools/azuredeployer/networkdeployer/run.sh
@@ -26,4 +26,4 @@ sudo docker run -e OE_SIMULATION=0 --privileged -v /dev/sgx:/dev/sgx -p 127.0.0.
 go-obscuro/go/host/main/host --id=1 --isGenesis=true --p2pBindAddress=0.0.0.0:10000 --p2pPublicAddress=127.0.0.1:10000 --enclaveRPCAddress=localhost:11000 --clientRPCHost=0.0.0.0 --clientRPCPortHttp=13000 --l1NodePort=12100 --privateKey=$PRIV_KEY_ONE > ./run_logs.txt 2>&1 &
 go-obscuro/go/host/main/host --id=2 --isGenesis=false --p2pBindAddress=0.0.0.0:10001 --p2pPublicAddress=127.0.0.1:10001 --enclaveRPCAddress=localhost:11001 --clientRPCHost=localhost --clientRPCPortHttp=13001 --l1NodePort=12101 --privateKey=$PRIV_KEY_TWO > ./run_logs.txt 2>&1 &
 cd go-obscuro
-sudo ./tools/obscuroscan/main/obscuroscan --rpcServerAddress=127.0.0.1:13000 --address=0.0.0.0:80 > ../run_logs.txt 2>&1 &
+sudo ./tools/obscuroscan/main/obscuroscan --rpcServerAddress=127.0.0.1:13001 --address=0.0.0.0:80 > ../run_logs.txt 2>&1 &

--- a/tools/networkmanager/cli.go
+++ b/tools/networkmanager/cli.go
@@ -81,7 +81,7 @@ func defaultNetworkManagerConfig() Config {
 		obscuroChainID:       integration.ObscuroChainID,
 		mgmtContractAddress:  common.BytesToAddress([]byte("")),
 		erc20ContractAddress: common.BytesToAddress([]byte("")),
-		obscuroClientAddress: "127.0.0.1:13000",
+		obscuroClientAddress: "127.0.0.1:13001",
 		erc20Token:           "TST",
 	}
 }

--- a/tools/obscuroscan/main/cli.go
+++ b/tools/obscuroscan/main/cli.go
@@ -25,7 +25,7 @@ type obscuroscanConfig struct {
 func defaultObscuroClientConfig() obscuroscanConfig {
 	return obscuroscanConfig{
 		nodeID:        "",
-		rpcServerAddr: "testnet.obscu.ro:13000",
+		rpcServerAddr: "testnet.obscu.ro:13001",
 		address:       "127.0.0.1:3000",
 	}
 }


### PR DESCRIPTION
### Why is this change needed?

- Some things have hardcoded URLs/ports for the RPC connections that need updating after we switched the clients to be WS-only (this was noticed by Moray using the testnet L2 contract deployment script)

### What changes were made as part of this PR:

- Searched for '13000' in the code and updated the ones that were being used as RPC addresses rather than HTTP ports

### What are the key areas to look at

- Did I change them correctly, did I miss any?

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
