### PR TITLE
Checks nonce to for user addresses.

### DIFF
--- a/go/enclave/events/subscription_manager.go
+++ b/go/enclave/events/subscription_manager.go
@@ -187,8 +187,9 @@ func getUserAddrsFromLogTopics(log *types.Log, db *state.StateDB) []string {
 			continue
 		}
 
-		// A user address must exist in the state DB.
-		if db.Exist(potentialAddr) {
+		// A user address must have a non-zero nonce. This prevents accidental or malicious sending of funds to an
+		// address matching a topic, forcing its events to become permanently private.
+		if db.GetNonce(potentialAddr) != 0 {
 			// If the address has code, it's a smart contract address instead.
 			if db.GetCode(potentialAddr) == nil {
 				userAddrs = append(userAddrs, potentialAddr.Hex())


### PR DESCRIPTION
### Why is this change needed?

A user address must have a non-zero nonce. This prevents accidental or malicious sending of funds to an address matching a topic, forcing its events to become permanently private.

### What changes were made as part of this PR:

- Provide a high level list of the changes made
- List key areas for the reviewer 

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
