### PR TITLE
Handle multiple requests on one websocket connection

### DIFF
--- a/tools/walletextension/userconn/user_conn.go
+++ b/tools/walletextension/userconn/user_conn.go
@@ -61,7 +61,9 @@ func NewUserConnWS(resp http.ResponseWriter, req *http.Request) (UserConn, error
 func (h *userConnHTTP) ReadRequest() ([]byte, error) {
 	body, err := io.ReadAll(h.req.Body)
 	if err != nil {
-		return nil, fmt.Errorf("could not read request body: %w", err)
+		wrappedErr := fmt.Errorf("could not read request body: %w", err)
+		h.HandleError(wrappedErr.Error())
+		return nil, wrappedErr
 	}
 	return body, nil
 }
@@ -69,7 +71,9 @@ func (h *userConnHTTP) ReadRequest() ([]byte, error) {
 func (h *userConnHTTP) WriteResponse(msg []byte) error {
 	_, err := h.resp.Write(msg)
 	if err != nil {
-		return fmt.Errorf("could not write response: %w", err)
+		wrappedErr := fmt.Errorf("could not write response: %w", err)
+		h.HandleError(wrappedErr.Error())
+		return wrappedErr
 	}
 	return nil
 }
@@ -92,7 +96,9 @@ func (w *userConnWS) ReadRequest() ([]byte, error) {
 		if websocket.IsCloseError(err) {
 			w.isClosed = true
 		}
-		return nil, fmt.Errorf("could not read request: %w", err)
+		wrappedErr := fmt.Errorf("could not read request: %w", err)
+		w.HandleError(wrappedErr.Error())
+		return nil, wrappedErr
 	}
 	return msg, nil
 }
@@ -103,7 +109,9 @@ func (w *userConnWS) WriteResponse(msg []byte) error {
 		if websocket.IsCloseError(err) {
 			w.isClosed = true
 		}
-		return fmt.Errorf("could not write response: %w", err)
+		wrappedErr := fmt.Errorf("could not write response: %w", err)
+		w.HandleError(wrappedErr.Error())
+		return wrappedErr
 	}
 	return nil
 }

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -224,14 +224,16 @@ func (we *WalletExtension) handleRequestWS(resp http.ResponseWriter, req *http.R
 	if err != nil {
 		return
 	}
-	fun(userConn)
+	// We handle requests in a loop until the connection is closed on the client side.
+	for !userConn.IsClosed() {
+		fun(userConn)
+	}
 }
 
 // Encrypts the Ethereum JSON-RPC request, forwards it to the Obscuro node over a websocket, and decrypts the response if needed.
 func (we *WalletExtension) handleEthJSON(userConn userconn.UserConn) {
 	body, err := userConn.ReadRequest()
 	if err != nil {
-		userConn.HandleError(err.Error())
 		return
 	}
 
@@ -277,7 +279,6 @@ func (we *WalletExtension) handleEthJSON(userConn userconn.UserConn) {
 
 	err = userConn.WriteResponse(rpcRespToSend)
 	if err != nil {
-		userConn.HandleError(err.Error())
 		return
 	}
 }
@@ -357,7 +358,6 @@ func parseRequest(body []byte) (*accountmanager.RPCRequest, error) {
 func (we *WalletExtension) handleGenerateViewingKey(userConn userconn.UserConn) {
 	body, err := userConn.ReadRequest()
 	if err != nil {
-		userConn.HandleError(err.Error())
 		return
 	}
 
@@ -388,7 +388,6 @@ func (we *WalletExtension) handleGenerateViewingKey(userConn userconn.UserConn) 
 	viewingKeyHex := hex.EncodeToString(viewingKeyBytes)
 	err = userConn.WriteResponse([]byte(viewingKeyHex))
 	if err != nil {
-		userConn.HandleError(fmt.Sprintf("could not return viewing key public key hex to client: %s", err))
 		return
 	}
 }
@@ -397,7 +396,6 @@ func (we *WalletExtension) handleGenerateViewingKey(userConn userconn.UserConn) 
 func (we *WalletExtension) handleSubmitViewingKey(userConn userconn.UserConn) {
 	body, err := userConn.ReadRequest()
 	if err != nil {
-		userConn.HandleError(err.Error())
 		return
 	}
 
@@ -441,7 +439,6 @@ func (we *WalletExtension) handleSubmitViewingKey(userConn userconn.UserConn) {
 
 	err = userConn.WriteResponse([]byte(successMsg))
 	if err != nil {
-		userConn.HandleError(fmt.Sprintf("could not return viewing key public key hex to client: %s", err))
 		return
 	}
 }


### PR DESCRIPTION
### Why is this change needed?

Previously, we closed the websocket connection after each request. This was breaking the e2e tests, which expected to be able to funnel multiple requests over a single websocket.

Also took the opportunity to wrap more of the error handling inside `userconn.go`.

### What changes were made as part of this PR:

- Provide a high level list of the changes made
- List key areas for the reviewer 

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
