### PR TITLE
Removes unused L1 methods.

### DIFF
--- a/go/ethadapter/geth_rpc_client.go
+++ b/go/ethadapter/geth_rpc_client.go
@@ -103,35 +103,6 @@ func (e *gethRPCClient) IsBlockAncestor(block *types.Block, maybeAncestor common
 	return e.IsBlockAncestor(p, maybeAncestor)
 }
 
-func (e *gethRPCClient) RPCBlockchainFeed() []*types.Block {
-	ctx, cancel := context.WithTimeout(context.Background(), e.timeout)
-	defer cancel()
-
-	var availBlocks []*types.Block
-	block, err := e.client.BlockByNumber(ctx, nil)
-	if err != nil {
-		log.Panic("could not fetch head block. Cause: %s", err)
-	}
-	availBlocks = append(availBlocks, block)
-
-	for {
-		// todo set this to genesis hash
-		if block.ParentHash().Hex() == "0x0000000000000000000000000000000000000000000000000000000000000000" {
-			break
-		}
-		block = e.getParentBlock(block)
-		availBlocks = append(availBlocks, block)
-	}
-
-	// TODO double check the list is ordered [genesis, 1, 2, 3, 4, ..., last]
-	// TODO It's pretty ugly but it avoids creating a new slice
-	// TODO The approach of feeding all the blocks should change from all-blocks-in-memory to a stream
-	for i, j := 0, len(availBlocks)-1; i < j; i, j = i+1, j-1 {
-		availBlocks[i], availBlocks[j] = availBlocks[j], availBlocks[i]
-	}
-	return availBlocks
-}
-
 func (e *gethRPCClient) SendTransaction(signedTx *types.Transaction) error {
 	ctx, cancel := context.WithTimeout(context.Background(), e.timeout)
 	defer cancel()
@@ -212,16 +183,4 @@ func connect(ipaddress string, port uint, connectionTimeout time.Duration) (*eth
 	}
 
 	return c, err
-}
-
-func (e *gethRPCClient) getParentBlock(block *types.Block) *types.Block {
-	ctx, cancel := context.WithTimeout(context.Background(), e.timeout)
-	defer cancel()
-
-	parentBlock, err := e.client.BlockByHash(ctx, block.ParentHash())
-	if err != nil {
-		log.Panic("could not fetch parent block with hash %s. Cause: %s", block.ParentHash().String(), err)
-	}
-
-	return parentBlock
 }

--- a/go/ethadapter/interface.go
+++ b/go/ethadapter/interface.go
@@ -26,7 +26,6 @@ type EthClient interface {
 	FetchHeadBlock() *types.Block                                       // retrieves the block at head height
 	BlocksBetween(block *types.Block, head *types.Block) []*types.Block // returns the blocks between two blocks
 	IsBlockAncestor(block *types.Block, proof common.L1RootHash) bool   // returns if the node considers a block the ancestor
-	RPCBlockchainFeed() []*types.Block                                  // returns all blocks from genesis to head
 	BlockListener() (chan *types.Header, ethereum.Subscription)         // subscribes to new blocks and returns a listener with the blocks heads and the subscription handler
 
 	CallContract(msg ethereum.CallMsg) ([]byte, error) // Runs the provided call message on the latest block.

--- a/integration/ethereummock/node.go
+++ b/integration/ethereummock/node.go
@@ -344,12 +344,6 @@ func (m *Node) BroadcastTx(tx types.TxData) {
 	m.Network.BroadcastTx(types.NewTx(tx))
 }
 
-func (m *Node) RPCBlockchainFeed() []*types.Block {
-	m.headInCh <- true
-	h := <-m.headOutCh
-	return m.BlocksBetween(common.GenesisBlock, h)
-}
-
 func (m *Node) Stop() {
 	// block all requests
 	atomic.StoreInt32(m.interrupt, 1)


### PR DESCRIPTION
### Why is this change needed?

There are some unused L1 methods left. I removed them.

### What changes were made as part of this PR:

- Removes `RPCBlockchainFeed`, since unused
- Removes `getParentBlock`, which is used by the above

### What are the key areas to look at

- Describe the key areas for a reviewer to look at 

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
