### PR TITLE
Don't store last seen rollup per subscription

### DIFF
--- a/go/common/logs.go
+++ b/go/common/logs.go
@@ -17,8 +17,6 @@ type LogSubscription struct {
 	Signature *[]byte
 	// A subscriber-defined filter to apply to the stream of logs.
 	Filter *filters.FilterCriteria
-	// Used to track which rollups the subscription has already been sent logs for.
-	LastSeenRollup uint64
 }
 
 // IDAndEncLog pairs an encrypted log with the ID of the subscription that generated it.

--- a/go/enclave/events/subscription_manager.go
+++ b/go/enclave/events/subscription_manager.go
@@ -234,7 +234,8 @@ func userAddrsContainAccount(account *gethcommon.Address, userAddrs []string) bo
 	return false
 }
 
-// Applies `filterLogs`, below, to determine whether the log should be filtered out based on the user's subscription criteria.
+// Applies `filterLogs`, below, to determine whether the log should be filtered out based on the user's subscription
+// criteria.
 func logMatchesFilter(log *types.Log, filterCriteria *filters.FilterCriteria) bool {
 	filteredLogs := filterLogs([]*types.Log{log}, filterCriteria.FromBlock, filterCriteria.ToBlock, filterCriteria.Addresses, filterCriteria.Topics)
 	return len(filteredLogs) != 0

--- a/go/enclave/events/subscription_manager.go
+++ b/go/enclave/events/subscription_manager.go
@@ -109,7 +109,7 @@ func (s *SubscriptionManager) FilterLogs(logs []*types.Log, rollupHash common.L2
 
 	for _, logItem := range logs {
 		userAddrs := getUserAddrsFromLogTopics(logItem, stateDB)
-		if userAddrsContainAccount(account, userAddrs) && logMatchesFilter(logItem, filter) {
+		if isRelevant(logItem, userAddrs, account, filter) {
 			filteredLogs = append(filteredLogs, logItem)
 		}
 	}
@@ -201,7 +201,7 @@ func (s *SubscriptionManager) updateRelevantLogs(logItem *types.Log, userAddrs [
 
 	for subscriptionID, subscription := range s.subscriptions {
 		// We ignore irrelevant logs.
-		if !isRelevant(logItem, userAddrs, subscription) {
+		if !isRelevant(logItem, userAddrs, subscription.Account, subscription.Filter) {
 			continue
 		}
 
@@ -214,8 +214,8 @@ func (s *SubscriptionManager) updateRelevantLogs(logItem *types.Log, userAddrs [
 }
 
 // Indicates whether the log is relevant for the subscription.
-func isRelevant(logItem *types.Log, userAddrs []string, subscription *common.LogSubscription) bool {
-	return userAddrsContainAccount(subscription.Account, userAddrs) && logMatchesFilter(logItem, subscription.Filter)
+func isRelevant(logItem *types.Log, userAddrs []string, account *gethcommon.Address, filter *filters.FilterCriteria) bool {
+	return userAddrsContainAccount(account, userAddrs) && logMatchesFilter(logItem, filter)
 }
 
 // Indicates whether the account is contained in the user addresses.

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -150,12 +150,13 @@ func (rc *RollupChain) isGenesisBlock(block *types.Block) bool {
 
 //  STATE
 
+// todo - joel - update description here
 // Recursively calculates the state and logs for the given block.
-func (rc *RollupChain) updateState(b *types.Block) (*obscurocore.BlockState, []*types.Log) {
+func (rc *RollupChain) updateState(b *types.Block) (*obscurocore.BlockState, []*types.Log, []*types.Log) {
 	// This method is called recursively in case of re-orgs. Stop when state was calculated already.
 	blockState, _, found := rc.storage.FetchBlockState(b.Hash())
 	if found {
-		return blockState, nil
+		return blockState, nil, nil
 	}
 
 	rollups := rc.bridge.ExtractRollups(b, rc.storage)
@@ -163,27 +164,27 @@ func (rc *RollupChain) updateState(b *types.Block) (*obscurocore.BlockState, []*
 
 	// processing blocks before genesis, so there is nothing to do
 	if genesisRollup == nil && len(rollups) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	// Detect if the incoming block contains the genesis rollup, and generate an updated state.
 	// Handles the case of the block containing the genesis being processed multiple times.
 	genesisState, isGenesis := rc.handleGenesisRollup(b, rollups, genesisRollup)
 	if isGenesis {
-		return genesisState, nil
+		return genesisState, nil, nil
 	}
 
 	// To calculate the state after the current block, we need the state after the parent.
 	// If this point is reached, there is a parent state guaranteed, because the genesis is handled above
-	parentState, logs, parentFound := rc.storage.FetchBlockState(b.ParentHash())
+	parentState, allLogs, parentFound := rc.storage.FetchBlockState(b.ParentHash())
 	if !parentFound {
 		// go back and calculate the Root of the Parent
 		parent, found := rc.storage.FetchBlock(b.ParentHash())
 		if !found {
 			common.LogWithID(rc.nodeID, "Could not find block parent. This should not happen.")
-			return nil, nil
+			return nil, nil, nil
 		}
-		parentState, logs = rc.updateState(parent)
+		parentState, allLogs, _ = rc.updateState(parent)
 	}
 
 	if parentState == nil {
@@ -192,7 +193,7 @@ func (rc *RollupChain) updateState(b *types.Block) (*obscurocore.BlockState, []*
 			common.ShortHash(b.Hash()),
 			common.ShortHash(b.Header().ParentHash),
 		)
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	bs, head, receipts := rc.calculateBlockState(b, parentState, rollups)
@@ -201,13 +202,15 @@ func (rc *RollupChain) updateState(b *types.Block) (*obscurocore.BlockState, []*
 		bs.FoundNewRollup,
 		common.ShortHash(bs.HeadRollup))
 
+	newLogs := []*types.Log{}
 	for _, receipt := range receipts {
-		logs = append(logs, receipt.Logs...)
+		newLogs = append(newLogs, receipt.Logs...)
 	}
+	allLogs = append(allLogs, newLogs...)
 
-	rc.storage.SaveNewHead(bs, head, receipts, logs)
+	rc.storage.SaveNewHead(bs, head, receipts, allLogs)
 
-	return bs, logs
+	return bs, allLogs, newLogs
 }
 
 func (rc *RollupChain) handleGenesisRollup(b *types.Block, rollups []*obscurocore.Rollup, genesisRollup *obscurocore.Rollup) (genesisState *obscurocore.BlockState, isGenesis bool) {
@@ -442,12 +445,12 @@ func (rc *RollupChain) SubmitBlock(block types.Block, isLatest bool) common.Bloc
 	}
 
 	common.TraceWithID(rc.nodeID, "Update state: b_%d", common.ShortHash(block.Hash()))
-	blockState, logs := rc.updateState(&block)
+	blockState, _, newLogs := rc.updateState(&block)
 	if blockState == nil {
 		return rc.noBlockStateBlockSubmissionResponse(&block)
 	}
 
-	encryptedLogs, err := rc.subscriptionManager.GetSubscribedLogsEncrypted(logs, blockState.HeadRollup)
+	encryptedLogs, err := rc.subscriptionManager.GetSubscribedLogsEncrypted(newLogs, blockState.HeadRollup)
 	if err != nil {
 		log.Panic("Could not get subscribed logs in encrypted form. Cause: %s", err)
 	}

--- a/go/rpc/encrypted_client.go
+++ b/go/rpc/encrypted_client.go
@@ -213,9 +213,8 @@ func (c *EncRPCClient) createAuthenticatedLogSubscription(args []interface{}) (*
 	}
 
 	logSubscription := &common.LogSubscription{
-		Account:        c.Account(),
-		Signature:      &accountSignature,
-		LastSeenRollup: 0,
+		Account:   c.Account(),
+		Signature: &accountSignature,
 	}
 
 	// If there are less than two arguments, it means no filter criteria was passed.


### PR DESCRIPTION
### Why is this change needed?

When I first implemented subscriptions, I thought subscriptions could also be used to return historical logs (e.g. subscribing from index `head - 100`). This meant we had to track which logs a subscription had been sent, to ensure it had "caught up" to the head without redelivering logs.

In practice, the `eth_subscribe` API is only for new subscriptions, so we can drop this mechanism.

### What changes were made as part of this PR:

- Provide a high level list of the changes made
- List key areas for the reviewer 

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
