### PR TITLE
Recalculate historical subscribed logs based on current subscriptions

### DIFF
--- a/go/enclave/db/interfaces.go
+++ b/go/enclave/db/interfaces.go
@@ -3,7 +3,6 @@ package db
 import (
 	"crypto/ecdsa"
 
-	"github.com/google/uuid"
 	"github.com/obscuronet/go-obscuro/go/enclave/crypto"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
@@ -54,11 +53,11 @@ type RollupResolver interface {
 
 type BlockStateStorage interface {
 	// FetchBlockState returns the block state and logs for the given block, and a boolean indicating if the block was found.
-	FetchBlockState(blockHash common.L1RootHash) (*core.BlockState, map[uuid.UUID][]*types.Log, bool)
+	FetchBlockState(blockHash common.L1RootHash) (*core.BlockState, []*types.Log, bool)
 	// FetchHeadState returns the head block state. Returns nil if nothing recorded yet
 	FetchHeadState() *core.BlockState
 	// SaveNewHead save the rollup-block mapping
-	SaveNewHead(state *core.BlockState, rollup *core.Rollup, receipts []*types.Receipt, logs map[uuid.UUID][]*types.Log)
+	SaveNewHead(state *core.BlockState, rollup *core.Rollup, receipts []*types.Receipt, logs []*types.Log)
 	// CreateStateDB create a database that can be used to execute transactions
 	CreateStateDB(hash common.L2RootHash) *state.StateDB
 	// EmptyStateDB create the original empty StateDB

--- a/go/enclave/db/rawdb/accessors_chain.go
+++ b/go/enclave/db/rawdb/accessors_chain.go
@@ -6,8 +6,6 @@ import (
 	"encoding/gob"
 
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/google/uuid"
-
 	"github.com/status-im/keycard-go/hexutils"
 
 	"github.com/obscuronet/go-obscuro/go/common/log"
@@ -182,7 +180,7 @@ func ReadBlockState(kv ethdb.KeyValueReader, hash gethcommon.Hash) *core.BlockSt
 	return bs
 }
 
-func WriteBlockLogs(db ethdb.KeyValueWriter, blockHash gethcommon.Hash, logs map[uuid.UUID][]*types.Log) {
+func WriteBlockLogs(db ethdb.KeyValueWriter, blockHash gethcommon.Hash, logs []*types.Log) {
 	// We use gobs instead of RLP here, because RLP cannot handle maps.
 	buffer := new(bytes.Buffer)
 	encoder := gob.NewEncoder(buffer)
@@ -195,14 +193,14 @@ func WriteBlockLogs(db ethdb.KeyValueWriter, blockHash gethcommon.Hash, logs map
 	}
 }
 
-func ReadBlockLogs(kv ethdb.KeyValueReader, blockHash gethcommon.Hash) map[uuid.UUID][]*types.Log {
+func ReadBlockLogs(kv ethdb.KeyValueReader, blockHash gethcommon.Hash) []*types.Log {
 	data, _ := kv.Get(logsKey(blockHash))
 	if data == nil {
 		return nil
 	}
 
 	decoder := gob.NewDecoder(bytes.NewBuffer(data))
-	var logs map[uuid.UUID][]*types.Log
+	var logs []*types.Log
 	if err := decoder.Decode(&logs); err != nil {
 		log.Panic("could not decode logs. Cause: %s", err)
 	}

--- a/go/enclave/db/rawdb/accessors_chain.go
+++ b/go/enclave/db/rawdb/accessors_chain.go
@@ -3,7 +3,6 @@ package rawdb
 import (
 	"bytes"
 	"encoding/binary"
-	"encoding/gob"
 
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/status-im/keycard-go/hexutils"
@@ -181,14 +180,12 @@ func ReadBlockState(kv ethdb.KeyValueReader, hash gethcommon.Hash) *core.BlockSt
 }
 
 func WriteBlockLogs(db ethdb.KeyValueWriter, blockHash gethcommon.Hash, logs []*types.Log) {
-	// We use gobs instead of RLP here, because RLP cannot handle maps.
-	buffer := new(bytes.Buffer)
-	encoder := gob.NewEncoder(buffer)
-	if err := encoder.Encode(logs); err != nil {
+	bytes, err := rlp.EncodeToBytes(logs)
+	if err != nil {
 		log.Panic("could not encode logs. Cause: %s", err)
 	}
 
-	if err := db.Put(logsKey(blockHash), buffer.Bytes()); err != nil {
+	if err := db.Put(logsKey(blockHash), bytes); err != nil {
 		log.Panic("could not put logs in DB. Cause: %s", err)
 	}
 }
@@ -199,13 +196,12 @@ func ReadBlockLogs(kv ethdb.KeyValueReader, blockHash gethcommon.Hash) []*types.
 		return nil
 	}
 
-	decoder := gob.NewDecoder(bytes.NewBuffer(data))
-	var logs []*types.Log
-	if err := decoder.Decode(&logs); err != nil {
+	logs := new([]*types.Log)
+	if err := rlp.Decode(bytes.NewReader(data), logs); err != nil {
 		log.Panic("could not decode logs. Cause: %s", err)
 	}
 
-	return logs
+	return *logs
 }
 
 // ReadCanonicalHash retrieves the hash assigned to a canonical block number.

--- a/go/enclave/db/storage.go
+++ b/go/enclave/db/storage.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/google/uuid"
-
 	"github.com/obscuronet/go-obscuro/go/enclave/crypto"
 
 	"github.com/obscuronet/go-obscuro/go/common/log"
@@ -215,7 +213,7 @@ func (s *storageImpl) Proof(r *core.Rollup) *types.Block {
 	return v
 }
 
-func (s *storageImpl) FetchBlockState(hash common.L1RootHash) (*core.BlockState, map[uuid.UUID][]*types.Log, bool) {
+func (s *storageImpl) FetchBlockState(hash common.L1RootHash) (*core.BlockState, []*types.Log, bool) {
 	bs := obscurorawdb.ReadBlockState(s.db, hash)
 	logs := obscurorawdb.ReadBlockLogs(s.db, hash)
 	// We expect both the block state and the logs to be stored. If one isn't, we return neither.
@@ -225,7 +223,7 @@ func (s *storageImpl) FetchBlockState(hash common.L1RootHash) (*core.BlockState,
 	return nil, nil, false
 }
 
-func (s *storageImpl) SaveNewHead(state *core.BlockState, rollup *core.Rollup, receipts []*types.Receipt, logs map[uuid.UUID][]*types.Log) {
+func (s *storageImpl) SaveNewHead(state *core.BlockState, rollup *core.Rollup, receipts []*types.Receipt, logs []*types.Log) {
 	batch := s.db.NewBatch()
 
 	if state.FoundNewRollup {

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -107,7 +107,7 @@ func (rc *RollupChain) IngestBlock(block *types.Block) common.BlockSubmissionRes
 	}
 
 	rc.storage.StoreBlock(block)
-	bs, subscribedLogs := rc.updateState(block)
+	bs, _, subscribedLogs := rc.updateState(block)
 	if bs == nil {
 		return rc.noBlockStateBlockSubmissionResponse(block)
 	}
@@ -182,12 +182,12 @@ func (rc *RollupChain) isGenesisBlock(block *types.Block) bool {
 
 //  STATE
 
-// Recursively calculates the state and logs for the given block.
-func (rc *RollupChain) updateState(b *types.Block) (*obscurocore.BlockState, map[uuid.UUID][]*types.Log) {
+// Recursively calculates the state, logs and subscribed logs for the given block.
+func (rc *RollupChain) updateState(b *types.Block) (*obscurocore.BlockState, []*types.Log, map[uuid.UUID][]*types.Log) {
 	// This method is called recursively in case of Re-orgs. Stop when state was calculated already.
 	blockState, _, found := rc.storage.FetchBlockState(b.Hash())
 	if found {
-		return blockState, nil
+		return blockState, nil, nil
 	}
 
 	rollups := rc.bridge.ExtractRollups(b, rc.storage)
@@ -195,27 +195,27 @@ func (rc *RollupChain) updateState(b *types.Block) (*obscurocore.BlockState, map
 
 	// processing blocks before genesis, so there is nothing to do
 	if genesisRollup == nil && len(rollups) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	// Detect if the incoming block contains the genesis rollup, and generate an updated state.
 	// Handles the case of the block containing the genesis being processed multiple times.
 	genesisState, isGenesis := rc.handleGenesisRollup(b, rollups, genesisRollup)
 	if isGenesis {
-		return genesisState, nil
+		return genesisState, nil, nil
 	}
 
 	// To calculate the state after the current block, we need the state after the parent.
 	// If this point is reached, there is a parent state guaranteed, because the genesis is handled above
-	parentState, parentLogs, parentFound := rc.storage.FetchBlockState(b.ParentHash())
+	parentState, logs, parentFound := rc.storage.FetchBlockState(b.ParentHash())
 	if !parentFound {
 		// go back and calculate the Root of the Parent
 		parent, found := rc.storage.FetchBlock(b.ParentHash())
 		if !found {
 			common.LogWithID(rc.nodeID, "Could not find block parent. This should not happen.")
-			return nil, nil
+			return nil, nil, nil
 		}
-		parentState, parentLogs = rc.updateState(parent)
+		parentState, logs, _ = rc.updateState(parent)
 	}
 
 	if parentState == nil {
@@ -224,7 +224,7 @@ func (rc *RollupChain) updateState(b *types.Block) (*obscurocore.BlockState, map
 			common.ShortHash(b.Hash()),
 			common.ShortHash(b.Header().ParentHash),
 		)
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	bs, head, receipts := rc.calculateBlockState(b, parentState, rollups)
@@ -233,33 +233,14 @@ func (rc *RollupChain) updateState(b *types.Block) (*obscurocore.BlockState, map
 		bs.FoundNewRollup,
 		common.ShortHash(bs.HeadRollup))
 
-	var logs []*types.Log
 	for _, receipt := range receipts {
 		logs = append(logs, receipt.Logs...)
 	}
 
-	subscribedLogs := map[uuid.UUID][]*types.Log{}
-	// For the genesis block, we do not emit any events, because we cannot yet validate whether all the topics refer to
-	// code addresses, since the state DB hasn't yet been constructed to check against.
-	if head.Header.ParentHash != common.GenesisHash {
-		subscribedLogs = rc.subscriptionManager.FilterRelevantLogs(logs, head.Header.ParentHash)
-	}
+	rc.storage.SaveNewHead(bs, head, receipts, logs)
 
-	// We append the rollup's logs to the logs of the parent rollup. This is to ensure events are not missed if a
-	// block is missed.
-	// TODO - Should we be including the parent logs based on the subscriptions at the time, or recalculating based on
-	//  the current subscriptions?
-	for subscriptionID, logs := range subscribedLogs {
-		logsForID, found := parentLogs[subscriptionID]
-		if !found {
-			logsForID = make([]*types.Log, 0)
-		}
-		subscribedLogs[subscriptionID] = append(logsForID, logs...)
-	}
-
-	rc.storage.SaveNewHead(bs, head, receipts, subscribedLogs)
-
-	return bs, subscribedLogs
+	subscribedLogs := rc.subscriptionManager.FilterRelevantLogs(logs, head.Header.Hash())
+	return bs, logs, subscribedLogs
 }
 
 func (rc *RollupChain) handleGenesisRollup(b *types.Block, rollups []*obscurocore.Rollup, genesisRollup *obscurocore.Rollup) (genesisState *obscurocore.BlockState, isGenesis bool) {
@@ -499,7 +480,7 @@ func (rc *RollupChain) SubmitBlock(block types.Block) common.BlockSubmissionResp
 	}
 
 	common.TraceWithID(rc.nodeID, "Update state: b_%d", common.ShortHash(block.Hash()))
-	blockState, logs := rc.updateState(&block)
+	blockState, _, subscribedLogs := rc.updateState(&block)
 	if blockState == nil {
 		return rc.noBlockStateBlockSubmissionResponse(&block)
 	}
@@ -513,7 +494,7 @@ func (rc *RollupChain) SubmitBlock(block types.Block) common.BlockSubmissionResp
 
 	common.TraceWithID(rc.nodeID, "Processed block: b_%d(%d). Produced rollup r_%d", common.ShortHash(block.Hash()), block.NumberU64(), common.ShortHash(r.Hash()))
 
-	encryptedLogs, err := rc.subscriptionManager.EncryptLogs(logs)
+	encryptedLogs, err := rc.subscriptionManager.EncryptLogs(subscribedLogs)
 	if err != nil {
 		log.Panic("Could not encrypt logs. Cause: %s", err)
 	}


### PR DESCRIPTION
### Why is this change needed?

Previously, we returned historical logs based on the subscriptions at the time the rollup was processed, rather than based on the current subscriptions. For example, a log in rollup N wouldn't be returned if the subscription was created at rollup N+1.

### What changes were made as part of this PR:

- Provide a high level list of the changes made
- List key areas for the reviewer 

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
