### PR TITLE
Use beefier SGX VMs for testnet to handle the 4GB EDB image

### DIFF
--- a/.github/workflows/manual-deploy-dev-testnet.yml
+++ b/.github/workflows/manual-deploy-dev-testnet.yml
@@ -174,7 +174,7 @@ jobs:
             --public-ip-address-dns-name "dev-obscuronode-${{ matrix.host_id }}-testnet-${{ GITHUB.RUN_NUMBER }}" \
             --tags deploygroup=Dev-ObscuroNodeTestnet-${{ GITHUB.RUN_NUMBER }} devtestnetlatest=true \
             --vnet-name Dev-ObscuroHostTestnet01VNET --subnet Dev-ObscuroHostTestnet01Subnet \
-            --size Standard_DC2s_v2 --image Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:20.04.202206220 \
+            --size Standard_DC4s_v2 --image Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:20.04.202206220 \
             --public-ip-sku Basic --authentication-type password
 
       - name: 'Open Obscuro node-${{ matrix.host_id }} ports on Azure'

--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -131,7 +131,7 @@ jobs:
             --public-ip-address-dns-name "obscuronode-${{ matrix.host_id }}-testnet-${{ GITHUB.RUN_NUMBER }}" \
             --tags deploygroup=ObscuroNodeTestnet-${{ GITHUB.RUN_NUMBER }}  testnetlatest=true \
             --vnet-name ObscuroHostTestnet01VNET --subnet ObscuroHostTestnet01Subnet \
-            --size Standard_DC2s_v2 --image Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:20.04.202206220 \
+            --size Standard_DC4s_v2 --image Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:20.04.202206220 \
             --public-ip-sku Basic --authentication-type password
 
       - name: 'Open Obscuro node-${{ matrix.host_id }} ports on Azure'


### PR DESCRIPTION
### Why is this change needed?

Following discussion with Thomas at Edgeless we came to the conclusion that the DC2s SGX VM might not have the memory to handle the 4GB EDB image. He tested it successfully with the DC4s VM so this PR bumps our VMs up to DC4s.

If this PR is merged then I will *not* merge the PR that rolls back the 1GB -> 4GB EDB image upgrade so we can test if this fixes our issues with EDB falling over.

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
