### PR TITLE
Avoids panicking if a subscription has been removed.

### DIFF
--- a/go/enclave/events/subscription_manager.go
+++ b/go/enclave/events/subscription_manager.go
@@ -146,7 +146,7 @@ func (s *SubscriptionManager) EncryptLogs(logsByRollupByID common.LogsByRollupBy
 	for subID, logByRollupNum := range logsByRollupByID {
 		subscription, found := s.subscriptions[subID]
 		if !found {
-			return nil, fmt.Errorf("could not find subscription with ID %s", subID)
+			continue
 		}
 
 		encLogsByRollup := map[uint64][]byte{}


### PR DESCRIPTION
### Why is this change needed?

It's a completely normal occurrence for the subscription to have been removed (i.e. unsubscribe has been called) before we can get around to encrypting the subscription results. It's fine to ignore this when it happens.

### What changes were made as part of this PR:

- Provide a high level list of the changes made
- List key areas for the reviewer 

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
