### PR TITLE
Filters out historical logs in subscriptions.

### DIFF
--- a/go/enclave/events/subscription_manager.go
+++ b/go/enclave/events/subscription_manager.go
@@ -63,8 +63,9 @@ func (s *SubscriptionManager) AddSubscription(id gethrpc.ID, encryptedSubscripti
 
 	// For subscriptions, only the Topics and Addresses fields of the filter are applied.
 	subscription.Filter.BlockHash = nil
-	subscription.Filter.FromBlock = nil
 	subscription.Filter.ToBlock = nil
+	// We set this to the current rollup height, so that historical logs aren't returned.
+	subscription.Filter.FromBlock = s.storage.FetchHeadBlock().Number()
 
 	s.subscriptions[id] = &subscription
 	return nil


### PR DESCRIPTION
### Why is this change needed?

Subscriptions should not return historical items, only new ones since the creation of the subscription.

### What changes were made as part of this PR:

- Provide a high level list of the changes made
- List key areas for the reviewer 

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
