### PR TITLE
Filters logs in transaction receipts.

### DIFF
--- a/go/enclave/events/subscription_manager.go
+++ b/go/enclave/events/subscription_manager.go
@@ -86,8 +86,8 @@ func (s *SubscriptionManager) FilteredLogs(logs []*types.Log, rollupHash common.
 	return allLogs
 }
 
-// FilteredLogsBySubID filters out irrelevant logs and those that are not subscribed to, and organises the logs by their subscribing ID.
-func (s *SubscriptionManager) FilteredLogsBySubID(logs []*types.Log, rollupHash common.L2RootHash) map[uuid.UUID][]*types.Log {
+// FilteredSubscribedLogs filters out irrelevant logs and those that are not subscribed to, and organises them by their subscribing ID.
+func (s *SubscriptionManager) FilteredSubscribedLogs(logs []*types.Log, rollupHash common.L2RootHash) map[uuid.UUID][]*types.Log {
 	relevantLogs := map[uuid.UUID][]*types.Log{}
 
 	// If there are no subscriptions, we do not need to do any processing.

--- a/go/enclave/events/subscription_manager.go
+++ b/go/enclave/events/subscription_manager.go
@@ -71,9 +71,23 @@ func (s *SubscriptionManager) RemoveSubscription(id uuid.UUID) {
 	delete(s.subscriptions, id)
 }
 
-// FilterRelevantLogs filters out logs that are not subscribed to, and organises the logs by their subscribing ID.
-// It uses a state DB created from the rollup with the given hash to identify lifecycle vs user topics.
-func (s *SubscriptionManager) FilterRelevantLogs(logs []*types.Log, rollupHash common.L2RootHash) map[uuid.UUID][]*types.Log {
+// FilteredLogs filters out logs that are not subscribed to.
+func (s *SubscriptionManager) FilteredLogs(logs []*types.Log, rollupHash common.L2RootHash, account *gethcommon.Address) []*types.Log {
+	allLogs := []*types.Log{}
+	stateDB := s.storage.CreateStateDB(rollupHash)
+
+	for _, log := range logs {
+		userAddrs := getUserAddrs(log, stateDB)
+		if isRelevant(userAddrs, account) {
+			allLogs = append(allLogs, log)
+		}
+	}
+
+	return allLogs
+}
+
+// FilteredLogsBySubID filters out logs that are not subscribed to, and organises the logs by their subscribing ID.
+func (s *SubscriptionManager) FilteredLogsBySubID(logs []*types.Log, rollupHash common.L2RootHash) map[uuid.UUID][]*types.Log {
 	relevantLogs := map[uuid.UUID][]*types.Log{}
 
 	// If there are no subscriptions, we do not need to do any processing.
@@ -92,7 +106,7 @@ func (s *SubscriptionManager) FilterRelevantLogs(logs []*types.Log, rollupHash c
 
 		// We check whether the log is relevant to each subscription.
 		for subscriptionID, subscription := range s.subscriptions {
-			if isRelevant(userAddrs, subscription) {
+			if isRelevant(userAddrs, subscription.SubscriptionAccount.Account) {
 				relevantLogs[subscriptionID] = append(relevantLogs[subscriptionID], log)
 			}
 		}
@@ -151,15 +165,14 @@ func getUserAddrs(log *types.Log, db *state.StateDB) []string {
 }
 
 // Indicates whether the log is relevant for the subscription.
-func isRelevant(userAddrs []string, sub *common.LogSubscription) bool {
+func isRelevant(userAddrs []string, account *gethcommon.Address) bool {
 	// If there are no potential user addresses, this is a lifecycle event, and is therefore relevant to everyone.
 	if len(userAddrs) == 0 {
 		return true
 	}
 
-	accountHex := sub.SubscriptionAccount.Account.Hex()
 	for _, addr := range userAddrs {
-		if addr == accountHex {
+		if addr == account.Hex() {
 			return true
 		}
 	}

--- a/go/enclave/events/subscription_manager.go
+++ b/go/enclave/events/subscription_manager.go
@@ -71,7 +71,7 @@ func (s *SubscriptionManager) RemoveSubscription(id uuid.UUID) {
 	delete(s.subscriptions, id)
 }
 
-// FilteredLogs filters out logs that are not subscribed to.
+// FilteredLogs filters out irrelevant logs.
 func (s *SubscriptionManager) FilteredLogs(logs []*types.Log, rollupHash common.L2RootHash, account *gethcommon.Address) []*types.Log {
 	allLogs := []*types.Log{}
 	stateDB := s.storage.CreateStateDB(rollupHash)
@@ -86,7 +86,7 @@ func (s *SubscriptionManager) FilteredLogs(logs []*types.Log, rollupHash common.
 	return allLogs
 }
 
-// FilteredLogsBySubID filters out logs that are not subscribed to, and organises the logs by their subscribing ID.
+// FilteredLogsBySubID filters out irrelevant logs and those that are not subscribed to, and organises the logs by their subscribing ID.
 func (s *SubscriptionManager) FilteredLogsBySubID(logs []*types.Log, rollupHash common.L2RootHash) map[uuid.UUID][]*types.Log {
 	relevantLogs := map[uuid.UUID][]*types.Log{}
 

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -242,7 +242,7 @@ func (rc *RollupChain) updateState(b *types.Block) (*obscurocore.BlockState, map
 	// For the genesis block, we do not emit any events, because we cannot yet validate whether all the topics refer to
 	// code addresses, since the state DB hasn't yet been constructed to check against.
 	if head.Header.ParentHash != common.GenesisHash {
-		subscribedLogs = rc.subscriptionManager.FilteredLogsBySubID(logs, head.Header.ParentHash)
+		subscribedLogs = rc.subscriptionManager.FilteredSubscribedLogs(logs, head.Header.ParentHash)
 	}
 
 	// We append the rollup's logs to the logs of the parent rollup. This is to ensure events are not missed if a

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -242,7 +242,7 @@ func (rc *RollupChain) updateState(b *types.Block) (*obscurocore.BlockState, map
 	// For the genesis block, we do not emit any events, because we cannot yet validate whether all the topics refer to
 	// code addresses, since the state DB hasn't yet been constructed to check against.
 	if head.Header.ParentHash != common.GenesisHash {
-		subscribedLogs = rc.subscriptionManager.FilterRelevantLogs(logs, head.Header.ParentHash)
+		subscribedLogs = rc.subscriptionManager.FilteredLogsBySubID(logs, head.Header.ParentHash)
 	}
 
 	// We append the rollup's logs to the logs of the parent rollup. This is to ensure events are not missed if a

--- a/go/enclave/rpc/rpc_utils.go
+++ b/go/enclave/rpc/rpc_utils.go
@@ -51,9 +51,9 @@ func ExtractAddress(getTransactionCountParams []byte) (gethcommon.Address, error
 	return txHash, err
 }
 
-// GetViewingKeyAddressForTransaction returns the address whose viewing key should be used to encrypt the response,
+// GetSender returns the address whose viewing key should be used to encrypt the response,
 // given a transaction.
-func GetViewingKeyAddressForTransaction(tx *common.L2Tx) (gethcommon.Address, error) {
+func GetSender(tx *common.L2Tx) (gethcommon.Address, error) {
 	// TODO - Once the enclave's genesis.json is set, retrieve the signer type using `types.MakeSigner`.
 	signer := types.NewLondonSigner(tx.ChainId())
 	sender, err := signer.Sender(tx)

--- a/integration/simulation/validate_chain.go
+++ b/integration/simulation/validate_chain.go
@@ -238,7 +238,7 @@ func checkBlockchainOfObscuroNode(t *testing.T, rpcHandles *network.RPCHandles, 
 			nodeAddr, notFoundWithdrawals, len(s.TxInjector.TxTracker.WithdrawalL2Transactions))
 	}
 
-	checkTransactionReceipts(s.ctx, nodeIdx, rpcHandles, s.TxInjector)
+	checkTransactionReceipts(t, s.ctx, nodeIdx, rpcHandles, s.TxInjector)
 
 	totalSuccessfullyWithdrawn, numberOfWithdrawalRequests := extractWithdrawals(t, nodeClient, nodeAddr)
 
@@ -327,7 +327,7 @@ func getSender(tx *common.L2Tx) gethcommon.Address {
 }
 
 // Checks that there is a receipt available for each L2 transaction.
-func checkTransactionReceipts(ctx context.Context, nodeIdx int, rpcHandles *network.RPCHandles, txInjector *TransactionInjector) {
+func checkTransactionReceipts(t *testing.T, ctx context.Context, nodeIdx int, rpcHandles *network.RPCHandles, txInjector *TransactionInjector) {
 	l2Txs := append(txInjector.TxTracker.TransferL2Transactions, txInjector.TxTracker.WithdrawalL2Transactions...)
 
 	for _, tx := range l2Txs {
@@ -335,10 +335,11 @@ func checkTransactionReceipts(ctx context.Context, nodeIdx int, rpcHandles *netw
 		// We check that there is a receipt available for each transaction
 		rec, err := rpcHandles.ObscuroWalletClient(sender, nodeIdx).TransactionReceipt(ctx, tx.Hash())
 		if err != nil {
-			panic(err)
+			t.Errorf("could not retrieve receipt for transaction %s. Cause: %s", tx.Hash().Hex(), err)
+			continue
 		}
 		if rec.Status == types.ReceiptStatusFailed {
-			log.Info("Transaction %s has failed.", tx.Hash().Hex())
+			log.Info("Transaction %s failed.", tx.Hash().Hex())
 		}
 	}
 }


### PR DESCRIPTION
### Why is this change needed?

A transaction can generate logs that are not relevant to the sender. These should be filtered out before the receipt is returned.

### What changes were made as part of this PR:

- Provide a high level list of the changes made
- List key areas for the reviewer 

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
