### PR TITLE
WE: Replace can-do integration tests with unit tests

### DIFF
--- a/go/host/node/node.go
+++ b/go/host/node/node.go
@@ -35,9 +35,9 @@ import (
 )
 
 const (
-	apiVersion1             = "1.0"
-	apiNamespaceObscuro     = "obscuro"
-	apiNamespaceEthereum    = "eth"
+	APIVersion1             = "1.0"
+	APINamespaceObscuro     = "obscuro"
+	APINamespaceEth         = "eth"
 	apiNamespaceObscuroScan = "obscuroscan"
 	apiNamespaceNetwork     = "net"
 	apiNamespaceTest        = "test"
@@ -127,38 +127,38 @@ func NewHost(
 	if config.HasClientRPCHTTP || config.HasClientRPCWebsockets {
 		rpcAPIs := []rpc.API{
 			{
-				Namespace: apiNamespaceObscuro,
-				Version:   apiVersion1,
+				Namespace: APINamespaceObscuro,
+				Version:   APIVersion1,
 				Service:   clientapi.NewObscuroAPI(node),
 				Public:    true,
 			},
 			{
-				Namespace: apiNamespaceEthereum,
-				Version:   apiVersion1,
+				Namespace: APINamespaceEth,
+				Version:   APIVersion1,
 				Service:   clientapi.NewEthereumAPI(node),
 				Public:    true,
 			},
 			{
 				Namespace: apiNamespaceObscuroScan,
-				Version:   apiVersion1,
+				Version:   APIVersion1,
 				Service:   clientapi.NewObscuroScanAPI(node),
 				Public:    true,
 			},
 			{
 				Namespace: apiNamespaceNetwork,
-				Version:   apiVersion1,
+				Version:   APIVersion1,
 				Service:   clientapi.NewNetworkAPI(node),
 				Public:    true,
 			},
 			{
 				Namespace: apiNamespaceTest,
-				Version:   apiVersion1,
+				Version:   APIVersion1,
 				Service:   clientapi.NewTestAPI(node),
 				Public:    true,
 			},
 			{
-				Namespace: apiNamespaceEthereum,
-				Version:   apiVersion1,
+				Namespace: APINamespaceEth,
+				Version:   APIVersion1,
 				Service:   clientapi.NewFilterAPI(node, node.logsCh),
 				Public:    true,
 			},

--- a/tools/walletextension/test/apis.go
+++ b/tools/walletextension/test/apis.go
@@ -11,6 +11,10 @@ import (
 	"github.com/obscuronet/go-obscuro/go/common"
 )
 
+const (
+	successMsg = "success"
+)
+
 // DummyObscuroAPI provides dummies for operations defined in the `obscuro_` namespace.
 type DummyObscuroAPI struct{}
 
@@ -19,7 +23,7 @@ func (api *DummyObscuroAPI) AddViewingKey([]byte, []byte) error {
 }
 
 // DummyEthAPI provides dummies for the RPC operations defined in the `eth_` namespace. For each sensitive RPC
-// operation, it returns the message "success", encrypted with the viewing key set via `setViewingKey`.
+// operation, it returns the message `successMsg`, encrypted with the viewing key set via `setViewingKey`.
 type DummyEthAPI struct {
 	viewingKey *ecies.PublicKey
 }
@@ -61,12 +65,12 @@ func (api *DummyEthAPI) GetTransactionReceipt(context.Context, common.EncryptedP
 	return &encryptedSuccess, err
 }
 
-func (api *DummyEthAPI) SendRawTransaction(_ context.Context, encryptedParams common.EncryptedParamsSendRawTx) (string, error) {
+func (api *DummyEthAPI) SendRawTransaction(context.Context, common.EncryptedParamsSendRawTx) (string, error) {
 	return api.encryptedSuccess()
 }
 
-// Returns the message "success", encrypted with the viewing key set via `setViewingKey`.
+// Returns the message `successMsg`, encrypted with the viewing key set via `setViewingKey`.
 func (api *DummyEthAPI) encryptedSuccess() (string, error) {
-	encryptedBytes, err := ecies.Encrypt(rand.Reader, api.viewingKey, []byte("success"), nil, nil) // todo - joel - use constant
+	encryptedBytes, err := ecies.Encrypt(rand.Reader, api.viewingKey, []byte(successMsg), nil, nil)
 	return gethcommon.Bytes2Hex(encryptedBytes), err
 }

--- a/tools/walletextension/test/apis.go
+++ b/tools/walletextension/test/apis.go
@@ -1,0 +1,72 @@
+package test
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/crypto/ecies"
+	"github.com/obscuronet/go-obscuro/go/common"
+)
+
+// DummyObscuroAPI provides dummies for operations defined in the `obscuro_` namespace.
+type DummyObscuroAPI struct{}
+
+func (api *DummyObscuroAPI) AddViewingKey([]byte, []byte) error {
+	return nil
+}
+
+// DummyEthAPI provides dummies for the RPC operations defined in the `eth_` namespace. For each sensitive RPC
+// operation, it returns the message "success", encrypted with the viewing key set via `setViewingKey`.
+type DummyEthAPI struct {
+	viewingKey *ecies.PublicKey
+}
+
+// Determines which key the API will encrypt responses with.
+func (api *DummyEthAPI) setViewingKey(viewingKeyHexBytes []byte) error {
+	viewingKeyBytes, err := hex.DecodeString(string(viewingKeyHexBytes))
+	if err != nil {
+		return err
+	}
+
+	viewingKey, err := crypto.DecompressPubkey(viewingKeyBytes)
+	if err != nil {
+		return fmt.Errorf("received viewing key bytes but could not decompress them. Cause: %w", err)
+	}
+	api.viewingKey = ecies.ImportECDSAPublic(viewingKey)
+	return nil
+}
+
+func (api *DummyEthAPI) Call(context.Context, common.EncryptedParamsCall) (string, error) {
+	return api.encryptedSuccess()
+}
+
+func (api *DummyEthAPI) GetBalance(context.Context, common.EncryptedParamsGetBalance) (string, error) {
+	return api.encryptedSuccess()
+}
+
+func (api *DummyEthAPI) GetTransactionByHash(context.Context, common.EncryptedParamsGetTxByHash) (*string, error) {
+	encryptedSuccess, err := api.encryptedSuccess()
+	return &encryptedSuccess, err
+}
+
+func (api *DummyEthAPI) GetTransactionCount(context.Context, common.EncryptedParamsGetTxCount) (string, error) {
+	return api.encryptedSuccess()
+}
+
+func (api *DummyEthAPI) GetTransactionReceipt(context.Context, common.EncryptedParamsGetTxReceipt) (*string, error) {
+	encryptedSuccess, err := api.encryptedSuccess()
+	return &encryptedSuccess, err
+}
+
+func (api *DummyEthAPI) SendRawTransaction(_ context.Context, encryptedParams common.EncryptedParamsSendRawTx) (string, error) {
+	return api.encryptedSuccess()
+}
+
+// Returns the message "success", encrypted with the viewing key set via `setViewingKey`.
+func (api *DummyEthAPI) encryptedSuccess() (string, error) {
+	encryptedBytes, err := ecies.Encrypt(rand.Reader, api.viewingKey, []byte("success"), nil, nil) // todo - joel - use constant
+	return gethcommon.Bytes2Hex(encryptedBytes), err
+}

--- a/tools/walletextension/test/utils.go
+++ b/tools/walletextension/test/utils.go
@@ -2,8 +2,15 @@ package test
 
 import (
 	"bytes"
+	"crypto/ecdsa"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"github.com/ethereum/go-ethereum/accounts"
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	enclaverpc "github.com/obscuronet/go-obscuro/go/enclave/rpc"
+	"github.com/obscuronet/go-obscuro/tools/walletextension"
 	"io"
 	"net/http"
 	"time"
@@ -28,10 +35,10 @@ func WaitForEndpoint(addr string) error {
 }
 
 // MakeHTTPEthJSONReq makes an Ethereum JSON RPC request over HTTP and returns the response body.
-func MakeHTTPEthJSONReq(address string, method string, params interface{}) []byte {
+func MakeHTTPEthJSONReq(walExtAddr string, method string, params interface{}) []byte {
 	reqBody := PrepareRequestBody(method, params)
 
-	resp, err := http.Post(address, "text/html", reqBody) //nolint:noctx,gosec
+	resp, err := http.Post(walExtAddr, "text/html", reqBody) //nolint:noctx,gosec
 	if resp != nil && resp.Body != nil {
 		defer resp.Body.Close()
 	}
@@ -50,8 +57,8 @@ func MakeHTTPEthJSONReq(address string, method string, params interface{}) []byt
 }
 
 // MakeWSEthJSONReq makes an Ethereum JSON RPC request over websockets and returns the response body.
-func MakeWSEthJSONReq(address string, method string, params interface{}) ([]byte, *websocket.Conn) {
-	conn, resp, err := websocket.DefaultDialer.Dial(address, nil)
+func MakeWSEthJSONReq(walExtAddr string, method string, params interface{}) ([]byte, *websocket.Conn) {
+	conn, resp, err := websocket.DefaultDialer.Dial(walExtAddr, nil)
 	if resp != nil && resp.Body != nil {
 		defer resp.Body.Close()
 	}
@@ -94,4 +101,92 @@ func PrepareRequestBody(method string, params interface{}) *bytes.Buffer {
 		panic(fmt.Errorf("failed to prepare request body. Cause: %w", err))
 	}
 	return bytes.NewBuffer(reqBodyBytes)
+}
+
+// todo - joel - move this back to the integration tests, to replace the existing one
+
+// Generates a new account and registers it with the node.
+func registerPrivateKey(walExtAddr string) (gethcommon.Address, *ecdsa.PrivateKey, []byte, error) {
+	privateKey, err := crypto.GenerateKey()
+	if err != nil {
+		return gethcommon.Address{}, nil, nil, err
+	}
+	accountAddr := crypto.PubkeyToAddress(privateKey.PublicKey)
+	viewingKeyBytes, err := generateAndSubmitViewingKey(walExtAddr, accountAddr.String(), privateKey)
+	if err != nil {
+		return gethcommon.Address{}, nil, nil, err
+	}
+	return accountAddr, privateKey, viewingKeyBytes, nil
+}
+
+// todo - joel - use this in integration tests, delete the one there
+
+// Generates a signed viewing key and submits it to the wallet extension.
+func generateAndSubmitViewingKey(walExtAddr string, accountAddr string, accountPrivateKey *ecdsa.PrivateKey) ([]byte, error) {
+	viewingKeyBytes := generateViewingKey(walExtAddr, accountAddr)
+	signature := signViewingKey(accountPrivateKey, viewingKeyBytes)
+
+	submitViewingKeyBodyBytes, err := json.Marshal(map[string]interface{}{
+		walletextension.ReqJSONKeySignature: hex.EncodeToString(signature),
+		walletextension.ReqJSONKeyAddress:   accountAddr,
+	})
+	if err != nil {
+		return nil, err
+	}
+	submitViewingKeyBody := bytes.NewBuffer(submitViewingKeyBodyBytes)
+	resp, err := http.Post(walExtAddr+walletextension.PathSubmitViewingKey, "application/json", submitViewingKeyBody) //nolint:noctx
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		respBody, err := io.ReadAll(resp.Body)
+		if err == nil {
+			return nil, fmt.Errorf("request to add viewing key failed with status %s: %s", resp.Status, respBody)
+		}
+		return nil, fmt.Errorf("request to add viewing key failed with status %s", resp.Status)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return viewingKeyBytes, resp.Body.Close()
+}
+
+// todo - joel - use this in integration tests, delete the one there
+
+// Generates a viewing key.
+func generateViewingKey(walExtAddr string, accountAddress string) []byte {
+	generateViewingKeyBodyBytes, err := json.Marshal(map[string]interface{}{
+		walletextension.ReqJSONKeyAddress: accountAddress,
+	})
+	if err != nil {
+		panic(err)
+	}
+	generateViewingKeyBody := bytes.NewBuffer(generateViewingKeyBodyBytes)
+	resp, err := http.Post(walExtAddr+walletextension.PathGenerateViewingKey, "application/json", generateViewingKeyBody) //nolint:noctx
+	if err != nil {
+		panic(err)
+	}
+	viewingKey, err := io.ReadAll(resp.Body)
+	if err != nil {
+		panic(err)
+	}
+	resp.Body.Close()
+	return viewingKey
+}
+
+// todo - joel - use this in integration tests, delete the one there
+
+// Signs a viewing key.
+func signViewingKey(privateKey *ecdsa.PrivateKey, viewingKey []byte) []byte {
+	msgToSign := enclaverpc.ViewingKeySignedMsgPrefix + string(viewingKey)
+	signature, err := crypto.Sign(accounts.TextHash([]byte(msgToSign)), privateKey)
+	if err != nil {
+		panic(err)
+	}
+
+	// We have to transform the V from 0/1 to 27/28, and add the leading "0".
+	signature[64] += 27
+	signatureWithLeadBytes := append([]byte("0"), signature...)
+
+	return signatureWithLeadBytes
 }

--- a/tools/walletextension/test/wallet_extension_test.go
+++ b/tools/walletextension/test/wallet_extension_test.go
@@ -2,11 +2,13 @@ package test
 
 import (
 	"fmt"
+	gethrpc "github.com/ethereum/go-ethereum/rpc"
+	"github.com/obscuronet/go-obscuro/go/host/node"
 	"os"
 	"strings"
 	"testing"
 
-	"github.com/ethereum/go-ethereum/node"
+	gethnode "github.com/ethereum/go-ethereum/node"
 	"github.com/obscuronet/go-obscuro/tools/walletextension/accountmanager"
 
 	"github.com/ethereum/go-ethereum/eth/filters"
@@ -15,13 +17,17 @@ import (
 	"github.com/obscuronet/go-obscuro/tools/walletextension"
 )
 
+const (
+	localhost = "127.0.0.1"
+)
+
 var (
-	localhost      = "127.0.0.1"
 	walExtPortHTTP = integration.StartPortWalletExtensionUnitTest
 	walExtPortWS   = integration.StartPortWalletExtensionUnitTest + 1
 	nodePortWS     = integration.StartPortWalletExtensionUnitTest + 2
 	walExtAddr     = fmt.Sprintf("http://%s:%d", localhost, walExtPortHTTP)
 	walExtAddrWS   = fmt.Sprintf("ws://%s:%d", localhost, walExtPortWS)
+	dummyEthAPI    = &DummyEthAPI{}
 )
 
 func TestCannotInvokeSensitiveMethodsWithoutViewingKey(t *testing.T) {
@@ -36,6 +42,40 @@ func TestCannotInvokeSensitiveMethodsWithoutViewingKey(t *testing.T) {
 
 		if !strings.Contains(string(respBody), fmt.Sprintf(accountmanager.ErrNoViewingKey, method)) {
 			t.Fatalf("expected response containing '%s', got '%s'", fmt.Sprintf(accountmanager.ErrNoViewingKey, method), string(respBody))
+		}
+	}
+}
+
+func TestCanInvokeSensitiveMethodsWithViewingKey(t *testing.T) {
+	err := createWalExt(t)
+	if err != nil {
+		t.Fatalf(fmt.Sprintf("could not create wallet extension. Cause: %s", err.Error()))
+	}
+
+	_, _, viewingKeyBytes, err := registerPrivateKey(walExtAddr)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	// We pass the viewing key to the API, so that the RPC layer can properly encrypt responses.
+	err = dummyEthAPI.setViewingKey(viewingKeyBytes)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	for _, method := range rpc.SensitiveMethods {
+		var params interface{}
+		if method == rpc.RPCSubscribe {
+			params = []interface{}{rpc.RPCSubscriptionTypeLogs}
+		} else {
+			params = []interface{}{map[string]interface{}{}}
+		}
+
+		// We use a websocket request because one of the sensitive methods, eth_subscribe, requires it.
+		respBody, _ := MakeWSEthJSONReq(walExtAddrWS, method, params)
+
+		if !strings.Contains(string(respBody), "success") { // todo - joel - use constant
+			t.Fatalf("expected response containing '%s', got '%s'", "success", string(respBody)) // todo - joel - use constant
 		}
 	}
 }
@@ -81,12 +121,26 @@ func createWalExt(t *testing.T) error {
 
 // Creates an RPC layer that the wallet extension can connect to. Returns a handle to shut down the host.
 func createDummyHost(t *testing.T) error {
-	cfg := node.Config{
+	cfg := gethnode.Config{
 		WSHost:    localhost,
 		WSPort:    int(nodePortWS),
 		WSOrigins: []string{"*"},
 	}
-	rpcServerNode, err := node.New(&cfg)
+	rpcServerNode, err := gethnode.New(&cfg)
+	rpcServerNode.RegisterAPIs([]gethrpc.API{
+		{
+			Namespace: node.APINamespaceObscuro,
+			Version:   node.APIVersion1,
+			Service:   &DummyObscuroAPI{},
+			Public:    true,
+		},
+		{
+			Namespace: node.APINamespaceEth,
+			Version:   node.APIVersion1,
+			Service:   dummyEthAPI,
+			Public:    true,
+		},
+	})
 	if err != nil {
 		return fmt.Errorf("could not create new client server. Cause: %w", err)
 	}

--- a/tools/walletextension/test/wallet_extension_test.go
+++ b/tools/walletextension/test/wallet_extension_test.go
@@ -64,18 +64,16 @@ func TestCanInvokeSensitiveMethodsWithViewingKey(t *testing.T) {
 	}
 
 	for _, method := range rpc.SensitiveMethods {
-		var params interface{}
+		// Subscriptions have to be tested separately, as they return results differently.
 		if method == rpc.RPCSubscribe {
-			params = []interface{}{rpc.RPCSubscriptionTypeLogs}
-		} else {
-			params = []interface{}{map[string]interface{}{}}
+			continue
 		}
 
 		// We use a websocket request because one of the sensitive methods, eth_subscribe, requires it.
-		respBody, _ := MakeWSEthJSONReq(walExtAddrWS, method, params)
+		respBody, _ := MakeWSEthJSONReq(walExtAddrWS, method, []interface{}{map[string]interface{}{}})
 
-		if !strings.Contains(string(respBody), "success") { // todo - joel - use constant
-			t.Fatalf("expected response containing '%s', got '%s'", "success", string(respBody)) // todo - joel - use constant
+		if !strings.Contains(string(respBody), successMsg) {
+			t.Fatalf("expected response containing '%s', got '%s'", successMsg, string(respBody))
 		}
 	}
 }

--- a/tools/walletextension/test/wallet_extension_test.go
+++ b/tools/walletextension/test/wallet_extension_test.go
@@ -52,10 +52,7 @@ func TestCanInvokeSensitiveMethodsWithViewingKey(t *testing.T) {
 		t.Fatalf(fmt.Sprintf("could not create wallet extension. Cause: %s", err.Error()))
 	}
 
-	_, _, viewingKeyBytes, err := registerPrivateKey(walExtAddr)
-	if err != nil {
-		t.Fatalf(err.Error())
-	}
+	_, _, viewingKeyBytes := RegisterPrivateKey(t, walExtAddr)
 
 	// We pass the viewing key to the API, so that the RPC layer can properly encrypt responses.
 	err = dummyEthAPI.setViewingKey(viewingKeyBytes)


### PR DESCRIPTION
### Why is this change needed?

It's simpler to have a unit test that tests all sensitive methods, rather than an integration test for each one.

### What changes were made as part of this PR:

- Creates a unit test to test the result can be decrypted for all sensitive methods
- Removes integration tests that test the same

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
