### PR TITLE
Fix stuck subscription go routine in client

### DIFF
--- a/go/rpc/encrypted_client.go
+++ b/go/rpc/encrypted_client.go
@@ -199,9 +199,9 @@ func (c *EncRPCClient) forwardLogs(clientChannel chan common.IDAndEncLog, logCh 
 				logCh <- idAndLog
 			}
 
-		case <-subscription.Err():
-			log.Error("subscription closed")
-			break
+		case err := <-subscription.Err():
+			log.Error("subscription closed. Cause: %s", err)
+			return
 		}
 	}
 }


### PR DESCRIPTION
### Why is this change needed?

- Reduce noise that we sometimes see in logs when looking into sim issues:
```
Oct 19 15:43:45.533 ERR subscription closed
Oct 19 15:43:45.533 ERR subscription closed
Oct 19 15:43:45.533 ERR subscription closed
Oct 19 15:43:45.533 ERR subscription closed
```
- Might be causing stuck goroutines after simulation ends

### What changes were made as part of this PR:

- Small bugfix where we weren't breaking out of the subscription loop when the client has been closed

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
