### PR TITLE
WE: Return correct response when new subscription is created

### DIFF
--- a/go/host/hostrunner/cli.go
+++ b/go/host/hostrunner/cli.go
@@ -90,8 +90,8 @@ func ParseConfig() config.HostConfig {
 	cfg.P2PPublicAddress = *p2pPublicAddress
 	cfg.L1NodeHost = *l1NodeHost
 	cfg.L1NodeWebsocketPort = uint(*l1NodePort)
-	cfg.ClientRPCTimeout = time.Duration(*enclaveRPCTimeoutSecs) * time.Second
-	cfg.EnclaveRPCTimeout = time.Duration(*clientRPCTimeoutSecs) * time.Second
+	cfg.ClientRPCTimeout = time.Duration(*clientRPCTimeoutSecs) * time.Second
+	cfg.EnclaveRPCTimeout = time.Duration(*enclaveRPCTimeoutSecs) * time.Second
 	cfg.L1RPCTimeout = time.Duration(*l1RPCTimeoutSecs) * time.Second
 	cfg.P2PConnectionTimeout = time.Duration(*p2pConnectionTimeoutSecs) * time.Second
 	cfg.RollupContractAddress = common.HexToAddress(*rollupContractAddress)

--- a/go/host/interfaces.go
+++ b/go/host/interfaces.go
@@ -26,7 +26,7 @@ type Host interface {
 	// Subscribe feeds logs matching the encrypted log subscription to the matchedLogs channel.
 	Subscribe(id rpc.ID, encryptedLogSubscription common.EncryptedParamsLogSubscription, matchedLogs chan []byte) error
 	// Unsubscribe terminates a log subscription between the host and the enclave.
-	Unsubscribe(id rpc.ID) error
+	Unsubscribe(id rpc.ID)
 	// Stop gracefully stops the host execution.
 	Stop()
 }

--- a/go/host/node/node.go
+++ b/go/host/node/node.go
@@ -337,7 +337,7 @@ func (a *Node) Subscribe(id rpc.ID, encryptedLogSubscription common.EncryptedPar
 func (a *Node) Unsubscribe(id rpc.ID) {
 	err := a.EnclaveClient().Unsubscribe(id)
 	if err != nil {
-		log.Error("could not terminate subscription %s with enclave. Cause: %w", id, err)
+		log.Error("could not terminate subscription %s with enclave. Cause: %s", id, err)
 	}
 	delete(a.logsChs, id)
 }

--- a/go/host/node/node.go
+++ b/go/host/node/node.go
@@ -334,13 +334,12 @@ func (a *Node) Subscribe(id rpc.ID, encryptedLogSubscription common.EncryptedPar
 	return nil
 }
 
-func (a *Node) Unsubscribe(id rpc.ID) error {
+func (a *Node) Unsubscribe(id rpc.ID) {
 	err := a.EnclaveClient().Unsubscribe(id)
 	if err != nil {
-		return fmt.Errorf("could not terminate subscription %s with enclave. Cause: %w", id, err)
+		log.Error("could not terminate subscription %s with enclave. Cause: %w", id, err)
 	}
 	delete(a.logsChs, id)
-	return nil
 }
 
 func (a *Node) Stop() {

--- a/go/host/rpc/clientapi/client_api_filter.go
+++ b/go/host/rpc/clientapi/client_api_filter.go
@@ -39,7 +39,7 @@ func (api *FilterAPI) Logs(ctx context.Context, encryptedParams common.Encrypted
 	}
 
 	// We return the ID of the newly-created subscription, before returning any log events.
-	err = notifier.Notify(subscription.ID, common.IDAndEncLog{ //nolint:contextcheck
+	err = notifier.Notify(subscription.ID, common.IDAndEncLog{
 		SubID: subscription.ID,
 	})
 	if err != nil {

--- a/go/host/rpc/clientapi/client_api_filter.go
+++ b/go/host/rpc/clientapi/client_api_filter.go
@@ -38,6 +38,9 @@ func (api *FilterAPI) Logs(ctx context.Context, encryptedParams common.Encrypted
 		return nil, fmt.Errorf("could not subscribe for logs. Cause: %w", err)
 	}
 
+	// todo - joel - send back ID immediately
+	// We return the ID of the newly-created subscription.
+
 	go func() {
 		for {
 			select {

--- a/go/host/rpc/clientapi/client_api_filter.go
+++ b/go/host/rpc/clientapi/client_api_filter.go
@@ -39,7 +39,7 @@ func (api *FilterAPI) Logs(ctx context.Context, encryptedParams common.Encrypted
 	}
 
 	// We return the ID of the newly-created subscription, before returning any log events.
-	err = notifier.Notify(subscription.ID, common.IDAndEncLog{
+	err = notifier.Notify(subscription.ID, common.IDAndEncLog{ //nolint:contextcheck
 		SubID: subscription.ID,
 	})
 	if err != nil {

--- a/go/obsclient/authclient.go
+++ b/go/obsclient/authclient.go
@@ -116,7 +116,7 @@ func (ac *AuthObsClient) SubscribeFilterLogs(ctx context.Context, filterCriteria
 		filterKeyAddress:   filterCriteria.Addresses,
 		filterKeyTopics:    filterCriteria.Topics,
 	}
-	return ac.rpcClient.Subscribe(ctx, rpc.RPCSubscribeNamespace, ch, rpc.RPCSubscriptionTypeLogs, filterCriteriaMap)
+	return ac.rpcClient.Subscribe(ctx, nil, rpc.RPCSubscribeNamespace, ch, rpc.RPCSubscriptionTypeLogs, filterCriteriaMap)
 }
 
 func (ac *AuthObsClient) Address() gethcommon.Address {

--- a/go/obsclient/test_util.go
+++ b/go/obsclient/test_util.go
@@ -23,7 +23,7 @@ func (m *rpcClientMock) CallContext(ctx context.Context, result interface{}, met
 	return arguments.Error(0)
 }
 
-func (m *rpcClientMock) Subscribe(context.Context, string, interface{}, ...interface{}) (*rpc.ClientSubscription, error) {
+func (m *rpcClientMock) Subscribe(context.Context, interface{}, string, interface{}, ...interface{}) (*rpc.ClientSubscription, error) {
 	panic("not implemented")
 }
 

--- a/go/rpc/client.go
+++ b/go/rpc/client.go
@@ -45,7 +45,7 @@ type Client interface {
 	// CallContext If the context is canceled before the call has successfully returned, CallContext returns immediately.
 	CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error
 	// Subscribe creates a subscription to the Obscuro host.
-	Subscribe(ctx context.Context, namespace string, channel interface{}, args ...interface{}) (*rpc.ClientSubscription, error)
+	Subscribe(ctx context.Context, result interface{}, namespace string, channel interface{}, args ...interface{}) (*rpc.ClientSubscription, error)
 	// Stop closes the client.
 	Stop()
 }

--- a/go/rpc/encrypted_client.go
+++ b/go/rpc/encrypted_client.go
@@ -152,57 +152,48 @@ func (c *EncRPCClient) Subscribe(ctx context.Context, result interface{}, namesp
 		return nil, err
 	}
 
-	// We set the response to the subscription's ID.
-	select {
-	case idAndEncLog := <-clientChannel:
-		if idAndEncLog.SubID == "" || idAndEncLog.EncLog != nil {
-			return nil, fmt.Errorf("expected an initial subscription response with the subscription ID only")
-		}
-		if result != nil {
-			err = c.setResult([]byte(idAndEncLog.SubID), result)
-			if err != nil {
-				return nil, fmt.Errorf("failed to extract result from subscription response: %w", err)
-			}
-		}
-
-	case <-subscription.Err(): // This channel's sole purpose is to be closed when the subscription is unsubscribed.
-		return nil, fmt.Errorf("did not receive the intial subscription response with the subscription ID")
+	err = c.setResultToSubID(clientChannel, result, subscription)
+	if err != nil {
+		subscription.Unsubscribe()
+		return nil, err
 	}
 
-	go func() {
-		for {
-			select {
-			case idAndEncLog := <-clientChannel:
-				jsonLogs, err := c.decryptResponse(idAndEncLog.EncLog)
-				if err != nil {
-					log.Error("could not decrypt logs received from subscription. Cause: %s", err)
-					continue
-				}
-
-				var logs []*types.Log
-				err = json.Unmarshal(jsonLogs, &logs)
-				if err != nil {
-					log.Error("could not unmarshal log from `data` field of log received from subscription. "+
-						"Data field contents: %s. Cause: %s", string(jsonLogs), err)
-					continue
-				}
-
-				for _, decryptedLog := range logs {
-					idAndLog := common.IDAndLog{
-						SubID: idAndEncLog.SubID,
-						Log:   decryptedLog,
-					}
-					logCh <- idAndLog
-				}
-
-			case <-subscription.Err(): // This channel's sole purpose is to be closed when the subscription is unsubscribed.
-				log.Error("subscription closed")
-				break
-			}
-		}
-	}()
+	go c.forwardLogs(clientChannel, logCh, subscription)
 
 	return subscription, nil
+}
+
+func (c *EncRPCClient) forwardLogs(clientChannel chan common.IDAndEncLog, logCh chan common.IDAndLog, subscription *rpc.ClientSubscription) {
+	for {
+		select {
+		case idAndEncLog := <-clientChannel:
+			jsonLogs, err := c.decryptResponse(idAndEncLog.EncLog)
+			if err != nil {
+				log.Error("could not decrypt logs received from subscription. Cause: %s", err)
+				continue
+			}
+
+			var logs []*types.Log
+			err = json.Unmarshal(jsonLogs, &logs)
+			if err != nil {
+				log.Error("could not unmarshal log from `data` field of log received from subscription. "+
+					"Data field contents: %s. Cause: %s", string(jsonLogs), err)
+				continue
+			}
+
+			for _, decryptedLog := range logs {
+				idAndLog := common.IDAndLog{
+					SubID: idAndEncLog.SubID,
+					Log:   decryptedLog,
+				}
+				logCh <- idAndLog
+			}
+
+		case <-subscription.Err():
+			log.Error("subscription closed")
+			break
+		}
+	}
 }
 
 func (c *EncRPCClient) createAuthenticatedLogSubscription(args []interface{}) (*common.LogSubscription, error) {
@@ -238,6 +229,24 @@ func (c *EncRPCClient) createAuthenticatedLogSubscription(args []interface{}) (*
 	}
 
 	return logSubscription, nil
+}
+
+func (c *EncRPCClient) setResultToSubID(clientChannel chan common.IDAndEncLog, result interface{}, subscription *rpc.ClientSubscription) error {
+	select {
+	case idAndEncLog := <-clientChannel:
+		if idAndEncLog.SubID == "" || idAndEncLog.EncLog != nil {
+			return fmt.Errorf("expected an initial subscription response with the subscription ID only")
+		}
+		if result != nil {
+			err := c.setResult([]byte(idAndEncLog.SubID), result)
+			if err != nil {
+				return fmt.Errorf("failed to extract result from subscription response: %w", err)
+			}
+		}
+	case <-subscription.Err():
+		return fmt.Errorf("did not receive the initial subscription response with the subscription ID")
+	}
+	return nil
 }
 
 func (c *EncRPCClient) executeRPCCall(ctx context.Context, result interface{}, method string, args ...interface{}) error {

--- a/go/rpc/network_client.go
+++ b/go/rpc/network_client.go
@@ -57,7 +57,7 @@ func (c *networkClient) CallContext(ctx context.Context, result interface{}, met
 	return c.rpcClient.CallContext(ctx, result, method, args...)
 }
 
-func (c *networkClient) Subscribe(ctx context.Context, namespace string, channel interface{}, args ...interface{}) (*rpc.ClientSubscription, error) {
+func (c *networkClient) Subscribe(ctx context.Context, _ interface{}, namespace string, channel interface{}, args ...interface{}) (*rpc.ClientSubscription, error) {
 	return c.rpcClient.Subscribe(ctx, namespace, channel, args...)
 }
 

--- a/integration/simulation/p2p/in_mem_obscuro_client.go
+++ b/integration/simulation/p2p/in_mem_obscuro_client.go
@@ -119,7 +119,7 @@ func (c *inMemObscuroClient) CallContext(_ context.Context, result interface{}, 
 	return c.Call(result, method, args...)
 }
 
-func (c *inMemObscuroClient) Subscribe(ctx context.Context, namespace string, channel interface{}, args ...interface{}) (*gethrpc.ClientSubscription, error) {
+func (c *inMemObscuroClient) Subscribe(ctx context.Context, result interface{}, namespace string, channel interface{}, args ...interface{}) (*gethrpc.ClientSubscription, error) {
 	panic("not implemented")
 }
 

--- a/tools/walletextension/accountmanager/account_manager.go
+++ b/tools/walletextension/accountmanager/account_manager.go
@@ -211,12 +211,12 @@ func performRequest(client *rpc.EncRPCClient, req *RPCRequest, resp *interface{}
 	return executeCall(client, req, resp)
 }
 
-func executeSubscribe(client *rpc.EncRPCClient, req *RPCRequest, _ *interface{}, userConn userconn.UserConn) error {
+func executeSubscribe(client *rpc.EncRPCClient, req *RPCRequest, resp *interface{}, userConn userconn.UserConn) error {
 	if len(req.Params) == 0 {
 		return fmt.Errorf("could not subscribe as no subscription namespace was provided")
 	}
 	ch := make(chan common.IDAndLog)
-	subscription, err := client.Subscribe(context.Background(), rpc.RPCSubscribeNamespace, ch, req.Params...)
+	subscription, err := client.Subscribe(context.Background(), resp, rpc.RPCSubscribeNamespace, ch, req.Params...)
 	if err != nil {
 		return fmt.Errorf("could not call %s with params %v. Cause: %w", req.Method, req.Params, err)
 	}

--- a/tools/walletextension/common/constants.go
+++ b/tools/walletextension/common/constants.go
@@ -15,6 +15,4 @@ const (
 	JSONKeyRPCVersion   = "jsonrpc"
 	JSONKeySignature    = "signature"
 	JSONKeySubscription = "subscription"
-
-	JSONID = "1"
 )

--- a/tools/walletextension/common/constants.go
+++ b/tools/walletextension/common/constants.go
@@ -15,4 +15,6 @@ const (
 	JSONKeyRPCVersion   = "jsonrpc"
 	JSONKeySignature    = "signature"
 	JSONKeySubscription = "subscription"
+
+	JSONID = "1"
 )

--- a/tools/walletextension/test/apis.go
+++ b/tools/walletextension/test/apis.go
@@ -119,7 +119,7 @@ func (api *DummyAPI) Logs(ctx context.Context, encryptedParams common.EncryptedP
 
 	subscription := notifier.CreateSubscription()
 
-	err = notifier.Notify(subscription.ID, common.IDAndEncLog{ //nolint:contextcheck
+	err = notifier.Notify(subscription.ID, common.IDAndEncLog{
 		SubID: subscription.ID,
 	})
 	if err != nil {

--- a/tools/walletextension/test/apis.go
+++ b/tools/walletextension/test/apis.go
@@ -119,7 +119,7 @@ func (api *DummyAPI) Logs(ctx context.Context, encryptedParams common.EncryptedP
 
 	subscription := notifier.CreateSubscription()
 
-	err = notifier.Notify(subscription.ID, common.IDAndEncLog{
+	err = notifier.Notify(subscription.ID, common.IDAndEncLog{ //nolint:contextcheck
 		SubID: subscription.ID,
 	})
 	if err != nil {

--- a/tools/walletextension/test/utils.go
+++ b/tools/walletextension/test/utils.go
@@ -130,7 +130,7 @@ func prepareRequestBody(method string, params interface{}) []byte {
 		common.JSONKeyRPCVersion: jsonrpc.Version,
 		common.JSONKeyMethod:     method,
 		common.JSONKeyParams:     params,
-		common.JSONKeyID:         "1",
+		common.JSONKeyID:         common.JSONID,
 	})
 	if err != nil {
 		panic(fmt.Errorf("failed to prepare request body. Cause: %w", err))

--- a/tools/walletextension/test/utils.go
+++ b/tools/walletextension/test/utils.go
@@ -30,6 +30,10 @@ import (
 	"github.com/gorilla/websocket"
 )
 
+const (
+	jsonID = "1"
+)
+
 var (
 	walExtPort   = integration.StartPortWalletExtensionUnitTest
 	walExtPortWS = integration.StartPortWalletExtensionUnitTest + 1
@@ -130,7 +134,7 @@ func prepareRequestBody(method string, params interface{}) []byte {
 		common.JSONKeyRPCVersion: jsonrpc.Version,
 		common.JSONKeyMethod:     method,
 		common.JSONKeyParams:     params,
-		common.JSONKeyID:         common.JSONID,
+		common.JSONKeyID:         jsonID,
 	})
 	if err != nil {
 		panic(fmt.Errorf("failed to prepare request body. Cause: %w", err))

--- a/tools/walletextension/test/wallet_extension_test.go
+++ b/tools/walletextension/test/wallet_extension_test.go
@@ -240,7 +240,7 @@ func TestCanSubscribeForLogsOverWebsockets(t *testing.T) {
 
 // Checks that the response to a subscription request is correctly-formatted.
 func validateSubscriptionResponse(t *testing.T, resp []byte) {
-	pattern := "{\"id\":\"1\",\"jsonrpc\":\"2.0\",\"result\":\"0x.{32}\"}"
+	pattern := "{\"id\":\"1\",\"jsonrpc\":\"2.0\",\"result\":\"0x.*\"}"
 	regex := regexp.MustCompile(pattern)
 	if !regex.MatchString(string(resp)) {
 		t.Fatalf("subscription response did not match regular expression. response was %s, expected pattern is %s", string(resp), pattern)

--- a/tools/walletextension/test/wallet_extension_test.go
+++ b/tools/walletextension/test/wallet_extension_test.go
@@ -4,12 +4,13 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"github.com/go-kit/kit/transport/http/jsonrpc"
 	"math/big"
 	"regexp"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/go-kit/kit/transport/http/jsonrpc"
 
 	"github.com/obscuronet/go-obscuro/tools/walletextension/common"
 

--- a/tools/walletextension/test/wallet_extension_test.go
+++ b/tools/walletextension/test/wallet_extension_test.go
@@ -252,7 +252,7 @@ func validateSubscriptionResponse(t *testing.T, resp []byte) {
 	jsonRPCVersion := respJSON[common.JSONKeyRPCVersion]
 	result := respJSON[common.JSONKeyResult]
 
-	if id != common.JSONID {
+	if id != jsonID {
 		t.Fatalf("subscription response did not contain expected ID. Expected 1, got %s", id)
 	}
 	if jsonRPCVersion != jsonrpc.Version {


### PR DESCRIPTION
### Why is this change needed?

A subscription is supposed to return the subscription ID when the subscription is created (e.g. to allow unsubscription, and to establish which events correct to which subscription). See https://geth.ethereum.org/docs/rpc/pubsub for the format the response is expected is.

### What changes were made as part of this PR:

- Provide a high level list of the changes made
- List key areas for the reviewer 

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
