### PR TITLE
Increase wait for enclave client connection

### DIFF
--- a/go/host/rpc/enclaverpc/enclave_client.go
+++ b/go/host/rpc/enclaverpc/enclave_client.go
@@ -43,7 +43,7 @@ func NewClient(config config.HostConfig) *Client {
 
 	// We wait for the RPC connection to be ready.
 	currentTime := time.Now()
-	deadline := currentTime.Add(30 * time.Second)
+	deadline := currentTime.Add(60 * time.Second)
 	currentState := connection.GetState()
 	for currentState == connectivity.Idle || currentState == connectivity.Connecting || currentState == connectivity.TransientFailure {
 		connection.Connect()


### PR DESCRIPTION
### Why is this change needed?

- After recent change to use the production-ready 4GB Edgeless DB image we are seeing the enclave client fail to connect from the host
- I can see in the logs that the enclave finished its handshake with the edgeless DB just one second later (the previous issue of it aborting has resolved).
- There is no rush for this connection, the host should wait a reasonable amount of time at startup for the enclave RPC server to be responsive

### What changes were made as part of this PR:

- Increase enclave client connection timeout from 30 seconds to 60 seconds

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
