### PR TITLE
Update obscuroscan client url to use http protocol

### DIFF
--- a/.github/workflows/manual-deploy-obscuroscan.yml
+++ b/.github/workflows/manual-deploy-obscuroscan.yml
@@ -63,7 +63,7 @@ jobs:
           name: testnet-obscuroscan
           location: 'uksouth'
           restart-policy: 'Never'
-          command-line: ./tools/obscuroscan/main/main --rpcServerAddress testnet.obscu.ro:13001 --address 0.0.0.0:80
+          command-line: ./tools/obscuroscan/main/main --rpcServerAddress http://testnet.obscu.ro:13000 --address 0.0.0.0:80
           ports: '80'
           cpu: 2
           memory: 2

--- a/tools/azuredeployer/networkdeployer/run.sh
+++ b/tools/azuredeployer/networkdeployer/run.sh
@@ -26,4 +26,4 @@ sudo docker run -e OE_SIMULATION=0 --privileged -v /dev/sgx:/dev/sgx -p 127.0.0.
 go-obscuro/go/host/main/host --id=1 --isGenesis=true --p2pBindAddress=0.0.0.0:10000 --p2pPublicAddress=127.0.0.1:10000 --enclaveRPCAddress=localhost:11000 --clientRPCHost=0.0.0.0 --clientRPCPortHttp=13000 --l1NodePort=12100 --privateKey=$PRIV_KEY_ONE > ./run_logs.txt 2>&1 &
 go-obscuro/go/host/main/host --id=2 --isGenesis=false --p2pBindAddress=0.0.0.0:10001 --p2pPublicAddress=127.0.0.1:10001 --enclaveRPCAddress=localhost:11001 --clientRPCHost=localhost --clientRPCPortHttp=13001 --l1NodePort=12101 --privateKey=$PRIV_KEY_TWO > ./run_logs.txt 2>&1 &
 cd go-obscuro
-sudo ./tools/obscuroscan/main/obscuroscan --rpcServerAddress=127.0.0.1:13001 --address=0.0.0.0:80 > ../run_logs.txt 2>&1 &
+sudo ./tools/obscuroscan/main/obscuroscan --rpcServerAddress=http://127.0.0.1:13000 --address=0.0.0.0:80 > ../run_logs.txt 2>&1 &

--- a/tools/obscuroscan/main/cli.go
+++ b/tools/obscuroscan/main/cli.go
@@ -25,7 +25,7 @@ type obscuroscanConfig struct {
 func defaultObscuroClientConfig() obscuroscanConfig {
 	return obscuroscanConfig{
 		nodeID:        "",
-		rpcServerAddr: "testnet.obscu.ro:13001",
+		rpcServerAddr: "http://testnet.obscu.ro:13000",
 		address:       "127.0.0.1:3000",
 	}
 }


### PR DESCRIPTION
### Why is this change needed?

Obscuroscan is failing to start in testnet with the following error:
```
panic: clients for Obscuro only support the http:// and ws:// protocols

goroutine 1 [running]:
github.com/obscuronet/go-obscuro/tools/obscuroscan.NewObscuroscan({0x7ffe0d14dd98, 0xc0000426e0})
	/home/go-obscuro/tools/obscuroscan/obscuroscan.go:85 +0x22e
main.main()
	/home/go-obscuro/tools/obscuroscan/main/main.go:12 +0xb1
```

The rpc address points to the websocket port but doesn't include the protocol.

### What changes were made as part of this PR:

- Changed to http and http port (can make it WS if preferred).
- updated any references to it in scripts

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
