### PR TITLE
Allows sub creation to be handled by the wallet extension.

### DIFF
--- a/go/common/enclave.go
+++ b/go/common/enclave.go
@@ -93,7 +93,7 @@ type Enclave interface {
 	// Subscribe adds a log subscription to the enclave under the given ID, provided the request is authenticated
 	// correctly. The events will be populated in the BlockSubmissionResponse. If there is an existing subscription
 	// with the given ID, it is overwritten.
-	Subscribe(id uuid.UUID, subscription EncryptedLogSubscription) error
+	Subscribe(id uuid.UUID, encryptedParams EncryptedParamsLogs) error
 
 	// Unsubscribe removes the log subscription with the given ID from the enclave. If there is no subscription with
 	// the given ID, nothing is deleted.

--- a/go/common/enclave.go
+++ b/go/common/enclave.go
@@ -93,7 +93,7 @@ type Enclave interface {
 	// Subscribe adds a log subscription to the enclave under the given ID, provided the request is authenticated
 	// correctly. The events will be populated in the BlockSubmissionResponse. If there is an existing subscription
 	// with the given ID, it is overwritten.
-	Subscribe(id uuid.UUID, encryptedParams EncryptedParamsLogs) error
+	Subscribe(id uuid.UUID, encryptedParams EncryptedParamsLogSubscription) error
 
 	// Unsubscribe removes the log subscription with the given ID from the enclave. If there is no subscription with
 	// the given ID, nothing is deleted.

--- a/go/common/types.go
+++ b/go/common/types.go
@@ -24,12 +24,12 @@ type (
 	EncryptedTx           []byte // A single transaction, encoded as a JSON list of transaction binary hexes and encrypted using the enclave's public key
 	EncryptedTransactions []byte // A blob of encrypted transactions, as they're stored in the rollup, with the nonce prepended.
 
-	EncryptedParamsGetBalance   []byte // The params for an RPC getBalance request, as a JSON object encrypted with the public key of the enclave.
-	EncryptedParamsCall         []byte // As above, but for an RPC call request.
-	EncryptedParamsGetTxByHash  []byte // As above, but for an RPC getTransactionByHash request.
-	EncryptedParamsGetTxReceipt []byte // As above, but for an RPC getTransactionReceipt request.
-	EncryptedParamsLogs         []byte // As above, but for an RPC logs subscription request.
-	EncryptedParamsSendRawTx    []byte // As above, but for an RPC sendRawTransaction request.
+	EncryptedParamsGetBalance      []byte // The params for an RPC getBalance request, as a JSON object encrypted with the public key of the enclave.
+	EncryptedParamsCall            []byte // As above, but for an RPC call request.
+	EncryptedParamsGetTxByHash     []byte // As above, but for an RPC getTransactionByHash request.
+	EncryptedParamsGetTxReceipt    []byte // As above, but for an RPC getTransactionReceipt request.
+	EncryptedParamsLogSubscription []byte // As above, but for an RPC logs subscription request.
+	EncryptedParamsSendRawTx       []byte // As above, but for an RPC sendRawTransaction request.
 
 	EncryptedResponseGetBalance   []byte // The response for an RPC getBalance request, as a JSON object encrypted with the viewing key of the user.
 	EncryptedResponseCall         []byte // As above, but for an RPC call request.

--- a/go/common/types.go
+++ b/go/common/types.go
@@ -26,9 +26,10 @@ type (
 
 	EncryptedParamsGetBalance   []byte // The params for an RPC getBalance request, as a JSON object encrypted with the public key of the enclave.
 	EncryptedParamsCall         []byte // As above, but for an RPC call request.
-	EncryptedParamsGetTxReceipt []byte // As above, but for an RPC getTransactionReceipt request.
-	EncryptedParamsSendRawTx    []byte // As above, but for an RPC sendRawTransaction request.
 	EncryptedParamsGetTxByHash  []byte // As above, but for an RPC getTransactionByHash request.
+	EncryptedParamsGetTxReceipt []byte // As above, but for an RPC getTransactionReceipt request.
+	EncryptedParamsLogs         []byte // As above, but for an RPC logs subscription request.
+	EncryptedParamsSendRawTx    []byte // As above, but for an RPC sendRawTransaction request.
 
 	EncryptedResponseGetBalance   []byte // The response for an RPC getBalance request, as a JSON object encrypted with the viewing key of the user.
 	EncryptedResponseCall         []byte // As above, but for an RPC call request.

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -163,7 +163,7 @@ func NewEnclave(
 	common.LogWithID(nodeShortID, "Generated public key %s", gethcommon.Bytes2Hex(serializedEnclavePubKey))
 
 	obscuroKey := obscurocrypto.GetObscuroKey()
-	rpcem := rpc.NewEncryptionManager(ecies.ImportECDSA(obscuroKey))
+	rpcEncryptionManager := rpc.NewEncryptionManager(ecies.ImportECDSA(obscuroKey))
 
 	transactionBlobCrypto := obscurocrypto.NewTransactionBlobCryptoImpl()
 
@@ -179,8 +179,8 @@ func NewEnclave(
 	)
 	memp := mempool.New(config.ObscuroChainID)
 
-	subscriptionManager := events.NewSubscriptionManager()
-	chain := rollupchain.New(nodeShortID, config.HostID, storage, l1Blockchain, obscuroBridge, subscriptionManager, transactionBlobCrypto, memp, rpcem, enclaveKey, config.L1ChainID, &chainConfig)
+	subscriptionManager := events.NewSubscriptionManager(&rpcEncryptionManager)
+	chain := rollupchain.New(nodeShortID, config.HostID, storage, l1Blockchain, obscuroBridge, subscriptionManager, transactionBlobCrypto, memp, rpcEncryptionManager, enclaveKey, config.L1ChainID, &chainConfig)
 
 	jsonConfig, _ := json.MarshalIndent(config, "", "  ")
 	log.Info("Enclave service created with following config:\n%s", string(jsonConfig))
@@ -192,7 +192,7 @@ func NewEnclave(
 		mempool:               memp,
 		statsCollector:        collector,
 		l1Blockchain:          l1Blockchain,
-		rpcEncryptionManager:  rpcem,
+		rpcEncryptionManager:  rpcEncryptionManager,
 		bridge:                obscuroBridge,
 		subscriptionManager:   subscriptionManager,
 		chain:                 chain,
@@ -510,11 +510,7 @@ func (e *enclaveImpl) GetCode(address gethcommon.Address, rollupHash *gethcommon
 }
 
 func (e *enclaveImpl) Subscribe(id uuid.UUID, encryptedSubscription common.EncryptedParamsLogs) error {
-	jsonSubscription, err := e.rpcEncryptionManager.DecryptBytes(encryptedSubscription)
-	if err != nil {
-		return fmt.Errorf("could not decrypt params in eth_subscribe logs request. Cause: %w", err)
-	}
-	return e.subscriptionManager.AddSubscription(id, jsonSubscription)
+	return e.subscriptionManager.AddSubscription(id, encryptedSubscription)
 }
 
 func (e *enclaveImpl) Unsubscribe(id uuid.UUID) error {

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -509,7 +509,7 @@ func (e *enclaveImpl) GetCode(address gethcommon.Address, rollupHash *gethcommon
 	return e.storage.CreateStateDB(*rollupHash).GetCode(address), nil
 }
 
-func (e *enclaveImpl) Subscribe(id uuid.UUID, encryptedSubscription common.EncryptedParamsLogs) error {
+func (e *enclaveImpl) Subscribe(id uuid.UUID, encryptedSubscription common.EncryptedParamsLogSubscription) error {
 	return e.subscriptionManager.AddSubscription(id, encryptedSubscription)
 }
 

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -509,8 +509,12 @@ func (e *enclaveImpl) GetCode(address gethcommon.Address, rollupHash *gethcommon
 	return e.storage.CreateStateDB(*rollupHash).GetCode(address), nil
 }
 
-func (e *enclaveImpl) Subscribe(id uuid.UUID, subscription common.EncryptedLogSubscription) error {
-	return e.subscriptionManager.AddSubscription(id, subscription)
+func (e *enclaveImpl) Subscribe(id uuid.UUID, encryptedSubscription common.EncryptedParamsLogs) error {
+	jsonSubscription, err := e.rpcEncryptionManager.DecryptBytes(encryptedSubscription)
+	if err != nil {
+		return fmt.Errorf("could not decrypt params in eth_subscribe logs request. Cause: %w", err)
+	}
+	return e.subscriptionManager.AddSubscription(id, jsonSubscription)
 }
 
 func (e *enclaveImpl) Unsubscribe(id uuid.UUID) error {

--- a/go/enclave/events/subscription_manager.go
+++ b/go/enclave/events/subscription_manager.go
@@ -28,7 +28,7 @@ func NewSubscriptionManager(rpcEncryptionManager *rpc.EncryptionManager) *Subscr
 // AddSubscription adds a log subscription to the enclave under the given ID, provided the request is authenticated
 // correctly. If there is an existing subscription with the given ID, it is overwritten.
 // TODO - #453 - Check each account in the subscription request is authenticated with a signature.
-func (s *SubscriptionManager) AddSubscription(id uuid.UUID, encryptedSubscription common.EncryptedParamsLogs) error {
+func (s *SubscriptionManager) AddSubscription(id uuid.UUID, encryptedSubscription common.EncryptedParamsLogSubscription) error {
 	jsonSubscription, err := s.rpcEncryptionManager.DecryptBytes(encryptedSubscription)
 	if err != nil {
 		return fmt.Errorf("could not decrypt params in eth_subscribe logs request. Cause: %w", err)

--- a/go/host/interfaces.go
+++ b/go/host/interfaces.go
@@ -23,7 +23,7 @@ type Host interface {
 	// ReceiveTx processes a transaction received from a peer host.
 	ReceiveTx(tx common.EncryptedTx)
 	// CreateSubscription sets up a subscription between the host and the enclave.
-	CreateSubscription(encryptedLogSubscription common.EncryptedLogSubscription) error
+	CreateSubscription(encryptedLogSubscription common.EncryptedParamsLogs) error
 	// Stop gracefully stops the host execution.
 	Stop()
 }

--- a/go/host/interfaces.go
+++ b/go/host/interfaces.go
@@ -23,7 +23,7 @@ type Host interface {
 	// ReceiveTx processes a transaction received from a peer host.
 	ReceiveTx(tx common.EncryptedTx)
 	// CreateSubscription sets up a subscription between the host and the enclave.
-	CreateSubscription(encryptedLogSubscription common.EncryptedParamsLogs) error
+	CreateSubscription(encryptedLogSubscription common.EncryptedParamsLogSubscription) error
 	// Stop gracefully stops the host execution.
 	Stop()
 }

--- a/go/host/node/node.go
+++ b/go/host/node/node.go
@@ -316,13 +316,13 @@ func (a *Node) ReceiveTx(tx common.EncryptedTx) {
 }
 
 // CreateSubscription sets up a subscription between the host and the enclave.
-func (a *Node) CreateSubscription(encryptedLogSubscription common.EncryptedLogSubscription) error {
+func (a *Node) CreateSubscription(encryptedParams common.EncryptedParamsLogs) error {
 	id, err := uuid.NewUUID()
 	if err != nil {
 		return fmt.Errorf("could not generate new UUID for subscription. Cause: %w", err)
 	}
 
-	err = a.EnclaveClient().Subscribe(id, encryptedLogSubscription)
+	err = a.EnclaveClient().Subscribe(id, encryptedParams)
 	if err != nil {
 		return fmt.Errorf("could not create subscription with enclave. Cause: %w", err)
 	}

--- a/go/host/node/node.go
+++ b/go/host/node/node.go
@@ -316,7 +316,7 @@ func (a *Node) ReceiveTx(tx common.EncryptedTx) {
 }
 
 // CreateSubscription sets up a subscription between the host and the enclave.
-func (a *Node) CreateSubscription(encryptedParams common.EncryptedParamsLogs) error {
+func (a *Node) CreateSubscription(encryptedParams common.EncryptedParamsLogSubscription) error {
 	id, err := uuid.NewUUID()
 	if err != nil {
 		return fmt.Errorf("could not generate new UUID for subscription. Cause: %w", err)

--- a/go/host/rpc/clientapi/client_api_filter.go
+++ b/go/host/rpc/clientapi/client_api_filter.go
@@ -33,7 +33,7 @@ func NewFilterAPI(host host.Host, logsCh chan []*types.Log) *FilterAPI {
 }
 
 // Logs returns a log subscription.
-func (api *FilterAPI) Logs(ctx context.Context, encryptedParams common.EncryptedParamsLogs) (*rpc.Subscription, error) {
+func (api *FilterAPI) Logs(ctx context.Context, encryptedParams common.EncryptedParamsLogSubscription) (*rpc.Subscription, error) {
 	err := api.host.CreateSubscription(encryptedParams)
 	if err != nil {
 		return nil, fmt.Errorf("could not subscribe for logs. Cause: %w", err)

--- a/go/host/rpc/clientapi/client_api_filter.go
+++ b/go/host/rpc/clientapi/client_api_filter.go
@@ -33,8 +33,8 @@ func NewFilterAPI(host host.Host, logsCh chan []*types.Log) *FilterAPI {
 }
 
 // Logs returns a log subscription.
-func (api *FilterAPI) Logs(ctx context.Context, encryptedLogSubscription common.EncryptedLogSubscription) (*rpc.Subscription, error) {
-	err := api.host.CreateSubscription(encryptedLogSubscription)
+func (api *FilterAPI) Logs(ctx context.Context, encryptedParams common.EncryptedParamsLogs) (*rpc.Subscription, error) {
+	err := api.host.CreateSubscription(encryptedParams)
 	if err != nil {
 		return nil, fmt.Errorf("could not subscribe for logs. Cause: %w", err)
 	}

--- a/go/host/rpc/enclaverpc/enclave_client.go
+++ b/go/host/rpc/enclaverpc/enclave_client.go
@@ -405,7 +405,7 @@ func (c *Client) StoreAttestation(report *common.AttestationReport) error {
 	return nil
 }
 
-func (c *Client) Subscribe(id uuid.UUID, subscription common.EncryptedLogSubscription) error {
+func (c *Client) Subscribe(id uuid.UUID, encryptedParams common.EncryptedParamsLogs) error {
 	timeoutCtx, cancel := context.WithTimeout(context.Background(), c.config.EnclaveRPCTimeout)
 	defer cancel()
 
@@ -416,7 +416,7 @@ func (c *Client) Subscribe(id uuid.UUID, subscription common.EncryptedLogSubscri
 
 	_, err = c.protoClient.Subscribe(timeoutCtx, &generated.SubscribeRequest{
 		Id:                    idBinary,
-		EncryptedSubscription: subscription,
+		EncryptedSubscription: encryptedParams,
 	})
 	return err
 }

--- a/go/host/rpc/enclaverpc/enclave_client.go
+++ b/go/host/rpc/enclaverpc/enclave_client.go
@@ -405,7 +405,7 @@ func (c *Client) StoreAttestation(report *common.AttestationReport) error {
 	return nil
 }
 
-func (c *Client) Subscribe(id uuid.UUID, encryptedParams common.EncryptedParamsLogs) error {
+func (c *Client) Subscribe(id uuid.UUID, encryptedParams common.EncryptedParamsLogSubscription) error {
 	timeoutCtx, cancel := context.WithTimeout(context.Background(), c.config.EnclaveRPCTimeout)
 	defer cancel()
 

--- a/go/obsclient/test_util.go
+++ b/go/obsclient/test_util.go
@@ -3,6 +3,8 @@ package obsclient
 import (
 	"context"
 
+	"github.com/ethereum/go-ethereum/rpc"
+
 	"github.com/stretchr/testify/mock"
 )
 
@@ -19,6 +21,10 @@ func (m *rpcClientMock) Call(result interface{}, method string, args ...interfac
 func (m *rpcClientMock) CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error {
 	arguments := m.Called(ctx, result, method, args)
 	return arguments.Error(0)
+}
+
+func (m *rpcClientMock) Subscribe(context.Context, string, interface{}, ...interface{}) (*rpc.ClientSubscription, error) {
+	panic("not implemented")
 }
 
 func (m *rpcClientMock) Stop() {

--- a/go/rpc/client.go
+++ b/go/rpc/client.go
@@ -15,6 +15,7 @@ const (
 	RPCNonce                   = "eth_getTransactionCount"
 	RPCGetTxReceipt            = "eth_getTransactionReceipt"
 	RPCSendRawTransaction      = "eth_sendRawTransaction"
+	RPCSubscribe               = "eth_subscribe"
 	RPCGetBlockHeaderByHash    = "obscuroscan_getBlockHeaderByHash"
 	RPCGetCurrentRollupHead    = "obscuroscan_getCurrentRollupHead"
 	RPCGetRollup               = "obscuroscan_getRollup"
@@ -27,6 +28,7 @@ const (
 	RPCGetCurrentBlockHead     = "test_getCurrentBlockHead"
 	RPCGetRollupHeader         = "test_getRollupHeader"
 	RPCStopHost                = "test_stopHost"
+	RPCSubscriptionLogs        = "logs"
 )
 
 var ErrNilResponse = errors.New("nil response received from Obscuro node")

--- a/go/rpc/client.go
+++ b/go/rpc/client.go
@@ -3,6 +3,8 @@ package rpc
 import (
 	"context"
 	"errors"
+
+	"github.com/ethereum/go-ethereum/rpc"
 )
 
 const (
@@ -15,7 +17,6 @@ const (
 	RPCNonce                   = "eth_getTransactionCount"
 	RPCGetTxReceipt            = "eth_getTransactionReceipt"
 	RPCSendRawTransaction      = "eth_sendRawTransaction"
-	RPCSubscribe               = "eth_subscribe"
 	RPCGetBlockHeaderByHash    = "obscuroscan_getBlockHeaderByHash"
 	RPCGetCurrentRollupHead    = "obscuroscan_getCurrentRollupHead"
 	RPCGetRollup               = "obscuroscan_getRollup"
@@ -28,7 +29,10 @@ const (
 	RPCGetCurrentBlockHead     = "test_getCurrentBlockHead"
 	RPCGetRollupHeader         = "test_getRollupHeader"
 	RPCStopHost                = "test_stopHost"
-	RPCSubscriptionLogs        = "logs"
+
+	RPCSubscribe            = "eth_subscribe"
+	RPCSubscribeNamespace   = "eth"
+	RPCSubscriptionTypeLogs = "logs"
 )
 
 var ErrNilResponse = errors.New("nil response received from Obscuro node")
@@ -39,6 +43,8 @@ type Client interface {
 	Call(result interface{}, method string, args ...interface{}) error
 	// CallContext If the context is canceled before the call has successfully returned, CallContext returns immediately.
 	CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error
+	// Subscribe creates a subscription to the Obscuro host.
+	Subscribe(ctx context.Context, namespace string, channel interface{}, args ...interface{}) (*rpc.ClientSubscription, error)
 	// Stop closes the client.
 	Stop()
 }

--- a/go/rpc/encrypted_client.go
+++ b/go/rpc/encrypted_client.go
@@ -142,9 +142,9 @@ func (c *EncRPCClient) Account() *common.Address {
 	return c.viewingKey.Account
 }
 
-func (c *EncRPCClient) encryptArgs(args ...interface{}) (interface{}, error) {
+func (c *EncRPCClient) encryptArgs(args ...interface{}) ([]byte, error) {
 	if len(args) == 0 {
-		return nil, nil //nolint:nilnil
+		return nil, nil
 	}
 
 	paramsJSON, err := json.Marshal(args)
@@ -152,12 +152,7 @@ func (c *EncRPCClient) encryptArgs(args ...interface{}) (interface{}, error) {
 		return nil, fmt.Errorf("could not json encode request params: %w", err)
 	}
 
-	encryptedArgs, err := c.encryptParamBytes(paramsJSON)
-	if err != nil {
-		return nil, err
-	}
-
-	return encryptedArgs, nil
+	return c.encryptParamBytes(paramsJSON)
 }
 
 func (c *EncRPCClient) encryptParamBytes(params []byte) ([]byte, error) {

--- a/go/rpc/network_client.go
+++ b/go/rpc/network_client.go
@@ -52,6 +52,10 @@ func (c *networkClient) CallContext(ctx context.Context, result interface{}, met
 	return c.rpcClient.CallContext(ctx, result, method, args...)
 }
 
+func (c *networkClient) Subscribe(ctx context.Context, namespace string, channel interface{}, args ...interface{}) (*rpc.ClientSubscription, error) {
+	return c.rpcClient.Subscribe(ctx, namespace, channel, args...)
+}
+
 func (c *networkClient) Stop() {
 	c.rpcClient.Close()
 }

--- a/integration/simulation/p2p/in_mem_obscuro_client.go
+++ b/integration/simulation/p2p/in_mem_obscuro_client.go
@@ -120,6 +120,10 @@ func (c *inMemObscuroClient) CallContext(_ context.Context, result interface{}, 
 	return c.Call(result, method, args...)
 }
 
+func (c *inMemObscuroClient) Subscribe(ctx context.Context, namespace string, channel interface{}, args ...interface{}) (*gethrpc.ClientSubscription, error) {
+	panic("not implemented")
+}
+
 func (c *inMemObscuroClient) sendRawTransaction(args []interface{}) error {
 	encBytes, err := getEncryptedBytes(args, rpc.RPCSendRawTransaction)
 	if err != nil {

--- a/integration/walletextension/wallet_extension_test.go
+++ b/integration/walletextension/wallet_extension_test.go
@@ -304,12 +304,12 @@ func TestCannotSubmitTxFromAnotherAddressAfterSubmittingViewingKey(t *testing.T)
 func TestCanSubscribeForLogs(t *testing.T) {
 	createWalletExtension(t)
 
-	// TODO - #453 - We should be passing standard arguments, and they should be mapped by the wallet extension.
+	// TODO - #453 - We should be passing a Geth FilterQuery, and it should be converted by the wallet extension.
 	logSubscription := common.LogSubscription{
 		Accounts: []*common.SubscriptionAccount{},
 	}
 
-	makeEthJSONReqAsJSON(rpc.RPCSubscribe, []interface{}{rpc.RPCSubscriptionLogs, logSubscription})
+	makeEthJSONReqAsJSON(rpc.RPCSubscribe, []interface{}{rpc.RPCSubscriptionTypeLogs, logSubscription})
 }
 
 func TestCanDecryptSuccessfullyAfterSubmittingMultipleViewingKeys(t *testing.T) {

--- a/tools/walletextension/multi_acc_helper.go
+++ b/tools/walletextension/multi_acc_helper.go
@@ -187,6 +187,7 @@ func executeCall(client *rpc.EncRPCClient, req *rpcRequest, resp *interface{}) e
 		}
 
 		// TODO - #453 - Route subscription events back to frontend.
+		// TODO - #453 - Manage subscriptions based on websockets being terminated.
 
 		return nil
 	}


### PR DESCRIPTION
### Why is this change needed?

Creation of subscriptions is encrypted, and needs special handling via the wallet extension

### What changes were made as part of this PR:

- Adds a `Subscribe` method to all clients
- Implements `Subscribe` for the encrypted client
- Encrypts outbound subscription creation requests via the wallet extension
- Adds a very basic wallet extension test, showing that creating a subscription via the wallet extension doesn't blow up

### What are the key areas to look at

- Describe the key areas for a reviewer to look at 

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
