### PR TITLE
Fix bug on network client call result pointer

### DIFF
--- a/go/rpc/network_client.go
+++ b/go/rpc/network_client.go
@@ -50,7 +50,7 @@ func NewNetworkClient(address string) (Client, error) {
 // Call handles JSON rpc requests, delegating to the geth RPC client
 // The result must be a pointer so that package json can unmarshal into it. You can also pass nil, in which case the result is ignored.
 func (c *networkClient) Call(result interface{}, method string, args ...interface{}) error {
-	return c.rpcClient.Call(&result, method, args...)
+	return c.rpcClient.Call(result, method, args...)
 }
 
 func (c *networkClient) CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error {


### PR DESCRIPTION
### Why is this change needed?

- client `Call` expects a pointer as the comment says, and it just passes it through to the next layer of client
- Tudor noticed difference between Call and CallContext, Call was taking the pointer of the result

### What changes were made as part of this PR:

- Change Call to pass the result through unchanged
- It's not used much, I've checked tests are passing and it should be identical to the context method.

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
