### PR TITLE
Validates the returned JSON in the wallet extension tests.

### DIFF
--- a/tools/walletextension/test/utils.go
+++ b/tools/walletextension/test/utils.go
@@ -291,12 +291,12 @@ func assertNoDupeLogs(t *testing.T, logsJSON [][]byte) {
 	}
 }
 
-// Checks that the response to a subscription request is correctly-formatted.
-func validateSubscriptionResponse(t *testing.T, resp []byte) {
+// Checks that the response to a request is correctly formatted, and returns the result field.
+func validateJSONResponse(t *testing.T, resp []byte) interface{} {
 	var respJSON map[string]interface{}
 	err := json.Unmarshal(resp, &respJSON)
 	if err != nil {
-		t.Fatalf("could not unmarshal subscription response to JSON")
+		t.Fatalf("could not unmarshal response to JSON")
 	}
 
 	id := respJSON[common.JSONKeyID]
@@ -304,11 +304,21 @@ func validateSubscriptionResponse(t *testing.T, resp []byte) {
 	result := respJSON[common.JSONKeyResult]
 
 	if id != jsonID {
-		t.Fatalf("subscription response did not contain expected ID. Expected 1, got %s", id)
+		t.Fatalf("response did not contain expected ID. Expected 1, got %s", id)
 	}
 	if jsonRPCVersion != jsonrpc.Version {
-		t.Fatalf("subscription response did not contain expected RPC version. Expected 2.0, got %s", jsonRPCVersion)
+		t.Fatalf("response did not contain expected RPC version. Expected 2.0, got %s", jsonRPCVersion)
 	}
+	if result == nil {
+		t.Fatalf("response did not contain `result` field")
+	}
+
+	return result
+}
+
+// Checks that the response to a subscription request is correctly formatted.
+func validateSubscriptionResponse(t *testing.T, resp []byte) {
+	result := validateJSONResponse(t, resp)
 	pattern := "0x.*"
 	resultString, ok := result.(string)
 	if !ok || !regexp.MustCompile(pattern).MatchString(resultString) {

--- a/tools/walletextension/test/wallet_extension_test.go
+++ b/tools/walletextension/test/wallet_extension_test.go
@@ -35,6 +35,7 @@ func TestCanInvokeNonSensitiveMethodsWithoutViewingKey(t *testing.T) {
 	createWalExt(t, createWalExtCfg())
 
 	respBody, _ := makeWSEthJSONReq(rpc.RPCChainID, []interface{}{})
+	validateJSONResponse(t, respBody)
 
 	if !strings.Contains(string(respBody), l2ChainIDHex) {
 		t.Fatalf("expected response containing '%s', got '%s'", l2ChainIDHex, string(respBody))
@@ -48,7 +49,6 @@ func TestCannotInvokeSensitiveMethodsWithoutViewingKey(t *testing.T) {
 	for _, method := range rpc.SensitiveMethods {
 		// We use a websocket request because one of the sensitive methods, eth_subscribe, requires it.
 		respBody, _ := makeWSEthJSONReq(method, []interface{}{})
-
 		if !strings.Contains(string(respBody), fmt.Sprintf(accountmanager.ErrNoViewingKey, method)) {
 			t.Fatalf("expected response containing '%s', got '%s'", fmt.Sprintf(accountmanager.ErrNoViewingKey, method), string(respBody))
 		}
@@ -69,6 +69,7 @@ func TestCanInvokeSensitiveMethodsWithViewingKey(t *testing.T) {
 		}
 
 		respBody := makeHTTPEthJSONReq(method, []interface{}{map[string]interface{}{"params": dummyParams}})
+		validateJSONResponse(t, respBody)
 
 		if !strings.Contains(string(respBody), dummyParams) {
 			t.Fatalf("expected response containing '%s', got '%s'", dummyParams, string(respBody))
@@ -97,7 +98,6 @@ func TestCannotInvokeSensitiveMethodsWithViewingKeyForAnotherAccount(t *testing.
 		}
 
 		respBody := makeHTTPEthJSONReq(method, []interface{}{map[string]interface{}{}})
-
 		if !strings.Contains(string(respBody), errFailedDecrypt) {
 			t.Fatalf("expected response containing '%s', got '%s'", errFailedDecrypt, string(respBody))
 		}
@@ -120,6 +120,7 @@ func TestCanInvokeSensitiveMethodsAfterSubmittingMultipleViewingKeys(t *testing.
 	dummyAPI.setViewingKey(arbitraryViewingKey)
 
 	respBody := makeHTTPEthJSONReq(rpc.RPCGetBalance, []interface{}{map[string]interface{}{"params": dummyParams}})
+	validateJSONResponse(t, respBody)
 
 	if !strings.Contains(string(respBody), dummyParams) {
 		t.Fatalf("expected response containing '%s', got '%s'", dummyParams, string(respBody))
@@ -140,6 +141,7 @@ func TestCanCallWithoutSettingFromField(t *testing.T) {
 			"value": nil,
 			"Value": "",
 		}})
+		validateJSONResponse(t, respBody)
 
 		// RPCCall and RPCEstimateGas payload might be manipulated ( added the From field information )
 		if !strings.Contains(strings.ToLower(string(respBody)), strings.ToLower(vkAddress.Hex())) {
@@ -161,6 +163,7 @@ func TestKeysAreReloadedWhenWalletExtensionRestarts(t *testing.T) {
 	createWalExt(t, walExtCfg)
 
 	respBody := makeHTTPEthJSONReq(rpc.RPCGetBalance, []interface{}{map[string]interface{}{"params": dummyParams}})
+	validateJSONResponse(t, respBody)
 
 	if !strings.Contains(string(respBody), dummyParams) {
 		t.Fatalf("expected response containing '%s', got '%s'", dummyParams, string(respBody))
@@ -191,6 +194,7 @@ func TestCanRegisterViewingKeyAndMakeRequestsOverWebsockets(t *testing.T) {
 		}
 
 		respBody, _ := makeWSEthJSONReq(method, []interface{}{map[string]interface{}{"params": dummyParams}})
+		validateJSONResponse(t, respBody)
 
 		if !strings.Contains(string(respBody), dummyParams) {
 			t.Fatalf("expected response containing '%s', got '%s'", dummyParams, string(respBody))


### PR DESCRIPTION
### Why is this change needed?

Just another layer of checking that will flag if something breaks the format of the JSON returned by the WE.

### What changes were made as part of this PR:

- Provide a high level list of the changes made
- List key areas for the reviewer 

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
