### PR TITLE
Adds missing protocols for connecting to node from WE.

### DIFF
--- a/integration/walletextension/wallet_extension_test.go
+++ b/integration/walletextension/wallet_extension_test.go
@@ -436,8 +436,8 @@ func createWalletExtensionConfig() *walletextension.Config {
 	return &walletextension.Config{
 		WalletExtensionPort:     walletExtensionPort,
 		WalletExtensionPortWS:   walletExtensionPortWS,
-		NodeRPCHTTPAddress:      fmt.Sprintf("http://%s:%d", network.Localhost, nodeRPCHTTPPort),
-		NodeRPCWebsocketAddress: fmt.Sprintf("ws://%s:%d", network.Localhost, nodeRPCWSPort),
+		NodeRPCHTTPAddress:      fmt.Sprintf("%s:%d", network.Localhost, nodeRPCHTTPPort),
+		NodeRPCWebsocketAddress: fmt.Sprintf("%s:%d", network.Localhost, nodeRPCWSPort),
 		PersistencePathOverride: testPersistencePath.Name(),
 	}
 }

--- a/tools/walletextension/main/cli.go
+++ b/tools/walletextension/main/cli.go
@@ -46,8 +46,8 @@ func parseCLIArgs() walletextension.Config {
 	return walletextension.Config{
 		WalletExtensionPort:     *walletExtensionPort,
 		WalletExtensionPortWS:   *walletExtensionPortWS,
-		NodeRPCHTTPAddress:      fmt.Sprintf("http://%s:%d", *nodeHost, *nodeHTTPPort),
-		NodeRPCWebsocketAddress: fmt.Sprintf("ws://%s:%d", *nodeHost, *nodeWebsocketPort),
+		NodeRPCHTTPAddress:      fmt.Sprintf("%s:%d", *nodeHost, *nodeHTTPPort),
+		NodeRPCWebsocketAddress: fmt.Sprintf("%s:%d", *nodeHost, *nodeWebsocketPort),
 		LogPath:                 *logPath,
 	}
 }

--- a/tools/walletextension/main/cli.go
+++ b/tools/walletextension/main/cli.go
@@ -46,8 +46,8 @@ func parseCLIArgs() walletextension.Config {
 	return walletextension.Config{
 		WalletExtensionPort:     *walletExtensionPort,
 		WalletExtensionPortWS:   *walletExtensionPortWS,
-		NodeRPCHTTPAddress:      fmt.Sprintf("%s:%d", *nodeHost, *nodeHTTPPort),
-		NodeRPCWebsocketAddress: fmt.Sprintf("%s:%d", *nodeHost, *nodeWebsocketPort),
+		NodeRPCHTTPAddress:      fmt.Sprintf("http://%s:%d", *nodeHost, *nodeHTTPPort),
+		NodeRPCWebsocketAddress: fmt.Sprintf("ws://%s:%d", *nodeHost, *nodeWebsocketPort),
 		LogPath:                 *logPath,
 	}
 }

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -35,6 +35,7 @@ const (
 	PathGenerateViewingKey = "/generateviewingkey/"
 	PathSubmitViewingKey   = "/submitviewingkey/"
 	staticDir              = "static"
+	wsProtocol             = "ws://"
 
 	reqJSONKeyID        = "id"
 	reqJSONKeyMethod    = "method"
@@ -71,13 +72,13 @@ type WalletExtension struct {
 func NewWalletExtension(config Config) *WalletExtension {
 	setUpLogs(config.LogPath)
 
-	unauthedClient, err := rpc.NewNetworkClient(config.NodeRPCWebsocketAddress)
+	unauthedClient, err := rpc.NewNetworkClient(wsProtocol + config.NodeRPCWebsocketAddress)
 	if err != nil {
 		log.Panic("unable to create temporary client for request - %s", err)
 	}
 
 	walletExtension := &WalletExtension{
-		hostAddr:       config.NodeRPCWebsocketAddress,
+		hostAddr:       wsProtocol + config.NodeRPCWebsocketAddress,
 		unsignedVKs:    make(map[common.Address]*rpc.ViewingKey),
 		accountManager: accountmanager.NewAccountManager(unauthedClient),
 		persistence:    persistence.NewPersistence(config.NodeRPCWebsocketAddress, config.PersistencePathOverride),


### PR DESCRIPTION
### Why is this change needed?

We modified the client to require either the HTTP or WE protocol to be specified, but didn't update the WE accordingly.

### What changes were made as part of this PR:

- Adds protocol when starting WE

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
