### PR TITLE
Updates API docs to cover subscriptions. Clean-up.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,15 +26,10 @@ This is the same as `Adding New Doc Site Pages`, above, but omitting step #3.
 You can check your changes (e.g. the Markdown formatting) by serving the changes locally as follows:
 
 1. [Install Jekyll](https://jekyllrb.com/docs/installation/)
-2. Run the Jekyll `build` command to build the updated HTML pages:
+2. Run the Jekyll `serve` command below to serve the updated pages on a local webserver at `http://127.0.0.1:4000`. Any 
+   changes will be automatically reflected
 
    ```
    cd ./docs
-   bundle exec jekyll build
-   ```
-
-3. Run the Jekyll `serve` command to serve the updated pages on a local webserver at `http://127.0.0.1:4000`:
-
-   ```
    bundle exec jekyll serve
    ```

--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -49,8 +49,12 @@ pages:
         url: wallet-extension/wallet-extension.html
       - title: Configure MetaMask
         url: wallet-extension/configure-metamask.html
-      - title: Handling Sensitive Data
-        url: wallet-extension/handling-sensitive-data.html
+  - title: API
+    children:
+      - title: APIs
+        url: api/apis.html
+      - title: Sensitive APIs
+        url: api/sensitive-apis.html
   - title: Whitepaper
     children:
       - title: Abstract

--- a/docs/api/apis.md
+++ b/docs/api/apis.md
@@ -7,19 +7,19 @@ page details which JSON-RPC API methods are supported.
 
 Obscuro nodes support the following JSON-RPC API methods over both HTTP and websockets:
 
-* `eth_chainId`
 * `eth_blockNumber`
-* `eth_getBalance`
-* `eth_getBlockByNumber`
-* `eth_getBlockByHash`
-* `eth_gasPrice`
 * `eth_call`
-* `eth_getTransactionReceipt`
+* `eth_chainId`
 * `eth_estimateGas`
-* `eth_sendRawTransaction`
+* `eth_gasPrice`
+* `eth_getBalance`
+* `eth_getBlockByHash`
+* `eth_getBlockByNumber`
 * `eth_getCode`
-* `eth_getTransactionCount`
 * `eth_getTransactionByHash`
+* `eth_getTransactionCount`
+* `eth_getTransactionReceipt`
+* `eth_sendRawTransaction`
 
 ## Supported subscription methods
 

--- a/docs/api/apis.md
+++ b/docs/api/apis.md
@@ -1,0 +1,31 @@
+# Obscuro JSON-RPC API
+
+Obscuro supports a subset of Ethereum's [JSON-RPC API](https://ethereum.org/en/developers/docs/apis/json-rpc/). This 
+page details which JSON-RPC API methods are supported.
+
+## Supported JSON-RPC API methods
+
+Obscuro nodes support the following JSON-RPC API methods over both HTTP and websockets:
+
+* `eth_chainId`
+* `eth_blockNumber`
+* `eth_getBalance`
+* `eth_getBlockByNumber`
+* `eth_getBlockByHash`
+* `eth_gasPrice`
+* `eth_call`
+* `eth_getTransactionReceipt`
+* `eth_estimateGas`
+* `eth_sendRawTransaction`
+* `eth_getCode`
+* `eth_getTransactionCount`
+* `eth_getTransactionByHash`
+
+## Supported subscription methods
+
+When connecting via websockets, the following API methods are also exposed:
+
+* `eth_subscribe`
+* `eth_unsubscribe`
+
+The only supported subscription type is `logs`.

--- a/docs/api/sensitive-apis.md
+++ b/docs/api/sensitive-apis.md
@@ -1,4 +1,4 @@
-# Handling Sensitive Information
+# Sensitive APIs
 
 Obscuro supports a subset of Ethereum's [JSON-RPC API](https://ethereum.org/en/developers/docs/apis/json-rpc/).
 
@@ -7,26 +7,8 @@ contain the balance of an account. An attacker could intercept this response to 
 this, the requests and responses for methods deemed sensitive are encrypted and decrypted by the 
 [wallet extension](wallet-extension.md). To provide a good user experience, this process is invisible to the end user.
 
-This page details which JSON-RPC API methods are supported, which ones are deemed sensitive, and the rules governing 
-who is able to decrypt the response to a given method call.
-
-## Supported JSON-RPC API methods
-
-Obscuro nodes support the following JSON-RPC API methods:
-
-* `eth_chainId`
-* `eth_blockNumber`
-* `eth_getBalance`
-* `eth_getBlockByNumber`
-* `eth_getBlockByHash`
-* `eth_gasPrice`
-* `eth_call`
-* `eth_getTransactionReceipt`
-* `eth_estimateGas`
-* `eth_sendRawTransaction`
-* `eth_getCode`
-* `eth_getTransactionCount`
-* `eth_getTransactionByHash`
+This page details which JSON-RPC API methods are deemed sensitive, and the rules governing who is able to decrypt the 
+response to a given method call.
 
 ## Sensitive JSON-RPC API Methods
 


### PR DESCRIPTION
### Why is this change needed?

We need to document the subscription APIs that we've introduced

### What changes were made as part of this PR:

- Split the API docs into sensitive and non-sensitive
- Pulled the API docs out of the wallet extension section, where they didn't belong
- Documented the eth_subscribe and eth_unsubscribe methods
- Updated the readme - the build step is unnecessary when building the docs locally, since serving the docs locally automatically builds them as well

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
