### PR TITLE
Authenticate subscription requests

### DIFF
--- a/go/common/types.go
+++ b/go/common/types.go
@@ -195,5 +195,6 @@ type SubscriptionAccount struct {
 	Account *common.Address
 	// A signature over the account address using the private viewing key. Prevents attackers from subscribing to
 	// (encrypted) logs for other accounts to see the pattern of logs.
+	// TODO - #453 - Note that this does not protect against replay attacks, where someone resends an intercepted subscription request.
 	Signature *[]byte
 }

--- a/go/common/types.go
+++ b/go/common/types.go
@@ -186,14 +186,14 @@ func (h *Header) Hash() L2RootHash {
 
 type LogSubscription struct {
 	Account *SubscriptionAccount
-	Filters *filters.FilterCriteria
+	Filter  *filters.FilterCriteria
 }
 
 // SubscriptionAccount is an authenticated account used when subscribing to logs.
 type SubscriptionAccount struct {
 	// The account the events relate to.
-	Account common.Address
+	Account *common.Address
 	// A signature over the subscription ID using the private viewing key. Prevents attackers from subscribing to
 	// (encrypted) logs for other accounts to see the pattern of logs.
-	Signature []byte
+	Signature *[]byte
 }

--- a/go/common/types.go
+++ b/go/common/types.go
@@ -185,8 +185,8 @@ func (h *Header) Hash() L2RootHash {
 }
 
 type LogSubscription struct {
-	Account *SubscriptionAccount
-	Filter  *filters.FilterCriteria
+	SubscriptionAccount *SubscriptionAccount
+	Filter              *filters.FilterCriteria
 }
 
 // SubscriptionAccount is an authenticated account used when subscribing to logs.

--- a/go/common/types.go
+++ b/go/common/types.go
@@ -185,8 +185,8 @@ func (h *Header) Hash() L2RootHash {
 }
 
 type LogSubscription struct {
-	Accounts []*SubscriptionAccount
-	Filters  []*filters.FilterCriteria
+	Account *SubscriptionAccount
+	Filters *filters.FilterCriteria
 }
 
 // SubscriptionAccount is an authenticated account used when subscribing to logs.

--- a/go/common/types.go
+++ b/go/common/types.go
@@ -193,7 +193,7 @@ type LogSubscription struct {
 type SubscriptionAccount struct {
 	// The account the events relate to.
 	Account *common.Address
-	// A signature over the subscription ID using the private viewing key. Prevents attackers from subscribing to
+	// A signature over the account address using the private viewing key. Prevents attackers from subscribing to
 	// (encrypted) logs for other accounts to see the pattern of logs.
 	Signature *[]byte
 }

--- a/go/enclave/events/subscription_manager.go
+++ b/go/enclave/events/subscription_manager.go
@@ -3,6 +3,7 @@ package events
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/ethereum/go-ethereum/crypto"
 
 	"github.com/obscuronet/go-obscuro/go/enclave/rpc"
@@ -40,14 +41,10 @@ func (s *SubscriptionManager) AddSubscription(id uuid.UUID, encryptedSubscriptio
 		return fmt.Errorf("could not unmarshall log subscription from JSON. Cause: %w", err)
 	}
 
-	subscriptionIDBinary, err := id.MarshalBinary()
-	if err != nil {
-		return fmt.Errorf("could not marshall subscription ID to binary to check subscription authentication")
-	}
 	// todo - joel - extract any shared logic (see rpcEncryptionManager)
-	recoveredPublicKey, err := crypto.SigToPub(subscriptionIDBinary, *subscription.Account.Signature)
+	recoveredPublicKey, err := crypto.SigToPub(subscription.Account.Account.Bytes(), *subscription.Account.Signature)
 	if err != nil {
-		return fmt.Errorf("received viewing key but could not validate its signature. Cause: %w", err)
+		return fmt.Errorf("could not recover account address from signature to authenticate subscription. Cause: %w", err)
 	}
 	recoveredAddress := crypto.PubkeyToAddress(*recoveredPublicKey)
 	// todo - joel - check the recovered address matches the account address

--- a/go/enclave/events/subscription_manager.go
+++ b/go/enclave/events/subscription_manager.go
@@ -35,7 +35,6 @@ func (s *SubscriptionManager) AddSubscription(id uuid.UUID, encryptedSubscriptio
 		return fmt.Errorf("could not decrypt params in eth_subscribe logs request. Cause: %w", err)
 	}
 
-	// TODO - #453 - Check if we can submit the subscriptions as a single item, rather than a list.
 	var subscriptions []common.LogSubscription
 	if err = json.Unmarshal(jsonSubscription, &subscriptions); err != nil {
 		return fmt.Errorf("could not unmarshall log subscription from JSON. Cause: %w", err)
@@ -45,12 +44,12 @@ func (s *SubscriptionManager) AddSubscription(id uuid.UUID, encryptedSubscriptio
 	}
 	subscription := subscriptions[0]
 
-	idBinary, err := id.MarshalBinary()
+	subscriptionIDBinary, err := id.MarshalBinary()
 	if err != nil {
 		return fmt.Errorf("could not marshall subscription ID to binary to check subscription authentication")
 	}
 	// todo - joel - extract any shared logic (see rpcEncryptionManager)
-	recoveredPublicKey, err := crypto.SigToPub(idBinary, subscription.Account.Signature)
+	recoveredPublicKey, err := crypto.SigToPub(subscriptionIDBinary, *subscription.Account.Signature)
 	if err != nil {
 		return fmt.Errorf("received viewing key but could not validate its signature. Cause: %w", err)
 	}

--- a/go/enclave/events/subscription_manager.go
+++ b/go/enclave/events/subscription_manager.go
@@ -27,7 +27,6 @@ func NewSubscriptionManager(rpcEncryptionManager *rpc.EncryptionManager) *Subscr
 
 // AddSubscription adds a log subscription to the enclave under the given ID, provided the request is authenticated
 // correctly. If there is an existing subscription with the given ID, it is overwritten.
-// TODO - #453 - Check each account in the subscription request is authenticated with a signature.
 func (s *SubscriptionManager) AddSubscription(id uuid.UUID, encryptedSubscription common.EncryptedParamsLogSubscription) error {
 	jsonSubscription, err := s.rpcEncryptionManager.DecryptBytes(encryptedSubscription)
 	if err != nil {

--- a/go/enclave/events/subscription_manager.go
+++ b/go/enclave/events/subscription_manager.go
@@ -40,25 +40,23 @@ func (s *SubscriptionManager) AddSubscription(id uuid.UUID, encryptedSubscriptio
 	if err = json.Unmarshal(jsonSubscription, &subscriptions); err != nil {
 		return fmt.Errorf("could not unmarshall log subscription from JSON. Cause: %w", err)
 	}
-
 	if len(subscriptions) != 1 {
 		return fmt.Errorf("expected a single log subscription, received %d", len(subscriptions))
 	}
-
 	subscription := subscriptions[0]
 
 	idBinary, err := id.MarshalBinary()
 	if err != nil {
-		panic(err) // todo - joel - handle better
+		return fmt.Errorf("could not marshall subscription ID to binary to check subscription authentication")
 	}
-	// todo - joel - extract any shared logic
+	// todo - joel - extract any shared logic (see rpcEncryptionManager)
 	recoveredPublicKey, err := crypto.SigToPub(idBinary, subscription.Account.Signature)
 	if err != nil {
 		return fmt.Errorf("received viewing key but could not validate its signature. Cause: %w", err)
 	}
 	recoveredAddress := crypto.PubkeyToAddress(*recoveredPublicKey)
 	// todo - joel - check the recovered address matches the account address
-	println(recoveredAddress)
+	println(recoveredAddress.Hex())
 
 	s.subscriptions[id] = &subscription
 	return nil

--- a/go/enclave/events/subscription_manager.go
+++ b/go/enclave/events/subscription_manager.go
@@ -3,6 +3,7 @@ package events
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/ethereum/go-ethereum/crypto"
 
 	"github.com/obscuronet/go-obscuro/go/enclave/rpc"
 
@@ -35,7 +36,7 @@ func (s *SubscriptionManager) AddSubscription(id uuid.UUID, encryptedSubscriptio
 	}
 
 	var subscriptions []common.LogSubscription
-	if err := json.Unmarshal(jsonSubscription, &subscriptions); err != nil {
+	if err = json.Unmarshal(jsonSubscription, &subscriptions); err != nil {
 		return fmt.Errorf("could not unmarshall log subscription from JSON. Cause: %w", err)
 	}
 
@@ -43,7 +44,24 @@ func (s *SubscriptionManager) AddSubscription(id uuid.UUID, encryptedSubscriptio
 		return fmt.Errorf("expected a single log subscription, received %d", len(subscriptions))
 	}
 
-	s.subscriptions[id] = &subscriptions[0]
+	subscription := subscriptions[0]
+
+	for _, account := range subscription.Accounts {
+		idBinary, err := id.MarshalBinary()
+		if err != nil {
+			panic(err) // todo - joel - handle better
+		}
+		// todo - joel - extract any shared logic
+		recoveredPublicKey, err := crypto.SigToPub(idBinary, account.Signature)
+		if err != nil {
+			return fmt.Errorf("received viewing key but could not validate its signature. Cause: %w", err)
+		}
+		recoveredAddress := crypto.PubkeyToAddress(*recoveredPublicKey)
+		// todo - joel - check the recovered address matches the account address
+		println(recoveredAddress)
+	}
+
+	s.subscriptions[id] = &subscription
 	return nil
 }
 

--- a/go/enclave/rpc/rpc_encryption_manager.go
+++ b/go/enclave/rpc/rpc_encryption_manager.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"github.com/obscuronet/go-obscuro/go/common"
 
 	"github.com/ethereum/go-ethereum/accounts"
 	gethcommon "github.com/ethereum/go-ethereum/common"
@@ -94,4 +95,21 @@ func (rpc *EncryptionManager) EncryptWithViewingKey(address gethcommon.Address, 
 	}
 
 	return encryptedBytes, nil
+}
+
+// AuthenticateSubscriptionRequest checks that a subscription request is authenticated correctly.
+func (rpc *EncryptionManager) AuthenticateSubscriptionRequest(subscription common.LogSubscription) error {
+	accountHashBytes := subscription.SubscriptionAccount.Account.Hash().Bytes()
+
+	recoveredViewingPublicKey, err := crypto.SigToPub(accountHashBytes, *subscription.SubscriptionAccount.Signature)
+	if err != nil {
+		return fmt.Errorf("could not recover viewing public key from signature to authenticate subscription. Cause: %w", err)
+	}
+
+	viewingPublicKey := rpc.viewingKeys[*subscription.SubscriptionAccount.Account]
+	if viewingPublicKey != ecies.ImportECDSAPublic(recoveredViewingPublicKey) {
+		return fmt.Errorf("viewing key used to authenticate subscription did not match")
+	}
+
+	return nil
 }

--- a/go/enclave/rpc/rpc_encryption_manager.go
+++ b/go/enclave/rpc/rpc_encryption_manager.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+
 	"github.com/obscuronet/go-obscuro/go/common"
 
 	"github.com/ethereum/go-ethereum/accounts"

--- a/go/enclave/rpc/rpc_encryption_manager.go
+++ b/go/enclave/rpc/rpc_encryption_manager.go
@@ -27,7 +27,7 @@ type EncryptionManager struct {
 	enclavePrivateKeyECIES *ecies.PrivateKey
 	// TODO - Replace with persistent storage.
 	// TODO - Handle multiple viewing keys per address.
-	viewingKeys map[gethcommon.Address]*ecies.PublicKey
+	viewingKeys map[gethcommon.Address]*ecies.PublicKey // Maps account addresses to viewing public keys.
 }
 
 func NewEncryptionManager(enclavePrivateKeyECIES *ecies.PrivateKey) EncryptionManager {
@@ -59,20 +59,20 @@ func (rpc *EncryptionManager) AddViewingKey(encryptedViewingKeyBytes []byte, sig
 	msgToSign := ViewingKeySignedMsgPrefix + hex.EncodeToString(viewingKeyBytes)
 
 	// We recover the key based on the signed message and the signature.
-	recoveredPublicKey, err := crypto.SigToPub(accounts.TextHash([]byte(msgToSign)), signature)
+	recoveredAccountPublicKey, err := crypto.SigToPub(accounts.TextHash([]byte(msgToSign)), signature)
 	if err != nil {
 		return fmt.Errorf("received viewing key but could not validate its signature. Cause: %w", err)
 	}
-	recoveredAddress := crypto.PubkeyToAddress(*recoveredPublicKey)
+	recoveredAccountAddress := crypto.PubkeyToAddress(*recoveredAccountPublicKey)
 
 	// We decompress the viewing key and create the corresponding ECIES key.
 	viewingKey, err := crypto.DecompressPubkey(viewingKeyBytes)
 	if err != nil {
 		return fmt.Errorf("received viewing key bytes but could not decompress them. Cause: %w", err)
 	}
-	eciesPublicKey := ecies.ImportECDSAPublic(viewingKey)
+	viewingKeyECIES := ecies.ImportECDSAPublic(viewingKey)
 
-	rpc.viewingKeys[recoveredAddress] = eciesPublicKey
+	rpc.viewingKeys[recoveredAccountAddress] = viewingKeyECIES
 
 	return nil
 }

--- a/go/enclave/rpc/rpc_encryption_manager.go
+++ b/go/enclave/rpc/rpc_encryption_manager.go
@@ -106,9 +106,9 @@ func (rpc *EncryptionManager) AuthenticateSubscriptionRequest(subscription commo
 		return fmt.Errorf("could not recover viewing public key from signature to authenticate subscription. Cause: %w", err)
 	}
 
-	viewingPublicKey := rpc.viewingKeys[*subscription.SubscriptionAccount.Account]
-	if viewingPublicKey != ecies.ImportECDSAPublic(recoveredViewingPublicKey) {
-		return fmt.Errorf("viewing key used to authenticate subscription did not match")
+	viewingPublicKey := rpc.viewingKeys[*subscription.SubscriptionAccount.Account].ExportECDSA()
+	if !viewingPublicKey.Equal(recoveredViewingPublicKey) {
+		return fmt.Errorf("viewing key used to authenticate subscription did not match viewing key stored by enclave")
 	}
 
 	return nil

--- a/go/rpc/encrypted_client.go
+++ b/go/rpc/encrypted_client.go
@@ -135,12 +135,12 @@ func (c *EncRPCClient) Subscribe(ctx context.Context, namespace string, ch inter
 		return nil, fmt.Errorf("expected a channel of type `chan *types.Log`, got %T", ch)
 	}
 
-	signedAccount, err := crypto.Sign(c.Account().Bytes(), c.viewingKey.PrivateKey.ExportECDSA())
+	signedAccount, err := crypto.Sign(c.Account().Hash().Bytes(), c.viewingKey.PrivateKey.ExportECDSA())
 	if err != nil {
-		return nil, fmt.Errorf("could not sign account address to authenticate subscription")
+		return nil, fmt.Errorf("could not sign account address to authenticate subscription. Cause: %w", err)
 	}
 	logSubscription := common.LogSubscription{
-		Account: &common.SubscriptionAccount{
+		SubscriptionAccount: &common.SubscriptionAccount{
 			Account:   c.Account(),
 			Signature: &signedAccount,
 		},

--- a/go/rpc/encrypted_client.go
+++ b/go/rpc/encrypted_client.go
@@ -135,14 +135,14 @@ func (c *EncRPCClient) Subscribe(ctx context.Context, namespace string, ch inter
 		return nil, fmt.Errorf("expected a channel of type `chan *types.Log`, got %T", ch)
 	}
 
-	signedAccount, err := crypto.Sign(c.Account().Hash().Bytes(), c.viewingKey.PrivateKey.ExportECDSA())
+	accountSignature, err := crypto.Sign(c.Account().Hash().Bytes(), c.viewingKey.PrivateKey.ExportECDSA())
 	if err != nil {
 		return nil, fmt.Errorf("could not sign account address to authenticate subscription. Cause: %w", err)
 	}
 	logSubscription := common.LogSubscription{
 		SubscriptionAccount: &common.SubscriptionAccount{
 			Account:   c.Account(),
-			Signature: &signedAccount,
+			Signature: &accountSignature,
 		},
 		// TODO - #453 - Add the incoming filters.FilterCriteria to the common.LogSubscription.
 	}

--- a/integration/walletextension/wallet_extension_test.go
+++ b/integration/walletextension/wallet_extension_test.go
@@ -458,15 +458,6 @@ func createWalletExtensionConfig() *walletextension.Config {
 
 // Creates and serves a wallet extension.
 func createWalletExtension(t *testing.T) *walletextension.WalletExtension {
-	walletExtension := walletextension.NewWalletExtension(*walletExtensionConfig)
-	t.Cleanup(walletExtension.Shutdown)
-
-	go walletExtension.Serve(network.Localhost, walletExtensionPort, walletExtensionPortWS)
-	err := waitForWalletExtension()
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	return createWalletExtensionWithConfig(t, walletExtensionConfig)
 }
 

--- a/integration/walletextension/wallet_extension_test.go
+++ b/integration/walletextension/wallet_extension_test.go
@@ -375,6 +375,7 @@ func TestCanGetErrorOverWS(t *testing.T) {
 
 func TestCanSubscribeForLogs(t *testing.T) {
 	createWalletExtension(t)
+	registerPrivateKey(t)
 
 	_, conn := makeWSEthJSONReqAsJSON(rpc.RPCSubscribe, []interface{}{rpc.RPCSubscriptionTypeLogs, filters.FilterCriteria{}})
 

--- a/integration/walletextension/wallet_extension_test.go
+++ b/integration/walletextension/wallet_extension_test.go
@@ -421,7 +421,7 @@ func TestCanSubscribeForLogs(t *testing.T) {
 
 func TestCannotSubscribeForLogsWithoutSubmittingViewingKey(t *testing.T) {
 	// By creating the wallet extension from a fresh config, we get a new persistence path, and thus do not
-	// accidentally reload existing viewing keys, allowing the subscription attempt to succeed.
+	// accidentally reload existing viewing keys, which would cause the subscription attempt to succeed.
 	createWalletExtensionWithConfig(t, createWalletExtensionConfig())
 
 	respBody, _ := makeWSEthJSONReq(rpc.RPCSubscribe, []interface{}{rpc.RPCSubscriptionTypeLogs, filters.FilterCriteria{}})

--- a/integration/walletextension/wallet_extension_test.go
+++ b/integration/walletextension/wallet_extension_test.go
@@ -61,7 +61,8 @@ const (
 	latestBlock             = "latest"
 	statusSuccess           = "0x1"
 	errInsecure             = "enclave could not respond securely to %s request"
-	errSubscribeFail        = "received an eth_subscribe request but the connection does not support subscriptions"
+	errSubscribeFailHTTP    = "received an eth_subscribe request but the connection does not support subscriptions"
+	errSubscribeFailVK      = "method eth_subscribe cannot be called with an unauthorised client - no signed viewing keys found"
 	errInvalidRPCMethod     = "rpc request failed: the method %s does not exist/is not available"
 
 	walletExtensionPort   = int(integration.StartPortWalletExtensionTest)
@@ -418,13 +419,25 @@ func TestCanSubscribeForLogs(t *testing.T) {
 	}
 }
 
+func TestCannotSubscribeForLogsWithoutSubmittingViewingKey(t *testing.T) {
+	// By creating the wallet extension from a fresh config, we get a new persistence path, and thus do not
+	// accidentally reload existing viewing keys, allowing the subscription attempt to succeed.
+	createWalletExtensionWithConfig(t, createWalletExtensionConfig())
+
+	respBody, _ := makeWSEthJSONReq(rpc.RPCSubscribe, []interface{}{rpc.RPCSubscriptionTypeLogs, filters.FilterCriteria{}})
+
+	if !strings.Contains(string(respBody), errSubscribeFailVK) {
+		t.Fatalf("Expected error message \"%s\", got \"%s\"", errSubscribeFailVK, respBody)
+	}
+}
+
 func TestCannotSubscribeOverHTTP(t *testing.T) {
 	createWalletExtension(t)
 
 	respBody := makeHTTPEthJSONReq(rpc.RPCSubscribe, []interface{}{rpc.RPCSubscriptionTypeLogs, filters.FilterCriteria{}})
 
-	if !strings.Contains(string(respBody), errSubscribeFail) {
-		t.Fatalf("Expected error message \"%s\", got \"%s\"", errSubscribeFail, respBody)
+	if !strings.Contains(string(respBody), errSubscribeFailHTTP) {
+		t.Fatalf("Expected error message \"%s\", got \"%s\"", errSubscribeFailHTTP, respBody)
 	}
 }
 
@@ -446,6 +459,20 @@ func createWalletExtensionConfig() *walletextension.Config {
 // Creates and serves a wallet extension.
 func createWalletExtension(t *testing.T) *walletextension.WalletExtension {
 	walletExtension := walletextension.NewWalletExtension(*walletExtensionConfig)
+	t.Cleanup(walletExtension.Shutdown)
+
+	go walletExtension.Serve(network.Localhost, walletExtensionPort, walletExtensionPortWS)
+	err := waitForWalletExtension()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return createWalletExtensionWithConfig(t, walletExtensionConfig)
+}
+
+// Creates and serves a wallet extension with custom configuration.
+func createWalletExtensionWithConfig(t *testing.T, config *walletextension.Config) *walletextension.WalletExtension {
+	walletExtension := walletextension.NewWalletExtension(*config)
 	t.Cleanup(walletExtension.Shutdown)
 
 	go walletExtension.Serve(network.Localhost, walletExtensionPort, walletExtensionPortWS)

--- a/tools/walletextension/accountmanager/account_manager.go
+++ b/tools/walletextension/accountmanager/account_manager.go
@@ -88,7 +88,7 @@ func suggestAccountClient(req *RPCRequest, accClients map[common.Address]*rpc.En
 	}
 
 	// TODO - #453 - Add special logic for log subscriptions (should happen before `parseParams`, which cannot handle
-	//  leading log-type parameter)
+	//  the leading log-type parameter)
 
 	paramsMap, err := parseParams(req.Params)
 	if err != nil {

--- a/tools/walletextension/accountmanager/account_manager.go
+++ b/tools/walletextension/accountmanager/account_manager.go
@@ -107,6 +107,8 @@ func suggestAccountClient(req *RPCRequest, accClients map[common.Address]*rpc.En
 		}
 	}
 
+	// TODO - #453 - Add special logic for log subscriptions.
+
 	// todo: add other mechanisms for determining the correct account to use. E.g. we may want to start caching and
 	// 	 	recent transaction hashes for accounts so that receipt lookups know which acc to use
 

--- a/tools/walletextension/accountmanager/account_manager.go
+++ b/tools/walletextension/accountmanager/account_manager.go
@@ -87,27 +87,28 @@ func suggestAccountClient(req *RPCRequest, accClients map[common.Address]*rpc.En
 		}
 	}
 
+	// TODO - #453 - Add special logic for log subscriptions (should happen before `parseParams`, which cannot handle
+	//  leading log-type parameter)
+
 	paramsMap, err := parseParams(req.Params)
 	if err != nil {
 		// no further info to deduce calling client
 		return nil
 	}
 
-	// check if request params had a "from" address and if we had a client for that address
-	fromClient, found := checkForFromField(paramsMap, accClients)
-	if found {
-		return fromClient
-	}
-
 	if req.Method == rpc.RPCCall {
+		// check if request params had a "from" address and if we had a client for that address
+		fromClient, found := checkForFromField(paramsMap, accClients)
+		if found {
+			return fromClient
+		}
+
 		// Otherwise, we search the `data` field for an address matching a registered viewing key.
 		addr, err := searchDataFieldForAccount(paramsMap, accClients)
 		if err == nil {
 			return accClients[*addr]
 		}
 	}
-
-	// TODO - #453 - Add special logic for log subscriptions.
 
 	// todo: add other mechanisms for determining the correct account to use. E.g. we may want to start caching and
 	// 	 	recent transaction hashes for accounts so that receipt lookups know which acc to use


### PR DESCRIPTION
### Why is this change needed?

We need to authenticate subscription requests, to prevent other people from subscribing to other accounts' logs to view the event patterns.

### What changes were made as part of this PR:

- Adds authentication for subscription requests
- Adds a test of subscription failing in the absence of viewing keys

### What are the key areas to look at

- Describe the key areas for a reviewer to look at 

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
