### PR TITLE
Replaces server with real Geth RPC layer.

### DIFF
--- a/tools/walletextension/test/wallet_extension_test.go
+++ b/tools/walletextension/test/wallet_extension_test.go
@@ -88,13 +88,13 @@ func createDummyHost(t *testing.T) error {
 	}
 	rpcServerNode, err := node.New(&cfg)
 	if err != nil {
-		return fmt.Errorf("could not create new client server. Cause: %s", err)
+		return fmt.Errorf("could not create new client server. Cause: %w", err)
 	}
 	t.Cleanup(func() { rpcServerNode.Close() })
 
 	err = rpcServerNode.Start()
 	if err != nil {
-		return fmt.Errorf("could not create new client server. Cause: %s", err)
+		return fmt.Errorf("could not create new client server. Cause: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
### Why is this change needed?

It will be easier to write tests going forward, as we can easily add API endpoints to hit.

### What changes were made as part of this PR:

- Replaces custom HTTP server with Geth RPC layer in WE unit tests
- Uses test cleanup instead of using defers and shutdown handles in WE unit tests

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
