### PR TITLE
Adds rudimentary log event checks to the sims

### DIFF
--- a/go/enclave/bridge/bridge.go
+++ b/go/enclave/bridge/bridge.go
@@ -34,8 +34,10 @@ import (
 type ERC20 string
 
 const (
-	HOC ERC20 = "HOC"
-	POC ERC20 = "POC"
+	HOC     ERC20 = "HOC"
+	POC     ERC20 = "POC"
+	HOCAddr       = "f3a8bd422097bFdd9B3519Eaeb533393a1c561aC"
+	POCAddr       = "9802F661d17c65527D7ABB59DAAD5439cb125a67"
 )
 
 var HOCOwner, _ = crypto.HexToECDSA("6e384a07a01263518a09a5424c7b6bbfc3604ba7d93f47e3a455cbdd7f9f0682")

--- a/go/obsclient/authclient.go
+++ b/go/obsclient/authclient.go
@@ -96,7 +96,7 @@ func (ac *AuthObsClient) BalanceAt(ctx context.Context, blockNumber *big.Int) (*
 	return hexutil.DecodeBig(result)
 }
 
-func (ac *AuthObsClient) SubscribeFilterLogs(ctx context.Context, _ ethereum.FilterQuery, ch chan<- types.Log) (ethereum.Subscription, error) {
+func (ac *AuthObsClient) SubscribeFilterLogs(ctx context.Context, _ ethereum.FilterQuery, ch chan types.Log) (ethereum.Subscription, error) {
 	// TODO - #453 - Parse the arguments from the Ethereum filter query.
 	return ac.rpcClient.Subscribe(ctx, rpc.RPCSubscribeNamespace, ch, rpc.RPCSubscriptionTypeLogs, nil)
 }

--- a/go/obsclient/authclient.go
+++ b/go/obsclient/authclient.go
@@ -96,6 +96,11 @@ func (ac *AuthObsClient) BalanceAt(ctx context.Context, blockNumber *big.Int) (*
 	return hexutil.DecodeBig(result)
 }
 
+func (ac *AuthObsClient) SubscribeFilterLogs(ctx context.Context, _ ethereum.FilterQuery, ch chan<- types.Log) (ethereum.Subscription, error) {
+	// TODO - #453 - Parse the arguments from the Ethereum filter query.
+	return ac.rpcClient.Subscribe(ctx, rpc.RPCSubscribeNamespace, ch, rpc.RPCSubscriptionTypeLogs, nil)
+}
+
 func (ac *AuthObsClient) Address() common.Address {
 	return ac.account
 }

--- a/go/rpc/encrypted_client.go
+++ b/go/rpc/encrypted_client.go
@@ -133,9 +133,9 @@ func (c *EncRPCClient) Subscribe(ctx context.Context, namespace string, ch inter
 		return nil, fmt.Errorf("only subscriptions of type %s are supported", RPCSubscriptionTypeLogs)
 	}
 
-	logCh, ok := ch.(chan<- types.Log)
+	logCh, ok := ch.(chan types.Log)
 	if !ok {
-		return nil, fmt.Errorf("expected a channel of type `chan<- types.Log`, got %T", ch)
+		return nil, fmt.Errorf("expected a channel of type `chan types.Log`, got %T", ch)
 	}
 
 	logSubscription, err := c.createAuthenticatedLogSubscription(args)

--- a/go/rpc/encrypted_client.go
+++ b/go/rpc/encrypted_client.go
@@ -133,9 +133,9 @@ func (c *EncRPCClient) Subscribe(ctx context.Context, namespace string, ch inter
 		return nil, fmt.Errorf("only subscriptions of type %s are supported", RPCSubscriptionTypeLogs)
 	}
 
-	logCh, ok := ch.(chan *types.Log)
+	logCh, ok := ch.(chan<- types.Log)
 	if !ok {
-		return nil, fmt.Errorf("expected a channel of type `chan *types.Log`, got %T", ch)
+		return nil, fmt.Errorf("expected a channel of type `chan<- types.Log`, got %T", ch)
 	}
 
 	logSubscription, err := c.createAuthenticatedLogSubscription(args)
@@ -168,7 +168,7 @@ func (c *EncRPCClient) Subscribe(ctx context.Context, namespace string, ch inter
 				}
 
 				for _, decryptedLog := range decryptedLogs {
-					logCh <- decryptedLog
+					logCh <- *decryptedLog
 				}
 
 			case <-subscription.Err(): // This channel's sole purpose is to be closed when the subscription is unsubscribed.

--- a/integration/simulation/p2p/in_mem_obscuro_client.go
+++ b/integration/simulation/p2p/in_mem_obscuro_client.go
@@ -120,21 +120,7 @@ func (c *inMemObscuroClient) CallContext(_ context.Context, result interface{}, 
 }
 
 func (c *inMemObscuroClient) Subscribe(ctx context.Context, namespace string, channel interface{}, args ...interface{}) (*gethrpc.ClientSubscription, error) {
-	if len(args) == 0 {
-		return nil, fmt.Errorf("received a subscription request but no subscription type as specified")
-	}
-
-	subscriptionType, ok := args[0].(string)
-	if !ok {
-		return nil, fmt.Errorf("first argument to subscription request must be of type string, got %T", args[0])
-	}
-
-	switch subscriptionType {
-	case rpc.RPCSubscriptionTypeLogs:
-		panic("todo - joel - implement this")
-	}
-
-	return nil, fmt.Errorf("unknown subscription type: %s", subscriptionType)
+	panic("not implemented")
 }
 
 func (c *inMemObscuroClient) sendRawTransaction(args []interface{}) error {
@@ -251,10 +237,6 @@ func (c *inMemObscuroClient) getBalance(result interface{}, args []interface{}) 
 	}
 	*result.(*interface{}) = encryptedResponse
 	return nil
-}
-
-func (c *inMemObscuroClient) logs(args []interface{}) error {
-	panic("todo - joel - not implemented")
 }
 
 func (c *inMemObscuroClient) Stop() {

--- a/integration/simulation/p2p/in_mem_obscuro_client.go
+++ b/integration/simulation/p2p/in_mem_obscuro_client.go
@@ -120,7 +120,21 @@ func (c *inMemObscuroClient) CallContext(_ context.Context, result interface{}, 
 }
 
 func (c *inMemObscuroClient) Subscribe(ctx context.Context, namespace string, channel interface{}, args ...interface{}) (*gethrpc.ClientSubscription, error) {
-	panic("not implemented")
+	if len(args) == 0 {
+		return nil, fmt.Errorf("received a subscription request but no subscription type as specified")
+	}
+
+	subscriptionType, ok := args[0].(string)
+	if !ok {
+		return nil, fmt.Errorf("first argument to subscription request must be of type string, got %T", args[0])
+	}
+
+	switch subscriptionType {
+	case rpc.RPCSubscriptionTypeLogs:
+		panic("todo - joel - implement this")
+	}
+
+	return nil, fmt.Errorf("unknown subscription type: %s", subscriptionType)
 }
 
 func (c *inMemObscuroClient) sendRawTransaction(args []interface{}) error {
@@ -237,6 +251,10 @@ func (c *inMemObscuroClient) getBalance(result interface{}, args []interface{}) 
 	}
 	*result.(*interface{}) = encryptedResponse
 	return nil
+}
+
+func (c *inMemObscuroClient) logs(args []interface{}) error {
+	panic("todo - joel - not implemented")
 }
 
 func (c *inMemObscuroClient) Stop() {

--- a/integration/simulation/params/params.go
+++ b/integration/simulation/params/params.go
@@ -43,5 +43,6 @@ type SimParams struct {
 	// Contains all the wallets required by the simulation
 	Wallets *SimWallets
 
-	StartPort int // The port from which to start allocating ports. Must be unique across all simulations.
+	StartPort int  // The port from which to start allocating ports. Must be unique across all simulations.
+	IsInMem   bool // Denotes that the sim does not have a full RPC layer.
 }

--- a/integration/simulation/simulation.go
+++ b/integration/simulation/simulation.go
@@ -108,6 +108,7 @@ func (s *Simulation) waitForObscuroGenesisOnL1() {
 	}
 }
 
+// We subscribe to logs on every authenticated client, and redirect them to the simulation's log channel.
 func (s *Simulation) trackLogs() {
 	// In-memory clients cannot handle subscriptions for now.
 	if s.Params.IsInMem {

--- a/integration/simulation/simulation.go
+++ b/integration/simulation/simulation.go
@@ -42,9 +42,9 @@ type Simulation struct {
 	SimulationTime   time.Duration
 	Stats            *stats.Stats
 	Params           *params.SimParams
-	ctx              context.Context
 	LogChannel       chan types.Log
 	Subscriptions    []ethereum.Subscription
+	ctx              context.Context
 }
 
 // Start executes the simulation given all the Params. Injects transactions.
@@ -109,6 +109,11 @@ func (s *Simulation) waitForObscuroGenesisOnL1() {
 }
 
 func (s *Simulation) trackLogs() {
+	// In-memory clients cannot handle subscriptions for now.
+	if s.Params.IsInMem {
+		return
+	}
+
 	for _, clients := range s.RPCHandles.AuthObsClients {
 		for _, client := range clients {
 			sub, err := client.SubscribeFilterLogs(context.Background(), ethereum.FilterQuery{}, s.LogChannel)

--- a/integration/simulation/simulation_geth_in_mem_test.go
+++ b/integration/simulation/simulation_geth_in_mem_test.go
@@ -35,6 +35,7 @@ func TestGethSimulation(t *testing.T) {
 		L2ToL1EfficiencyThreshold: 0.7, // nodes might stop producing rollups but the geth network is still going
 		Wallets:                   wallets,
 		StartPort:                 integration.StartPortSimulationGethInMem,
+		IsInMem:                   true,
 	}
 
 	simParams.AvgNetworkLatency = simParams.AvgBlockDuration / 15

--- a/integration/simulation/simulation_in_mem_test.go
+++ b/integration/simulation/simulation_in_mem_test.go
@@ -34,6 +34,7 @@ func TestInMemoryMonteCarloSimulation(t *testing.T) {
 		ERC20ContractLib:          ethereum_mock.NewERC20ContractLibMock(),
 		Wallets:                   wallets,
 		StartPort:                 integration.StartPortSimulationInMem,
+		IsInMem:                   true,
 	}
 
 	simParams.AvgNetworkLatency = simParams.AvgBlockDuration / 15

--- a/integration/simulation/simulation_tester.go
+++ b/integration/simulation/simulation_tester.go
@@ -7,6 +7,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/core/types"
+
 	"github.com/obscuronet/go-obscuro/go/common/log"
 
 	"github.com/obscuronet/go-obscuro/integration/simulation/network"
@@ -55,6 +58,8 @@ func testSimulation(t *testing.T, netw network.Network, params *params.SimParams
 		SimulationTime:   params.SimulationTime,
 		Stats:            stats,
 		Params:           params,
+		LogChannel:       make(chan types.Log),
+		Subscriptions:    []ethereum.Subscription{},
 	}
 
 	// execute the simulation

--- a/integration/simulation/validate_chain.go
+++ b/integration/simulation/validate_chain.go
@@ -369,6 +369,11 @@ func extractWithdrawals(t *testing.T, nodeClient rpc.Client, nodeAddr uint64) (t
 // Terminates all subscriptions, and checks that we received events for both the HOC and POC ERC20 contracts.
 // TODO - #453 - Extend logic of this test.
 func checkLogsReceived(t *testing.T, s *Simulation) {
+	// In-memory clients cannot handle subscriptions for now.
+	if s.Params.IsInMem {
+		return
+	}
+
 	for _, sub := range s.Subscriptions {
 		sub.Unsubscribe()
 	}

--- a/integration/simulation/validate_chain.go
+++ b/integration/simulation/validate_chain.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/obscuronet/go-obscuro/integration/simulation/network"
 
@@ -49,6 +50,7 @@ func checkNetworkValidity(t *testing.T, s *Simulation) {
 
 	l1MaxHeight := checkEthereumBlockchainValidity(t, s)
 	checkObscuroBlockchainValidity(t, s, l1MaxHeight)
+	checkLogsReceived(t, s)
 }
 
 // checkEthereumBlockchainValidity: sanity check of the state of all L1 nodes
@@ -360,6 +362,38 @@ func extractWithdrawals(t *testing.T, nodeClient rpc.Client, nodeAddr uint64) (t
 		for _, w := range r.Withdrawals {
 			totalSuccessfullyWithdrawn.Add(totalSuccessfullyWithdrawn, w.Amount)
 			numberOfWithdrawalRequests++
+		}
+	}
+}
+
+// Terminates all subscriptions, and checks that we received events for both the HOC and POC ERC20 contracts.
+// TODO - #453 - Extend logic of this test.
+func checkLogsReceived(t *testing.T, s *Simulation) {
+	for _, sub := range s.Subscriptions {
+		sub.Unsubscribe()
+	}
+
+	var gotHOCEvent bool
+	var gotPOCEvent bool
+	for {
+		select {
+		case receivedLog := <-s.LogChannel:
+			if receivedLog.Address.Hex() == "0x"+bridge.HOCAddr {
+				gotHOCEvent = true
+			} else if receivedLog.Address.Hex() == "0x"+bridge.POCAddr {
+				gotPOCEvent = true
+			}
+			if gotHOCEvent && gotPOCEvent {
+				// We have received both HOC and POC events. The test is successful.
+				return
+			}
+
+		case <-time.After(100 * time.Millisecond):
+			if !(gotHOCEvent && gotPOCEvent) {
+				// The logs will have built up on the channel throughout the simulation, so they should arrive immediately.
+				t.Fatalf("did not receive events for both the HOC and POC contracts")
+			}
+			return
 		}
 	}
 }

--- a/integration/simulation/validate_chain.go
+++ b/integration/simulation/validate_chain.go
@@ -394,8 +394,8 @@ func checkLogsReceived(t *testing.T, s *Simulation) {
 			}
 
 		case <-time.After(100 * time.Millisecond):
+			// The logs will have built up on the channel throughout the simulation, so they should arrive immediately.
 			if !(gotHOCEvent && gotPOCEvent) {
-				// The logs will have built up on the channel throughout the simulation, so they should arrive immediately.
 				t.Fatalf("did not receive events for both the HOC and POC contracts")
 			}
 			return

--- a/tools/walletextension/accountmanager/account_manager.go
+++ b/tools/walletextension/accountmanager/account_manager.go
@@ -210,7 +210,7 @@ func executeSubscribe(client *rpc.EncRPCClient, req *RPCRequest, _ *interface{},
 	if len(req.Params) == 0 {
 		return fmt.Errorf("could not subscribe as no subscription namespace was provided")
 	}
-	ch := make(chan *types.Log)
+	ch := make(chan types.Log)
 	subscription, err := client.Subscribe(context.Background(), rpc.RPCSubscribeNamespace, ch, req.Params...)
 	if err != nil {
 		return fmt.Errorf("could not call %s with params %v. Cause: %w", req.Method, req.Params, err)


### PR DESCRIPTION
### Why is this change needed?

We need an end-to-end test to check that logs are working fine (e.g. to flag breaking changes in PRs).

### What changes were made as part of this PR:

- Adds a check in the full-network sims that the HOC and POC deployment events are received correctly

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
