### PR TITLE
Does not hardcode use of WS or HTTP for Obscuro clients

### DIFF
--- a/go/rpc/network_client.go
+++ b/go/rpc/network_client.go
@@ -3,12 +3,14 @@ package rpc
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
 const (
-	ws = "ws://"
+	ws   = "ws://"
+	http = "http://"
 )
 
 // networkClient is a Client implementation that wraps Geth's rpc.Client to make calls to the obscuro node
@@ -31,10 +33,13 @@ func NewEncNetworkClient(rpcAddress string, viewingKey *ViewingKey) (*EncRPCClie
 
 // NewNetworkClient returns a client that can make RPC calls to an Obscuro node
 func NewNetworkClient(address string) (Client, error) {
-	// TODO - Allow instantiator to choose between websockets and HTTP
-	rpcClient, err := rpc.Dial(ws + address)
+	if !strings.HasPrefix(address, http) && !strings.HasPrefix(address, ws) {
+		return nil, fmt.Errorf("clients for Obscuro only support the %s and %s protocols", http, ws)
+	}
+
+	rpcClient, err := rpc.Dial(address)
 	if err != nil {
-		return nil, fmt.Errorf("could not create RPC client on %s. Cause: %w", ws+address, err)
+		return nil, fmt.Errorf("could not create RPC client on %s. Cause: %w", address, err)
 	}
 
 	return &networkClient{

--- a/integration/contractdeployer/contract_deployer_test.go
+++ b/integration/contractdeployer/contract_deployer_test.go
@@ -35,7 +35,7 @@ const (
 
 var (
 	config = &contractdeployer.Config{
-		NodeHost:          "ws://" + network.Localhost, // todo - joel - pass protocol properly
+		NodeHost:          network.Localhost,
 		NodePort:          integration.StartPortContractDeployerTest + network.DefaultHostRPCWSOffset,
 		IsL1Deployment:    false,
 		PrivateKey:        contractDeployerPrivateKeyHex,
@@ -43,7 +43,7 @@ var (
 		ContractName:      contractdeployer.GuessingGameContract,
 		ConstructorParams: []string{guessingGameParamOne, guessingGameParamTwo},
 	}
-	nodeAddress = fmt.Sprintf("%s:%d", config.NodeHost, config.NodePort)
+	nodeAddress = fmt.Sprintf("ws://%s:%d", config.NodeHost, config.NodePort)
 )
 
 func TestCanDeployGuessingGameContract(t *testing.T) {

--- a/integration/contractdeployer/contract_deployer_test.go
+++ b/integration/contractdeployer/contract_deployer_test.go
@@ -35,7 +35,7 @@ const (
 
 var (
 	config = &contractdeployer.Config{
-		NodeHost:          network.Localhost,
+		NodeHost:          "ws://" + network.Localhost, // todo - joel - pass protocol properly
 		NodePort:          integration.StartPortContractDeployerTest + network.DefaultHostRPCWSOffset,
 		IsL1Deployment:    false,
 		PrivateKey:        contractDeployerPrivateKeyHex,

--- a/integration/noderunner/noderunner_test.go
+++ b/integration/noderunner/noderunner_test.go
@@ -46,7 +46,7 @@ func TestCanStartStandaloneObscuroHostAndEnclave(t *testing.T) {
 	})
 
 	enclaveAddr := fmt.Sprintf("%s:%d", localhost, integration.StartPortNodeRunnerTest)
-	rpcAddress := fmt.Sprintf("%s:%d", localhost, obscuroWebsocketPort)
+	rpcAddress := fmt.Sprintf("ws://%s:%d", localhost, obscuroWebsocketPort)
 
 	privateKey, err := crypto.GenerateKey()
 	if err != nil {

--- a/integration/simulation/network/obscuro_node_utils.go
+++ b/integration/simulation/network/obscuro_node_utils.go
@@ -265,7 +265,7 @@ func isAddressAvailable(address string) bool {
 	if ln != nil {
 		err = ln.Close()
 		if err != nil {
-			log.Error("could not close listener when checking if address %w was available", address)
+			log.Error("could not close listener when checking if address %s was available", address)
 		}
 	}
 	if err != nil {

--- a/integration/simulation/network/obscuro_node_utils.go
+++ b/integration/simulation/network/obscuro_node_utils.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/big"
 	"net"
+	"strings"
 	"sync"
 	"time"
 
@@ -248,12 +249,19 @@ func waitTimeout(wg *sync.WaitGroup, timeout time.Duration) bool {
 }
 
 func isAddressAvailable(address string) bool {
-	ln, err := net.Listen("tcp", address)
-	if err != nil {
-		return false
+	// `net.Listen` requires us to strip the protocol, if it exists.
+	addressNoProtocol := address
+	splitAddress := strings.Split(address, "://")
+	if len(splitAddress) == 2 {
+		addressNoProtocol = splitAddress[1]
 	}
+
+	ln, err := net.Listen("tcp", addressNoProtocol)
 	if ln != nil {
 		_ = ln.Close()
+	}
+	if err != nil {
+		return false
 	}
 	return true
 }

--- a/integration/simulation/network/obscuro_node_utils.go
+++ b/integration/simulation/network/obscuro_node_utils.go
@@ -99,7 +99,7 @@ func startStandaloneObscuroNodes(params *params.SimParams, stats *stats.Stats, g
 			gethClients[i],
 		)
 
-		nodeRPCAddresses[i] = fmt.Sprintf("%s:%d", Localhost, nodeRPCPortWS)
+		nodeRPCAddresses[i] = fmt.Sprintf("ws://%s:%d", Localhost, nodeRPCPortWS)
 	}
 
 	// start each obscuro node

--- a/integration/walletextension/wallet_extension_test.go
+++ b/integration/walletextension/wallet_extension_test.go
@@ -364,8 +364,8 @@ func createWalletExtensionConfig() *walletextension.Config {
 	return &walletextension.Config{
 		WalletExtensionPort:     walletExtensionPort,
 		WalletExtensionPortWS:   walletExtensionPortWS,
-		NodeRPCHTTPAddress:      fmt.Sprintf("%s:%d", network.Localhost, nodeRPCHTTPPort),
-		NodeRPCWebsocketAddress: fmt.Sprintf("%s:%d", network.Localhost, nodeRPCWSPort),
+		NodeRPCHTTPAddress:      fmt.Sprintf("http://%s:%d", network.Localhost, nodeRPCHTTPPort),
+		NodeRPCWebsocketAddress: fmt.Sprintf("ws://%s:%d", network.Localhost, nodeRPCWSPort),
 		PersistencePathOverride: testPersistencePath.Name(),
 	}
 }

--- a/tools/contractdeployer/obscuro_deployer.go
+++ b/tools/contractdeployer/obscuro_deployer.go
@@ -126,5 +126,5 @@ func (o *obscuroDeployer) TransactionReceipt(hash gethcommon.Hash) (*types.Recei
 }
 
 func getURL(cfg *Config) string {
-	return fmt.Sprintf("%s:%d", cfg.NodeHost, cfg.NodePort)
+	return fmt.Sprintf("ws://%s:%d", cfg.NodeHost, cfg.NodePort)
 }


### PR DESCRIPTION
### Why is this change needed?

Using WS everywhere may hog too many resources.

### What changes were made as part of this PR:

- Does not add WS protocol to every attempt to dial the client
- Fix-ups in tests

### What are the key areas to look at

- Describe the key areas for a reviewer to look at 

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
