### PR TITLE
Revert EDB heap change back to 1GB

### DIFF
--- a/docs/testnet/create-a-new-node.md
+++ b/docs/testnet/create-a-new-node.md
@@ -122,7 +122,7 @@ Docker Engine is installed and running. The `docker` group is created but no use
 ## Start Edgeless Database
 1. Run EdgelessDB on an SGX-capable system:
 
-     `docker run --name my-edb -p3306:3306 -p8080:8080 --privileged -v /dev/sgx:/dev/sgx -t ghcr.io/edgelesssys/edgelessdb-sgx-4gb`
+     `docker run --name my-edb -p3306:3306 -p8080:8080 --privileged -v /dev/sgx:/dev/sgx -t ghcr.io/edgelesssys/edgelessdb-sgx-1gb`
 
 ## Start Enclave
 1. Create a Dockerfile so the Docker image can be created:

--- a/testnet/docker-compose.dev-testnet.yml
+++ b/testnet/docker-compose.dev-testnet.yml
@@ -83,4 +83,4 @@ services:
     ports:
       - "3306:3306"
       - "8080:8080"
-    image: ghcr.io/edgelesssys/edgelessdb-sgx-4gb:latest
+    image: ghcr.io/edgelesssys/edgelessdb-sgx-1gb:latest

--- a/testnet/docker-compose.yml
+++ b/testnet/docker-compose.yml
@@ -83,4 +83,4 @@ services:
     ports:
       - "3306:3306"
       - "8080:8080"
-    image: ghcr.io/edgelesssys/edgelessdb-sgx-4gb:latest
+    image: ghcr.io/edgelesssys/edgelessdb-sgx-1gb:latest


### PR DESCRIPTION
### Why is this change needed?

- Our VMs don't seem to be able to handle the 4GB EdgelessDB image (based on testing and discussion with Thomas on the Edgeless team)
- We need to get testnets up again and revisit this issue

### What changes were made as part of this PR:

- git revert of the previous commit (This PR https://github.com/obscuronet/go-obscuro/pull/703)

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
