### PR TITLE
Removes unnecessary AccountSubscription type.

### DIFF
--- a/go/common/types.go
+++ b/go/common/types.go
@@ -186,17 +186,14 @@ func (h *Header) Hash() L2RootHash {
 	return hash
 }
 
+// LogSubscription is an authenticated subscription to logs.
 type LogSubscription struct {
-	SubscriptionAccount *SubscriptionAccount
-	Filter              *filters.FilterCriteria
-}
-
-// SubscriptionAccount is an authenticated account used when subscribing to logs.
-type SubscriptionAccount struct {
 	// The account the events relate to.
 	Account *common.Address
-	// A signature over the account address using the private viewing key. Prevents attackers from subscribing to
+	// A signature over the account address using a private viewing key. Prevents attackers from subscribing to
 	// (encrypted) logs for other accounts to see the pattern of logs.
 	// TODO - This does not protect against replay attacks, where someone resends an intercepted subscription request.
 	Signature *[]byte
+	// A subscriber-defined filter to apply to the stream of logs.
+	Filter *filters.FilterCriteria
 }

--- a/go/enclave/events/subscription_manager.go
+++ b/go/enclave/events/subscription_manager.go
@@ -106,7 +106,7 @@ func (s *SubscriptionManager) FilteredSubscribedLogs(logs []*types.Log, rollupHa
 
 		// We check whether the log is relevant to each subscription.
 		for subscriptionID, subscription := range s.subscriptions {
-			if isRelevant(userAddrs, subscription.SubscriptionAccount.Account) {
+			if isRelevant(userAddrs, subscription.Account) {
 				relevantLogs[subscriptionID] = append(relevantLogs[subscriptionID], log)
 			}
 		}
@@ -129,7 +129,7 @@ func (s *SubscriptionManager) EncryptLogs(logsBySubID map[uuid.UUID][]*types.Log
 			return nil, fmt.Errorf("could not marshal logs to JSON. Cause: %w", err)
 		}
 
-		encryptedLogs, err := s.rpcEncryptionManager.EncryptWithViewingKey(*subscription.SubscriptionAccount.Account, jsonLogs)
+		encryptedLogs, err := s.rpcEncryptionManager.EncryptWithViewingKey(*subscription.Account, jsonLogs)
 		if err != nil {
 			return nil, err
 		}

--- a/go/enclave/rpc/rpc_encryption_manager.go
+++ b/go/enclave/rpc/rpc_encryption_manager.go
@@ -100,14 +100,14 @@ func (rpc *EncryptionManager) EncryptWithViewingKey(address gethcommon.Address, 
 
 // AuthenticateSubscriptionRequest checks that a subscription request is authenticated correctly.
 func (rpc *EncryptionManager) AuthenticateSubscriptionRequest(subscription common.LogSubscription) error {
-	accountHashBytes := subscription.SubscriptionAccount.Account.Hash().Bytes()
+	accountHashBytes := subscription.Account.Hash().Bytes()
 
-	recoveredViewingPublicKey, err := crypto.SigToPub(accountHashBytes, *subscription.SubscriptionAccount.Signature)
+	recoveredViewingPublicKey, err := crypto.SigToPub(accountHashBytes, *subscription.Signature)
 	if err != nil {
 		return fmt.Errorf("could not recover viewing public key from signature to authenticate subscription. Cause: %w", err)
 	}
 
-	viewingPublicKey := rpc.viewingKeys[*subscription.SubscriptionAccount.Account].ExportECDSA()
+	viewingPublicKey := rpc.viewingKeys[*subscription.Account].ExportECDSA()
 	if !viewingPublicKey.Equal(recoveredViewingPublicKey) {
 		return fmt.Errorf("viewing key used to authenticate subscription did not match viewing key stored by enclave")
 	}

--- a/go/rpc/encrypted_client.go
+++ b/go/rpc/encrypted_client.go
@@ -193,10 +193,8 @@ func (c *EncRPCClient) createAuthenticatedLogSubscription(args []interface{}) (*
 	}
 
 	logSubscription := &common.LogSubscription{
-		SubscriptionAccount: &common.SubscriptionAccount{
-			Account:   c.Account(),
-			Signature: &accountSignature,
-		},
+		Account:   c.Account(),
+		Signature: &accountSignature,
 	}
 
 	// If there are less than two arguments, it means no filter criteria was passed.


### PR DESCRIPTION
### Why is this change needed?

Previously, each subscription was going to have a list of authenticated accounts, so we made a struct to represent each one.

Since, we've decided to move towards a single account per subscription, so the struct isn't necessary.

### What changes were made as part of this PR:

- Provide a high level list of the changes made
- List key areas for the reviewer 

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
