### PR TITLE
Allow the wallet extension persistence path to be set on the cli

### DIFF
--- a/docs/wallet-extension/wallet-extension.md
+++ b/docs/wallet-extension/wallet-extension.md
@@ -59,6 +59,8 @@ tools.
    * `nodePortHTTP` (default: `13000`): The Obscuro node's HTTP RPC port.
    * `nodePortWS` (default: `13001`): The Obscuro node's websockets RPC port.
    * `logPath` (default: `wallet_extension_logs.txt`): The path for the wallet extension's logs.
+   * `persistencePath` (default: `~/.obscuro/wallet_extension_persistence`): The path to use for the wallet extension's 
+      persistence file. 
 
    The wallet extension is now listening on the specified host and port. For the remainder of this document, we'll 
    assume that the default ports of `3000` and `3001` were selected.

--- a/tools/walletextension/main/cli.go
+++ b/tools/walletextension/main/cli.go
@@ -32,6 +32,10 @@ const (
 	logPathName    = "logPath"
 	logPathDefault = "wallet_extension_logs.txt"
 	logPathUsage   = "The path to use for the wallet extension's log file"
+
+	persistencePathName    = "persistencePath"
+	persistencePathDefault = ""
+	persistencePathUsage   = "The path for the wallet extension's persistence file. Default: ~/.obscuro/wallet_extension_persistence"
 )
 
 func parseCLIArgs() walletextension.Config {
@@ -41,6 +45,7 @@ func parseCLIArgs() walletextension.Config {
 	nodeHTTPPort := flag.Int(nodeHTTPPortName, nodeHTTPPortDefault, nodeHTTPPortUsage)
 	nodeWebsocketPort := flag.Int(nodeWebsocketPortName, nodeWebsocketPortDefault, nodeWebsocketPortUsage)
 	logPath := flag.String(logPathName, logPathDefault, logPathUsage)
+	persistencePath := flag.String(persistencePathName, persistencePathDefault, persistencePathUsage)
 	flag.Parse()
 
 	return walletextension.Config{
@@ -49,5 +54,6 @@ func parseCLIArgs() walletextension.Config {
 		NodeRPCHTTPAddress:      fmt.Sprintf("%s:%d", *nodeHost, *nodeHTTPPort),
 		NodeRPCWebsocketAddress: fmt.Sprintf("%s:%d", *nodeHost, *nodeWebsocketPort),
 		LogPath:                 *logPath,
+		PersistencePathOverride: *persistencePath,
 	}
 }


### PR DESCRIPTION
### Why is this change needed?

- As part of the end to end testing I need to run multiple wallet extensions concurrently. At the moment the wallet extension persistence file is not exposed at the cli to allow setting, which makes it a single point of contention. This PR exposes setting the persistence file location. 

### What changes were made as part of this PR:

- CLI parsing and docs 

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [x] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
