### PR TITLE
Missed return statement in walext error handling

### DIFF
--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -418,6 +418,7 @@ func (we *WalletExtension) handleSubmitViewingKey(userConn userconn.UserConn) {
 	client, err := rpc.NewEncNetworkClient(we.hostAddr, vk)
 	if err != nil {
 		userConn.HandleError(fmt.Sprintf("failed to create encrypted RPC client for account %s. Cause: %s", accAddress, err))
+		return
 	}
 	we.accountManager.AddClient(accAddress, client)
 


### PR DESCRIPTION
### Why is this change needed?

- If wallet extension fails to create and register an obscuro client then it returns the error but then stores a nil client in the map, causing nil pointers to be spammed in the logs

### What changes were made as part of this PR:

- Put in the return statement that I missed originally after returning the error to the caller

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
