### PR TITLE
Each subscription receives each log exactly once

### DIFF
--- a/go/host/node/node.go
+++ b/go/host/node/node.go
@@ -67,15 +67,12 @@ type Node struct {
 	forkRPCCh    chan []common.EncodedBlock // The channel that new forks from the L1 node are sent to
 	rollupsP2PCh chan common.EncodedRollup  // The channel that new rollups from peers are sent to
 	txP2PCh      chan common.EncryptedTx    // The channel that new transactions from peers are sent to
-	logsChs      map[rpc.ID]chan []byte     // The channels that logs are sent to, one per subscription
 
 	nodeDB *db.DB // Stores the node's publicly-available data
 
-	// library to handle Management Contract lib operations
-	mgmtContractLib mgmtcontractlib.MgmtContractLib
-
-	// Wallet used to issue ethereum transactions
-	ethWallet wallet.Wallet
+	mgmtContractLib  mgmtcontractlib.MgmtContractLib // Library to handle Management Contract lib operations
+	ethWallet        wallet.Wallet                   // Wallet used to issue ethereum transactions
+	logSubscriptions map[rpc.ID]logSubscription      // The channels that logs are sent to, one per subscription
 }
 
 func NewHost(
@@ -110,16 +107,14 @@ func NewHost(
 		forkRPCCh:    make(chan []common.EncodedBlock),
 		rollupsP2PCh: make(chan common.EncodedRollup),
 		txP2PCh:      make(chan common.EncryptedTx),
-		logsChs:      map[rpc.ID]chan []byte{},
 
 		// Initialize the node DB
 		// nodeDB:       NewLevelDBBackedDB(), // todo - make this config driven
 		nodeDB: db.NewInMemoryDB(),
 
-		// library that provides a handler for Management Contract
-		mgmtContractLib: mgmtContractLib,
-		// the nodes ethereum wallet
-		ethWallet: ethWallet,
+		mgmtContractLib:  mgmtContractLib, // library that provides a handler for Management Contract
+		ethWallet:        ethWallet,       // the node's ethereum wallet
+		logSubscriptions: map[rpc.ID]logSubscription{},
 	}
 
 	if config.HasClientRPCHTTP || config.HasClientRPCWebsockets {
@@ -325,12 +320,12 @@ func (a *Node) ReceiveTx(tx common.EncryptedTx) {
 	a.txP2PCh <- tx
 }
 
-func (a *Node) Subscribe(id rpc.ID, encryptedLogSubscription common.EncryptedParamsLogSubscription, matchedLogs chan []byte) error {
+func (a *Node) Subscribe(id rpc.ID, encryptedLogSubscription common.EncryptedParamsLogSubscription, matchedLogsCh chan []byte) error {
 	err := a.EnclaveClient().Subscribe(id, encryptedLogSubscription)
 	if err != nil {
 		return fmt.Errorf("could not create subscription with enclave. Cause: %w", err)
 	}
-	a.logsChs[id] = matchedLogs
+	a.logSubscriptions[id] = logSubscription{ch: matchedLogsCh}
 	return nil
 }
 
@@ -339,7 +334,11 @@ func (a *Node) Unsubscribe(id rpc.ID) {
 	if err != nil {
 		log.Error("could not terminate subscription %s with enclave. Cause: %s", id, err)
 	}
-	delete(a.logsChs, id)
+	logSubscription, found := a.logSubscriptions[id]
+	if found {
+		close(logSubscription.ch)
+		delete(a.logSubscriptions, id)
+	}
 }
 
 func (a *Node) Stop() {
@@ -611,7 +610,7 @@ func (a *Node) storeBlockProcessingResult(result common.BlockSubmissionResponse)
 func (a *Node) sendLogsToSubscribers(result common.BlockSubmissionResponse) {
 	for subscriptionID, encLogsByRollup := range result.SubscribedLogs {
 		for _, encryptedLogs := range encLogsByRollup {
-			a.logsChs[subscriptionID] <- encryptedLogs
+			a.logSubscriptions[subscriptionID].ch <- encryptedLogs
 		}
 	}
 }
@@ -1062,4 +1061,10 @@ func retryWithBackoff(tries int, funcToRetry func() error) error {
 		time.Sleep(pause)
 		pause = pause * 2
 	}
+}
+
+// Pairs the latest seen rollup for a log subscription with the channel on which new logs should be sent.
+type logSubscription struct {
+	latestSeenRollup uint64      // The latest rollup for which logs have been distributed to this subscription.
+	ch               chan []byte // The channel that logs for this subscription are sent to.
 }

--- a/integration/simulation/simulation_tester.go
+++ b/integration/simulation/simulation_tester.go
@@ -60,7 +60,7 @@ func testSimulation(t *testing.T, netw network.Network, params *params.SimParams
 		SimulationTime:   params.SimulationTime,
 		Stats:            stats,
 		Params:           params,
-		LogChannels:      make(map[string]chan common.IDAndLog),
+		LogChannels:      make(map[string][]chan common.IDAndLog),
 		Subscriptions:    []ethereum.Subscription{},
 	}
 

--- a/integration/simulation/validate_chain.go
+++ b/integration/simulation/validate_chain.go
@@ -7,6 +7,8 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/rlp"
+
 	"github.com/obscuronet/go-obscuro/integration/simulation/network"
 
 	"github.com/obscuronet/go-obscuro/go/common/log"
@@ -416,6 +418,7 @@ out:
 
 	for _, receivedLog := range logsReceived {
 		assertIsRelevant(t, owner, *receivedLog)
+		assertNoDupeLogs(t, logsReceived)
 
 		logAddrHex := receivedLog.Address.Hex()
 		if logAddrHex != "0x"+bridge.HOCAddr {
@@ -454,4 +457,39 @@ func assertIsRelevant(t *testing.T, owner string, receivedLog types.Log) {
 
 	// If we've fallen through to here, it means the log was not relevant.
 	t.Errorf("received log that was not relevant (neither a lifecycle event nor relevant to the client's account)")
+}
+
+// Asserts that there are no duplicate logs in the provided list.
+func assertNoDupeLogs(t *testing.T, logs []*types.Log) {
+	logCount := make(map[string]int)
+
+	for _, item := range logs {
+		logBytes, err := rlp.EncodeToBytes(item)
+		if err != nil {
+			t.Errorf("could not encode log to RLP to check for duplicate logs")
+			continue
+		}
+		logBytesHex := gethcommon.Bytes2Hex(logBytes)
+
+		// check if the item/element exist in the duplicate_frequency map
+		_, exist := logCount[logBytesHex]
+		if exist {
+			logCount[logBytesHex]++ // increase counter by 1 if already in the map
+		} else {
+			logCount[logBytesHex] = 1 // else start counting from 1
+		}
+	}
+
+	for logBytesHex, count := range logCount {
+		if count > 1 {
+			var item *types.Log
+			logBytes := gethcommon.Hex2Bytes(logBytesHex)
+			err := rlp.DecodeBytes(logBytes, &item)
+			if err != nil {
+				t.Errorf("could not decode log from RLP to check for duplicate logs")
+				continue
+			}
+			t.Errorf("received duplicate log")
+		}
+	}
 }


### PR DESCRIPTION
### Why is this change needed?

Previously, each subscription would receive all logs matching the subscription every time there was a new block, even if they'd been sent them before. This did not match Geth's semantics, which was to send each log only once.

### What changes were made as part of this PR:

- Changes logic on the host, so that each log is only distributed once
- Adds tests of no duplicate logs to the integration tests

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
