### PR TITLE
Revert to always encoding rpc params as a list

### DIFF
--- a/go/enclave/enclave_test.go
+++ b/go/enclave/enclave_test.go
@@ -215,7 +215,7 @@ func gasEstimateInvalidNumParams(t *testing.T, w wallet.Wallet, enclave common.E
 	callMsg.From = w.Address()
 
 	// create the request
-	req := []interface{}{callMsg}
+	var req []interface{}
 	reqBytes, err := json.Marshal(req)
 	if err != nil {
 		t.Fatal(err)
@@ -229,7 +229,7 @@ func gasEstimateInvalidNumParams(t *testing.T, w wallet.Wallet, enclave common.E
 
 	// Run gas Estimation
 	_, err = enclave.EstimateGas(encryptedParams)
-	if !assert.ErrorContains(t, err, "invalid number of params") {
+	if !assert.ErrorContains(t, err, "required at least one param") {
 		t.Fatal("unexpected error")
 	}
 }

--- a/go/enclave/events/subscription_manager.go
+++ b/go/enclave/events/subscription_manager.go
@@ -33,10 +33,15 @@ func (s *SubscriptionManager) AddSubscription(id uuid.UUID, encryptedSubscriptio
 		return fmt.Errorf("could not decrypt params in eth_subscribe logs request. Cause: %w", err)
 	}
 
-	var subscription common.LogSubscription
-	if err = json.Unmarshal(jsonSubscription, &subscription); err != nil {
+	var subscriptions []common.LogSubscription
+	if err := json.Unmarshal(jsonSubscription, &subscriptions); err != nil {
 		return fmt.Errorf("could not unmarshall log subscription from JSON. Cause: %w", err)
 	}
+
+	if len(subscriptions) != 1 {
+		return fmt.Errorf("expected a single log subscription, received %d", len(subscriptions))
+	}
+	subscription := subscriptions[0]
 
 	err = s.rpcEncryptionManager.AuthenticateSubscriptionRequest(subscription)
 	if err != nil {

--- a/go/enclave/rpc/rpc_utils.go
+++ b/go/enclave/rpc/rpc_utils.go
@@ -23,19 +23,24 @@ const (
 
 // ExtractTxHash returns the transaction hash from the params of an eth_getTransactionReceipt request.
 func ExtractTxHash(getTxReceiptParams []byte) (gethcommon.Hash, error) {
-	var txHex string
-	err := json.Unmarshal(getTxReceiptParams, &txHex)
+	var paramsJSONList []string
+	err := json.Unmarshal(getTxReceiptParams, &paramsJSONList)
 	if err != nil {
 		return gethcommon.Hash{}, fmt.Errorf("could not parse JSON params in eth_getTransactionReceipt "+
 			"request. JSON params are: %s. Cause: %w", string(getTxReceiptParams), err)
 	}
-	return gethcommon.HexToHash(txHex), nil
+	if len(paramsJSONList) != 1 {
+		return gethcommon.Hash{}, fmt.Errorf("expected a single param (the tx hash) but received %d params", len(paramsJSONList))
+	}
+	txHash := paramsJSONList[0]
+
+	return gethcommon.HexToHash(txHash), nil
 }
 
 // ExtractTx returns the common.L2Tx from the params of an eth_sendRawTransaction request.
 func ExtractTx(sendRawTxParams []byte) (*common.L2Tx, error) {
-	// We remove the leading `"0x` and the trailing `"` from the transaction hex.
-	txBinary := sendRawTxParams[3 : len(sendRawTxParams)-1]
+	// We need to extract the transaction hex from the JSON list encoding. We remove the leading `"[0x`, and the trailing `]"`.
+	txBinary := sendRawTxParams[4 : len(sendRawTxParams)-2]
 	txBytes := gethcommon.Hex2Bytes(string(txBinary))
 
 	tx := &common.L2Tx{}

--- a/go/rpc/encrypted_client.go
+++ b/go/rpc/encrypted_client.go
@@ -213,13 +213,7 @@ func (c *EncRPCClient) encryptArgs(args ...interface{}) ([]byte, error) {
 		return nil, nil
 	}
 
-	var paramsJSON []byte
-	var err error
-	if len(args) == 1 {
-		paramsJSON, err = json.Marshal(args[0])
-	} else {
-		paramsJSON, err = json.Marshal(args)
-	}
+	paramsJSON, err := json.Marshal(args)
 	if err != nil {
 		return nil, fmt.Errorf("could not json encode request params: %w", err)
 	}

--- a/integration/walletextension/wallet_extension_test.go
+++ b/integration/walletextension/wallet_extension_test.go
@@ -742,7 +742,7 @@ func registerPrivateKey(t *testing.T) (gethcommon.Address, *ecdsa.PrivateKey) {
 // Submits a transaction and awaits the transaction receipt.
 func sendTransactionAndAwaitConfirmation(txWallet wallet.Wallet, tx types.LegacyTx) (map[string]interface{}, error) {
 	// Set the transaction's nonce.
-	nonceJSON := makeHTTPEthJSONReqAsJSON(rpc.RPCGetTransactionCount, []interface{}{txWallet.Address().Hex(), latestBlock})
+	nonceJSON := makeHTTPEthJSONReqAsJSON(rpc.RPCGetTransactionCount, txWallet.Address().Hex())
 	nonceString, ok := nonceJSON[walletextension.RespJSONKeyResult].(string)
 	if !ok {
 		respJSON, err := json.Marshal(nonceJSON)

--- a/integration/walletextension/wallet_extension_test.go
+++ b/integration/walletextension/wallet_extension_test.go
@@ -742,7 +742,7 @@ func registerPrivateKey(t *testing.T) (gethcommon.Address, *ecdsa.PrivateKey) {
 // Submits a transaction and awaits the transaction receipt.
 func sendTransactionAndAwaitConfirmation(txWallet wallet.Wallet, tx types.LegacyTx) (map[string]interface{}, error) {
 	// Set the transaction's nonce.
-	nonceJSON := makeHTTPEthJSONReqAsJSON(rpc.RPCGetTransactionCount, txWallet.Address().Hex())
+	nonceJSON := makeHTTPEthJSONReqAsJSON(rpc.RPCGetTransactionCount, []interface{}{txWallet.Address().Hex(), latestBlock})
 	nonceString, ok := nonceJSON[walletextension.RespJSONKeyResult].(string)
 	if !ok {
 		respJSON, err := json.Marshal(nonceJSON)


### PR DESCRIPTION
### Why is this change needed?

- We made a change to encrypt param as a single element if there was just one of them but semantically it is a list really and we hit issues with methods that have one req param and one optional param (fiddly for code that handles it)

### What changes were made as part of this PR:

- Revert commit https://github.com/obscuronet/go-obscuro/commit/1f6f04ba81cf907ceade1ffa1a9bb40e98ec6531
- Make estimateGas tolerant to not always getting two params

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
