### PR TITLE
WE: Move integration tests of sensitive methods without viewing key to unit tests

### DIFF
--- a/go/rpc/encrypted_client.go
+++ b/go/rpc/encrypted_client.go
@@ -28,7 +28,7 @@ const (
 	enclavePublicKeyHex = "034d3b7e63a8bcd532ee3d1d6ecad9d67fca7821981a044551f0f0cbec74d0bc5e"
 )
 
-// for these methods, the RPC method's requests and responses should be encrypted
+// SensitiveMethods for which the RPC requests and responses should be encrypted
 var SensitiveMethods = []string{
 	RPCCall,
 	RPCGetBalance,

--- a/go/rpc/encrypted_client.go
+++ b/go/rpc/encrypted_client.go
@@ -29,7 +29,7 @@ const (
 )
 
 // for these methods, the RPC method's requests and responses should be encrypted
-var sensitiveMethods = []string{
+var SensitiveMethods = []string{
 	RPCCall,
 	RPCGetBalance,
 	RPCGetTransactionByHash,
@@ -312,7 +312,7 @@ func (c *EncRPCClient) registerViewingKey() error {
 
 // IsSensitiveMethod indicates whether the RPC method's requests and responses should be encrypted.
 func IsSensitiveMethod(method string) bool {
-	for _, m := range sensitiveMethods {
+	for _, m := range SensitiveMethods {
 		if m == method {
 			return true
 		}

--- a/integration/walletextension/wallet_extension_test.go
+++ b/integration/walletextension/wallet_extension_test.go
@@ -63,7 +63,6 @@ const (
 	latestBlock             = "latest"
 	statusSuccess           = "0x1"
 	errInsecure             = "enclave could not respond securely to %s request"
-	errSubscribeFailVK      = "method eth_subscribe cannot be called with an unauthorised client - no signed viewing keys found"
 	errInvalidRPCMethod     = "rpc request failed: the method %s does not exist/is not available"
 
 	walletExtensionPort   = int(integration.StartPortWalletExtensionTest)
@@ -114,17 +113,6 @@ func TestCanMakeNonSensitiveRequestWithoutSubmittingViewingKey(t *testing.T) {
 	}
 }
 
-func TestCannotGetBalanceWithoutSubmittingViewingKey(t *testing.T) {
-	createWalletExtension(t)
-
-	respBody := test.MakeHTTPEthJSONReq(walletExtensionAddrHTTP, rpc.RPCGetBalance, []string{dummyAccountAddress.Hex(), latestBlock})
-	expectedErr := fmt.Sprintf(errInsecure, rpc.RPCGetBalance)
-
-	if !strings.Contains(string(respBody), expectedErr) {
-		t.Fatalf("Expected error message to contain \"%s\", got \"%s\"", expectedErr, respBody)
-	}
-}
-
 func TestCanGetOwnBalanceAfterSubmittingViewingKey(t *testing.T) {
 	createWalletExtension(t)
 	accountAddr, _ := registerPrivateKey(t)
@@ -145,33 +133,6 @@ func TestCannotGetAnothersBalanceAfterSubmittingViewingKey(t *testing.T) {
 
 	if !strings.Contains(string(respBody), expectedErr) {
 		t.Fatalf("Expected error message to contain \"%s\", got \"%s\"", expectedErr, respBody)
-	}
-}
-
-func TestCannotCallWithoutSubmittingViewingKey(t *testing.T) {
-	createWalletExtension(t)
-
-	// We generate an account, but do not register it with the node.
-	privateKey, err := crypto.GenerateKey()
-	if err != nil {
-		t.Fatal(err)
-	}
-	accountAddress := crypto.PubkeyToAddress(privateKey.PublicKey)
-
-	// We submit a transaction to the Obscuro ERC20 contract. By transferring an amount of zero, we avoid the need to
-	// deposit any funds in the ERC20 contract.
-	transferTxBytes := erc20contractlib.CreateTransferTxData(accountAddress, big.NewInt(0))
-	reqParams := map[string]interface{}{
-		reqJSONKeyTo:   bridge.HOCContract,
-		reqJSONKeyFrom: accountAddress.String(),
-		reqJSONKeyData: "0x" + gethcommon.Bytes2Hex(transferTxBytes),
-	}
-
-	respBody := test.MakeHTTPEthJSONReq(walletExtensionAddrHTTP, rpc.RPCCall, []interface{}{reqParams, latestBlock})
-	expectedErr := fmt.Sprintf(errInsecure, rpc.RPCCall)
-
-	if !strings.Contains(string(respBody), expectedErr) {
-		t.Fatalf("Expected error message \"%s\", got \"%s\"", expectedErr, respBody)
 	}
 }
 
@@ -233,24 +194,6 @@ func TestCannotCallForAnotherAddressAfterSubmittingViewingKey(t *testing.T) {
 
 	respBody := test.MakeHTTPEthJSONReq(walletExtensionAddrHTTP, rpc.RPCCall, []interface{}{reqParams, latestBlock})
 	expectedErr := fmt.Sprintf(errInsecure, rpc.RPCCall)
-
-	if !strings.Contains(string(respBody), expectedErr) {
-		t.Fatalf("Expected error message \"%s\", got \"%s\"", expectedErr, respBody)
-	}
-}
-
-func TestCannotSubmitTxWithoutSubmittingViewingKey(t *testing.T) {
-	createWalletExtension(t)
-
-	privateKey, err := crypto.GenerateKey()
-	if err != nil {
-		panic(err)
-	}
-	txWallet := wallet.NewInMemoryWalletFromPK(big.NewInt(integration.ObscuroChainID), privateKey)
-	txBinaryHex := signAndSerialiseTransaction(txWallet, &deployERC20Tx)
-
-	respBody := test.MakeHTTPEthJSONReq(walletExtensionAddrHTTP, rpc.RPCSendRawTransaction, []interface{}{txBinaryHex})
-	expectedErr := fmt.Sprintf(errInsecure, rpc.RPCSendRawTransaction)
 
 	if !strings.Contains(string(respBody), expectedErr) {
 		t.Fatalf("Expected error message \"%s\", got \"%s\"", expectedErr, respBody)
@@ -420,18 +363,6 @@ func TestCanSubscribeForLogs(t *testing.T) {
 	}
 }
 
-func TestCannotSubscribeForLogsWithoutSubmittingViewingKey(t *testing.T) {
-	// By creating the wallet extension from a fresh config, we get a new persistence path, and thus do not
-	// accidentally reload existing viewing keys, which would cause the subscription attempt to succeed.
-	createWalletExtensionWithConfig(t, createWalletExtensionConfig())
-
-	respBody, _ := makeWSEthJSONReq(rpc.RPCSubscribe, []interface{}{rpc.RPCSubscriptionTypeLogs, filterCriteriaJSON{}})
-
-	if !strings.Contains(string(respBody), errSubscribeFailVK) {
-		t.Fatalf("Expected error message \"%s\", got \"%s\"", errSubscribeFailVK, respBody)
-	}
-}
-
 func TestCanEstimateGasAfterSubmittingViewingKey(t *testing.T) {
 	createWalletExtension(t)
 	accountAddr, _ := registerPrivateKey(t)
@@ -442,19 +373,6 @@ func TestCanEstimateGasAfterSubmittingViewingKey(t *testing.T) {
 
 	if getBalanceJSON[walletextension.RespJSONKeyResult].(string) != "0x12a05f200" {
 		t.Fatalf("unexpected gas")
-	}
-}
-
-func TestCannotEstimateGasWithoutSubmittingViewingKey(t *testing.T) {
-	createWalletExtension(t)
-
-	callMsg := datagenerator.CreateCallMsg()
-
-	respBody := test.MakeHTTPEthJSONReq(walletExtensionAddrHTTP, rpc.RPCEstimateGas, []interface{}{callMsg, latestBlock})
-	expectedErr := fmt.Sprintf(errInsecure, rpc.RPCEstimateGas)
-
-	if !strings.Contains(string(respBody), expectedErr) {
-		t.Fatalf("Expected error message to contain \"%s\", got \"%s\"", expectedErr, respBody)
 	}
 }
 

--- a/tools/walletextension/accountmanager/account_manager.go
+++ b/tools/walletextension/accountmanager/account_manager.go
@@ -23,6 +23,8 @@ const (
 	reqJSONKeyData      = "data"
 	ethCallPaddedArgLen = 64
 	ethCallAddrPadding  = "000000000000000000000000"
+
+	ErrNoViewingKey = "method %s cannot be called with an unauthorised client - no signed viewing keys found"
 )
 
 // AccountManager provides a single location for code that helps wallet extension in determining the appropriate
@@ -72,7 +74,7 @@ func (m *AccountManager) ProxyRequest(rpcReq *RPCRequest, rpcResp *interface{}, 
 
 	default: // no clients registered, use the unauthenticated one
 		if rpc.IsSensitiveMethod(rpcReq.Method) {
-			return fmt.Errorf("method %s cannot be called with an unauthorised client - no signed viewing keys found", rpcReq.Method)
+			return fmt.Errorf(ErrNoViewingKey, rpcReq.Method)
 		}
 		return m.unauthedClient.Call(rpcResp, rpcReq.Method, rpcReq.Params...)
 	}


### PR DESCRIPTION
### Why is this change needed?

Previously, we had individual integration tests for each sensitive method. This was a pain to update.

### What changes were made as part of this PR:

- Deleted the integration tests for calling each sensitive method without a viewing key
- Added a unit test to check that none of the sensitive methods can be called without a viewing key

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
