### PR TITLE
Encrypts logs between enclave and client

### DIFF
--- a/go/common/rpc/converters.go
+++ b/go/common/rpc/converters.go
@@ -36,7 +36,7 @@ func ToBlockSubmissionResponseMsg(response common.BlockSubmissionResponse) (gene
 		// We marshal to text rather than to bytes because bytes cannot be used as a map key in protobufs.
 		uuidString, err := id.MarshalText()
 		if err != nil {
-			return generated.BlockSubmissionResponseMsg{}, fmt.Errorf("could not marshall UUID to string. Cause: %w", err)
+			return generated.BlockSubmissionResponseMsg{}, fmt.Errorf("could not marshal UUID to string. Cause: %w", err)
 		}
 		subscribedLogsMsg[string(uuidString)] = log
 	}

--- a/go/enclave/events/subscription_manager.go
+++ b/go/enclave/events/subscription_manager.go
@@ -48,7 +48,7 @@ func (s *SubscriptionManager) AddSubscription(id uuid.UUID, encryptedSubscriptio
 
 	var subscriptions []common.LogSubscription
 	if err := json.Unmarshal(jsonSubscription, &subscriptions); err != nil {
-		return fmt.Errorf("could not unmarshall log subscription from JSON. Cause: %w", err)
+		return fmt.Errorf("could not unmarshal log subscription from JSON. Cause: %w", err)
 	}
 
 	if len(subscriptions) != 1 {

--- a/go/host/rpc/enclaverpc/enclave_client.go
+++ b/go/host/rpc/enclaverpc/enclave_client.go
@@ -400,7 +400,7 @@ func (c *Client) Subscribe(id uuid.UUID, encryptedParams common.EncryptedParamsL
 
 	idBinary, err := id.MarshalBinary()
 	if err != nil {
-		return fmt.Errorf("could not marshall subscription ID to binary. Cause: %w", err)
+		return fmt.Errorf("could not marshal subscription ID to binary. Cause: %w", err)
 	}
 
 	_, err = c.protoClient.Subscribe(timeoutCtx, &generated.SubscribeRequest{
@@ -416,7 +416,7 @@ func (c *Client) Unsubscribe(id uuid.UUID) error {
 
 	idBinary, err := id.MarshalBinary()
 	if err != nil {
-		return fmt.Errorf("could not marshall subscription ID to binary. Cause: %w", err)
+		return fmt.Errorf("could not marshal subscription ID to binary. Cause: %w", err)
 	}
 
 	_, err = c.protoClient.Unsubscribe(timeoutCtx, &generated.UnsubscribeRequest{

--- a/go/rpc/encrypted_client.go
+++ b/go/rpc/encrypted_client.go
@@ -108,7 +108,7 @@ func (c *EncRPCClient) CallContext(ctx context.Context, result interface{}, meth
 		return ErrNilResponse
 	}
 
-	// method is sensitive, so we decrypt it before unmarshaling the result
+	// method is sensitive, so we decrypt it before unmarshalling the result
 	decrypted, err := c.decryptHexString(rawResult)
 	if err != nil {
 		return fmt.Errorf("could not decrypt response for %s call - %w", method, err)

--- a/go/rpc/encrypted_client.go
+++ b/go/rpc/encrypted_client.go
@@ -109,7 +109,7 @@ func (c *EncRPCClient) CallContext(ctx context.Context, result interface{}, meth
 	}
 
 	// method is sensitive, so we decrypt it before unmarshaling the result
-	decrypted, err := c.decryptResponse(rawResult)
+	decrypted, err := c.decryptHexString(rawResult)
 	if err != nil {
 		return fmt.Errorf("could not decrypt response for %s call - %w", method, err)
 	}
@@ -157,17 +157,23 @@ func (c *EncRPCClient) Subscribe(ctx context.Context, namespace string, ch inter
 	go func() {
 		for {
 			select {
-			case receivedLog := <-clientChannel:
-				// Due to our reuse of the Geth log subscription API, we have to return the logs as types.Log objects, and not
-				// encrypted bytes. To get around this, we place the encrypted log bytes into a "fake" log's data field.
-				// TODO - #453 - Add decryption of logs here once it's added on the enclave side.
-				var decryptedLogs []*types.Log
-				err = json.Unmarshal(receivedLog.Data, &decryptedLogs)
+			case wrapperLog := <-clientChannel:
+				// Due to our reuse of the Geth log subscription API, we have to return the logs as types.Log objects,
+				// and not encrypted bytes. To get around this, the encrypted log bytes are placed into a "fake" log's
+				// data field.
+				encryptedLogs := wrapperLog.Data
+				jsonLogs, err := c.decryptResponse(encryptedLogs)
+				if err != nil {
+					log.Error("could not decrypt logs received from subscription. Cause: %s", err)
+				}
+
+				var logs []*types.Log
+				err = json.Unmarshal(jsonLogs, &logs)
 				if err != nil {
 					log.Error("could not unmarshal log from `data` field of log received from subscription. Cause: %s", err)
 				}
 
-				for _, decryptedLog := range decryptedLogs {
+				for _, decryptedLog := range logs {
 					logCh <- *decryptedLog
 				}
 
@@ -251,18 +257,19 @@ func (c *EncRPCClient) encryptParamBytes(params []byte) ([]byte, error) {
 	return encryptedParams, nil
 }
 
-func (c *EncRPCClient) decryptResponse(resultBlob interface{}) ([]byte, error) {
+func (c *EncRPCClient) decryptHexString(resultBlob interface{}) ([]byte, error) {
 	resultStr, ok := resultBlob.(string)
 	if !ok {
 		return nil, fmt.Errorf("expected hex string but result was of type %t instead, with value %s", resultBlob, resultBlob)
 	}
-	encryptedResult := gethcommon.Hex2Bytes(resultStr)
+	return c.decryptResponse(gethcommon.Hex2Bytes(resultStr))
+}
 
-	decryptedResult, err := c.viewingKey.PrivateKey.Decrypt(encryptedResult, nil, nil)
+func (c *EncRPCClient) decryptResponse(encryptedBytes []byte) ([]byte, error) {
+	decryptedResult, err := c.viewingKey.PrivateKey.Decrypt(encryptedBytes, nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("could not decrypt result with viewing key - %w", err)
 	}
-
 	return decryptedResult, nil
 }
 

--- a/integration/simulation/simulation.go
+++ b/integration/simulation/simulation.go
@@ -178,7 +178,7 @@ func (s *Simulation) deployObscuroERC20s() {
 
 			err = testcommon.AwaitReceipt(s.ctx, s.RPCHandles.ObscuroWalletRndClient(owner), signedTx.Hash())
 			if err != nil {
-				panic(fmt.Sprintf("ERC20 deployment transaction failed. Cause: %s", err))
+				panic(fmt.Sprintf("ERC20 deployment transaction unsuccessful. Cause: %s", err))
 			}
 		}(token)
 	}

--- a/tools/walletextension/accountmanager/account_manager.go
+++ b/tools/walletextension/accountmanager/account_manager.go
@@ -137,7 +137,7 @@ func parseParams(args []interface{}) (map[string]interface{}, error) {
 
 		err := json.Unmarshal(callParamsJSON, &params)
 		if err != nil {
-			return nil, fmt.Errorf("first arg couldn't be unmarshalled into a params map")
+			return nil, fmt.Errorf("first arg couldn't be unmarshaled into a params map")
 		}
 	}
 
@@ -285,7 +285,7 @@ func setCallFromFieldIfMissing(args []interface{}, account gethcommon.Address) (
 
 	callMsg, err := gethenconding.ExtractEthCallMapString(args[0])
 	if err != nil {
-		return nil, fmt.Errorf("unable to marshall callMsg - %w", err)
+		return nil, fmt.Errorf("unable to marshal callMsg - %w", err)
 	}
 
 	// We only modify `eth_call` requests where the `from` field is not set.

--- a/tools/walletextension/test/wallet_extension_test.go
+++ b/tools/walletextension/test/wallet_extension_test.go
@@ -205,7 +205,7 @@ func TestCanSubscribeForLogs(t *testing.T) {
 	var receivedLog *types.Log
 	err = json.Unmarshal(receivedLogJSON, &receivedLog)
 	if err != nil {
-		t.Fatalf("could not unmarshall received log from JSON")
+		t.Fatalf("could not unmarshal received log from JSON")
 	}
 
 	if !strings.Contains(string(receivedLog.Data), dummyHash.Hex()) {


### PR DESCRIPTION
### Why is this change needed?

The host must not be able to inspect the logs

### What changes were made as part of this PR:

- Encrypts the logs with the relevant viewing key on the enclave
- Decrypts the logs with the relevant viewing key in the EncRPCClient

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
