### PR TITLE
Implement GetLogs method

### DIFF
--- a/go/common/logs.go
+++ b/go/common/logs.go
@@ -37,7 +37,9 @@ type LogsByRollupByID = map[rpc.ID]map[uint64][]*types.Log
 // EncLogsByRollupByID is identical to LogsByRollupByID, but with the logs encrypted as bytes.
 type EncLogsByRollupByID = map[rpc.ID]map[uint64][]byte
 
-// FilterCriteriaJSON is a structure that JSON-serialises to the expected format for log filter criteria.
+// FilterCriteriaJSON is a structure that JSON-serialises to a format that can be successfully deserialised into a
+// filters.FilterCriteria object (round-tripping a filters.FilterCriteria to JSON and back doesn't work, due to a
+// custom serialiser implemented by filters.FilterCriteria).
 type FilterCriteriaJSON struct {
 	BlockHash *common.Hash     `json:"blockHash"`
 	FromBlock *rpc.BlockNumber `json:"fromBlock"`

--- a/go/common/logs.go
+++ b/go/common/logs.go
@@ -36,3 +36,12 @@ type LogsByRollupByID = map[rpc.ID]map[uint64][]*types.Log
 
 // EncLogsByRollupByID is identical to LogsByRollupByID, but with the logs encrypted as bytes.
 type EncLogsByRollupByID = map[rpc.ID]map[uint64][]byte
+
+// FilterCriteriaJSON is a structure that JSON-serialises to the expected format for log filter criteria.
+type FilterCriteriaJSON struct {
+	BlockHash *common.Hash     `json:"blockHash"`
+	FromBlock *rpc.BlockNumber `json:"fromBlock"`
+	ToBlock   *rpc.BlockNumber `json:"toBlock"`
+	Addresses interface{}      `json:"address"`
+	Topics    []interface{}    `json:"topics"`
+}

--- a/go/enclave/db/rawdb/log_for_storage.go
+++ b/go/enclave/db/rawdb/log_for_storage.go
@@ -1,0 +1,45 @@
+package rawdb
+
+import (
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// This type is required because Geth serialises its logs in a reduced form to minimise storage space. For now, it is
+// more straightforward for us to serialise all the fields by converting the logs to this type.
+type logForStorage struct {
+	Address     gethcommon.Address
+	Topics      []gethcommon.Hash
+	Data        []byte
+	BlockNumber uint64
+	TxHash      gethcommon.Hash
+	TxIndex     uint
+	BlockHash   gethcommon.Hash
+	Index       uint
+}
+
+func toLogForStorage(fullFatLog *types.Log) *logForStorage {
+	return &logForStorage{
+		Address:     fullFatLog.Address,
+		Topics:      fullFatLog.Topics,
+		Data:        fullFatLog.Data,
+		BlockNumber: fullFatLog.BlockNumber,
+		TxHash:      fullFatLog.TxHash,
+		TxIndex:     fullFatLog.TxIndex,
+		BlockHash:   fullFatLog.BlockHash,
+		Index:       fullFatLog.Index,
+	}
+}
+
+func (l logForStorage) toLog() *types.Log {
+	return &types.Log{
+		Address:     l.Address,
+		Topics:      l.Topics,
+		Data:        l.Data,
+		BlockNumber: l.BlockNumber,
+		TxHash:      l.TxHash,
+		TxIndex:     l.TxIndex,
+		BlockHash:   l.BlockHash,
+		Index:       l.Index,
+	}
+}

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -625,33 +625,14 @@ func (e *enclaveImpl) GetLogs(encryptedParams common.EncryptedParamsGetLogs) (co
 	// We marshal the filter criteria from a map to JSON, then back from JSON into a FilterCriteria. This is
 	// because the filter criteria arrives as a map, and there is no way to convert it to a map directly into a
 	// FilterCriteria.
-	filterCriteriaJSON, err := json.Marshal(paramsList[1])
+	filterJSON, err := json.Marshal(paramsList[1])
 	if err != nil {
 		return nil, fmt.Errorf("could not marshal filter criteria to JSON. Cause: %w", err)
 	}
-
-	filterCriteria := filters.FilterCriteria{}
-	err = filterCriteria.UnmarshalJSON(filterCriteriaJSON)
+	filter := filters.FilterCriteria{}
+	err = filter.UnmarshalJSON(filterJSON)
 	if err != nil {
 		return nil, fmt.Errorf("could not unmarshal filter criteria from JSON. Cause: %w", err)
-	}
-
-	//blockHashString, ok := filterCriteriaMap["BlockHash"].(string),
-	//blockHash := gethcommon.BytesToHash(blockHashString)
-	//fromHash, ok := filterCriteriaMap["FromBlock"].(float64),
-	//toBlock, ok  :=   filterCriteriaMap["ToBlock"].(float64),
-	//addresses, ok := filterCriteriaMap["Addresses"].([]string),
-	//topics, ok := filterCriteriaMap["Topics"].[string],
-
-	// We marshal the filter criteria from a map to JSON, then back from JSON into a FilterCriteria. This is
-	// because the filter criteria arrives as a map, and there is no way to convert it to a map directly into a
-	// FilterCriteria.
-	filter := filters.FilterCriteria{
-		//BlockHash: filterCriteriaMap["BlockHash"],
-		//FromBlock: filterCriteriaMap["FromBlock"],
-		//ToBlock:   filterCriteriaMap["ToBlock"],
-		//Addresses: filterCriteriaMap["Addresses"],
-		//Topics:    filterCriteriaMap["Topics"],
 	}
 
 	headBlockHash := e.storage.FetchHeadBlock().Hash()

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -635,6 +635,7 @@ func (e *enclaveImpl) GetLogs(encryptedParams common.EncryptedParamsGetLogs) (co
 		return nil, fmt.Errorf("could not unmarshal filter criteria from JSON. Cause: %w", err)
 	}
 
+	// We retrieve the relevant logs that match the filter.
 	headBlockHash := e.storage.FetchHeadBlock().Hash()
 	_, logs, found := e.storage.FetchBlockState(headBlockHash)
 	if !found {

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -607,52 +607,24 @@ func (e *enclaveImpl) GetLogs(encryptedParams common.EncryptedParamsGetLogs) (co
 		return nil, fmt.Errorf("unable to decrypt params in GetLogs request. Cause: %w", err)
 	}
 
-	// We verify the params.
-	var paramsList []interface{}
-	err = json.Unmarshal(paramBytes, &paramsList)
+	// We extract the arguments from the param bytes.
+	filter, forAddress, err := extractGetLogsParams(paramBytes)
 	if err != nil {
-		return nil, fmt.Errorf("unable to decode GetLogs params - %w", err)
+		return nil, err
 	}
-	if len(paramsList) != 2 {
-		return nil, fmt.Errorf("expected 2 params in GetLogs request, but received %d", len(paramsList))
-	}
-
-	// We extract the first param, the filter for the logs.
-	// We marshal the filter criteria from a map to JSON, then back from JSON into a FilterCriteria. This is
-	// because the filter criteria arrives as a map, and there is no way to convert it to a map directly into a
-	// FilterCriteria.
-	filterJSON, err := json.Marshal(paramsList[0])
-	if err != nil {
-		return nil, fmt.Errorf("could not marshal filter criteria to JSON. Cause: %w", err)
-	}
-	filter := filters.FilterCriteria{}
-	err = filter.UnmarshalJSON(filterJSON)
-	if err != nil {
-		return nil, fmt.Errorf("could not unmarshal filter criteria from JSON. Cause: %w", err)
-	}
-
-	// We extract the second param, the address the logs are for.
-	forAddressHex, ok := paramsList[1].(string)
-	if !ok {
-		return nil, fmt.Errorf("expected second argument in GetLogs request to be of type string, but got %T", paramsList[0])
-	}
-	forAddress := gethcommon.HexToAddress(forAddressHex)
 
 	// We retrieve the relevant logs that match the filter.
-	headBlockHash := e.storage.FetchHeadBlock().Hash()
-	_, logs, found := e.storage.FetchBlockState(headBlockHash)
-	if !found {
-		log.Error("could not retrieve logs for head state. Something is wrong")
-		return nil, fmt.Errorf("could not retrieve logs for head state. Something is wrong")
+	filteredLogs, err := e.subscriptionManager.FilteredLogsHead(forAddress, filter)
+	if err != nil {
+		return nil, fmt.Errorf("could not retrieve logs matching the filter. Cause: %w", err)
 	}
-	filteredLogs := e.subscriptionManager.FilteredLogs(logs, e.storage.FetchHeadRollup().Hash(), &forAddress, &filter)
 
 	// We encode and encrypt the logs with the viewing key for the requester's address.
 	logBytes, err := json.Marshal(filteredLogs)
 	if err != nil {
 		return nil, fmt.Errorf("could not marshal logs to JSON. Cause: %w", err)
 	}
-	encryptedLogs, err := e.rpcEncryptionManager.EncryptWithViewingKey(forAddress, logBytes)
+	encryptedLogs, err := e.rpcEncryptionManager.EncryptWithViewingKey(*forAddress, logBytes)
 	if err != nil {
 		return nil, fmt.Errorf("enclave could not respond securely to GetLogs request. Cause: %w", err)
 	}
@@ -730,6 +702,41 @@ func (e *enclaveImpl) processSecretRequest(req *ethadapter.L1RequestSecretTx) (*
 		RequesterID: att.Owner,
 		HostAddress: att.HostAddress,
 	}, nil
+}
+
+// Returns the params extracted from an eth_getLogs request.
+func extractGetLogsParams(paramBytes []byte) (*filters.FilterCriteria, *gethcommon.Address, error) {
+	// We verify the params.
+	var paramsList []interface{}
+	err := json.Unmarshal(paramBytes, &paramsList)
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to decode GetLogs params. Cause: %w", err)
+	}
+	if len(paramsList) != 2 {
+		return nil, nil, fmt.Errorf("expected 2 params in GetLogs request, but received %d", len(paramsList))
+	}
+
+	// We extract the first param, the filter for the logs.
+	// We marshal the filter criteria from a map to JSON, then back from JSON into a FilterCriteria. This is
+	// because the filter criteria arrives as a map, and there is no way to convert it to a map directly into a
+	// FilterCriteria.
+	filterJSON, err := json.Marshal(paramsList[0])
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not marshal filter criteria to JSON. Cause: %w", err)
+	}
+	filter := filters.FilterCriteria{}
+	err = filter.UnmarshalJSON(filterJSON)
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not unmarshal filter criteria from JSON. Cause: %w", err)
+	}
+
+	// We extract the second param, the address the logs are for.
+	forAddressHex, ok := paramsList[1].(string)
+	if !ok {
+		return nil, nil, fmt.Errorf("expected second argument in GetLogs request to be of type string, but got %T", paramsList[0])
+	}
+	forAddress := gethcommon.HexToAddress(forAddressHex)
+	return &filter, &forAddress, nil
 }
 
 // Todo - reinstate speculative execution after TN1

--- a/go/enclave/events/subscription_manager.go
+++ b/go/enclave/events/subscription_manager.go
@@ -78,18 +78,18 @@ func (s *SubscriptionManager) RemoveSubscription(id gethrpc.ID) {
 }
 
 // FilteredLogs filters out irrelevant logs.
-func (s *SubscriptionManager) FilteredLogs(logs []*types.Log, rollupHash common.L2RootHash, account *gethcommon.Address) []*types.Log {
-	allLogs := []*types.Log{}
+func (s *SubscriptionManager) FilteredLogs(logs []*types.Log, rollupHash common.L2RootHash, account *gethcommon.Address, filter *filters.FilterCriteria) []*types.Log {
+	filteredLogs := []*types.Log{}
 	stateDB := s.storage.CreateStateDB(rollupHash)
 
 	for _, log := range logs {
 		userAddrs := getUserAddrs(log, stateDB)
-		if isRelevant(userAddrs, account) {
-			allLogs = append(allLogs, log)
+		if isRelevant(userAddrs, account) && !isFilteredOut(log, filter) {
+			filteredLogs = append(filteredLogs, log)
 		}
 	}
 
-	return allLogs
+	return filteredLogs
 }
 
 // FilteredSubscribedLogs filters out irrelevant logs and those that are not subscribed to, and organises them by their subscribing ID.

--- a/go/host/rpc/clientapi/client_api_filter.go
+++ b/go/host/rpc/clientapi/client_api_filter.go
@@ -73,14 +73,13 @@ func (api *FilterAPI) Logs(ctx context.Context, encryptedParams common.Encrypted
 }
 
 // GetLogs returns the logs matching the filter.
-func (api *FilterAPI) GetLogs(_ context.Context, encryptedParams common.EncryptedParamsGetLogs) (*string, error) {
+func (api *FilterAPI) GetLogs(_ context.Context, encryptedParams common.EncryptedParamsGetLogs) (string, error) {
 	encryptedResponse, err := api.host.EnclaveClient().GetLogs(encryptedParams)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 	if encryptedResponse == nil {
-		return nil, err
+		return "", err
 	}
-	encryptedResponseHex := gethcommon.Bytes2Hex(encryptedResponse)
-	return &encryptedResponseHex, nil
+	return gethcommon.Bytes2Hex(encryptedResponse), nil
 }

--- a/go/obsclient/authclient.go
+++ b/go/obsclient/authclient.go
@@ -119,7 +119,7 @@ func (ac *AuthObsClient) SubscribeFilterLogs(ctx context.Context, filterCriteria
 	return ac.rpcClient.Subscribe(ctx, nil, rpc.RPCSubscribeNamespace, ch, rpc.RPCSubscriptionTypeLogs, filterCriteriaMap)
 }
 
-func (ac *AuthObsClient) GetLogs(ctx context.Context, filterCriteria filters.FilterCriteria) ([]*types.Log, error) {
+func (ac *AuthObsClient) GetLogs(ctx context.Context, filterCriteria common.FilterCriteriaJSON) ([]*types.Log, error) {
 	var logs []*types.Log
 	err := ac.rpcClient.CallContext(ctx, &logs, rpc.RPCGetLogs, ac.account, filterCriteria)
 	return logs, err

--- a/go/obsclient/authclient.go
+++ b/go/obsclient/authclient.go
@@ -119,9 +119,9 @@ func (ac *AuthObsClient) SubscribeFilterLogs(ctx context.Context, filterCriteria
 	return ac.rpcClient.Subscribe(ctx, nil, rpc.RPCSubscribeNamespace, ch, rpc.RPCSubscriptionTypeLogs, filterCriteriaMap)
 }
 
-func (ac *AuthObsClient) GetLogs(ctx context.Context, filterCriteria filters.FilterCriteria) ([]*types.Log, error) {
+func (ac *AuthObsClient) GetLogs(ctx context.Context, forAddress gethcommon.Address, filterCriteria filters.FilterCriteria) ([]*types.Log, error) {
 	var logs []*types.Log
-	err := ac.rpcClient.CallContext(ctx, &logs, rpc.RPCGetLogs, filterCriteria)
+	err := ac.rpcClient.CallContext(ctx, &logs, rpc.RPCGetLogs, forAddress, filterCriteria)
 	return logs, err
 }
 

--- a/go/obsclient/authclient.go
+++ b/go/obsclient/authclient.go
@@ -119,9 +119,9 @@ func (ac *AuthObsClient) SubscribeFilterLogs(ctx context.Context, filterCriteria
 	return ac.rpcClient.Subscribe(ctx, nil, rpc.RPCSubscribeNamespace, ch, rpc.RPCSubscriptionTypeLogs, filterCriteriaMap)
 }
 
-func (ac *AuthObsClient) GetLogs(ctx context.Context, forAddress gethcommon.Address, filterCriteria filters.FilterCriteria) ([]*types.Log, error) {
+func (ac *AuthObsClient) GetLogs(ctx context.Context, filterCriteria filters.FilterCriteria) ([]*types.Log, error) {
 	var logs []*types.Log
-	err := ac.rpcClient.CallContext(ctx, &logs, rpc.RPCGetLogs, forAddress, filterCriteria)
+	err := ac.rpcClient.CallContext(ctx, &logs, rpc.RPCGetLogs, ac.account, filterCriteria)
 	return logs, err
 }
 

--- a/go/obsclient/authclient.go
+++ b/go/obsclient/authclient.go
@@ -121,7 +121,7 @@ func (ac *AuthObsClient) SubscribeFilterLogs(ctx context.Context, filterCriteria
 
 func (ac *AuthObsClient) GetLogs(ctx context.Context, filterCriteria common.FilterCriteriaJSON) ([]*types.Log, error) {
 	var logs []*types.Log
-	err := ac.rpcClient.CallContext(ctx, &logs, rpc.RPCGetLogs, ac.account, filterCriteria)
+	err := ac.rpcClient.CallContext(ctx, &logs, rpc.RPCGetLogs, filterCriteria, ac.account)
 	return logs, err
 }
 

--- a/go/rpc/encrypted_client.go
+++ b/go/rpc/encrypted_client.go
@@ -220,6 +220,7 @@ func (c *EncRPCClient) createAuthenticatedLogSubscription(args []interface{}) (*
 	if len(args) < 2 {
 		logSubscription.Filter = &filters.FilterCriteria{}
 	} else {
+		// TODO - Consider switching to using the common.FilterCriteriaJSON type. Should allow us to avoid RLP serialisation.
 		// We marshal the filter criteria from a map to JSON, then back from JSON into a FilterCriteria. This is
 		// because the filter criteria arrives as a map, and there is no way to convert it to a map directly into a
 		// FilterCriteria.

--- a/integration/simulation/p2p/in_mem_obscuro_client.go
+++ b/integration/simulation/p2p/in_mem_obscuro_client.go
@@ -49,6 +49,7 @@ func NewInMemObscuroClient(nodeHost host.Host) rpc.Client {
 	return &inMemObscuroClient{
 		obscuroAPI:       clientapi.NewObscuroAPI(nodeHost),
 		ethAPI:           clientapi.NewEthereumAPI(nodeHost),
+		filterAPI:        clientapi.NewFilterAPI(nodeHost),
 		obscuroScanAPI:   clientapi.NewObscuroScanAPI(nodeHost),
 		testAPI:          clientapi.NewTestAPI(nodeHost),
 		enclavePublicKey: enclPubKey,

--- a/integration/simulation/simulation.go
+++ b/integration/simulation/simulation.go
@@ -59,7 +59,7 @@ func (s *Simulation) Start() {
 	// Arbitrary sleep to wait for RPC clients to get up and running
 	time.Sleep(1 * time.Second)
 
-	s.trackLogs()              // Capture emitted logs, to validate later
+	s.trackLogs()              // Create log subscriptions, to validate that they're working correctly later.
 	s.prefundObscuroAccounts() // Prefund every L2 wallet
 	s.deployObscuroERC20s()    // Deploy the Obscuro HOC and POC ERC20 contracts
 	s.prefundL1Accounts()      // Prefund every L1 wallet

--- a/integration/simulation/validate_chain.go
+++ b/integration/simulation/validate_chain.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ethereum/go-ethereum/eth/filters"
 	"github.com/obscuronet/go-obscuro/go/obsclient"
 
 	"github.com/obscuronet/go-obscuro/integration/simulation/network"
@@ -435,14 +434,8 @@ out:
 
 func checkSnapshotLogs(t *testing.T, client *obsclient.AuthObsClient) int {
 	// To exercise the filtering mechanism, we get a snapshot for HOC events only, ignoring POC events.
-	// todo - joel - revert this crazy filter
-	//blockHash := gethcommon.HexToAddress("0x" + bridge.HOCAddr).Hash()
-	hocFilter := filters.FilterCriteria{
-		FromBlock: big.NewInt(3),
-		ToBlock:   big.NewInt(4),
-		//BlockHash: &blockHash,
+	hocFilter := common.FilterCriteriaJSON{
 		Addresses: []gethcommon.Address{gethcommon.HexToAddress("0x" + bridge.HOCAddr)},
-		//Topics:    [][]gethcommon.Hash{{blockHash}},
 	}
 	logs, err := client.GetLogs(context.Background(), hocFilter)
 	if err != nil {

--- a/integration/simulation/validate_chain.go
+++ b/integration/simulation/validate_chain.go
@@ -428,7 +428,6 @@ out:
 	}
 
 	assertLogsValid(t, owner, logs)
-	assertNoDupeLogs(t, logs)
 	return len(logs)
 }
 
@@ -444,9 +443,6 @@ func checkSnapshotLogs(t *testing.T, client *obsclient.AuthObsClient) int {
 
 	assertLogsValid(t, client.Address().Hex(), logs)
 
-	// TODO - #1016 - Prevent duplicate logs from being returned from the enclave, and re-enable this check.
-	// assertNoDupeLogs(t, logs)
-
 	return len(logs)
 }
 
@@ -460,6 +456,8 @@ func assertLogsValid(t *testing.T, owner string, logs []*types.Log) {
 			t.Errorf("due to filter, expected logs from the HOC contract only, but got a log from %s", logAddrHex)
 		}
 	}
+
+	assertNoDupeLogs(t, logs)
 }
 
 // Asserts that the log is relevant to the recipient (either a lifecycle event or a relevant user event).

--- a/integration/simulation/validate_chain.go
+++ b/integration/simulation/validate_chain.go
@@ -3,12 +3,13 @@ package simulation
 import (
 	"context"
 	"fmt"
-	"github.com/ethereum/go-ethereum/eth/filters"
-	"github.com/obscuronet/go-obscuro/go/obsclient"
 	"math/big"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/ethereum/go-ethereum/eth/filters"
+	"github.com/obscuronet/go-obscuro/go/obsclient"
 
 	"github.com/ethereum/go-ethereum/rlp"
 


### PR DESCRIPTION
### Why is this change needed?

- Implements the GetLog method

There are a few ToDos that I'd like to pick up in a subsequent PR:

1. We're going to shift from passing in the address of the account the eth_getLogs request is for, to parsing the address from the first topic of the filter criteria
2. We're still seeing dupe logs returned, which all have zero hashes, indices, and block hashes. These are being created by the chain processing in the enclave, so I will fix separately (getting the logs is just highlighting the issue)

### What changes were made as part of this PR:

- Provide a high level list of the changes made
- List key areas for the reviewer 

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
