### PR TITLE
Upgrade EdgelessDB to 4GB heap memory for testnets

### DIFF
--- a/docs/testnet/create-a-new-node.md
+++ b/docs/testnet/create-a-new-node.md
@@ -122,7 +122,7 @@ Docker Engine is installed and running. The `docker` group is created but no use
 ## Start Edgeless Database
 1. Run EdgelessDB on an SGX-capable system:
 
-     `docker run --name my-edb -p3306:3306 -p8080:8080 --privileged -v /dev/sgx:/dev/sgx -t ghcr.io/edgelesssys/edgelessdb-sgx-1gb`
+     `docker run --name my-edb -p3306:3306 -p8080:8080 --privileged -v /dev/sgx:/dev/sgx -t ghcr.io/edgelesssys/edgelessdb-sgx-4gb`
 
 ## Start Enclave
 1. Create a Dockerfile so the Docker image can be created:

--- a/testnet/docker-compose.dev-testnet.yml
+++ b/testnet/docker-compose.dev-testnet.yml
@@ -83,4 +83,4 @@ services:
     ports:
       - "3306:3306"
       - "8080:8080"
-    image: ghcr.io/edgelesssys/edgelessdb-sgx-1gb:latest
+    image: ghcr.io/edgelesssys/edgelessdb-sgx-4gb:latest

--- a/testnet/docker-compose.yml
+++ b/testnet/docker-compose.yml
@@ -83,4 +83,4 @@ services:
     ports:
       - "3306:3306"
       - "8080:8080"
-    image: ghcr.io/edgelesssys/edgelessdb-sgx-1gb:latest
+    image: ghcr.io/edgelesssys/edgelessdb-sgx-4gb:latest


### PR DESCRIPTION
### Why is this change needed?

We have seen some testnet and dev-testnet failures recently where the enclave fails to write to its enclave (which is running in a different docker container on the same VM).

The EDB logs are not helpful, they just say something like "Aborted." Given this is a new issue and we've been running for longer with more state to persist recently I think we might be pushing up against some sort of limit.

- Edgeless provide EDB in two pre-canned flavours, 1GB heap and 4GB heap (customisable heap is on the roadmap)
- They say [here](https://docs.edgeless.systems/edgelessdb/#/getting-started/install?id=install-edgelessdb):
"Use edgelessdb-sgx-1gb primarily to test EdgelessDB on machines with limited resources. Prefer edgelessdb-sgx-4gb for production deployments."

And our testnets feel more like the latter description.

After this change we should continue to monitor and long term find some way to get stats on usage in non-production testnets (help us identify when it is problematic or if changes have dramatically increased it etc.).

### What changes were made as part of this PR:

- Upgrade testnet configs to use 4GB EDB image

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
