### PR TITLE
WE: Remove cannot-do-for-another-account integration tests

### DIFF
--- a/integration/walletextension/wallet_extension_test.go
+++ b/integration/walletextension/wallet_extension_test.go
@@ -94,16 +94,6 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func TestCanMakeNonSensitiveRequestWithoutSubmittingViewingKey(t *testing.T) {
-	createWalletExtension(t)
-
-	respJSON := makeHTTPEthJSONReqAsJSON(rpc.RPCChainID, []string{})
-
-	if respJSON[walletextension.RespJSONKeyResult] != l2ChainIDHex {
-		t.Fatalf("Expected chainId of %s, got %s", l2ChainIDHex, respJSON[walletextension.RespJSONKeyResult])
-	}
-}
-
 func TestCannotGetAnothersBalanceAfterSubmittingViewingKey(t *testing.T) {
 	createWalletExtension(t)
 	test.RegisterPrivateKey(t, walletExtensionAddrHTTP)

--- a/integration/walletextension/wallet_extension_test.go
+++ b/integration/walletextension/wallet_extension_test.go
@@ -12,8 +12,6 @@ import (
 	gethrpc "github.com/ethereum/go-ethereum/rpc"
 	"github.com/obscuronet/go-obscuro/tools/walletextension/test"
 
-	"github.com/obscuronet/go-obscuro/tools/walletextension/userconn"
-
 	"github.com/gorilla/websocket"
 
 	"github.com/obscuronet/go-obscuro/go/enclave/rollupchain"
@@ -149,18 +147,6 @@ func TestCanDecryptSuccessfullyAfterRestartingWalletExtension(t *testing.T) {
 
 	if getBalanceJSON[walletextension.RespJSONKeyResult] != zeroBalance {
 		t.Fatalf("Expected balance of %s, got %s", zeroBalance, getBalanceJSON[walletextension.RespJSONKeyResult])
-	}
-}
-
-func TestCanGetErrorOverWS(t *testing.T) {
-	createWalletExtension(t)
-
-	invalidMethod := "invalidRPCMethod"
-	respJSON, _ := makeWSEthJSONReqAsJSON(invalidMethod, []string{})
-
-	expectedErr := fmt.Sprintf(errInvalidRPCMethod, invalidMethod)
-	if respJSON[userconn.RespJSONKeyErr] != expectedErr {
-		t.Fatalf("Expected error '%s', got '%s'", expectedErr, respJSON[userconn.RespJSONKeyErr])
 	}
 }
 

--- a/integration/walletextension/wallet_extension_test.go
+++ b/integration/walletextension/wallet_extension_test.go
@@ -134,21 +134,6 @@ func TestCanDecryptSuccessfullyAfterSubmittingMultipleViewingKeys(t *testing.T) 
 	}
 }
 
-func TestCanDecryptSuccessfullyAfterRestartingWalletExtension(t *testing.T) {
-	walletExtension := createWalletExtension(t)
-	accountAddr, _, _ := test.RegisterPrivateKey(t, walletExtensionAddrHTTP)
-
-	// We shut down the wallet extension and restart it, forcing the viewing keys to be reloaded.
-	walletExtension.Shutdown()
-	createWalletExtension(t)
-
-	getBalanceJSON := makeHTTPEthJSONReqAsJSON(rpc.RPCGetBalance, []string{accountAddr.String(), latestBlock})
-
-	if getBalanceJSON[walletextension.RespJSONKeyResult] != zeroBalance {
-		t.Fatalf("Expected balance of %s, got %s", zeroBalance, getBalanceJSON[walletextension.RespJSONKeyResult])
-	}
-}
-
 func TestCanSubscribeForLogs(t *testing.T) {
 	createWalletExtension(t)
 	test.RegisterPrivateKey(t, walletExtensionAddrHTTP)
@@ -209,14 +194,9 @@ func createWalletExtensionConfig() *walletextension.Config {
 	}
 }
 
-// Creates and serves a wallet extension.
-func createWalletExtension(t *testing.T) *walletextension.WalletExtension {
-	return createWalletExtensionWithConfig(t, walletExtensionConfig)
-}
-
 // Creates and serves a wallet extension with custom configuration.
