### PR TITLE
Move filtering out of already-seen logs from host to enclave

### DIFF
--- a/go/common/enclave.go
+++ b/go/common/enclave.go
@@ -121,7 +121,7 @@ type BlockSubmissionResponse struct {
 
 	ProducedSecretResponses []*ProducedSecretResponse // if L1 block contained secret requests then there may be responses to publish
 
-	SubscribedLogs EncLogsByRollupByID // The logs produced by the block and all its ancestors for each subscription ID.
+	SubscribedLogs map[rpc.ID][]byte // The logs produced by the block and all its ancestors for each subscription ID.
 }
 
 // ProducedSecretResponse contains the data to publish to L1 in response to a secret request discovered while processing an L1 block

--- a/go/common/logs.go
+++ b/go/common/logs.go
@@ -17,6 +17,8 @@ type LogSubscription struct {
 	Signature *[]byte
 	// A subscriber-defined filter to apply to the stream of logs.
 	Filter *filters.FilterCriteria
+	// Used to track which rollups the subscription has already been sent logs for.
+	LastSeenRollup uint64
 }
 
 // IDAndEncLog pairs an encrypted log with the ID of the subscription that generated it.

--- a/go/common/logs.go
+++ b/go/common/logs.go
@@ -33,12 +33,6 @@ type IDAndLog struct {
 	Log   *types.Log
 }
 
-// LogsByRollupByID is a double-map from subscription IDs to rollup numbers to logs generated in that rollup.
-type LogsByRollupByID = map[rpc.ID]map[uint64][]*types.Log
-
-// EncLogsByRollupByID is identical to LogsByRollupByID, but with the logs encrypted as bytes.
-type EncLogsByRollupByID = map[rpc.ID]map[uint64][]byte
-
 // FilterCriteriaJSON is a structure that JSON-serialises to a format that can be successfully deserialised into a
 // filters.FilterCriteria object (round-tripping a filters.FilterCriteria to JSON and back doesn't work, due to a
 // custom serialiser implemented by filters.FilterCriteria).

--- a/go/common/rpc/converters.go
+++ b/go/common/rpc/converters.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/ethereum/go-ethereum/rpc"
+
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/obscuronet/go-obscuro/go/common"
@@ -77,7 +79,7 @@ func FromSecretRespMsg(secretResponses []*generated.SecretResponseMsg) []*common
 }
 
 func FromBlockSubmissionResponseMsg(msg *generated.BlockSubmissionResponseMsg) (common.BlockSubmissionResponse, error) {
-	var subscribedLogs common.EncLogsByRollupByID
+	var subscribedLogs map[rpc.ID][]byte
 	if err := json.Unmarshal(msg.SubscribedLogs, &subscribedLogs); err != nil {
 		return common.BlockSubmissionResponse{}, fmt.Errorf("could not unmarshal subscribed logs from JSON. Cause: %w", err)
 	}

--- a/go/enclave/events/subscription_manager.go
+++ b/go/enclave/events/subscription_manager.go
@@ -29,6 +29,8 @@ const (
 	zeroBytesHex = "000000000000000000000000"
 )
 
+// TODO - Ensure chain reorgs are handled gracefully.
+
 // SubscriptionManager manages the creation/deletion of subscriptions, and the filtering and encryption of logs for
 // active subscriptions.
 type SubscriptionManager struct {

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -119,7 +119,7 @@ func (rc *RollupChain) noBlockStateBlockSubmissionResponse(block *types.Block) c
 	}
 }
 
-func (rc *RollupChain) newBlockSubmissionResponse(bs *obscurocore.BlockState, rollup common.ExtRollup, logs common.EncLogsByRollupByID) common.BlockSubmissionResponse {
+func (rc *RollupChain) newBlockSubmissionResponse(bs *obscurocore.BlockState, rollup common.ExtRollup, logs map[gethrpc.ID][]byte) common.BlockSubmissionResponse {
 	headRollup, f := rc.storage.FetchRollup(bs.HeadRollup)
 	if !f {
 		log.Panic(msgNoRollup)
@@ -151,7 +151,7 @@ func (rc *RollupChain) isGenesisBlock(block *types.Block) bool {
 //  STATE
 
 // Recursively calculates the state, logs and subscribed logs for the given block.
-func (rc *RollupChain) updateState(b *types.Block) (*obscurocore.BlockState, []*types.Log, common.LogsByRollupByID) {
+func (rc *RollupChain) updateState(b *types.Block) (*obscurocore.BlockState, []*types.Log, map[gethrpc.ID][]*types.Log) {
 	// This method is called recursively in case of Re-orgs. Stop when state was calculated already.
 	blockState, _, found := rc.storage.FetchBlockState(b.Hash())
 	if found {

--- a/go/host/events/logs.go
+++ b/go/host/events/logs.go
@@ -30,18 +30,15 @@ func (l *LogEventManager) RemoveSubscription(id rpc.ID) {
 	}
 }
 
-// SendLogsToSubscribers distributes logs to subscribed clients. We only send logs for rollups the subscription hasn't seen before.
+// SendLogsToSubscribers distributes logs to subscribed clients.
 func (l *LogEventManager) SendLogsToSubscribers(result common.BlockSubmissionResponse) {
 	// todo - joel - stop sending over mapped by rollup number
-	for subscriptionID, encLogsByRollup := range result.SubscribedLogs {
+	for subscriptionID, encryptedLogs := range result.SubscribedLogs {
 		logSub, found := l.subscriptions[subscriptionID]
 		if !found {
 			continue
 		}
-
-		for _, encryptedLogs := range encLogsByRollup {
-			logSub.ch <- encryptedLogs
-		}
+		logSub.ch <- encryptedLogs
 	}
 }
 

--- a/go/rpc/encrypted_client.go
+++ b/go/rpc/encrypted_client.go
@@ -213,8 +213,9 @@ func (c *EncRPCClient) createAuthenticatedLogSubscription(args []interface{}) (*
 	}
 
 	logSubscription := &common.LogSubscription{
-		Account:   c.Account(),
-		Signature: &accountSignature,
+		Account:        c.Account(),
+		Signature:      &accountSignature,
+		LastSeenRollup: 0,
 	}
 
 	// If there are less than two arguments, it means no filter criteria was passed.


### PR DESCRIPTION
### Why is this change needed?

Currently, we send all logs over RPC, only to drop the already-seen ones on the host. It's much more efficient to discard the already-seen ones on the enclave.

### What changes were made as part of this PR:

- Provide a high level list of the changes made
- List key areas for the reviewer 

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
