### PR TITLE
Replaces panics in enclave client with errors

### DIFF
--- a/go/common/enclave.go
+++ b/go/common/enclave.go
@@ -38,7 +38,7 @@ type Enclave interface {
 	InitEnclave(secret EncryptedSharedEnclaveSecret) error
 
 	// ProduceGenesis - the genesis enclave produces the genesis rollup
-	ProduceGenesis(blkHash gethcommon.Hash) BlockSubmissionResponse
+	ProduceGenesis(blkHash gethcommon.Hash) (BlockSubmissionResponse, error)
 
 	// IngestBlocks - feed L1 blocks into the enclave to catch up
 	IngestBlocks(blocks []*types.Block) []BlockSubmissionResponse

--- a/go/common/enclave.go
+++ b/go/common/enclave.go
@@ -41,7 +41,7 @@ type Enclave interface {
 	ProduceGenesis(blkHash gethcommon.Hash) (BlockSubmissionResponse, error)
 
 	// IngestBlocks - feed L1 blocks into the enclave to catch up
-	IngestBlocks(blocks []*types.Block) []BlockSubmissionResponse
+	IngestBlocks(blocks []*types.Block) ([]BlockSubmissionResponse, error)
 
 	// Start - start speculative execution
 	Start(block types.Block) error

--- a/go/common/enclave.go
+++ b/go/common/enclave.go
@@ -23,10 +23,10 @@ type Enclave interface {
 	Status() (Status, error)
 
 	// Attestation - Produces an attestation report which will be used to request the shared secret from another enclave.
-	Attestation() *AttestationReport
+	Attestation() (*AttestationReport, error)
 
 	// GenerateSecret - the genesis enclave is responsible with generating the secret entropy
-	GenerateSecret() EncryptedSharedEnclaveSecret
+	GenerateSecret() (EncryptedSharedEnclaveSecret, error)
 
 	// ShareSecret - verify the attestation and return the shared secret (encrypted with the key from the attestation)
 	ShareSecret(report *AttestationReport) (EncryptedSharedEnclaveSecret, error)

--- a/go/common/enclave.go
+++ b/go/common/enclave.go
@@ -44,7 +44,7 @@ type Enclave interface {
 	IngestBlocks(blocks []*types.Block) []BlockSubmissionResponse
 
 	// Start - start speculative execution
-	Start(block types.Block)
+	Start(block types.Block) error
 
 	// SubmitBlock - When a new POBI round starts, the host submits a block to the enclave, which responds with a rollup
 	// it is the responsibility of the host to gossip the returned rollup

--- a/go/common/enclave.go
+++ b/go/common/enclave.go
@@ -53,7 +53,7 @@ type Enclave interface {
 	SubmitBlock(block types.Block) (BlockSubmissionResponse, error)
 
 	// SubmitRollup - receive gossiped rollups
-	SubmitRollup(rollup ExtRollup)
+	SubmitRollup(rollup ExtRollup) error
 
 	// SubmitTx - user transactions
 	SubmitTx(tx EncryptedTx) (EncryptedResponseSendRawTx, error)

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -221,13 +221,14 @@ func (e *enclaveImpl) StopClient() error {
 	return nil // The enclave is local so there is no client to stop
 }
 
-func (e *enclaveImpl) Start(block types.Block) {
+func (e *enclaveImpl) Start(block types.Block) error {
 	// todo - reinstate after TN1
 	/*	if e.config.SpeculativeExecution {
 			//start the speculative rollup execution loop on its own go routine
 			go e.start(block)
 		}
 	*/
+	return nil
 }
 
 func (e *enclaveImpl) ProduceGenesis(blkHash gethcommon.Hash) (common.BlockSubmissionResponse, error) {

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -268,7 +268,7 @@ func (e *enclaveImpl) SubmitBlock(block types.Block) (common.BlockSubmissionResp
 	return bsr, nil
 }
 
-func (e *enclaveImpl) SubmitRollup(rollup common.ExtRollup) {
+func (e *enclaveImpl) SubmitRollup(rollup common.ExtRollup) error {
 	r := core.ToEnclaveRollup(rollup.ToRollup(), e.transactionBlobCrypto)
 
 	// only store if the parent exists
@@ -278,6 +278,8 @@ func (e *enclaveImpl) SubmitRollup(rollup common.ExtRollup) {
 	} else {
 		common.LogWithID(e.nodeShortID, "Received rollup with no parent: r_%d", common.ShortHash(r.Hash()))
 	}
+
+	return nil
 }
 
 func (e *enclaveImpl) SubmitTx(tx common.EncryptedTx) (common.EncryptedResponseSendRawTx, error) {

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -230,13 +230,13 @@ func (e *enclaveImpl) Start(block types.Block) {
 	*/
 }
 
-func (e *enclaveImpl) ProduceGenesis(blkHash gethcommon.Hash) common.BlockSubmissionResponse {
+func (e *enclaveImpl) ProduceGenesis(blkHash gethcommon.Hash) (common.BlockSubmissionResponse, error) {
 	rolGenesis, b := e.chain.ProduceGenesis(blkHash)
 	return common.BlockSubmissionResponse{
 		ProducedRollup: rolGenesis.ToExtRollup(e.transactionBlobCrypto),
 		BlockHeader:    b.Header(),
 		IngestedBlock:  true,
-	}
+	}, nil
 }
 
 // IngestBlocks is used to update the enclave with the full history of the L1 chain to date.

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -241,16 +241,16 @@ func (e *enclaveImpl) ProduceGenesis(blkHash gethcommon.Hash) (common.BlockSubmi
 }
 
 // IngestBlocks is used to update the enclave with the full history of the L1 chain to date.
-func (e *enclaveImpl) IngestBlocks(blocks []*types.Block) []common.BlockSubmissionResponse {
+func (e *enclaveImpl) IngestBlocks(blocks []*types.Block) ([]common.BlockSubmissionResponse, error) {
 	result := make([]common.BlockSubmissionResponse, len(blocks))
 	for i, block := range blocks {
 		response := e.chain.IngestBlock(block)
 		result[i] = response
 		if !response.IngestedBlock {
-			return result // We return early, as all descendant blocks will also fail verification.
+			return result, nil // We return early, as all descendant blocks will also fail verification.
 		}
 	}
-	return result
+	return result, nil
 }
 
 // SubmitBlock is used to update the enclave with an additional L1 block.

--- a/go/enclave/rpc_server.go
+++ b/go/enclave/rpc_server.go
@@ -146,7 +146,10 @@ func (s *server) IngestBlocks(_ context.Context, request *generated.IngestBlocks
 
 func (s *server) Start(_ context.Context, request *generated.StartRequest) (*generated.StartResponse, error) {
 	bl := s.decodeBlock(request.EncodedBlock)
-	s.enclave.Start(bl)
+	err := s.enclave.Start(bl)
+	if err != nil {
+		return nil, err
+	}
 	return &generated.StartResponse{}, nil
 }
 
@@ -166,7 +169,10 @@ func (s *server) SubmitBlock(_ context.Context, request *generated.SubmitBlockRe
 
 func (s *server) SubmitRollup(_ context.Context, request *generated.SubmitRollupRequest) (*generated.SubmitRollupResponse, error) {
 	extRollup := rpc.FromExtRollupMsg(request.ExtRollup)
-	s.enclave.SubmitRollup(extRollup)
+	err := s.enclave.SubmitRollup(extRollup)
+	if err != nil {
+		return nil, err
+	}
 	return &generated.SubmitRollupResponse{}, nil
 }
 

--- a/go/enclave/rpc_server.go
+++ b/go/enclave/rpc_server.go
@@ -105,11 +105,16 @@ func (s *server) InitEnclave(_ context.Context, request *generated.InitEnclaveRe
 }
 
 func (s *server) ProduceGenesis(_ context.Context, request *generated.ProduceGenesisRequest) (*generated.ProduceGenesisResponse, error) {
-	genesisRollup := s.enclave.ProduceGenesis(gethcommon.BytesToHash(request.GetBlockHash()))
+	genesisRollup, err := s.enclave.ProduceGenesis(gethcommon.BytesToHash(request.GetBlockHash()))
+	if err != nil {
+		return nil, err
+	}
+
 	blockSubmissionResponse, err := rpc.ToBlockSubmissionResponseMsg(genesisRollup)
 	if err != nil {
 		return nil, err
 	}
+	
 	return &generated.ProduceGenesisResponse{BlockSubmissionResponse: &blockSubmissionResponse}, nil
 }
 

--- a/go/enclave/rpc_server.go
+++ b/go/enclave/rpc_server.go
@@ -74,13 +74,19 @@ func (s *server) Status(context.Context, *generated.StatusRequest) (*generated.S
 }
 
 func (s *server) Attestation(context.Context, *generated.AttestationRequest) (*generated.AttestationResponse, error) {
-	attestation := s.enclave.Attestation()
+	attestation, err := s.enclave.Attestation()
+	if err != nil {
+		return nil, err
+	}
 	msg := rpc.ToAttestationReportMsg(attestation)
 	return &generated.AttestationResponse{AttestationReportMsg: &msg}, nil
 }
 
 func (s *server) GenerateSecret(context.Context, *generated.GenerateSecretRequest) (*generated.GenerateSecretResponse, error) {
-	secret := s.enclave.GenerateSecret()
+	secret, err := s.enclave.GenerateSecret()
+	if err != nil {
+		return nil, err
+	}
 	return &generated.GenerateSecretResponse{EncryptedSharedEnclaveSecret: secret}, nil
 }
 

--- a/go/enclave/rpc_server.go
+++ b/go/enclave/rpc_server.go
@@ -114,7 +114,7 @@ func (s *server) ProduceGenesis(_ context.Context, request *generated.ProduceGen
 	if err != nil {
 		return nil, err
 	}
-	
+
 	return &generated.ProduceGenesisResponse{BlockSubmissionResponse: &blockSubmissionResponse}, nil
 }
 
@@ -125,7 +125,11 @@ func (s *server) IngestBlocks(_ context.Context, request *generated.IngestBlocks
 		blocks = append(blocks, &bl)
 	}
 
-	r := s.enclave.IngestBlocks(blocks)
+	r, err := s.enclave.IngestBlocks(blocks)
+	if err != nil {
+		return nil, err
+	}
+
 	blockSubmissionResponses := make([]*generated.BlockSubmissionResponseMsg, len(r))
 	for i, response := range r {
 		b, err := rpc.ToBlockSubmissionResponseMsg(response)

--- a/go/host/node/node.go
+++ b/go/host/node/node.go
@@ -622,7 +622,10 @@ func (a *Node) sendLogsToSubscribers(result common.BlockSubmissionResponse) {
 // Called only by the first enclave to bootstrap the network
 func (a *Node) initialiseProtocol(block *types.Block) (common.L2RootHash, error) {
 	// Create the genesis rollup and submit it to the management contract
-	genesisResponse := a.enclaveClient.ProduceGenesis(block.Hash())
+	genesisResponse, err := a.enclaveClient.ProduceGenesis(block.Hash())
+	if err != nil {
+		return common.L2RootHash{}, fmt.Errorf("could not produce genesis. Cause: %w", err)
+	}
 	common.LogWithID(
 		a.shortID,
 		"Initialising network. Genesis rollup r_%d.",

--- a/go/host/node/node.go
+++ b/go/host/node/node.go
@@ -945,7 +945,10 @@ func (a *Node) bootstrapNode() types.Block {
 		cb := *currentBlock
 		a.processBlock(&cb)
 		// TODO ingest one block at a time or batch the blocks
-		result := a.enclaveClient.IngestBlocks([]*types.Block{&cb})
+		result, err := a.enclaveClient.IngestBlocks([]*types.Block{&cb})
+		if err != nil {
+			log.Panic(err.Error())
+		}
 		if !result[0].IngestedBlock && result[0].BlockNotIngestedCause != "" {
 			common.LogWithID(
 				a.shortID,

--- a/go/host/node/node.go
+++ b/go/host/node/node.go
@@ -232,19 +232,28 @@ func (a *Node) Start() {
 func (a *Node) broadcastSecret() error {
 	common.LogWithID(a.shortID, "Node is genesis node. Broadcasting secret.")
 	// Create the shared secret and submit it to the management contract for storage
-	attestation := a.enclaveClient.Attestation()
+	attestation, err := a.enclaveClient.Attestation()
+	if err != nil {
+		return fmt.Errorf("could not retrieve attestation from enclave. Cause: %w", err)
+	}
 	if attestation.Owner != a.config.ID {
 		return fmt.Errorf("genesis node has ID %s, but its enclave produced an attestation using ID %s", a.config.ID.Hex(), attestation.Owner.Hex())
 	}
 
 	encodedAttestation, err := common.EncodeAttestation(attestation)
 	if err != nil {
-		return fmt.Errorf("could not encode attestation Cause: %w", err)
+		return fmt.Errorf("could not encode attestation. Cause: %w", err)
 	}
+
+	secret, err := a.enclaveClient.GenerateSecret()
+	if err != nil {
+		return fmt.Errorf("could not generate secret. Cause: %w", err)
+	}
+
 	l1tx := &ethadapter.L1InitializeSecretTx{
 		AggregatorID:  &a.config.ID,
 		Attestation:   encodedAttestation,
-		InitialSecret: a.enclaveClient.GenerateSecret(),
+		InitialSecret: secret,
 		HostAddress:   a.config.P2PPublicAddress,
 	}
 	initialiseSecretTx := a.mgmtContractLib.CreateInitializeSecret(l1tx, a.ethWallet.GetNonceAndIncrement())
@@ -654,7 +663,10 @@ func (a *Node) signAndBroadcastTx(tx types.TxData, tries int) error {
 // This method implements the procedure by which a node obtains the secret
 func (a *Node) requestSecret() error {
 	common.LogWithID(a.shortID, "Requesting secret.")
-	att := a.enclaveClient.Attestation()
+	att, err := a.enclaveClient.Attestation()
+	if err != nil {
+		return fmt.Errorf("could not retrieve attestation from enclave. Cause: %w", err)
+	}
 	if att.Owner != a.config.ID {
 		return fmt.Errorf("node has ID %s, but its enclave produced an attestation using ID %s", a.config.ID.Hex(), att.Owner.Hex())
 	}

--- a/go/host/rpc/clientapi/client_api_obscuroscan.go
+++ b/go/host/rpc/clientapi/client_api_obscuroscan.go
@@ -120,6 +120,6 @@ func (api *ObscuroScanAPI) GetTotalTransactions() *big.Int {
 }
 
 // Attestation returns the node's attestation details.
-func (api *ObscuroScanAPI) Attestation() *common.AttestationReport {
+func (api *ObscuroScanAPI) Attestation() (*common.AttestationReport, error) {
 	return api.host.EnclaveClient().Attestation()
 }

--- a/go/host/rpc/enclaverpc/enclave_client.go
+++ b/go/host/rpc/enclaverpc/enclave_client.go
@@ -224,15 +224,16 @@ func (c *Client) SubmitBlock(block types.Block) (common.BlockSubmissionResponse,
 	return blockSubmissionResponse, nil
 }
 
-func (c *Client) SubmitRollup(rollup common.ExtRollup) {
+func (c *Client) SubmitRollup(rollup common.ExtRollup) error {
 	timeoutCtx, cancel := context.WithTimeout(context.Background(), c.config.EnclaveRPCTimeout)
 	defer cancel()
 
 	extRollupMsg := rpc.ToExtRollupMsg(&rollup)
 	_, err := c.protoClient.SubmitRollup(timeoutCtx, &generated.SubmitRollupRequest{ExtRollup: &extRollupMsg})
 	if err != nil {
-		common.PanicWithID(c.nodeShortID, "Could not submit rollup. Cause: %s", err)
+		return fmt.Errorf("could not submit rollup. Cause: %w", err)
 	}
+	return nil
 }
 
 func (c *Client) SubmitTx(tx common.EncryptedTx) (common.EncryptedResponseSendRawTx, error) {

--- a/go/host/rpc/enclaverpc/enclave_client.go
+++ b/go/host/rpc/enclaverpc/enclave_client.go
@@ -92,26 +92,26 @@ func (c *Client) Status() (common.Status, error) {
 	return common.Status(resp.GetStatus()), nil
 }
 
-func (c *Client) Attestation() *common.AttestationReport {
+func (c *Client) Attestation() (*common.AttestationReport, error) {
 	timeoutCtx, cancel := context.WithTimeout(context.Background(), c.config.EnclaveRPCTimeout)
 	defer cancel()
 
 	response, err := c.protoClient.Attestation(timeoutCtx, &generated.AttestationRequest{})
 	if err != nil {
-		common.PanicWithID(c.nodeShortID, "Failed to retrieve attestation. Cause: %s", err)
+		return nil, fmt.Errorf("failed to retrieve attestation. Cause: %s", err)
 	}
-	return rpc.FromAttestationReportMsg(response.AttestationReportMsg)
+	return rpc.FromAttestationReportMsg(response.AttestationReportMsg), nil
 }
 
-func (c *Client) GenerateSecret() common.EncryptedSharedEnclaveSecret {
+func (c *Client) GenerateSecret() (common.EncryptedSharedEnclaveSecret, error) {
 	timeoutCtx, cancel := context.WithTimeout(context.Background(), c.config.EnclaveRPCTimeout)
 	defer cancel()
 
 	response, err := c.protoClient.GenerateSecret(timeoutCtx, &generated.GenerateSecretRequest{})
 	if err != nil {
-		common.PanicWithID(c.nodeShortID, "Failed to generate secret. Cause: %s", err)
+		return nil, fmt.Errorf("failed to generate secret. Cause: %s", err)
 	}
-	return response.EncryptedSharedEnclaveSecret
+	return response.EncryptedSharedEnclaveSecret, nil
 }
 
 func (c *Client) ShareSecret(report *common.AttestationReport) (common.EncryptedSharedEnclaveSecret, error) {

--- a/go/host/rpc/enclaverpc/enclave_client.go
+++ b/go/host/rpc/enclaverpc/enclave_client.go
@@ -94,7 +94,7 @@ func (c *Client) Attestation() (*common.AttestationReport, error) {
 
 	response, err := c.protoClient.Attestation(timeoutCtx, &generated.AttestationRequest{})
 	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve attestation. Cause: %s", err)
+		return nil, fmt.Errorf("failed to retrieve attestation. Cause: %w", err)
 	}
 	return rpc.FromAttestationReportMsg(response.AttestationReportMsg), nil
 }
@@ -105,7 +105,7 @@ func (c *Client) GenerateSecret() (common.EncryptedSharedEnclaveSecret, error) {
 
 	response, err := c.protoClient.GenerateSecret(timeoutCtx, &generated.GenerateSecretRequest{})
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate secret. Cause: %s", err)
+		return nil, fmt.Errorf("failed to generate secret. Cause: %w", err)
 	}
 	return response.EncryptedSharedEnclaveSecret, nil
 }
@@ -177,7 +177,7 @@ func (c *Client) IngestBlocks(blocks []*types.Block) ([]common.BlockSubmissionRe
 	for i, r := range responses {
 		blockSubmissionResponse, err := rpc.FromBlockSubmissionResponseMsg(r)
 		if err != nil {
-			return nil, fmt.Errorf("could not produce block submission response. Cause: %s", err)
+			return nil, fmt.Errorf("could not produce block submission response. Cause: %w", err)
 		}
 		result[i] = blockSubmissionResponse
 	}

--- a/go/host/rpc/enclaverpc/enclave_client.go
+++ b/go/host/rpc/enclaverpc/enclave_client.go
@@ -282,7 +282,7 @@ func (c *Client) RoundWinner(parent common.L2RootHash) (common.ExtRollup, bool, 
 
 	response, err := c.protoClient.RoundWinner(timeoutCtx, &generated.RoundWinnerRequest{Parent: parent.Bytes()})
 	if err != nil {
-		common.PanicWithID(c.nodeShortID, "Failed to determine round winner. Cause: %s", err)
+		return common.ExtRollup{}, false, fmt.Errorf("could not determine round winner. Cause: %w", err)
 	}
 
 	if response.Winner {


### PR DESCRIPTION
### Why is this change needed?

Occasionally, during simulation shutdown, the shutdown sequence will cause one of these panics to be triggered, causing a successful simulation to fail. More generally, it's better to raise these issues and allow them to be handled.

### What changes were made as part of this PR:

- Replace panics in enclave_client with return of errors

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
