### PR TITLE
Reduce number of testnet L1 + L2 nodes from 3 to 2

### DIFF
--- a/.github/workflows/manual-deploy-dev-testnet.yml
+++ b/.github/workflows/manual-deploy-dev-testnet.yml
@@ -1,9 +1,10 @@
 # Deploys an Obscuro network on Azure for DEV Testnet
 #
-# The Obscuro network is composed of 3 obscuro nodes running on individual vms
-# It exposes the following ports:
-# HTTP:       8025, 8026, 8027
-# WebSocket:  9000, 9001, 9002
+# The Obscuro network is composed of 2 obscuro nodes running on individual vms.
+#
+# The L1 network consists of 2 geth nodes running on a docker container and exposes the following ports:
+# HTTP:       8025, 8026
+# WebSocket:  9000, 9001
 #
 
 name: '[M] Deploy Dev-Testnet'
@@ -52,10 +53,10 @@ jobs:
           name: dev-testnet-gethnetwork
           location: 'uksouth'
           restart-policy: 'Never'
-          command-line: /home/go-obscuro/integration/gethnetwork/main/main --blockTimeSecs 15 --numNodes=3 --startPort=8000 --websocketStartPort=9000 --prefundedAddrs=${{ secrets.GETHNETWORK_PREFUNDED_ADDR_WORKER }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_0 }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_1 }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_2 }}
-          # Ports start at 9000 for Websockets and 8000 for Start port and 80025 for Http Port
+          command-line: /home/go-obscuro/integration/gethnetwork/main/main --blockTimeSecs 15 --numNodes=2 --startPort=8000 --websocketStartPort=9000 --prefundedAddrs=${{ secrets.GETHNETWORK_PREFUNDED_ADDR_WORKER }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_0 }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_1 }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_2 }}
+          # Ports start at 9000 for Websockets and 8000 for Start port and 8025 for Http Port
           # Each node has Port + id
-          ports: '8025 8026 8027 9000 9001 9002'
+          ports: '8025 8026 9000 9001'
           cpu: 2
           memory: 4
 
@@ -124,35 +125,27 @@ jobs:
 
     strategy:
       matrix:
-        host_id: [ 0,1,2 ]
+        host_id: [ 0,1 ]
         include:
           # Hardcoded host addresses
           - host_addr: 0x0000000000000000000000000000000000000000
             host_id: 0
           - host_addr: 0x0000000000000000000000000000000000000001
             host_id: 1
-          - host_addr: 0x0000000000000000000000000000000000000002
-            host_id: 2
           # Hardcoded host prefunded keys
           - node_pk_str: GETHNETWORK_PREFUNDED_PKSTR_0
             host_id: 0
           - node_pk_str: GETHNETWORK_PREFUNDED_PKSTR_1
             host_id: 1
-          - node_pk_str: GETHNETWORK_PREFUNDED_PKSTR_2
-            host_id: 2
           - node_pk_addr: GETHNETWORK_PREFUNDED_ADDR_0
             host_id: 0
           - node_pk_addr: GETHNETWORK_PREFUNDED_ADDR_1
             host_id: 1
-          - node_pk_addr: GETHNETWORK_PREFUNDED_ADDR_2
-            host_id: 2
           # Ensure there is a genesis node
           - is_genesis: true
             host_id: 0
           - is_genesis: false
             host_id: 1
-          - is_genesis: false
-            host_id: 2
 
     steps:
       - name: 'Extract branch name'

--- a/.github/workflows/manual-deploy-testnet-l1.yml
+++ b/.github/workflows/manual-deploy-testnet-l1.yml
@@ -1,10 +1,10 @@
 # Deploys a L1 network on Azure for Testnet
 # Builds the l1 network image, kills any running container, pushes the image to dockerhub and starts the l1 network on azure
 #
-# The L1 network is a docker container that runs 3 geth nodes
+# The L1 network is a docker container that runs 2 geth nodes
 # It exposes the following ports:
-# HTTP:       8025, 8026, 8027
-# WebSocket:  9000, 9001, 9002
+# HTTP:       8025, 8026
+# WebSocket:  9000, 9001
 #
 # Exposes the following addresses: (only accessible internally)
 #  testnet-gethnetwork-DEPLOYNUMBER.uksouth.azurecontainer.io
@@ -64,9 +64,9 @@ jobs:
           name: testnet-gethnetwork
           location: 'uksouth'
           restart-policy: 'Never'