-func createWalletExtensionWithConfig(t *testing.T, config *walletextension.Config) *walletextension.WalletExtension {
-	walletExtension := walletextension.NewWalletExtension(*config)
+func createWalletExtension(t *testing.T) {
+	walletExtension := walletextension.NewWalletExtension(*walletExtensionConfig)
 	t.Cleanup(walletExtension.Shutdown)
 
 	go walletExtension.Serve(network.Localhost, walletExtensionPort, walletExtensionPortWS)
@@ -224,8 +204,6 @@ func createWalletExtensionWithConfig(t *testing.T, config *walletextension.Confi
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	return walletExtension
 }
 
 // Makes an Ethereum JSON RPC request over HTTP and returns the response body as JSON.

--- a/integration/walletextension/wallet_extension_test.go
+++ b/integration/walletextension/wallet_extension_test.go
@@ -57,8 +57,7 @@ const (
 	nodeRPCWSPort         = networkStartPort + network.DefaultHostRPCWSOffset
 
 	// Returned by the EVM to indicate a zero result.
-	zeroResult  = "0x0000000000000000000000000000000000000000000000000000000000000000"
-	zeroBalance = "0x0"
+	zeroResult = "0x0000000000000000000000000000000000000000000000000000000000000000"
 
 	faucetAlloc = 750000000000000 // The amount the faucet allocates to each Obscuro wallet.
 )
@@ -104,33 +103,6 @@ func TestCanCallWithoutSettingFromField(t *testing.T) {
 
 	if callJSON[walletextension.RespJSONKeyResult] != zeroResult {
 		t.Fatalf("Expected call result of %s, got %s", zeroResult, callJSON[walletextension.RespJSONKeyResult])
-	}
-}
-
-func TestCanDecryptSuccessfullyAfterSubmittingMultipleViewingKeys(t *testing.T) {
-	createWalletExtension(t)
-
-	// We submit a viewing key for a random account.
-	var accountAddrs []string
-	for i := 0; i < 10; i++ {
-		privateKey, err := crypto.GenerateKey()
-		if err != nil {
-			t.Fatal(err)
-		}
-		accountAddr := crypto.PubkeyToAddress(privateKey.PublicKey).String()
-		_, err = test.GenerateAndSubmitViewingKey(walletExtensionAddrHTTP, accountAddr, privateKey)
-		if err != nil {
-			t.Fatalf(err.Error())
-		}
-		accountAddrs = append(accountAddrs, accountAddr)
-	}
-
-	// We request the balance of a random account about halfway through the list.
-	randAccountAddr := accountAddrs[len(accountAddrs)/2]
-	getBalanceJSON := makeHTTPEthJSONReqAsJSON(rpc.RPCGetBalance, []string{randAccountAddr, latestBlock})
-
-	if getBalanceJSON[walletextension.RespJSONKeyResult] != zeroBalance {
-		t.Fatalf("Expected balance of %s, got %s", zeroBalance, getBalanceJSON[walletextension.RespJSONKeyResult])
 	}
 }
 

--- a/integration/walletextension/wallet_extension_test.go
+++ b/integration/walletextension/wallet_extension_test.go
@@ -49,7 +49,6 @@ const (
 	respJSONKeyContractAddr = "contractAddress"
 	latestBlock             = "latest"
 	statusSuccess           = "0x1"
-	errInvalidRPCMethod     = "rpc request failed: the method %s does not exist/is not available"
 
 	walletExtensionPort   = int(integration.StartPortWalletExtensionTest)
 	walletExtensionPortWS = int(integration.StartPortWalletExtensionTest + 1)

--- a/tools/walletextension/test/apis.go
+++ b/tools/walletextension/test/apis.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -46,7 +47,7 @@ func (api *DummyEthAPI) setViewingKey(viewingKeyHexBytes []byte) error {
 	return nil
 }
 
-func (api *DummyEthAPI) ChainId() (*hexutil.Big, error) {
+func (api *DummyEthAPI) ChainId() (*hexutil.Big, error) { //nolint:stylecheck,revive
 	chainID, err := hexutil.DecodeBig(l2ChainIDHex)
 	return (*hexutil.Big)(chainID), err
 }

--- a/tools/walletextension/test/apis.go
+++ b/tools/walletextension/test/apis.go
@@ -5,8 +5,8 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
-
 	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/crypto/ecies"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -14,7 +14,8 @@ import (
 )
 
 const (
-	successMsg = "success"
+	successMsg   = "success"
+	l2ChainIDHex = "0x309"
 )
 
 // DummyObscuroAPI provides dummies for operations defined in the `obscuro_` namespace.
@@ -43,6 +44,11 @@ func (api *DummyEthAPI) setViewingKey(viewingKeyHexBytes []byte) error {
 	}
 	api.viewingKey = ecies.ImportECDSAPublic(viewingKey)
 	return nil
+}
+
+func (api *DummyEthAPI) ChainId() (*hexutil.Big, error) {
+	chainID, err := hexutil.DecodeBig(l2ChainIDHex)
+	return (*hexutil.Big)(chainID), err
 }
 
 func (api *DummyEthAPI) Call(context.Context, common.EncryptedParamsCall) (string, error) {

--- a/tools/walletextension/test/wallet_extension_test.go
+++ b/tools/walletextension/test/wallet_extension_test.go
@@ -32,14 +32,13 @@ var (
 	nodePortWS     = integration.StartPortWalletExtensionUnitTest + 2
 	walExtAddr     = fmt.Sprintf("http://%s:%d", localhost, walExtPortHTTP)
 	walExtAddrWS   = fmt.Sprintf("ws://%s:%d", localhost, walExtPortWS)
+	walExtCfg      = createWalExtCfg()
 	dummyEthAPI    = &DummyEthAPI{}
 )
 
 func TestCanInvokeNonSensitiveMethodsWithoutViewingKey(t *testing.T) {
-	err := createWalExt(t)
-	if err != nil {
-		t.Fatalf(fmt.Sprintf("could not create wallet extension. Cause: %s", err.Error()))
-	}
+	createDummyHost(t)
+	createWalExt(t)
 
 	respBody, _ := MakeWSEthJSONReq(walExtAddrWS, rpc.RPCChainID, []interface{}{})
 
@@ -49,10 +48,8 @@ func TestCanInvokeNonSensitiveMethodsWithoutViewingKey(t *testing.T) {
 }
 
 func TestCannotInvokeSensitiveMethodsWithoutViewingKey(t *testing.T) {
-	err := createWalExt(t)
-	if err != nil {
-		t.Fatalf(fmt.Sprintf("could not create wallet extension. Cause: %s", err.Error()))
-	}
+	createDummyHost(t)
+	createWalExt(t)
 
 	for _, method := range rpc.SensitiveMethods {
 		// We use a websocket request because one of the sensitive methods, eth_subscribe, requires it.
@@ -65,15 +62,12 @@ func TestCannotInvokeSensitiveMethodsWithoutViewingKey(t *testing.T) {
 }
 
 func TestCanInvokeSensitiveMethodsWithViewingKey(t *testing.T) {
-	err := createWalExt(t)
-	if err != nil {
-		t.Fatalf(fmt.Sprintf("could not create wallet extension. Cause: %s", err.Error()))
-	}
+	createDummyHost(t)
+	createWalExt(t)
 
+	// We register a viewing key and pass it to the API, so that the RPC layer can properly encrypt responses.
 	_, _, viewingKeyBytes := RegisterPrivateKey(t, walExtAddr)
-
-	// We pass the viewing key to the API, so that the RPC layer can properly encrypt responses.
-	err = dummyEthAPI.setViewingKey(viewingKeyBytes)
+	err := dummyEthAPI.setViewingKey(viewingKeyBytes)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -93,10 +87,8 @@ func TestCanInvokeSensitiveMethodsWithViewingKey(t *testing.T) {
 }
 
 func TestCannotInvokeSensitiveMethodsWithViewingKeyForAnotherAccount(t *testing.T) {
-	err := createWalExt(t)
-	if err != nil {
-		t.Fatalf(fmt.Sprintf("could not create wallet extension. Cause: %s", err.Error()))
-	}
+	createDummyHost(t)
+	createWalExt(t)
 
 	RegisterPrivateKey(t, walExtAddr)
 
@@ -125,11 +117,31 @@ func TestCannotInvokeSensitiveMethodsWithViewingKeyForAnotherAccount(t *testing.
 	}
 }
 
-func TestCannotSubscribeOverHTTP(t *testing.T) {
-	err := createWalExt(t)
+func TestKeysAreReloadedWhenWalletExtensionRestarts(t *testing.T) {
+	createDummyHost(t)
+	shutdown := createWalExt(t)
+
+	// We register a viewing key and pass it to the API, so that the RPC layer can properly encrypt responses.
+	_, _, viewingKeyBytes := RegisterPrivateKey(t, walExtAddr)
+	err := dummyEthAPI.setViewingKey(viewingKeyBytes)
 	if err != nil {
-		t.Fatalf("could not create wallet extension")
+		t.Fatalf(err.Error())
 	}
+
+	// We shut down the wallet extension and restart it, forcing the viewing keys to be reloaded.
+	shutdown()
+	createWalExt(t)
+
+	respBody := MakeHTTPEthJSONReq(walExtAddr, rpc.RPCGetBalance, []interface{}{map[string]interface{}{}})
+
+	if !strings.Contains(string(respBody), successMsg) {
+		t.Fatalf("expected response containing '%s', got '%s'", successMsg, string(respBody))
+	}
+}
+
+func TestCannotSubscribeOverHTTP(t *testing.T) {
+	createDummyHost(t)
+	createWalExt(t)
 
 	respBody := MakeHTTPEthJSONReq(walExtAddr, rpc.RPCSubscribe, []interface{}{rpc.RPCSubscriptionTypeLogs, filters.FilterCriteria{}})
 	if string(respBody) != walletextension.ErrSubscribeFailHTTP+"\n" {
@@ -137,35 +149,32 @@ func TestCannotSubscribeOverHTTP(t *testing.T) {
 	}
 }
 
-func createWalExt(t *testing.T) error {
-	err := createDummyHost(t)
-	if err != nil {
-		return err
-	}
-
+func createWalExtCfg() *walletextension.Config {
 	testPersistencePath, err := os.CreateTemp("", "")
 	if err != nil {
-		return fmt.Errorf("could not create persistence file for wallet extension tests")
+		panic("could not create persistence file for wallet extension tests")
 	}
-	cfg := walletextension.Config{
+	return &walletextension.Config{
 		NodeRPCWebsocketAddress: fmt.Sprintf("localhost:%d", nodePortWS),
 		PersistencePathOverride: testPersistencePath.Name(),
 	}
+}
 
-	walExt := walletextension.NewWalletExtension(cfg)
+func createWalExt(t *testing.T) func() {
+	walExt := walletextension.NewWalletExtension(*walExtCfg)
 	t.Cleanup(walExt.Shutdown)
 	go walExt.Serve(localhost, int(walExtPortHTTP), int(walExtPortWS))
 
-	err = WaitForEndpoint(walExtAddr + walletextension.PathReady)
+	err := WaitForEndpoint(walExtAddr + walletextension.PathReady)
 	if err != nil {
-		return err
+		t.Fatalf(err.Error())
 	}
 
-	return nil
+	return walExt.Shutdown
 }
 
 // Creates an RPC layer that the wallet extension can connect to. Returns a handle to shut down the host.
-func createDummyHost(t *testing.T) error {
+func createDummyHost(t *testing.T) {
 	cfg := gethnode.Config{
 		WSHost:    localhost,
 		WSPort:    int(nodePortWS),
@@ -187,14 +196,12 @@ func createDummyHost(t *testing.T) error {
 		},
 	})
 	if err != nil {
-		return fmt.Errorf("could not create new client server. Cause: %w", err)
+		t.Fatalf(fmt.Sprintf("could not create new client server. Cause: %s", err))
 	}
 	t.Cleanup(func() { rpcServerNode.Close() })
 
 	err = rpcServerNode.Start()
 	if err != nil {
-		return fmt.Errorf("could not create new client server. Cause: %w", err)
+		t.Fatalf(fmt.Sprintf("could not create new client server. Cause: %s", err))
 	}
-
-	return nil
 }

--- a/tools/walletextension/test/wallet_extension_test.go
+++ b/tools/walletextension/test/wallet_extension_test.go
@@ -117,6 +117,34 @@ func TestCannotInvokeSensitiveMethodsWithViewingKeyForAnotherAccount(t *testing.
 	}
 }
 
+func TestCanInvokeSensitiveMethodsAfterSubmittingMultipleViewingKeys(t *testing.T) {
+	createDummyHost(t)
+	createWalExt(t)
+
+	// todo - joel - update naming below
+	// todo - joel - get rid of equivalent integration test
+
+	// We submit viewing keys for ten arbitrary accounts.
+	var viewingKeys [][]byte
+	for i := 0; i < 10; i++ {
+		_, _, viewingKeyBytes := RegisterPrivateKey(t, walExtAddr)
+		viewingKeys = append(viewingKeys, viewingKeyBytes)
+	}
+
+	// We set the API to decrypt with an arbitrary key from the list we just generated.
+	arbitraryPrivateKey := viewingKeys[len(viewingKeys)/2]
+	err := dummyEthAPI.setViewingKey(arbitraryPrivateKey)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	respBody := MakeHTTPEthJSONReq(walExtAddr, rpc.RPCGetBalance, []interface{}{map[string]interface{}{}})
+
+	if !strings.Contains(string(respBody), successMsg) {
+		t.Fatalf("expected response containing '%s', got '%s'", successMsg, string(respBody))
+	}
+}
+
 func TestKeysAreReloadedWhenWalletExtensionRestarts(t *testing.T) {
 	createDummyHost(t)
 	shutdown := createWalExt(t)

--- a/tools/walletextension/test/wallet_extension_test.go
+++ b/tools/walletextension/test/wallet_extension_test.go
@@ -84,8 +84,7 @@ func TestCanInvokeSensitiveMethodsWithViewingKey(t *testing.T) {
 			continue
 		}
 
-		// We use a websocket request because one of the sensitive methods, eth_subscribe, requires it.
-		respBody, _ := MakeWSEthJSONReq(walExtAddrWS, method, []interface{}{map[string]interface{}{}})
+		respBody := MakeHTTPEthJSONReq(walExtAddr, method, []interface{}{map[string]interface{}{}})
 
 		if !strings.Contains(string(respBody), successMsg) {
 			t.Fatalf("expected response containing '%s', got '%s'", successMsg, string(respBody))
@@ -118,8 +117,7 @@ func TestCannotInvokeSensitiveMethodsWithViewingKeyForAnotherAccount(t *testing.
 			continue
 		}
 
-		// We use a websocket request because one of the sensitive methods, eth_subscribe, requires it.
-		respBody, _ := MakeWSEthJSONReq(walExtAddrWS, method, []interface{}{map[string]interface{}{}})
+		respBody := MakeHTTPEthJSONReq(walExtAddr, method, []interface{}{map[string]interface{}{}})
 
 		if !strings.Contains(string(respBody), errFailedDecrypt) {
 			t.Fatalf("expected response containing '%s', got '%s'", errFailedDecrypt, string(respBody))

--- a/tools/walletextension/test/wallet_extension_test.go
+++ b/tools/walletextension/test/wallet_extension_test.go
@@ -31,6 +31,19 @@ var (
 	dummyEthAPI    = &DummyEthAPI{}
 )
 
+func TestCanInvokeNonSensitiveMethodsWithoutViewingKey(t *testing.T) {
+	err := createWalExt(t)
+	if err != nil {
+		t.Fatalf(fmt.Sprintf("could not create wallet extension. Cause: %s", err.Error()))
+	}
+
+	respBody, _ := MakeWSEthJSONReq(walExtAddrWS, rpc.RPCChainID, []interface{}{})
+
+	if !strings.Contains(string(respBody), l2ChainIDHex) {
+		t.Fatalf("expected response containing '%s', got '%s'", l2ChainIDHex, string(respBody))
+	}
+}
+
 func TestCannotInvokeSensitiveMethodsWithoutViewingKey(t *testing.T) {
 	err := createWalExt(t)
 	if err != nil {

--- a/tools/walletextension/test/wallet_extension_test.go
+++ b/tools/walletextension/test/wallet_extension_test.go
@@ -3,10 +3,11 @@ package test
 import (
 	"encoding/hex"
 	"fmt"
-	"github.com/ethereum/go-ethereum/crypto"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/ethereum/go-ethereum/crypto"
 
 	gethrpc "github.com/ethereum/go-ethereum/rpc"
 	"github.com/obscuronet/go-obscuro/go/host/node"

--- a/tools/walletextension/test/wallet_extension_test.go
+++ b/tools/walletextension/test/wallet_extension_test.go
@@ -121,9 +121,6 @@ func TestCanInvokeSensitiveMethodsAfterSubmittingMultipleViewingKeys(t *testing.
 	createDummyHost(t)
 	createWalExt(t)
 
-	// todo - joel - update naming below
-	// todo - joel - get rid of equivalent integration test
-
 	// We submit viewing keys for ten arbitrary accounts.
 	var viewingKeys [][]byte
 	for i := 0; i < 10; i++ {
@@ -132,8 +129,8 @@ func TestCanInvokeSensitiveMethodsAfterSubmittingMultipleViewingKeys(t *testing.
 	}
 
 	// We set the API to decrypt with an arbitrary key from the list we just generated.
-	arbitraryPrivateKey := viewingKeys[len(viewingKeys)/2]
-	err := dummyEthAPI.setViewingKey(arbitraryPrivateKey)
+	arbitraryViewingKey := viewingKeys[len(viewingKeys)/2]
+	err := dummyEthAPI.setViewingKey(arbitraryViewingKey)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}


### PR DESCRIPTION
### Why is this change needed?

Ongoing move to WE unit tests instead of integration tests where suitable

### What changes were made as part of this PR:

- Moved more tests over

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
