### PR TITLE
Adds WS port to wallet extension server

### DIFF
--- a/docs/wallet-extension/wallet-extension.md
+++ b/docs/wallet-extension/wallet-extension.md
@@ -54,13 +54,14 @@ tools.
    supports the following flags:
 
    * `port` (default: `3000`): The local port on which to serve the wallet extension.
+   * `portWS` (default: `3001`): The local port on which to handle websocket requests.
    * `nodeHost` (default: `testnet.obscu.ro`): The Obscuro node for the RPC connection.
    * `nodePortHTTP` (default: `13000`): The Obscuro node's HTTP RPC port.
    * `nodePortWS` (default: `13001`): The Obscuro node's websockets RPC port.
    * `logPath` (default: `wallet_extension_logs.txt`): The path for the wallet extension's logs.
 
    The wallet extension is now listening on the specified host and port. For the remainder of this document, we'll 
-   assume that the default port of `3000` was selected.
+   assume that the default ports of `3000` and `3001` were selected.
 
 3. Sign in to MetaMask and add the Obscuro Testnet network following the instructions [here](/wallet-extension/configure-metamask.html)
 

--- a/integration/walletextension/wallet_extension_test.go
+++ b/integration/walletextension/wallet_extension_test.go
@@ -58,10 +58,12 @@ const (
 	errInsecure       = "enclave could not respond securely to %s request"
 	errSubscribeFail  = "received an eth_subscribe request but the connection does not support subscriptions"
 
-	networkStartPort = integration.StartPortWalletExtensionTest + 1
-	nodeRPCHTTPPort  = integration.StartPortWalletExtensionTest + 1 + network.DefaultHostRPCHTTPOffset
-	nodeRPCWSPort    = integration.StartPortWalletExtensionTest + 1 + network.DefaultHostRPCWSOffset
-	httpProtocol     = "http://"
+	walletExtensionPort   = int(integration.StartPortWalletExtensionTest)
+	walletExtensionPortWS = int(integration.StartPortWalletExtensionTest + 1)
+	networkStartPort      = integration.StartPortWalletExtensionTest + 2
+	nodeRPCHTTPPort       = networkStartPort + network.DefaultHostRPCHTTPOffset
+	nodeRPCWSPort         = networkStartPort + network.DefaultHostRPCWSOffset
+	httpProtocol          = "http://"
 
 	// Returned by the EVM to indicate a zero result.
 	zeroResult  = "0x0000000000000000000000000000000000000000000000000000000000000000"
@@ -71,8 +73,8 @@ const (
 )
 
 var (
-	walletExtensionAddr   = fmt.Sprintf("%s:%d", network.Localhost, integration.StartPortWalletExtensionTest)
-	walletExtensionConfig = createWalletExtensionConfig()
+	walletExtensionAddrHTTP = fmt.Sprintf("%s:%d", network.Localhost, walletExtensionPort)
+	walletExtensionConfig   = createWalletExtensionConfig()
 
 	dummyAccountAddress = gethcommon.HexToAddress("0x8D97689C9818892B700e27F316cc3E41e17fBeb9")
 	deployERC20Tx       = types.LegacyTx{
@@ -97,7 +99,7 @@ func TestMain(m *testing.M) {
 func TestCanMakeNonSensitiveRequestWithoutSubmittingViewingKey(t *testing.T) {
 	createWalletExtension(t)
 
-	respJSON := makeEthJSONReqAsJSON(rpc.RPCChainID, []string{})
+	respJSON := makeHTTPEthJSONReqAsJSON(rpc.RPCChainID, []string{})
 
 	if respJSON[walletextension.RespJSONKeyResult] != l2ChainIDHex {
 		t.Fatalf("Expected chainId of %s, got %s", l2ChainIDHex, respJSON[walletextension.RespJSONKeyResult])
@@ -107,7 +109,7 @@ func TestCanMakeNonSensitiveRequestWithoutSubmittingViewingKey(t *testing.T) {
 func TestCannotGetBalanceWithoutSubmittingViewingKey(t *testing.T) {
 	createWalletExtension(t)
 
-	respBody := makeEthJSONReq(rpc.RPCGetBalance, []string{dummyAccountAddress.Hex(), latestBlock})
+	respBody := makeHTTPEthJSONReq(rpc.RPCGetBalance, []string{dummyAccountAddress.Hex(), latestBlock})
 	expectedErr := fmt.Sprintf(errInsecure, rpc.RPCGetBalance)
 
 	if !strings.Contains(string(respBody), expectedErr) {
@@ -119,7 +121,7 @@ func TestCanGetOwnBalanceAfterSubmittingViewingKey(t *testing.T) {
 	createWalletExtension(t)
 	accountAddr, _ := registerPrivateKey(t)
 
-	getBalanceJSON := makeEthJSONReqAsJSON(rpc.RPCGetBalance, []string{accountAddr.String(), latestBlock})
+	getBalanceJSON := makeHTTPEthJSONReqAsJSON(rpc.RPCGetBalance, []string{accountAddr.String(), latestBlock})
 
 	if getBalanceJSON[walletextension.RespJSONKeyResult] != zeroBalance {
 		t.Fatalf("Expected balance of %s, got %s", zeroBalance, getBalanceJSON[walletextension.RespJSONKeyResult])
@@ -130,7 +132,7 @@ func TestCannotGetAnothersBalanceAfterSubmittingViewingKey(t *testing.T) {
 	createWalletExtension(t)
 	registerPrivateKey(t)
 
-	respBody := makeEthJSONReq(rpc.RPCGetBalance, []string{dummyAccountAddress.Hex(), latestBlock})
+	respBody := makeHTTPEthJSONReq(rpc.RPCGetBalance, []string{dummyAccountAddress.Hex(), latestBlock})
 	expectedErr := fmt.Sprintf(errInsecure, rpc.RPCGetBalance)
 
 	if !strings.Contains(string(respBody), expectedErr) {
@@ -157,7 +159,7 @@ func TestCannotCallWithoutSubmittingViewingKey(t *testing.T) {
 		reqJSONKeyData: "0x" + gethcommon.Bytes2Hex(transferTxBytes),
 	}
 
-	respBody := makeEthJSONReq(rpc.RPCCall, []interface{}{reqParams, latestBlock})
+	respBody := makeHTTPEthJSONReq(rpc.RPCCall, []interface{}{reqParams, latestBlock})
 	expectedErr := fmt.Sprintf(errInsecure, rpc.RPCCall)
 
 	if !strings.Contains(string(respBody), expectedErr) {
@@ -179,7 +181,7 @@ func TestCanCallAfterSubmittingViewingKey(t *testing.T) {
 		reqJSONKeyData: convertedData,
 	}
 
-	callJSON := makeEthJSONReqAsJSON(rpc.RPCCall, []interface{}{reqParams, latestBlock})
+	callJSON := makeHTTPEthJSONReqAsJSON(rpc.RPCCall, []interface{}{reqParams, latestBlock})
 
 	if callJSON[walletextension.RespJSONKeyResult] != zeroResult {
 		t.Fatalf("Expected call result of %s, got %s", zeroResult, callJSON[walletextension.RespJSONKeyResult])
@@ -199,7 +201,7 @@ func TestCanCallWithoutSettingFromField(t *testing.T) {
 		reqJSONKeyData: convertedData,
 	}
 
-	callJSON := makeEthJSONReqAsJSON(rpc.RPCCall, []interface{}{reqParams, latestBlock})
+	callJSON := makeHTTPEthJSONReqAsJSON(rpc.RPCCall, []interface{}{reqParams, latestBlock})
 
 	if callJSON[walletextension.RespJSONKeyResult] != zeroResult {
 		t.Fatalf("Expected call result of %s, got %s", zeroResult, callJSON[walletextension.RespJSONKeyResult])
@@ -221,7 +223,7 @@ func TestCannotCallForAnotherAddressAfterSubmittingViewingKey(t *testing.T) {
 		reqJSONKeyData: convertedData,
 	}
 
-	respBody := makeEthJSONReq(rpc.RPCCall, []interface{}{reqParams, latestBlock})
+	respBody := makeHTTPEthJSONReq(rpc.RPCCall, []interface{}{reqParams, latestBlock})
 	expectedErr := fmt.Sprintf(errInsecure, rpc.RPCCall)
 
 	if !strings.Contains(string(respBody), expectedErr) {
@@ -239,7 +241,7 @@ func TestCannotSubmitTxWithoutSubmittingViewingKey(t *testing.T) {
 	txWallet := wallet.NewInMemoryWalletFromPK(big.NewInt(integration.ObscuroChainID), privateKey)
 	txBinaryHex := signAndSerialiseTransaction(txWallet, &deployERC20Tx)
 
-	respBody := makeEthJSONReq(rpc.RPCSendRawTransaction, []interface{}{txBinaryHex})
+	respBody := makeHTTPEthJSONReq(rpc.RPCSendRawTransaction, []interface{}{txBinaryHex})
 	expectedErr := fmt.Sprintf(errInsecure, rpc.RPCSendRawTransaction)
 
 	if !strings.Contains(string(respBody), expectedErr) {
@@ -273,7 +275,7 @@ func TestCanSubmitTxAndGetTxReceiptAndTxAfterSubmittingViewingKey(t *testing.T) 
 	}
 
 	// We check we can retrieve the transaction by hash.
-	getTxJSON := makeEthJSONReqAsJSON(rpc.RPCGetTransactionByHash, []string{signedTx.Hash().Hex()})
+	getTxJSON := makeHTTPEthJSONReqAsJSON(rpc.RPCGetTransactionByHash, []string{signedTx.Hash().Hex()})
 	getTxJSONResult := fmt.Sprintf("%s", getTxJSON[walletextension.RespJSONKeyResult])
 	expectedGetTxJSON := fmt.Sprintf("hash:%s", signedTx.Hash())
 	if !strings.Contains(getTxJSONResult, expectedGetTxJSON) {
@@ -293,7 +295,7 @@ func TestCannotSubmitTxFromAnotherAddressAfterSubmittingViewingKey(t *testing.T)
 	txWallet := wallet.NewInMemoryWalletFromPK(big.NewInt(integration.ObscuroChainID), privateKey)
 	txBinaryHex := signAndSerialiseTransaction(txWallet, &deployERC20Tx)
 
-	respBody := makeEthJSONReq(rpc.RPCSendRawTransaction, []interface{}{txBinaryHex})
+	respBody := makeHTTPEthJSONReq(rpc.RPCSendRawTransaction, []interface{}{txBinaryHex})
 	expectedErr := fmt.Sprintf(errInsecure, rpc.RPCSendRawTransaction)
 
 	if !strings.Contains(string(respBody), expectedErr) {
@@ -321,7 +323,7 @@ func TestCanDecryptSuccessfullyAfterSubmittingMultipleViewingKeys(t *testing.T) 
 
 	// We request the balance of a random account about halfway through the list.
 	randAccountAddr := accountAddrs[len(accountAddrs)/2]
-	getBalanceJSON := makeEthJSONReqAsJSON(rpc.RPCGetBalance, []string{randAccountAddr, latestBlock})
+	getBalanceJSON := makeHTTPEthJSONReqAsJSON(rpc.RPCGetBalance, []string{randAccountAddr, latestBlock})
 
 	if getBalanceJSON[walletextension.RespJSONKeyResult] != zeroBalance {
 		t.Fatalf("Expected balance of %s, got %s", zeroBalance, getBalanceJSON[walletextension.RespJSONKeyResult])
@@ -336,7 +338,7 @@ func TestCanDecryptSuccessfullyAfterRestartingWalletExtension(t *testing.T) {
 	walletExtension.Shutdown()
 	createWalletExtension(t)
 
-	getBalanceJSON := makeEthJSONReqAsJSON(rpc.RPCGetBalance, []string{accountAddr.String(), latestBlock})
+	getBalanceJSON := makeHTTPEthJSONReqAsJSON(rpc.RPCGetBalance, []string{accountAddr.String(), latestBlock})
 
 	if getBalanceJSON[walletextension.RespJSONKeyResult] != zeroBalance {
 		t.Fatalf("Expected balance of %s, got %s", zeroBalance, getBalanceJSON[walletextension.RespJSONKeyResult])
@@ -346,7 +348,7 @@ func TestCanDecryptSuccessfullyAfterRestartingWalletExtension(t *testing.T) {
 func TestCannotSubscribeOverHTTP(t *testing.T) {
 	createWalletExtension(t)
 
-	respBody := makeEthJSONReq(rpc.RPCSubscribe, []interface{}{rpc.RPCSubscriptionTypeLogs, filters.FilterCriteria{}})
+	respBody := makeHTTPEthJSONReq(rpc.RPCSubscribe, []interface{}{rpc.RPCSubscriptionTypeLogs, filters.FilterCriteria{}})
 
 	if !strings.Contains(string(respBody), errSubscribeFail) {
 		t.Fatalf("Expected error message \"%s\", got \"%s\"", errSubscribeFail, respBody)
@@ -360,7 +362,8 @@ func createWalletExtensionConfig() *walletextension.Config {
 	}
 
 	return &walletextension.Config{
-		WalletExtensionPort:     int(integration.StartPortWalletExtensionTest),
+		WalletExtensionPort:     walletExtensionPort,
+		WalletExtensionPortWS:   walletExtensionPortWS,
 		NodeRPCHTTPAddress:      fmt.Sprintf("%s:%d", network.Localhost, nodeRPCHTTPPort),
 		NodeRPCWebsocketAddress: fmt.Sprintf("%s:%d", network.Localhost, nodeRPCWSPort),
 		PersistencePathOverride: testPersistencePath.Name(),
@@ -372,8 +375,8 @@ func createWalletExtension(t *testing.T) *walletextension.WalletExtension {
 	walletExtension := walletextension.NewWalletExtension(*walletExtensionConfig)
 	t.Cleanup(walletExtension.Shutdown)
 
-	go walletExtension.Serve(walletExtensionAddr)
-	err := waitForWalletExtension(walletExtensionAddr)
+	go walletExtension.Serve(network.Localhost, walletExtensionPort, walletExtensionPortWS)
+	err := waitForWalletExtension(walletExtensionAddrHTTP)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -398,7 +401,7 @@ func waitForWalletExtension(walletExtensionAddr string) error {
 }
 
 // Makes an Ethereum JSON RPC request and returns the response body.
-func makeEthJSONReq(method string, params interface{}) []byte {
+func makeHTTPEthJSONReq(method string, params interface{}) []byte {
 	reqBodyBytes, err := json.Marshal(map[string]interface{}{
 		"jsonrpc": "2.0",
 		"method":  method,
@@ -414,7 +417,7 @@ func makeEthJSONReq(method string, params interface{}) []byte {
 	// We retry for three seconds to handle node start-up time.
 	timeout := time.Now().Add(3 * time.Second)
 	for i := time.Now(); i.Before(timeout); i = time.Now() {
-		resp, err = http.Post(httpProtocol+walletExtensionAddr, "text/html", reqBody) //nolint:noctx
+		resp, err = http.Post(httpProtocol+walletExtensionAddrHTTP, "text/html", reqBody) //nolint:noctx
 		if err == nil {
 			break
 		}
@@ -442,8 +445,8 @@ func makeEthJSONReq(method string, params interface{}) []byte {
 }
 
 // Makes an Ethereum JSON RPC request and returns the response body as JSON.
-func makeEthJSONReqAsJSON(method string, params interface{}) map[string]interface{} {
-	respBody := makeEthJSONReq(method, params)
+func makeHTTPEthJSONReqAsJSON(method string, params interface{}) map[string]interface{} {
+	respBody := makeHTTPEthJSONReq(method, params)
 
 	if respBody[0] != '{' {
 		panic(fmt.Errorf("expected JSON response but received: %s", respBody))
@@ -460,7 +463,7 @@ func makeEthJSONReqAsJSON(method string, params interface{}) map[string]interfac
 
 // Generates a signed viewing key and submits it to the wallet extension.
 func generateAndSubmitViewingKey(accountAddr string, accountPrivateKey *ecdsa.PrivateKey) error {
-	viewingKey := generateViewingKey(accountAddr, walletExtensionAddr)
+	viewingKey := generateViewingKey(accountAddr, walletExtensionAddrHTTP)
 	signature := signViewingKey(accountPrivateKey, viewingKey)
 
 	submitViewingKeyBodyBytes, err := json.Marshal(map[string]interface{}{
@@ -471,7 +474,7 @@ func generateAndSubmitViewingKey(accountAddr string, accountPrivateKey *ecdsa.Pr
 		return err
 	}
 	submitViewingKeyBody := bytes.NewBuffer(submitViewingKeyBodyBytes)
-	resp, err := http.Post(httpProtocol+walletExtensionAddr+walletextension.PathSubmitViewingKey, "application/json", submitViewingKeyBody) //nolint:noctx
+	resp, err := http.Post(httpProtocol+walletExtensionAddrHTTP+walletextension.PathSubmitViewingKey, "application/json", submitViewingKeyBody) //nolint:noctx
 	if err != nil {
 		return err
 	}
@@ -548,8 +551,8 @@ func createObscuroNetwork() (func(), error) {
 	// Create a wallet extension to allow the creation of the ERC20 contracts.
 	walletExtension := walletextension.NewWalletExtension(*walletExtensionConfig)
 	defer walletExtension.Shutdown()
-	go walletExtension.Serve(walletExtensionAddr)
-	err = waitForWalletExtension(walletExtensionAddr)
+	go walletExtension.Serve(network.Localhost, walletExtensionPort, walletExtensionPortWS)
+	err = waitForWalletExtension(walletExtensionAddrHTTP)
 	if err != nil {
 		return obscuroNetwork.TearDown, fmt.Errorf("failed to create test Obscuro network. Cause: %w", err)
 	}
@@ -586,7 +589,7 @@ func registerPrivateKey(t *testing.T) (gethcommon.Address, *ecdsa.PrivateKey) {
 // Submits a transaction and awaits the transaction receipt.
 func sendTransactionAndAwaitConfirmation(txWallet wallet.Wallet, tx types.LegacyTx) (map[string]interface{}, error) {
 	// Set the transaction's nonce.
-	nonceJSON := makeEthJSONReqAsJSON(rpc.RPCNonce, []interface{}{txWallet.Address().Hex(), latestBlock})
+	nonceJSON := makeHTTPEthJSONReqAsJSON(rpc.RPCNonce, []interface{}{txWallet.Address().Hex(), latestBlock})
 	nonceString, ok := nonceJSON[walletextension.RespJSONKeyResult].(string)
 	if !ok {
 		respJSON, err := json.Marshal(nonceJSON)
@@ -603,7 +606,7 @@ func sendTransactionAndAwaitConfirmation(txWallet wallet.Wallet, tx types.Legacy
 
 	// Send the transaction.
 	txBinaryHex := signAndSerialiseTransaction(txWallet, &tx)
-	sendTxJSON := makeEthJSONReqAsJSON(rpc.RPCSendRawTransaction, []interface{}{txBinaryHex})
+	sendTxJSON := makeHTTPEthJSONReqAsJSON(rpc.RPCSendRawTransaction, []interface{}{txBinaryHex})
 
 	// Verify the transaction was successful.
 	txHash, ok := sendTxJSON[walletextension.RespJSONKeyResult].(string)
@@ -616,7 +619,7 @@ func sendTransactionAndAwaitConfirmation(txWallet wallet.Wallet, tx types.Legacy
 		if counter > 10 {
 			return nil, fmt.Errorf("could not get ERC20 receipt after 10 seconds")
 		}
-		getReceiptJSON := makeEthJSONReqAsJSON(rpc.RPCGetTxReceipt, []interface{}{txHash})
+		getReceiptJSON := makeHTTPEthJSONReqAsJSON(rpc.RPCGetTxReceipt, []interface{}{txHash})
 		getReceiptJSONResult, ok := getReceiptJSON[walletextension.RespJSONKeyResult].(map[string]interface{})
 		if ok && getReceiptJSONResult[respJSONKeyStatus] == statusSuccess {
 			return getReceiptJSON, nil

--- a/tools/walletextension/main/cli.go
+++ b/tools/walletextension/main/cli.go
@@ -13,9 +13,9 @@ const (
 	walletExtensionPortDefault = 3000
 	walletExtensionPortUsage   = "The port on which to serve the wallet extension. Default: 3000."
 
-	walletExtensionWSPortName    = "wsRPC"
-	walletExtensionWSPortDefault = 3001
-	walletExtensionWSPortUsage   = "The port on which to serve websocket JSON RPC requests. Default: 3001."
+	walletExtensionPortWSName    = "wsRPC"
+	walletExtensionPortWSDefault = 3001
+	walletExtensionPortWSUsage   = "The port on which to serve websocket JSON RPC requests. Default: 3001."
 
 	nodeHostName    = "nodeHost"
 	nodeHostDefault = "testnet.obscu.ro"
@@ -36,7 +36,7 @@ const (
 
 func parseCLIArgs() walletextension.Config {
 	walletExtensionPort := flag.Int(walletExtensionPortName, walletExtensionPortDefault, walletExtensionPortUsage)
-	walletExtensionWSPort := flag.Int(walletExtensionWSPortName, walletExtensionWSPortDefault, walletExtensionWSPortUsage)
+	walletExtensionPortWS := flag.Int(walletExtensionPortWSName, walletExtensionPortWSDefault, walletExtensionPortWSUsage)
 	nodeHost := flag.String(nodeHostName, nodeHostDefault, nodeHostUsage)
 	nodeHTTPPort := flag.Int(nodeHTTPPortName, nodeHTTPPortDefault, nodeHTTPPortUsage)
 	nodeWebsocketPort := flag.Int(nodeWebsocketPortName, nodeWebsocketPortDefault, nodeWebsocketPortUsage)
@@ -45,7 +45,7 @@ func parseCLIArgs() walletextension.Config {
 
 	return walletextension.Config{
 		WalletExtensionPort:     *walletExtensionPort,
-		WalletExtensionWSPort:   *walletExtensionWSPort,
+		WalletExtensionPortWS:   *walletExtensionPortWS,
 		NodeRPCHTTPAddress:      fmt.Sprintf("%s:%d", *nodeHost, *nodeHTTPPort),
 		NodeRPCWebsocketAddress: fmt.Sprintf("%s:%d", *nodeHost, *nodeWebsocketPort),
 		LogPath:                 *logPath,

--- a/tools/walletextension/main/cli.go
+++ b/tools/walletextension/main/cli.go
@@ -13,6 +13,10 @@ const (
 	walletExtensionPortDefault = 3000
 	walletExtensionPortUsage   = "The port on which to serve the wallet extension. Default: 3000."
 
+	walletExtensionWSPortName    = "wsRPC"
+	walletExtensionWSPortDefault = 3001
+	walletExtensionWSPortUsage   = "The port on which to serve websocket JSON RPC requests. Default: 3001."
+
 	nodeHostName    = "nodeHost"
 	nodeHostDefault = "testnet.obscu.ro"
 	nodeHostUsage   = "The host on which to connect to the Obscuro node. Default: `testnet.obscu.ro`."
@@ -32,6 +36,7 @@ const (
 
 func parseCLIArgs() walletextension.Config {
 	walletExtensionPort := flag.Int(walletExtensionPortName, walletExtensionPortDefault, walletExtensionPortUsage)
+	walletExtensionWSPort := flag.Int(walletExtensionWSPortName, walletExtensionWSPortDefault, walletExtensionWSPortUsage)
 	nodeHost := flag.String(nodeHostName, nodeHostDefault, nodeHostUsage)
 	nodeHTTPPort := flag.Int(nodeHTTPPortName, nodeHTTPPortDefault, nodeHTTPPortUsage)
 	nodeWebsocketPort := flag.Int(nodeWebsocketPortName, nodeWebsocketPortDefault, nodeWebsocketPortUsage)
@@ -40,6 +45,7 @@ func parseCLIArgs() walletextension.Config {
 
 	return walletextension.Config{
 		WalletExtensionPort:     *walletExtensionPort,
+		WalletExtensionWSPort:   *walletExtensionWSPort,
 		NodeRPCHTTPAddress:      fmt.Sprintf("%s:%d", *nodeHost, *nodeHTTPPort),
 		NodeRPCWebsocketAddress: fmt.Sprintf("%s:%d", *nodeHost, *nodeWebsocketPort),
 		LogPath:                 *logPath,

--- a/tools/walletextension/main/cli.go
+++ b/tools/walletextension/main/cli.go
@@ -13,7 +13,7 @@ const (
 	walletExtensionPortDefault = 3000
 	walletExtensionPortUsage   = "The port on which to serve the wallet extension. Default: 3000."
 
-	walletExtensionPortWSName    = "wsRPC"
+	walletExtensionPortWSName    = "portWS"
 	walletExtensionPortWSDefault = 3001
 	walletExtensionPortWSUsage   = "The port on which to serve websocket JSON RPC requests. Default: 3001."
 

--- a/tools/walletextension/main/main.go
+++ b/tools/walletextension/main/main.go
@@ -42,8 +42,10 @@ func main() {
 
 	walletExtension := walletextension.NewWalletExtension(config)
 	defer walletExtension.Shutdown()
+
+	go walletExtension.Serve(localhost, config.WalletExtensionPort, config.WalletExtensionPortWS)
+
 	walletExtensionAddr := fmt.Sprintf("%s:%d", localhost, config.WalletExtensionPort)
-	go walletExtension.Serve(walletExtensionAddr)
 	fmt.Printf("💡 Wallet extension started - visit http://%s/viewingkeys/ to generate an ephemeral viewing key.\n", walletExtensionAddr)
 
 	select {}

--- a/tools/walletextension/readwriter/read_writer.go
+++ b/tools/walletextension/readwriter/read_writer.go
@@ -11,9 +11,7 @@ import (
 )
 
 const (
-	headerUpgrade   = "Upgrade"
-	headerWebsocket = "websocket"
-	httpCodeErr     = 500
+	httpCodeErr = 500
 )
 
 var upgrader = websocket.Upgrader{} // Used to upgrade connections to websocket connections.

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -528,6 +528,7 @@ func logReRegisteredViewingKeys(viewingKeys map[common.Address]*rpc.ViewingKey) 
 // Config contains the configuration required by the WalletExtension.
 type Config struct {
 	WalletExtensionPort     int
+	WalletExtensionWSPort   int
 	NodeRPCHTTPAddress      string // TODO - Remove this unused field.
 	NodeRPCWebsocketAddress string
 	LogPath                 string

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -168,7 +168,7 @@ func (we *WalletExtension) Shutdown() {
 	}
 
 	if we.serverWS != nil {
-		err := we.serverHTTP.Shutdown(context.Background())
+		err := we.serverWS.Shutdown(context.Background())
 		if err != nil {
 			log.Warn("could not shut down wallet extension: %s\n", err)
 		}


### PR DESCRIPTION
### Why is this change needed?

Previously, we tried to handle both HTTP and WS connections on a single port. To be consistent with Geth, and to enable us to use lower-cost HTTP clients where possible, we should have two ports.

### What changes were made as part of this PR:

- Adds a port to the wallet extension dedicated to WS connections
- Adds some todos, about creating WS clients selectively and lazily

### What are the key areas to look at

- Describe the key areas for a reviewer to look at 

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