-          command-line: /home/go-obscuro/integration/gethnetwork/main/main --blockTimeSecs 15 --numNodes=3 --startPort=8000 --websocketStartPort=9000 --prefundedAddrs=${{ secrets.GETHNETWORK_PREFUNDED_ADDR_WORKER }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_0 }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_1 }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_2 }}
+          command-line: /home/go-obscuro/integration/gethnetwork/main/main --blockTimeSecs 15 --numNodes=2 --startPort=8000 --websocketStartPort=9000 --prefundedAddrs=${{ secrets.GETHNETWORK_PREFUNDED_ADDR_WORKER }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_0 }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_1 }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_2 }}
           # Ports start at 9000 for Websockets and 8000 for Start port and 80025 for Http Port
           # Each node has Port + id
-          ports: '8025 8026 8027 9000 9001 9002'
+          ports: '8025 8026 9000 9001'
           cpu: 2
           memory: 4

--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -1,10 +1,7 @@
 # Deploys an Obscuro network on Azure for Testnet
 # TO BE FILLED IN
 #
-# The Obscuro network is composed of 3 obscuro nodes running on individual vms
-# It exposes the following ports:
-# HTTP:       8025, 8026, 8027
-# WebSocket:  9000, 9001, 9002
+# The Obscuro network is composed of 2 obscuro nodes running on individual vms
 #
 
 name: '[M] Deploy Testnet L2'
@@ -81,35 +78,27 @@ jobs:
 
     strategy:
       matrix:
-        host_id: [ 0,1,2 ]
+        host_id: [ 0,1 ]
         include:
           # Hardcoded host addresses
           - host_addr: 0x0000000000000000000000000000000000000000
             host_id: 0
           - host_addr: 0x0000000000000000000000000000000000000001
             host_id: 1
-          - host_addr: 0x0000000000000000000000000000000000000002
-            host_id: 2
           # Hardcoded host prefunded keys
           - node_pk_str: GETHNETWORK_PREFUNDED_PKSTR_0
             host_id: 0
           - node_pk_str: GETHNETWORK_PREFUNDED_PKSTR_1
             host_id: 1
-          - node_pk_str: GETHNETWORK_PREFUNDED_PKSTR_2
-            host_id: 2
           - node_pk_addr: GETHNETWORK_PREFUNDED_ADDR_0
             host_id: 0
           - node_pk_addr: GETHNETWORK_PREFUNDED_ADDR_1
             host_id: 1
-          - node_pk_addr: GETHNETWORK_PREFUNDED_ADDR_2
-            host_id: 2
           # Ensure there is a genesis node
           - is_genesis: true
             host_id: 0
           - is_genesis: false
             host_id: 1
-          - is_genesis: false
-            host_id: 2
 
     steps:
       - name: Extract branch name

--- a/testnet/gethnetwork.Dockerfile
+++ b/testnet/gethnetwork.Dockerfile
@@ -29,5 +29,5 @@ WORKDIR /home/go-obscuro/integration/gethnetwork/main
 RUN go build
 
 # expose the http and the ws ports to the host
-EXPOSE 8025 8026 8027 9000 9001 9002
-ENTRYPOINT ["/home/go-obscuro/integration/gethnetwork/main/main", "--numNodes=3", "--startPort=8000","--websocketStartPort=9000"]
+EXPOSE 8025 8026 9000 9001
+ENTRYPOINT ["/home/go-obscuro/integration/gethnetwork/main/main", "--numNodes=2", "--startPort=8000","--websocketStartPort=9000"]

--- a/testnet/testnet-local-gethnetwork.sh
+++ b/testnet/testnet-local-gethnetwork.sh
@@ -57,7 +57,7 @@ echo "Starting the gethnetwork.."
 docker network create --driver bridge node_network || true
 docker run --name=gethnetwork -d \
   --network=node_network \
-  -p 8025:8025 -p 8026:8026 -p 8027:8027 -p 9000:9000 -p 9001:9001 -p 9002:9002 \
+  -p 8025:8025 -p 8026:8026 -p 9000:9000 -p 9001:9001 \
   --entrypoint /home/go-obscuro/integration/gethnetwork/main/main \
    testnetobscuronet.azurecr.io/obscuronet/obscuro_gethnetwork:latest \
   --numNodes=3 \


### PR DESCRIPTION
### Why is this change needed?

- Per discussions between Gavin and Tudor we have decided 3 nodes is unnecessary for testnet and dev-testnet
- This will save resources on azure (and datadog)

### What changes were made as part of this PR:

- Change L1 geth network scripts to only setup 2 geth nodes
- Change L2 docker compose scripts to only setup 2 obscuro nodes
- Update some comments

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
