### PR TITLE
Allows viewing keys to be registered over websockets

### DIFF
--- a/tools/walletextension/test/utils.go
+++ b/tools/walletextension/test/utils.go
@@ -270,4 +270,9 @@ func submitViewingKeyWS(accountAddr string, signature []byte) {
 	if err != nil {
 		panic(err)
 	}
+
+	_, _, err = conn.ReadMessage()
+	if err != nil {
+		panic(err)
+	}
 }

--- a/tools/walletextension/test/utils.go
+++ b/tools/walletextension/test/utils.go
@@ -21,8 +21,8 @@ import (
 	"github.com/gorilla/websocket"
 )
 
-// WaitForEndpoint waits for the endpoint to be available. Times out after three seconds.
-func WaitForEndpoint(addr string) error {
+// Waits for the endpoint to be available. Times out after three seconds.
+func waitForEndpoint(addr string) error {
 	retries := 30
 	for i := 0; i < retries; i++ {
 		resp, err := http.Get(addr) //nolint:noctx,gosec
@@ -37,8 +37,8 @@ func WaitForEndpoint(addr string) error {
 	return fmt.Errorf("could not establish connection to wallet extension")
 }
 
-// MakeHTTPEthJSONReq makes an Ethereum JSON RPC request over HTTP and returns the response body.
-func MakeHTTPEthJSONReq(walExtAddr string, method string, params interface{}) []byte {
+// Makes an Ethereum JSON RPC request over HTTP and returns the response body.
+func makeHTTPEthJSONReq(walExtAddr string, method string, params interface{}) []byte {
 	reqBody := prepareRequestBody(method, params)
 
 	resp, err := http.Post(walExtAddr, "text/html", reqBody) //nolint:noctx,gosec
@@ -59,8 +59,8 @@ func MakeHTTPEthJSONReq(walExtAddr string, method string, params interface{}) []
 	return respBody
 }
 
-// MakeWSEthJSONReq makes an Ethereum JSON RPC request over websockets and returns the response body.
-func MakeWSEthJSONReq(walExtAddr string, method string, params interface{}) ([]byte, *websocket.Conn) {
+// Makes an Ethereum JSON RPC request over websockets and returns the response body.
+func makeWSEthJSONReq(walExtAddr string, method string, params interface{}) ([]byte, *websocket.Conn) {
 	conn, resp, err := websocket.DefaultDialer.Dial(walExtAddr, nil)
 	if resp != nil && resp.Body != nil {
 		defer resp.Body.Close()
@@ -92,8 +92,8 @@ func MakeWSEthJSONReq(walExtAddr string, method string, params interface{}) ([]b
 	return respBody, conn
 }
 
-// RegisterPrivateKey generates a new account and registers it with the node.
-func RegisterPrivateKey(t *testing.T, walExtAddr string) (gethcommon.Address, []byte) {
+// Generates a new account and registers it with the node.
+func registerPrivateKey(t *testing.T, walExtAddr string) (gethcommon.Address, []byte) {
 	privateKey, err := crypto.GenerateKey()
 	if err != nil {
 		t.Fatalf(err.Error())

--- a/tools/walletextension/test/utils.go
+++ b/tools/walletextension/test/utils.go
@@ -124,36 +124,6 @@ func generateAndSubmitViewingKey(walExtAddr string, accountAddr string, accountP
 	return submitViewingKey(walExtAddr, accountAddr, signature, viewingKeyBytes)
 }
 
-func submitViewingKey(walExtAddr string, accountAddr string, signature []byte, viewingKeyBytes []byte) []byte {
-	submitViewingKeyBodyBytes, err := json.Marshal(map[string]interface{}{
-		walletextension.ReqJSONKeySignature: hex.EncodeToString(signature),
-		walletextension.ReqJSONKeyAddress:   accountAddr,
-	})
-	if err != nil {
-		panic(err)
-	}
-	submitViewingKeyBody := bytes.NewBuffer(submitViewingKeyBodyBytes)
-	resp, err := http.Post(walExtAddr+walletextension.PathSubmitViewingKey, "application/json", submitViewingKeyBody) //nolint:noctx
-	if err != nil {
-		panic(err)
-	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		respBody, err := io.ReadAll(resp.Body)
-		if err == nil {
-			panic(fmt.Errorf("request to add viewing key failed with status %s: %s", resp.Status, respBody))
-		}
-		panic(fmt.Errorf("request to add viewing key failed with status %s", resp.Status))
-	}
-	if err != nil {
-		panic(err)
-	}
-	err = resp.Body.Close()
-	if err != nil {
-		panic(err)
-	}
-	return viewingKeyBytes
-}
-
 // Generates a viewing key.
 func generateViewingKey(walExtAddr string, accountAddress string) []byte {
 	generateViewingKeyBodyBytes, err := json.Marshal(map[string]interface{}{
@@ -188,4 +158,35 @@ func signViewingKey(privateKey *ecdsa.PrivateKey, viewingKey []byte) []byte {
 	signatureWithLeadBytes := append([]byte("0"), signature...)
 
 	return signatureWithLeadBytes
+}
+
+// Submits a viewing key.
+func submitViewingKey(walExtAddr string, accountAddr string, signature []byte, viewingKeyBytes []byte) []byte {
+	submitViewingKeyBodyBytes, err := json.Marshal(map[string]interface{}{
+		walletextension.ReqJSONKeySignature: hex.EncodeToString(signature),
+		walletextension.ReqJSONKeyAddress:   accountAddr,
+	})
+	if err != nil {
+		panic(err)
+	}
+	submitViewingKeyBody := bytes.NewBuffer(submitViewingKeyBodyBytes)
+	resp, err := http.Post(walExtAddr+walletextension.PathSubmitViewingKey, "application/json", submitViewingKeyBody) //nolint:noctx
+	if err != nil {
+		panic(err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		respBody, err := io.ReadAll(resp.Body)
+		if err == nil {
+			panic(fmt.Errorf("request to add viewing key failed with status %s: %s", resp.Status, respBody))
+		}
+		panic(fmt.Errorf("request to add viewing key failed with status %s", resp.Status))
+	}
+	if err != nil {
+		panic(err)
+	}
+	err = resp.Body.Close()
+	if err != nil {
+		panic(err)
+	}
+	return viewingKeyBytes
 }

--- a/tools/walletextension/test/wallet_extension_test.go
+++ b/tools/walletextension/test/wallet_extension_test.go
@@ -193,8 +193,6 @@ func TestCanRegisterViewingKeyAndMakeRequestsOverWebsockets(t *testing.T) {
 	_, viewingKeyBytes := registerPrivateKey(t, true)
 	dummyAPI.setViewingKey(viewingKeyBytes)
 
-	time.Sleep(100 * time.Millisecond) // todo - joel - better wait
-
 	for _, method := range rpc.SensitiveMethods {
 		// Subscriptions have to be tested separately, as they return results differently.
 		if method == rpc.RPCSubscribe {

--- a/tools/walletextension/test/wallet_extension_test.go
+++ b/tools/walletextension/test/wallet_extension_test.go
@@ -181,7 +181,25 @@ func TestKeysAreReloadedWhenWalletExtensionRestarts(t *testing.T) {
 	}
 }
 
-func TestCanSubscribeForLogs(t *testing.T) {
+func TestCannotSubscribeOverHTTP(t *testing.T) {
+	createDummyHost(t)
+	createWalExt(t, createWalExtCfg())
+
+	respBody := makeHTTPEthJSONReq(walExtAddr, rpc.RPCSubscribe, []interface{}{rpc.RPCSubscriptionTypeLogs})
+	if string(respBody) != walletextension.ErrSubscribeFailHTTP+"\n" {
+		t.Fatalf("expected response of '%s', got '%s'", walletextension.ErrSubscribeFailHTTP, string(respBody))
+	}
+}
+
+func TestCanRegisterViewingKeyOverWebsockets(t *testing.T) {
+	createDummyHost(t)
+	createWalExt(t, createWalExtCfg())
+
+	// This will blow up if private keys cannot be registered over websockets.
+	registerPrivateKey(t, walExtAddrWS)
+}
+
+func TestCanSubscribeForLogsOverWebsockets(t *testing.T) {
 	createDummyHost(t)
 	createWalExt(t, createWalExtCfg())
 
@@ -210,16 +228,6 @@ func TestCanSubscribeForLogs(t *testing.T) {
 
 	if !strings.Contains(string(receivedLog.Data), dummyHash.Hex()) {
 		t.Fatalf("expected response containing '%s', got '%s'", dummyHash.Hex(), string(receivedLog.Data))
-	}
-}
-
-func TestCannotSubscribeOverHTTP(t *testing.T) {
-	createDummyHost(t)
-	createWalExt(t, createWalExtCfg())
-
-	respBody := makeHTTPEthJSONReq(walExtAddr, rpc.RPCSubscribe, []interface{}{rpc.RPCSubscriptionTypeLogs})
-	if string(respBody) != walletextension.ErrSubscribeFailHTTP+"\n" {
-		t.Fatalf("expected response of '%s', got '%s'", walletextension.ErrSubscribeFailHTTP, string(respBody))
 	}
 }
 

--- a/tools/walletextension/test/wallet_extension_test.go
+++ b/tools/walletextension/test/wallet_extension_test.go
@@ -193,17 +193,15 @@ func TestCanRegisterViewingKeyAndMakeRequestsOverWebsockets(t *testing.T) {
 	_, viewingKeyBytes := registerPrivateKey(t, true)
 	dummyAPI.setViewingKey(viewingKeyBytes)
 
+	time.Sleep(100 * time.Millisecond) // todo - joel - better wait
+
 	for _, method := range rpc.SensitiveMethods {
 		// Subscriptions have to be tested separately, as they return results differently.
 		if method == rpc.RPCSubscribe {
 			continue
 		}
 
-		_, conn := makeWSEthJSONReq(method, []interface{}{map[string]interface{}{"params": dummyParams}})
-		_, respBody, err := conn.ReadMessage()
-		if err != nil {
-			t.Fatalf("could not read response from websocket")
-		}
+		respBody, _ := makeWSEthJSONReq(method, []interface{}{map[string]interface{}{"params": dummyParams}})
 
 		if !strings.Contains(string(respBody), dummyParams) {
 			t.Fatalf("expected response containing '%s', got '%s'", dummyParams, string(respBody))

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -54,6 +54,8 @@ const (
 	reqOptions       = "OPTIONS"
 	corsAllowHeaders = "Access-Control-Allow-Headers"
 	corsHeaders      = "Accept, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization"
+
+	successMsg = "success"
 )
 
 var ErrSubscribeFailHTTP = fmt.Sprintf("received an %s request but the connection does not support subscriptions", rpc.RPCSubscribe)
@@ -432,6 +434,12 @@ func (we *WalletExtension) handleSubmitViewingKey(userConn userconn.UserConn) {
 	we.persistence.PersistViewingKey(vk)
 	// finally we remove the VK from the pending 'unsigned VKs' map now the client has been created
 	delete(we.unsignedVKs, accAddress)
+
+	err = userConn.WriteResponse([]byte(successMsg))
+	if err != nil {
+		userConn.HandleError(fmt.Sprintf("could not return viewing key public key hex to client: %s", err))
+		return
+	}
 }
 
 // Config contains the configuration required by the WalletExtension.

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -191,56 +191,46 @@ func (we *WalletExtension) handleReady(resp http.ResponseWriter, req *http.Reque
 	}
 }
 
-// todo - joel - use helper to reduce duplication below
-
-// Handles the Ethereum JSON-RPC request over HTTP.
 func (we *WalletExtension) handleEthJSONHTTP(resp http.ResponseWriter, req *http.Request) {
-	if we.enableCORS(resp, req) {
-		return
-	}
-	userConn := userconn.NewUserConnHTTP(resp, req)
-	we.handleEthJSON(userConn)
+	we.handleRequestHTTP(resp, req, we.handleEthJSON)
 }
 
-// Handles the Ethereum JSON-RPC request over websockets.
 func (we *WalletExtension) handleEthJSONWS(resp http.ResponseWriter, req *http.Request) {
-	userConn, err := userconn.NewUserConnWS(resp, req)
-	if err != nil {
-		return
-	}
-	we.handleEthJSON(userConn)
+	we.handleRequestWS(resp, req, we.handleEthJSON)
 }
 
 func (we *WalletExtension) handleGenerateViewingKeyHTTP(resp http.ResponseWriter, req *http.Request) {
-	if we.enableCORS(resp, req) {
-		return
-	}
-	userConn := userconn.NewUserConnHTTP(resp, req)
-	we.handleGenerateViewingKey(userConn)
+	we.handleRequestHTTP(resp, req, we.handleGenerateViewingKey)
 }
 
 func (we *WalletExtension) handleGenerateViewingKeyWS(resp http.ResponseWriter, req *http.Request) {
-	userConn, err := userconn.NewUserConnWS(resp, req)
-	if err != nil {
-		return
-	}
-	we.handleGenerateViewingKey(userConn)
+	we.handleRequestWS(resp, req, we.handleGenerateViewingKey)
 }
 
 func (we *WalletExtension) handleSubmitViewingKeyHTTP(resp http.ResponseWriter, req *http.Request) {
+	we.handleRequestHTTP(resp, req, we.handleSubmitViewingKey)
+}
+
+func (we *WalletExtension) handleSubmitViewingKeyWS(resp http.ResponseWriter, req *http.Request) {
+	we.handleRequestWS(resp, req, we.handleSubmitViewingKey)
+}
+
+// Creates an HTTP connection to handle the request.
+func (we *WalletExtension) handleRequestHTTP(resp http.ResponseWriter, req *http.Request, fun func(conn userconn.UserConn)) {
 	if we.enableCORS(resp, req) {
 		return
 	}
 	userConn := userconn.NewUserConnHTTP(resp, req)
-	we.handleSubmitViewingKey(userConn)
+	fun(userConn)
 }
 
-func (we *WalletExtension) handleSubmitViewingKeyWS(resp http.ResponseWriter, req *http.Request) {
+// Creates a websocket connection to handle the request.
+func (we *WalletExtension) handleRequestWS(resp http.ResponseWriter, req *http.Request, fun func(conn userconn.UserConn)) {
 	userConn, err := userconn.NewUserConnWS(resp, req)
 	if err != nil {
 		return
 	}
-	we.handleSubmitViewingKey(userConn)
+	fun(userConn)
 }
 
 // Encrypts the Ethereum JSON-RPC request, forwards it to the Obscuro node over a websocket, and decrypts the response if needed.


### PR DESCRIPTION
### Why is this change needed?

To avoid the need to create separate clients to register viewing keys and create subscriptions.

### What changes were made as part of this PR:

- Added support for registering viewing keys over WS
- Added test
- Test cleanup

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
