### PR TITLE
Fix broken subscription filter criteria. Expand integration tests of subscriptions.

### DIFF
--- a/integration/simulation/simulation.go
+++ b/integration/simulation/simulation.go
@@ -120,14 +120,7 @@ func (s *Simulation) trackLogs() {
 		return
 	}
 
-	subscriptionsCreated := 0
 	for wallet, clients := range s.RPCHandles.AuthObsClients {
-		subscriptionsCreated++
-		// TODO - Consider enabling subscriptions for all wallets, following performance optimisations.
-		if subscriptionsCreated > maxSubscriptions {
-			break
-		}
-
 		s.LogChannels[wallet] = make(chan common.IDAndLog)
 
 		for _, client := range clients {
@@ -140,10 +133,6 @@ func (s *Simulation) trackLogs() {
 				panic(fmt.Errorf("subscription failed. Cause: %w", err))
 			}
 			s.Subscriptions = append(s.Subscriptions, sub)
-
-			// We only subscribe on a single client for each wallet, to reduce the load on the simulation.
-			// TODO - Consider enabling subscriptions for all clients on each wallet, following performance optimisations.
-			break //nolint:staticcheck
 		}
 	}
 }

--- a/integration/simulation/validate_chain.go
+++ b/integration/simulation/validate_chain.go
@@ -3,7 +3,6 @@ package simulation
 import (
 	"context"
 	"fmt"
-	"github.com/ethereum/go-ethereum/rlp"
 	"math/big"
 	"sync"
 	"testing"
@@ -424,9 +423,6 @@ out:
 		}
 	}
 
-	// todo - joel - reenable this
-	//assertNoDupeLogs(t, logsReceived)
-
 	return len(logsReceived)
 }
 
@@ -458,39 +454,4 @@ func assertIsRelevant(t *testing.T, owner string, receivedLog types.Log) {
 
 	// If we've fallen through to here, it means the log was not relevant.
 	t.Errorf("received log that was not relevant (neither a lifecycle event nor relevant to the client's account)")
-}
-
-// Asserts that there are no duplicate logs in the provided list.
-func assertNoDupeLogs(t *testing.T, logs []*types.Log) {
-	logCount := make(map[string]int)
-
-	for _, item := range logs {
-		logBytes, err := rlp.EncodeToBytes(item)
-		if err != nil {
-			t.Errorf("could not encode log to RLP to check for duplicate logs")
-			continue
-		}
-		logBytesHex := gethcommon.Bytes2Hex(logBytes)
-
-		// check if the item/element exist in the duplicate_frequency map
-		_, exist := logCount[logBytesHex]
-		if exist {
-			logCount[logBytesHex]++ // increase counter by 1 if already in the map
-		} else {
-			logCount[logBytesHex] = 1 // else start counting from 1
-		}
-	}
-
-	for logBytesHex, count := range logCount {
-		if count > 1 {
-			var item *types.Log
-			logBytes := gethcommon.Hex2Bytes(logBytesHex)
-			err := rlp.DecodeBytes(logBytes, &item)
-			if err != nil {
-				t.Errorf("could not decode log from RLP to check for duplicate logs")
-				continue
-			}
-			t.Errorf("received duplicate log")
-		}
-	}
 }


### PR DESCRIPTION
### Why is this change needed?

The filter criteria were broken before. This is something I'd meant to investigate for a while, as I was seeing some failures in the CI gates. But because we were testing so few subscriptions, it usually passed.

### What changes were made as part of this PR:

- Fixes encoding and decoding of filter criteria when adding a subscription. For some reason, JSON marshaling of the subscription was causing the filter criteria to decode as an empty object, so the filters were lost. This is fixed by switching to RLP
- Expands subscriptions, creating one for every client on every wallet, rather than one client each on only two wallets. This was causing performance issues before, but these have been addressed

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
