### PR TITLE
Encrypts one-arg params as object, not list.

### DIFF
--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -364,15 +364,12 @@ func (e *enclaveImpl) GetTransaction(encryptedParams common.EncryptedParamsGetTx
 	if err != nil {
 		return nil, fmt.Errorf("failed to decrypt encrypted RPC request params. Cause: %w", err)
 	}
-	var paramList []string
-	err = json.Unmarshal(hashBytes, &paramList)
+	var txHex string
+	err = json.Unmarshal(hashBytes, &txHex)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal RPC request params from JSON. Cause: %w", err)
+		return nil, fmt.Errorf("failed to unmarshal eth_getTransactionByHash params from JSON. Cause: %w", err)
 	}
-	if len(paramList) == 0 {
-		return nil, fmt.Errorf("required at least one param, but received zero")
-	}
-	txHash := gethcommon.HexToHash(paramList[0])
+	txHash := gethcommon.HexToHash(txHex)
 
 	// Unlike in the Geth impl, we do not try and retrieve unconfirmed transactions from the mempool.
 	tx, blockHash, blockNumber, index, err := e.storage.GetTransaction(txHash)

--- a/go/enclave/events/subscription_manager.go
+++ b/go/enclave/events/subscription_manager.go
@@ -34,16 +34,12 @@ func (s *SubscriptionManager) AddSubscription(id uuid.UUID, encryptedSubscriptio
 		return fmt.Errorf("could not decrypt params in eth_subscribe logs request. Cause: %w", err)
 	}
 
-	var subscriptions []common.LogSubscription
-	if err := json.Unmarshal(jsonSubscription, &subscriptions); err != nil {
+	var subscription common.LogSubscription
+	if err := json.Unmarshal(jsonSubscription, &subscription); err != nil {
 		return fmt.Errorf("could not unmarshall log subscription from JSON. Cause: %w", err)
 	}
 
-	if len(subscriptions) != 1 {
-		return fmt.Errorf("expected a single log subscription, received %d", len(subscriptions))
-	}
-
-	s.subscriptions[id] = &subscriptions[0]
+	s.subscriptions[id] = &subscription
 	return nil
 }
 

--- a/go/enclave/rpc/rpc_utils.go
+++ b/go/enclave/rpc/rpc_utils.go
@@ -22,20 +22,19 @@ const (
 
 // ExtractTxHash returns the transaction hash from the params of an eth_getTransactionReceipt request.
 func ExtractTxHash(getTxReceiptParams []byte) (gethcommon.Hash, error) {
-	var paramsJSONList []string
-	err := json.Unmarshal(getTxReceiptParams, &paramsJSONList)
+	var txHex string
+	err := json.Unmarshal(getTxReceiptParams, &txHex)
 	if err != nil {
 		return gethcommon.Hash{}, fmt.Errorf("could not parse JSON params in eth_getTransactionReceipt "+
 			"request. JSON params are: %s. Cause: %w", string(getTxReceiptParams), err)
 	}
-	txHash := gethcommon.HexToHash(paramsJSONList[0]) // The only argument is the transaction hash.
-	return txHash, err
+	return gethcommon.HexToHash(txHex), nil
 }
 
 // ExtractTx returns the common.L2Tx from the params of an eth_sendRawTransaction request.
 func ExtractTx(sendRawTxParams []byte) (*common.L2Tx, error) {
-	// We need to extract the transaction hex from the JSON list encoding. We remove the leading `"[0x`, and the trailing `]"`.
-	txBinary := sendRawTxParams[4 : len(sendRawTxParams)-2]
+	// We remove the leading `"0x` and the trailing `"` from the transaction hex.
+	txBinary := sendRawTxParams[3 : len(sendRawTxParams)-1]
 	txBytes := gethcommon.Hex2Bytes(string(txBinary))
 
 	tx := &common.L2Tx{}

--- a/go/rpc/encrypted_client.go
+++ b/go/rpc/encrypted_client.go
@@ -192,7 +192,13 @@ func (c *EncRPCClient) encryptArgs(args ...interface{}) ([]byte, error) {
 		return nil, nil
 	}
 
-	paramsJSON, err := json.Marshal(args)
+	var paramsJSON []byte
+	var err error
+	if len(args) == 1 {
+		paramsJSON, err = json.Marshal(args[0])
+	} else {
+		paramsJSON, err = json.Marshal(args)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("could not json encode request params: %w", err)
 	}


### PR DESCRIPTION
### Why is this change needed?

Previously, the `EncRPCClient` would encrypt params as a JSON list, regardless of whether they were a single object or an actual list. This added some messy handling on the enclave side.

### What changes were made as part of this PR:

- Encrypts single params as JSON objects, not lists

### What are the key areas to look at

- Describe the key areas for a reviewer to look at 

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
