### PR TITLE
Wraps encoded logs to send back.

### DIFF
--- a/go/host/events/backend.go
+++ b/go/host/events/backend.go
@@ -77,8 +77,8 @@ func (b Backend) SubscribeLogsEvent(ch chan<- []*types.Log) event.Subscription {
 			select {
 			case <-quit:
 				break
-			case logs := <-b.logsCh:
-				ch <- []*types.Log{logs}
+			case receivedLog := <-b.logsCh:
+				ch <- []*types.Log{receivedLog}
 			}
 		}
 	}

--- a/go/host/node/node.go
+++ b/go/host/node/node.go
@@ -596,9 +596,10 @@ func (a *Node) sendLogsToSubscribers(result common.BlockSubmissionResponse) {
 	for _, encryptedLogs := range result.SubscribedLogs {
 		// Due to our reuse of the Geth log subscription API, we have to return the logs as types.Log objects, and not
 		// encrypted bytes. To get around this, we place the encrypted log bytes into a "fake" log's data field.
-		// TODO - #453 - Tag the "fake" log objects with a topic that's the padded subscription ID.
 		wrapperLog := types.Log{
-			Data: encryptedLogs,
+			// TODO - #453 - Tag the "fake" log objects with a topic that's the padded subscription ID instead.
+			Topics: []gethcommon.Hash{gethcommon.BytesToHash([]byte("placeholder"))},
+			Data:   encryptedLogs,
 		}
 		a.logsCh <- &wrapperLog
 	}

--- a/integration/walletextension/wallet_extension_test.go
+++ b/integration/walletextension/wallet_extension_test.go
@@ -305,6 +305,24 @@ func TestCanSubscribeForLogs(t *testing.T) {
 	createWalletExtension(t)
 
 	makeEthJSONReqAsJSON(rpc.RPCSubscribe, []interface{}{rpc.RPCSubscriptionTypeLogs, filters.FilterCriteria{}})
+
+	// TODO - #453 - Remove temp code below, which is intended only to force an event to happen, then wait for it to be
+	//  processed by the wallet extension.
+	_, privateKey := registerPrivateKey(t)
+	txWallet := wallet.NewInMemoryWalletFromPK(big.NewInt(integration.ObscuroChainID), privateKey)
+	err := fundAccount(txWallet.Address())
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = txWallet.SignTransaction(&deployERC20Tx)
+	if err != nil {
+		panic(fmt.Errorf("could not sign transaction. Cause: %w", err))
+	}
+	_, err = sendTransactionAndAwaitConfirmation(txWallet, deployERC20Tx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(5 * time.Second)
 }
 
 func TestCanDecryptSuccessfullyAfterSubmittingMultipleViewingKeys(t *testing.T) {

--- a/tools/walletextension/multi_acc_helper.go
+++ b/tools/walletextension/multi_acc_helper.go
@@ -197,10 +197,8 @@ func executeSubscribe(client *rpc.EncRPCClient, req *rpcRequest, _ *interface{})
 	go func() {
 		for {
 			select {
-			case receivedLog := <-ch:
+			case _ = <-ch:
 				// TODO - #453 - Route subscription events back to frontend.
-				println(fmt.Sprintf("Received logs. Block number: %d. Index: %d. Data: %s.",
-					receivedLog.BlockNumber, receivedLog.Index, string(receivedLog.Data)))
 			case err = <-subscription.Err():
 				// TODO - #453 - Route error back to frontend.
 			}


### PR DESCRIPTION
### Why is this change needed?

Because we want to send our logs encrypted, but the Geth subscription API works in terms of log objects, we need to wrap our encrypted logs in the data field of a log object.

### What changes were made as part of this PR:

- Provide a high level list of the changes made

### What are the key areas to look at

- Describe the key areas for a reviewer to look at 

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
