### PR TITLE
Add better user address checks

### DIFF
--- a/go/enclave/events/subscription_manager.go
+++ b/go/enclave/events/subscription_manager.go
@@ -176,8 +176,8 @@ func getUserAddrsFromLogTopics(log *types.Log, db *state.StateDB) []string {
 	for _, topic := range log.Topics {
 		potentialAddr := gethcommon.HexToAddress(topic.Hex())
 
-		// A user address must have (at least) 12 leading zero bytes (since addresses are 20 bytes long, while hashes
-		// are 32).
+		// A user address must have (at least) 12 leading zero bytes, since addresses are 20 bytes long, while hashes
+		// are 32.
 		if topic.Hex()[2:len(zeroBytesHex)+2] != zeroBytesHex {
 			continue
 		}

--- a/go/enclave/events/subscription_manager.go
+++ b/go/enclave/events/subscription_manager.go
@@ -184,7 +184,7 @@ func getUserAddrsFromLogTopics(log *types.Log, db *state.StateDB) []string {
 
 		// A user address must exist in the state DB, and have a non-zero balance and nonce.
 		if db.Exist(potentialAddr) && db.GetBalance(potentialAddr).Cmp(big.NewInt(0)) != 0 && db.GetNonce(potentialAddr) != 0 {
-			// If the address has code, it's a smart contract address.
+			// If the address has code, it's a smart contract address instead.
 			if db.GetCode(potentialAddr) == nil {
 				userAddrs = append(userAddrs, potentialAddr.Hex())
 			}

--- a/go/enclave/events/subscription_manager.go
+++ b/go/enclave/events/subscription_manager.go
@@ -173,7 +173,12 @@ func (s *SubscriptionManager) encryptLogs(logsByID map[gethrpc.ID][]*types.Log) 
 func getUserAddrsFromLogTopics(log *types.Log, db *state.StateDB) []string {
 	var userAddrs []string
 
-	for _, topic := range log.Topics {
+	for idx, topic := range log.Topics {
+		// The first topic is always the hash of the event.
+		if idx == 0 {
+			continue
+		}
+
 		potentialAddr := gethcommon.HexToAddress(topic.Hex())
 
 		// A user address must have (at least) 12 leading zero bytes, since addresses are 20 bytes long, while hashes

--- a/go/enclave/events/subscription_manager.go
+++ b/go/enclave/events/subscription_manager.go
@@ -169,8 +169,7 @@ func (s *SubscriptionManager) encryptLogs(logsByID map[gethrpc.ID][]*types.Log) 
 	return encryptedLogsByID, nil
 }
 
-// Extracts the (potential) user addresses from the topics. An address is considered a user address if it exists in the
-// state, there is no code associated with the address, and it has at least 12 leading zero bytes.
+// Extracts the user addresses from the topics.
 func getUserAddrsFromLogTopics(log *types.Log, db *state.StateDB) []string {
 	var userAddrs []string //nolint:prealloc
 
@@ -178,19 +177,18 @@ func getUserAddrsFromLogTopics(log *types.Log, db *state.StateDB) []string {
 		topicHex := topic.Hex()
 		potentialAddr := gethcommon.HexToAddress(topicHex)
 
-		// If the potential account address does not exist in the state, it is not a user address.
-		if !db.Exist(potentialAddr) {
-			continue
-		}
-
-		// If there is code associated with the address, it is not a user address.
-		if db.GetCode(potentialAddr) != nil {
-			continue
-		}
-
 		// Since addresses are 20 bytes long, while hashes are 32, only topics with 12 leading zero bytes can
 		// (potentially) be user addresses.
 		if topicHex[2:len(zeroBytesHex)+2] != zeroBytesHex {
+			continue
+		}
+
+		// We also assume that a potential address is *not* a user address if any of the following is true:
+		// * It does not exist in the state
+		// * It has a zero balance
+		// * It has a zero nonce
+		// * It has associated code
+		if !db.Exist(potentialAddr) || db.GetBalance(potentialAddr) == big.NewInt(0) || db.GetNonce(potentialAddr) == 0 || db.GetCode(potentialAddr) != nil {
 			continue
 		}
 

--- a/go/enclave/events/subscription_manager.go
+++ b/go/enclave/events/subscription_manager.go
@@ -182,8 +182,8 @@ func getUserAddrsFromLogTopics(log *types.Log, db *state.StateDB) []string {
 			continue
 		}
 
-		// A user address must exist in the state DB, and have a non-zero balance and nonce.
-		if db.Exist(potentialAddr) && db.GetBalance(potentialAddr).Cmp(big.NewInt(0)) != 0 && db.GetNonce(potentialAddr) != 0 {
+		// A user address must exist in the state DB.
+		if db.Exist(potentialAddr) {
 			// If the address has code, it's a smart contract address instead.
 			if db.GetCode(potentialAddr) == nil {
 				userAddrs = append(userAddrs, potentialAddr.Hex())

--- a/integration/datagenerator/wallet.go
+++ b/integration/datagenerator/wallet.go
@@ -1,7 +1,6 @@
 package datagenerator
 
 import (
-	"crypto/rand"
 	"encoding/hex"
 
 	"github.com/obscuronet/go-obscuro/go/config"
@@ -11,10 +10,7 @@ import (
 
 // RandomWallet returns a wallet with a random private key
 func RandomWallet(chainID int64) wallet.Wallet {
-	pk, err := randomHex(32)
-	if err != nil {
-		panic(err) // this should never panic - world should stop if it does
-	}
+	pk := randomHex(32)
 	walletConfig := config.HostConfig{
 		PrivateKeyString: pk,
 		L1ChainID:        chainID,
@@ -22,10 +18,6 @@ func RandomWallet(chainID int64) wallet.Wallet {
 	return wallet.NewInMemoryWalletFromConfig(walletConfig)
 }
 
-func randomHex(n int) (string, error) {
-	bytes := make([]byte, n)
-	if _, err := rand.Read(bytes); err != nil {
-		return "", err
-	}
-	return hex.EncodeToString(bytes), nil
+func randomHex(n int) string {
+	return hex.EncodeToString(RandomBytes(n))
 }

--- a/integration/ethereummock/mgmt_contract_lib.go
+++ b/integration/ethereummock/mgmt_contract_lib.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"encoding/gob"
 
+	"github.com/obscuronet/go-obscuro/integration/datagenerator"
+
 	"github.com/obscuronet/go-obscuro/go/ethadapter"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
@@ -15,11 +17,11 @@ import (
 )
 
 var (
-	depositTxAddr          = gethcommon.HexToAddress("0x01")
-	rollupTxAddr           = gethcommon.HexToAddress("0x02")
-	storeSecretTxAddr      = gethcommon.HexToAddress("0x03")
-	requestSecretTxAddr    = gethcommon.HexToAddress("0x04")
-	initializeSecretTxAddr = gethcommon.HexToAddress("0x05")
+	depositTxAddr          = datagenerator.RandomAddress()
+	rollupTxAddr           = datagenerator.RandomAddress()
+	storeSecretTxAddr      = datagenerator.RandomAddress()
+	requestSecretTxAddr    = datagenerator.RandomAddress()
+	initializeSecretTxAddr = datagenerator.RandomAddress()
 )
 
 // mockContractLib is an implementation of the mgmtcontractlib.MgmtContractLib

--- a/integration/simulation/network/inmemory.go
+++ b/integration/simulation/network/inmemory.go
@@ -3,11 +3,12 @@ package network
 import (
 	"time"
 
+	"github.com/obscuronet/go-obscuro/integration/datagenerator"
+
 	"github.com/obscuronet/go-obscuro/go/host"
 
 	"github.com/obscuronet/go-obscuro/go/enclave/bridge"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/obscuronet/go-obscuro/integration/simulation/p2p"
 
 	"github.com/obscuronet/go-obscuro/go/rpc"
@@ -39,9 +40,9 @@ func (n *basicNetworkOfInMemoryNodes) Create(params *params.SimParams, stats *st
 	p2pLayers := make([]*p2p.MockP2P, params.NumberOfNodes)
 
 	// Invent some addresses to assign as the L1 erc20 contracts
-	dummyOBXAddress := common.HexToAddress("AA")
+	dummyOBXAddress := datagenerator.RandomAddress()
 	params.Wallets.Tokens[bridge.HOC].L1ContractAddress = &dummyOBXAddress
-	dummyETHAddress := common.HexToAddress("BB")
+	dummyETHAddress := datagenerator.RandomAddress()
 	params.Wallets.Tokens[bridge.POC].L1ContractAddress = &dummyETHAddress
 
 	for i := 0; i < params.NumberOfNodes; i++ {

--- a/integration/simulation/validate_chain.go
+++ b/integration/simulation/validate_chain.go
@@ -463,10 +463,15 @@ func assertLogsValid(t *testing.T, owner string, logs []*types.Log) {
 // Asserts that the log is relevant to the recipient (either a lifecycle event or a relevant user event).
 func assertRelevantLogsOnly(t *testing.T, owner string, receivedLog types.Log) {
 	// Since addresses are 20 bytes long, while hashes are 32, only topics with 12 leading zero bytes can (potentially)
-	// be user addresses. We filter these out. In theory, we should also check whether the topics are contract
-	// addresses, but in practice no events of this type are sent in the simulations.
+	// be user addresses. We filter these out. In theory, we should also check whether the topics exist in the state DB
+	// and are contract addresses, but we cannot do this as part of chain validation.
 	var userAddrs []string
-	for _, topic := range receivedLog.Topics {
+	for idx, topic := range receivedLog.Topics {
+		// The first topic is always the hash of the event.
+		if idx == 0 {
+			continue
+		}
+
 		// Since addresses are 20 bytes long, while hashes are 32, only topics with 12 leading zero bytes can
 		// (potentially) be user addresses.
 		topicHex := topic.Hex()


### PR DESCRIPTION
### Why is this change needed?

With the existing logic for checking whether an address is a user address, stuff like topic indices (e.g. `0x0000000000000000000000000000000000000002`) was being flagged as a user address.

We now only consider something to be a user address if:

* It exists in the state DB
* It has a non-zero balance
* It has a non-zero nonce

(On top of the existing checks - no associated code and at least twelve leading zero bytes).

### What changes were made as part of this PR:

- Provide a high level list of the changes made
- List key areas for the reviewer 

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
