### PR TITLE
WE: Return subscribed logs over websockets

### DIFF
--- a/go/host/node/node.go
+++ b/go/host/node/node.go
@@ -591,7 +591,6 @@ func (a *Node) storeBlockProcessingResult(result common.BlockSubmissionResponse)
 }
 
 // Distributes logs to subscribed clients.
-// TODO - #453 - Distribute logs specifically based on subscription IDs, rather than sending all logs to everyone.
 func (a *Node) sendLogsToSubscribers(result common.BlockSubmissionResponse) {
 	for _, encryptedLogs := range result.SubscribedLogs {
 		// Due to our reuse of the Geth log subscription API, we have to return the logs as types.Log objects, and not

--- a/go/host/rpc/clientapi/client_api_filter.go
+++ b/go/host/rpc/clientapi/client_api_filter.go
@@ -48,10 +48,7 @@ func (api *FilterAPI) Logs(ctx context.Context, encryptedParams common.Encrypted
 		return nil, fmt.Errorf("could not subscribe for logs. Cause: %w", err)
 	}
 
-	// TODO - #453 - The empty filter here is incorrect. The API retrieves all logs, then filters them based on the
-	//  filter. If we pass an empty filter, we'll get back all the logs for all the subscription IDs. We could always
-	//  filter this on the wallet extension side, but we could also use custom topics in the filter (e.g. a topic that
-	//  was the subscription ID).
+	// TODO - #453 - Use padded subscription ID as the topic instead in the filter, to auto-remove irrelevant logs.
 	subscription, err := api.gethFilterAPI.Logs(ctx, emptyFilter)
 	if err != nil {
 		return nil, err

--- a/integration/walletextension/wallet_extension_test.go
+++ b/integration/walletextension/wallet_extension_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/obscuronet/go-obscuro/tools/walletextension/readwriter"
+	"github.com/obscuronet/go-obscuro/tools/walletextension/userconn"
 
 	"github.com/gorilla/websocket"
 
@@ -368,8 +368,8 @@ func TestCanGetErrorOverWS(t *testing.T) {
 	respJSON, _ := makeWSEthJSONReqAsJSON(invalidMethod, []string{})
 
 	expectedErr := fmt.Sprintf(errInvalidRPCMethod, invalidMethod)
-	if respJSON[readwriter.RespJSONKeyErr] != expectedErr {
-		t.Fatalf("Expected error '%s', got '%s'", expectedErr, respJSON[readwriter.RespJSONKeyErr])
+	if respJSON[userconn.RespJSONKeyErr] != expectedErr {
+		t.Fatalf("Expected error '%s', got '%s'", expectedErr, respJSON[userconn.RespJSONKeyErr])
 	}
 }
 

--- a/tools/walletextension/accountmanager/account_manager.go
+++ b/tools/walletextension/accountmanager/account_manager.go
@@ -240,6 +240,7 @@ func executeSubscribe(client *rpc.EncRPCClient, req *RPCRequest, _ *interface{},
 		for {
 			if userConn.IsClosed() {
 				subscription.Unsubscribe()
+				return
 			}
 			time.Sleep(100 * time.Millisecond)
 		}

--- a/tools/walletextension/accountmanager/account_manager.go
+++ b/tools/walletextension/accountmanager/account_manager.go
@@ -226,7 +226,9 @@ func executeSubscribe(client *rpc.EncRPCClient, req *RPCRequest, _ *interface{},
 					log.Error("could not write the JSON log to the websocket. Cause: %s", err)
 				}
 			case err = <-subscription.Err():
-				// TODO - #453 - Route error back to frontend.
+				// An error on this channel means the subscription has ended, so we exit the loop.
+				readWriter.HandleError(err.Error())
+				return
 			}
 		}
 	}()

--- a/tools/walletextension/accountmanager/account_manager.go
+++ b/tools/walletextension/accountmanager/account_manager.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/obscuronet/go-obscuro/tools/walletextension/readwriter"
+	"github.com/obscuronet/go-obscuro/tools/walletextension/userconn"
 
 	"github.com/obscuronet/go-obscuro/go/common/log"
 
@@ -47,7 +47,7 @@ func (m *AccountManager) AddClient(address common.Address, client *rpc.EncRPCCli
 
 // ProxyRequest tries to identify the correct EncRPCClient to proxy the request to the Obscuro node, or it will attempt
 // the request with all clients until it succeeds
-func (m *AccountManager) ProxyRequest(rpcReq *RPCRequest, rpcResp *interface{}, readWriter readwriter.ReadWriter) error {
+func (m *AccountManager) ProxyRequest(rpcReq *RPCRequest, rpcResp *interface{}, userConn userconn.UserConn) error {
 	// for obscuro RPC requests it is important we know the sender account for the viewing key encryption/decryption
 	suggestedClient := suggestAccountClient(rpcReq, m.accountClients)
 
@@ -55,13 +55,13 @@ func (m *AccountManager) ProxyRequest(rpcReq *RPCRequest, rpcResp *interface{}, 
 	case suggestedClient != nil: // use the suggested client if there is one
 		// todo: if we have a suggested client, should we still loop through the other clients if it fails?
 		// 		The call data guessing won't often be wrong but there could be edge-cases there
-		return performRequest(suggestedClient, rpcReq, rpcResp, readWriter)
+		return performRequest(suggestedClient, rpcReq, rpcResp, userConn)
 
 	case len(m.accountClients) > 0: // try registered clients until there's a successful execution
 		log.Info("appropriate client not found, attempting request with up to %d clients", len(m.accountClients))
 		var err error
 		for _, client := range m.accountClients {
-			err = performRequest(client, rpcReq, rpcResp, readWriter)
+			err = performRequest(client, rpcReq, rpcResp, userConn)
 			if err == nil || errors.Is(err, rpc.ErrNilResponse) {
 				// request didn't fail, we don't need to continue trying the other clients
 				return nil
@@ -197,14 +197,14 @@ func searchDataFieldForAccount(callParams map[string]interface{}, accClients map
 	return nil, fmt.Errorf("no known account found in data bytes")
 }
 
-func performRequest(client *rpc.EncRPCClient, req *RPCRequest, resp *interface{}, readWriter readwriter.ReadWriter) error {
+func performRequest(client *rpc.EncRPCClient, req *RPCRequest, resp *interface{}, userConn userconn.UserConn) error {
 	if req.Method == rpc.RPCSubscribe {
-		return executeSubscribe(client, req, resp, readWriter)
+		return executeSubscribe(client, req, resp, userConn)
 	}
 	return executeCall(client, req, resp)
 }
 
-func executeSubscribe(client *rpc.EncRPCClient, req *RPCRequest, _ *interface{}, readWriter readwriter.ReadWriter) error {
+func executeSubscribe(client *rpc.EncRPCClient, req *RPCRequest, _ *interface{}, userConn userconn.UserConn) error {
 	if len(req.Params) == 0 {
 		return fmt.Errorf("could not subscribe as no subscription namespace was provided")
 	}
@@ -223,13 +223,13 @@ func executeSubscribe(client *rpc.EncRPCClient, req *RPCRequest, _ *interface{},
 				if err != nil {
 					log.Error("could not marshal received log to JSON. Cause: %s", err)
 				}
-				err = readWriter.WriteResponse(jsonLog)
+				err = userConn.WriteResponse(jsonLog)
 				if err != nil {
 					log.Error("could not write the JSON log to the websocket. Cause: %s", err)
 				}
 			case err = <-subscription.Err():
 				// An error on this channel means the subscription has ended, so we exit the loop.
-				readWriter.HandleError(err.Error())
+				userConn.HandleError(err.Error())
 				return
 			}
 		}
@@ -238,7 +238,7 @@ func executeSubscribe(client *rpc.EncRPCClient, req *RPCRequest, _ *interface{},
 	// We periodically check if the websocket is closed, and terminate the subscription.
 	go func() {
 		for {
-			if readWriter.IsClosed() {
+			if userConn.IsClosed() {
 				subscription.Unsubscribe()
 			}
 			time.Sleep(100 * time.Millisecond)

--- a/tools/walletextension/userconn/user_conn.go
+++ b/tools/walletextension/userconn/user_conn.go
@@ -27,20 +27,20 @@ type UserConn interface {
 	IsClosed() bool
 }
 
-// UserConnHTTP represents a user's connection over HTTP.
-type UserConnHTTP struct {
+// Represents a user's connection over HTTP.
+type userConnHTTP struct {
 	resp http.ResponseWriter
 	req  *http.Request
 }
 
-// UserConnWS represents a user's connection websockets.
-type UserConnWS struct {
+// Represents a user's connection websockets.
+type userConnWS struct {
 	conn     *websocket.Conn
 	isClosed bool
 }
 
 func NewUserConnHTTP(resp http.ResponseWriter, req *http.Request) UserConn {
-	return &UserConnHTTP{resp: resp, req: req}
+	return &userConnHTTP{resp: resp, req: req}
 }
 
 func NewUserConnWS(resp http.ResponseWriter, req *http.Request) (UserConn, error) {
@@ -52,12 +52,12 @@ func NewUserConnWS(resp http.ResponseWriter, req *http.Request) (UserConn, error
 		return nil, err
 	}
 
-	return &UserConnWS{
+	return &userConnWS{
 		conn: conn,
 	}, nil
 }
 
-func (h *UserConnHTTP) ReadRequest() ([]byte, error) {
+func (h *userConnHTTP) ReadRequest() ([]byte, error) {
 	body, err := io.ReadAll(h.req.Body)
 	if err != nil {
 		return nil, fmt.Errorf("could not read request body: %w", err)
@@ -65,7 +65,7 @@ func (h *UserConnHTTP) ReadRequest() ([]byte, error) {
 	return body, nil
 }
 
-func (h *UserConnHTTP) WriteResponse(msg []byte) error {
+func (h *userConnHTTP) WriteResponse(msg []byte) error {
 	_, err := h.resp.Write(msg)
 	if err != nil {
 		return fmt.Errorf("could not write response: %w", err)
@@ -73,19 +73,19 @@ func (h *UserConnHTTP) WriteResponse(msg []byte) error {
 	return nil
 }
 
-func (h *UserConnHTTP) HandleError(msg string) {
+func (h *userConnHTTP) HandleError(msg string) {
 	httpLogAndSendErr(h.resp, msg)
 }
 
-func (h *UserConnHTTP) SupportsSubscriptions() bool {
+func (h *userConnHTTP) SupportsSubscriptions() bool {
 	return false
 }
 
-func (h *UserConnHTTP) IsClosed() bool {
+func (h *userConnHTTP) IsClosed() bool {
 	return false
 }
 
-func (w *UserConnWS) ReadRequest() ([]byte, error) {
+func (w *userConnWS) ReadRequest() ([]byte, error) {
 	_, msg, err := w.conn.ReadMessage()
 	if err != nil {
 		if websocket.IsCloseError(err) {
@@ -96,7 +96,7 @@ func (w *UserConnWS) ReadRequest() ([]byte, error) {
 	return msg, nil
 }
 
-func (w *UserConnWS) WriteResponse(msg []byte) error {
+func (w *userConnWS) WriteResponse(msg []byte) error {
 	err := w.conn.WriteMessage(websocket.TextMessage, msg)
 	if err != nil {
 		if websocket.IsCloseError(err) {
@@ -108,7 +108,7 @@ func (w *UserConnWS) WriteResponse(msg []byte) error {
 }
 
 // HandleError logs and prints the error, and writes it to the websocket as a JSON object with a single key, "error".
-func (w *UserConnWS) HandleError(msg string) {
+func (w *userConnWS) HandleError(msg string) {
 	log.Error(msg)
 	fmt.Println(msg)
 
@@ -130,11 +130,11 @@ func (w *UserConnWS) HandleError(msg string) {
 	}
 }
 
-func (w *UserConnWS) SupportsSubscriptions() bool {
+func (w *userConnWS) SupportsSubscriptions() bool {
 	return true
 }
 
-func (w *UserConnWS) IsClosed() bool {
+func (w *userConnWS) IsClosed() bool {
 	return w.isClosed
 }
 

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -41,9 +41,10 @@ const (
 	reqJSONKeyParams    = "params"
 	ReqJSONKeyAddress   = "address"
 	ReqJSONKeySignature = "signature"
-	resJSONKeyID        = "id"
-	resJSONKeyRPCVer    = "jsonrpc"
+	respJSONKeyID       = "id"
+	respJSONKeyRPCVer   = "jsonrpc"
 	RespJSONKeyResult   = "result"
+	respJSONKeyRoot     = "root"
 
 	// CORS-related constants.
 	corsAllowOrigin  = "Access-Control-Allow-Origin"
@@ -223,17 +224,17 @@ func (we *WalletExtension) handleEthJSON(readWriter readwriter.ReadWriter) {
 	}
 
 	respMap := make(map[string]interface{})
-	respMap[resJSONKeyID] = rpcReq.ID
-	respMap[resJSONKeyRPCVer] = jsonrpc.Version
+	respMap[respJSONKeyID] = rpcReq.ID
+	respMap[respJSONKeyRPCVer] = jsonrpc.Version
 	respMap[RespJSONKeyResult] = rpcResp
 
 	// https://github.com/ethereum/EIPs/blob/master/EIPS/eip-658.md
 	// TODO fix this upstream on the decode
-	if result, found := respMap["result"]; found { //nolint
+	if result, found := respMap[RespJSONKeyResult]; found { //nolint
 		if resultMap, ok := result.(map[string]interface{}); ok {
-			if val, foundRoot := resultMap["root"]; foundRoot {
+			if val, foundRoot := resultMap[respJSONKeyRoot]; foundRoot {
 				if val == "0x" {
-					respMap["result"].(map[string]interface{})["root"] = nil
+					respMap[RespJSONKeyResult].(map[string]interface{})[respJSONKeyRoot] = nil
 				}
 			}
 		}

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -213,7 +213,7 @@ func (we *WalletExtension) handleEthJSON(readWriter readwriter.ReadWriter) {
 
 	var rpcResp interface{}
 	// proxyRequest will find the correct client to proxy the request (or try them all if appropriate)
-	err = we.accountManager.ProxyRequest(rpcReq, &rpcResp)
+	err = we.accountManager.ProxyRequest(rpcReq, &rpcResp, readWriter)
 	if err != nil {
 		// if err was for a nil response then we will return an RPC result of null to the caller (this is a valid "not-found" response for some methods)
 		if !errors.Is(err, rpc.ErrNilResponse) {


### PR DESCRIPTION
### Why is this change needed?

We'd already plumbed in the return of logs from the enclave to the host to the WE. The final step was to return the logs from the WE to the user.

### What changes were made as part of this PR:

- Sends logs onwards from the WE to the user
- Adds integration test of logs being received

### What are the key areas to look at

- Describe the key areas for a reviewer to look at 

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
