### PR TITLE
Fixes start block of subscription.

### DIFF
--- a/go/enclave/events/subscription_manager.go
+++ b/go/enclave/events/subscription_manager.go
@@ -67,7 +67,7 @@ func (s *SubscriptionManager) AddSubscription(id gethrpc.ID, encryptedSubscripti
 	subscription.Filter.BlockHash = nil
 	subscription.Filter.ToBlock = nil
 	// We set this to the current rollup height, so that historical logs aren't returned.
-	subscription.Filter.FromBlock = s.storage.FetchHeadRollup().Number()
+	subscription.Filter.FromBlock = big.NewInt(0).Add(s.storage.FetchHeadRollup().Number(), big.NewInt(1))
 
 	s.subscriptions[id] = &subscription
 	return nil


### PR DESCRIPTION
### Why is this change needed?

We were starting the subscriptions from the current block, not the next block. This does not align with the Geth API.

### What changes were made as part of this PR:

- Provide a high level list of the changes made
- List key areas for the reviewer 

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
