### PR TITLE
Fixes bug that lead to sending of duplicate logs.

### DIFF
--- a/go/host/events/logs.go
+++ b/go/host/events/logs.go
@@ -8,18 +8,18 @@ import (
 
 // LogEventManager manages the routing of logs back to their subscribers.
 type LogEventManager struct {
-	subscriptions map[rpc.ID]subscription // The channels that logs are sent to, one per subscription
+	subscriptions map[rpc.ID]*subscription // The channels that logs are sent to, one per subscription
 }
 
 func NewLogEventManager() LogEventManager {
 	return LogEventManager{
-		subscriptions: map[rpc.ID]subscription{},
+		subscriptions: map[rpc.ID]*subscription{},
 	}
 }
 
 // AddSubscription adds a subscription to the set of managed subscriptions.
 func (l *LogEventManager) AddSubscription(id rpc.ID, matchedLogsCh chan []byte) {
-	l.subscriptions[id] = subscription{ch: matchedLogsCh}
+	l.subscriptions[id] = &subscription{ch: matchedLogsCh}
 }
 
 // RemoveSubscription removes a subscription from the set of managed subscriptions.


### PR DESCRIPTION
### Why is this change needed?

There was a bug that led to the logs for each rollup being distributed multiple times. Because the subscriptions were stored by value not by pointer, retrieving them and then updating them was having no effect.

### What changes were made as part of this PR:

- Provide a high level list of the changes made
- List key areas for the reviewer 

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
