### PR TITLE
Do not calculate subscribed logs on every step on `rollup_chain.go/update_state()`

### DIFF
--- a/go/enclave/events/subscription_manager.go
+++ b/go/enclave/events/subscription_manager.go
@@ -116,16 +116,16 @@ func (s *SubscriptionManager) FilteredLogs(logs []*types.Log, rollupHash common.
 	return filteredLogs
 }
 
-// EncryptFilteredLogs filters the logs based on the current subscriptions, then encrypts them the appropriate viewing
-// keys.
-func (s *SubscriptionManager) EncryptFilteredLogs(logs []*types.Log, rollupHash common.L2RootHash) (map[gethrpc.ID][]byte, error) {
-	filteredLogs := s.getFilteredLogs(logs, rollupHash)
+// EncryptSubscribedLogs filters the logs based on the current subscriptions, then encrypts them the appropriate
+// viewing keys.
+func (s *SubscriptionManager) EncryptSubscribedLogs(logs []*types.Log, rollupHash common.L2RootHash) (map[gethrpc.ID][]byte, error) {
+	filteredLogs := s.getSubscribedLogs(logs, rollupHash)
 	return s.encryptLogs(filteredLogs)
 }
 
 // Filters out irrelevant logs, those that are not subscribed to, and those a subscription has seen before, and
 // organises them by their subscribing ID.
-func (s *SubscriptionManager) getFilteredLogs(logs []*types.Log, rollupHash common.L2RootHash) map[gethrpc.ID][]*types.Log {
+func (s *SubscriptionManager) getSubscribedLogs(logs []*types.Log, rollupHash common.L2RootHash) map[gethrpc.ID][]*types.Log {
 	relevantLogsByID := map[gethrpc.ID][]*types.Log{}
 	lastSeenRollupByID := map[gethrpc.ID]uint64{}
 

--- a/go/enclave/events/subscription_manager.go
+++ b/go/enclave/events/subscription_manager.go
@@ -116,9 +116,16 @@ func (s *SubscriptionManager) FilteredLogs(logs []*types.Log, rollupHash common.
 	return filteredLogs
 }
 
-// FilteredSubscribedLogs filters out irrelevant logs, those that are not subscribed to, and those a subscription has
-// seen before, and organises them by their subscribing ID.
-func (s *SubscriptionManager) FilteredSubscribedLogs(logs []*types.Log, rollupHash common.L2RootHash) map[gethrpc.ID][]*types.Log {
+// EncryptFilteredLogs filters the logs based on the current subscriptions, then encrypts them the appropriate viewing
+// keys.
+func (s *SubscriptionManager) EncryptFilteredLogs(logs []*types.Log, rollupHash common.L2RootHash) (map[gethrpc.ID][]byte, error) {
+	filteredLogs := s.getFilteredLogs(logs, rollupHash)
+	return s.encryptLogs(filteredLogs)
+}
+
+// Filters out irrelevant logs, those that are not subscribed to, and those a subscription has seen before, and
+// organises them by their subscribing ID.
+func (s *SubscriptionManager) getFilteredLogs(logs []*types.Log, rollupHash common.L2RootHash) map[gethrpc.ID][]*types.Log {
 	relevantLogsByID := map[gethrpc.ID][]*types.Log{}
 	lastSeenRollupByID := map[gethrpc.ID]uint64{}
 
@@ -147,8 +154,8 @@ func (s *SubscriptionManager) FilteredSubscribedLogs(logs []*types.Log, rollupHa
 	return relevantLogsByID
 }
 
-// EncryptLogs encrypts each log with the appropriate viewing key.
-func (s *SubscriptionManager) EncryptLogs(logsByID map[gethrpc.ID][]*types.Log) (map[gethrpc.ID][]byte, error) {
+// Encrypts each log with the appropriate viewing key.
+func (s *SubscriptionManager) encryptLogs(logsByID map[gethrpc.ID][]*types.Log) (map[gethrpc.ID][]byte, error) {
 	encryptedLogsByID := map[gethrpc.ID][]byte{}
 
 	for subID, logs := range logsByID {

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -447,7 +447,7 @@ func (rc *RollupChain) SubmitBlock(block types.Block, isLatest bool) common.Bloc
 		return rc.noBlockStateBlockSubmissionResponse(&block)
 	}
 
-	encryptedLogs, err := rc.subscriptionManager.EncryptFilteredLogs(logs, blockState.HeadRollup)
+	encryptedLogs, err := rc.subscriptionManager.EncryptSubscribedLogs(logs, blockState.HeadRollup)
 	if err != nil {
 		log.Panic("Could not encrypt logs. Cause: %s", err)
 	}

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -150,9 +150,9 @@ func (rc *RollupChain) isGenesisBlock(block *types.Block) bool {
 
 //  STATE
 
-// Recursively calculates the state, logs and subscribed logs for the given block.
+// Recursively calculates the state and logs for the given block.
 func (rc *RollupChain) updateState(b *types.Block) (*obscurocore.BlockState, []*types.Log) {
-	// This method is called recursively in case of Re-orgs. Stop when state was calculated already.
+	// This method is called recursively in case of re-orgs. Stop when state was calculated already.
 	blockState, _, found := rc.storage.FetchBlockState(b.Hash())
 	if found {
 		return blockState, nil

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -447,8 +447,7 @@ func (rc *RollupChain) SubmitBlock(block types.Block, isLatest bool) common.Bloc
 		return rc.noBlockStateBlockSubmissionResponse(&block)
 	}
 
-	subscribedLogs := rc.subscriptionManager.FilteredSubscribedLogs(logs, blockState.HeadRollup)
-	encryptedLogs, err := rc.subscriptionManager.EncryptLogs(subscribedLogs)
+	encryptedLogs, err := rc.subscriptionManager.EncryptFilteredLogs(logs, blockState.HeadRollup)
 	if err != nil {
 		log.Panic("Could not encrypt logs. Cause: %s", err)
 	}


### PR DESCRIPTION
### Why is this change needed?

Previously, the subscribed logs were calculated at every recursive step of `rollup_chain.go/update_state()`. This was unnecessary and made the method signature of `update_state()` too complex.

### What changes were made as part of this PR:

- Provide a high level list of the changes made
- List key areas for the reviewer 

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
