### PR TITLE
Starts subscriptions from latest rollup.

### DIFF
--- a/go/enclave/db/interfaces.go
+++ b/go/enclave/db/interfaces.go
@@ -49,6 +49,8 @@ type RollupResolver interface {
 	StoreGenesisRollup(rol *core.Rollup)
 	// FetchGenesisRollup returns the rollup genesis
 	FetchGenesisRollup() *core.Rollup
+	// FetchHeadRollup returns the current head rollup
+	FetchHeadRollup() *core.Rollup
 }
 
 type BlockStateStorage interface {

--- a/go/enclave/db/storage.go
+++ b/go/enclave/db/storage.go
@@ -57,6 +57,15 @@ func (s *storageImpl) FetchGenesisRollup() *core.Rollup {
 	return r
 }
 
+func (s *storageImpl) FetchHeadRollup() *core.Rollup {
+	hash := obscurorawdb.ReadHeadRollupHash(s.db)
+	if hash == (gethcommon.Hash{}) {
+		return nil
+	}
+	r, _ := s.FetchRollup(hash)
+	return r
+}
+
 func (s *storageImpl) StoreRollup(rollup *core.Rollup) {
 	s.assertSecretAvailable()
 

--- a/go/enclave/events/subscription_manager.go
+++ b/go/enclave/events/subscription_manager.go
@@ -65,7 +65,7 @@ func (s *SubscriptionManager) AddSubscription(id gethrpc.ID, encryptedSubscripti
 	subscription.Filter.BlockHash = nil
 	subscription.Filter.ToBlock = nil
 	// We set this to the current rollup height, so that historical logs aren't returned.
-	subscription.Filter.FromBlock = s.storage.FetchHeadBlock().Number()
+	subscription.Filter.FromBlock = s.storage.FetchHeadRollup().Number()
 
 	s.subscriptions[id] = &subscription
 	return nil

--- a/integration/simulation/transaction_injector.go
+++ b/integration/simulation/transaction_injector.go
@@ -345,7 +345,7 @@ func NextNonce(ctx context.Context, clients *network.RPCHandles, w wallet.Wallet
 
 		counter++
 		if counter > nonceTimeoutMillis {
-			panic(fmt.Sprintf("transaction injector failed to retrieve nonce after thirty seconds for address %s. "+
+			panic(fmt.Sprintf("transaction injector could not retrieve nonce after thirty seconds for address %s. "+
 				"Local nonce was %d, remote nonce was %d", w.Address().Hex(), localNonce, remoteNonce))
 		}
 		time.Sleep(time.Millisecond)


### PR DESCRIPTION
### Why is this change needed?

There was a bug whereby the subscriptions where started from the number of the current L1 block, rather than of the current L2 block.

### What changes were made as part of this PR:

- Provide a high level list of the changes made
- List key areas for the reviewer 

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
