### PR TITLE
Non-redundant log storage

### DIFF
--- a/go/enclave/db/interfaces.go
+++ b/go/enclave/db/interfaces.go
@@ -54,12 +54,14 @@ type RollupResolver interface {
 }
 
 type BlockStateStorage interface {
-	// FetchBlockState returns the block's state, all the logs up to this block in the chain, and a boolean indicating if the block was found.
-	FetchBlockState(blockHash common.L1RootHash) (*core.BlockState, []*types.Log, bool)
+	// FetchBlockState returns the block's state, and a boolean indicating if the block was found.
+	FetchBlockState(blockHash common.L1RootHash) (*core.BlockState, bool)
+	// FetchLogs returns the block's logs, and a boolean indicating if the block was found.
+	FetchLogs(blockHash common.L1RootHash) ([]*types.Log, bool)
 	// FetchHeadState returns the head block state. Returns nil if nothing recorded yet
 	FetchHeadState() *core.BlockState
-	// SaveNewHead saves the block state alongside its rollup, receipts and all the logs up to this block in the chain.
-	SaveNewHead(state *core.BlockState, rollup *core.Rollup, receipts []*types.Receipt, logs []*types.Log)
+	// StoreNewHead saves the block state alongside its rollup, receipts and logs.
+	StoreNewHead(state *core.BlockState, rollup *core.Rollup, receipts []*types.Receipt, logs []*types.Log)
 	// CreateStateDB creates a database that can be used to execute transactions
 	CreateStateDB(hash common.L2RootHash) *state.StateDB
 	// EmptyStateDB creates the original empty StateDB
@@ -74,22 +76,19 @@ type SharedSecretStorage interface {
 }
 
 type TransactionStorage interface {
-	// GetReceiptsByHash retrieves the receipts for all transactions in a given rollup.
-	GetReceiptsByHash(hash gethcommon.Hash) types.Receipts
-
 	// GetTransaction - returns the positional metadata of the tx by hash
 	GetTransaction(txHash gethcommon.Hash) (*types.Transaction, gethcommon.Hash, uint64, uint64, error)
-
 	// GetTransactionReceipt - returns the receipt of a tx by tx hash
 	GetTransactionReceipt(txHash gethcommon.Hash) (*types.Receipt, error)
-
+	// GetReceiptsByHash retrieves the receipts for all transactions in a given rollup.
+	GetReceiptsByHash(hash gethcommon.Hash) types.Receipts
+	// GetSender returns the sender of the tx by hash
 	GetSender(txHash gethcommon.Hash) (gethcommon.Address, error)
 }
 
 type AttestationStorage interface {
 	// FetchAttestedKey returns the public key of an attested aggregator, returns nil if not found
 	FetchAttestedKey(aggregator gethcommon.Address) *ecdsa.PublicKey
-
 	// StoreAttestedKey - store the public key of an attested aggregator
 	StoreAttestedKey(aggregator gethcommon.Address, key *ecdsa.PublicKey)
 }

--- a/go/enclave/db/rawdb/accessors_chain.go
+++ b/go/enclave/db/rawdb/accessors_chain.go
@@ -182,9 +182,9 @@ func ReadBlockState(kv ethdb.KeyValueReader, hash gethcommon.Hash) *core.BlockSt
 func WriteBlockLogs(db ethdb.KeyValueWriter, blockHash gethcommon.Hash, logs []*types.Log) {
 	// Geth serialises its logs in a reduced form to minimise storage space. For now, it is more straightforward for us
 	// to serialise all the fields by converting the logs to this type.
-	logsForStorage := []*logForStorage{}
-	for _, fullFatLog := range logs {
-		logsForStorage = append(logsForStorage, toLogForStorage(fullFatLog))
+	logsForStorage := make([]*logForStorage, len(logs))
+	for idx, fullFatLog := range logs {
+		logsForStorage[idx] = toLogForStorage(fullFatLog)
 	}
 
 	logBytes, err := rlp.EncodeToBytes(logsForStorage)

--- a/go/enclave/db/rawdb/accessors_chain.go
+++ b/go/enclave/db/rawdb/accessors_chain.go
@@ -182,9 +182,9 @@ func ReadBlockState(kv ethdb.KeyValueReader, hash gethcommon.Hash) *core.BlockSt
 func WriteBlockLogs(db ethdb.KeyValueWriter, blockHash gethcommon.Hash, logs []*types.Log) {
 	// Geth serialises its logs in a reduced form to minimise storage space. For now, it is more straightforward for us
 	// to serialise all the fields by converting the logs to this type.
-	logsForStorage := make([]*logForStorage, len(logs))
-	for idx, fullFatLog := range logs {
-		logsForStorage[idx] = toLogForStorage(fullFatLog)
+	logsForStorage := []*logForStorage{}
+	for _, fullFatLog := range logs {
+		logsForStorage = append(logsForStorage, toLogForStorage(fullFatLog))
 	}
 
 	logBytes, err := rlp.EncodeToBytes(logsForStorage)

--- a/go/enclave/db/storage.go
+++ b/go/enclave/db/storage.go
@@ -222,17 +222,23 @@ func (s *storageImpl) Proof(r *core.Rollup) *types.Block {
 	return v
 }
 
-func (s *storageImpl) FetchBlockState(hash common.L1RootHash) (*core.BlockState, []*types.Log, bool) {
+func (s *storageImpl) FetchBlockState(hash common.L1RootHash) (*core.BlockState, bool) {
 	bs := obscurorawdb.ReadBlockState(s.db, hash)
-	logs := obscurorawdb.ReadBlockLogs(s.db, hash)
-	// We expect both the block state and the logs to be stored. If one isn't, we return neither.
-	if bs != nil && logs != nil {
-		return bs, logs, true
+	if bs != nil {
+		return bs, true
 	}
-	return nil, nil, false
+	return nil, false
 }
 
-func (s *storageImpl) SaveNewHead(state *core.BlockState, rollup *core.Rollup, receipts []*types.Receipt, logs []*types.Log) {
+func (s *storageImpl) FetchLogs(hash common.L1RootHash) ([]*types.Log, bool) {
+	logs := obscurorawdb.ReadBlockLogs(s.db, hash)
+	if logs != nil {
+		return logs, true
+	}
+	return nil, false
+}
+
+func (s *storageImpl) StoreNewHead(state *core.BlockState, rollup *core.Rollup, receipts []*types.Receipt, logs []*types.Log) {
 	batch := s.db.NewBatch()
 
 	if state.FoundNewRollup {

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -614,7 +614,7 @@ func (e *enclaveImpl) GetLogs(encryptedParams common.EncryptedParamsGetLogs) (co
 	}
 
 	// We retrieve the relevant logs that match the filter.
-	filteredLogs, err := e.subscriptionManager.FilterHeadBlockLogs(forAddress, filter)
+	filteredLogs, err := e.subscriptionManager.GetFilteredLogs(forAddress, filter)
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve logs matching the filter. Cause: %w", err)
 	}

--- a/go/enclave/events/subscription_manager.go
+++ b/go/enclave/events/subscription_manager.go
@@ -93,6 +93,7 @@ func (s *SubscriptionManager) GetFilteredLogs(account *gethcommon.Address, filte
 	headBlock := s.storage.FetchHeadBlock()
 
 	// We collect all the block hashes in the canonical chain.
+	// TODO: Only collect blocks within the filter's range.
 	blockHashes := []gethcommon.Hash{}
 	currentBlock := headBlock
 	for {

--- a/go/enclave/events/subscription_manager.go
+++ b/go/enclave/events/subscription_manager.go
@@ -106,7 +106,7 @@ func (s *SubscriptionManager) GetFilteredLogs(account *gethcommon.Address, filte
 	for _, hash := range blockHashes {
 		blockLogs, found := s.storage.FetchLogs(hash)
 		if !found {
-			continue
+			continue // Some blocks do not have any block state or logs saved against them.
 		}
 		logs = append(logs, blockLogs...)
 	}

--- a/go/enclave/events/subscription_manager.go
+++ b/go/enclave/events/subscription_manager.go
@@ -94,7 +94,7 @@ func (s *SubscriptionManager) RemoveSubscription(id gethrpc.ID) {
 func (s *SubscriptionManager) GetFilteredLogs(account *gethcommon.Address, filter *filters.FilterCriteria) ([]*types.Log, error) {
 	headBlockHash := s.storage.FetchHeadBlock().Hash()
 	// todo - joel - need to return all logs here, and not just the latest
-	_, logs, found := s.storage.FetchBlockState(headBlockHash)
+	logs, found := s.storage.FetchLogs(headBlockHash)
 	if !found {
 		log.Error("could not retrieve logs for head state. Something is wrong")
 		return nil, fmt.Errorf("could not retrieve logs for head state. Something is wrong")

--- a/go/enclave/events/subscription_manager.go
+++ b/go/enclave/events/subscription_manager.go
@@ -110,7 +110,7 @@ func (s *SubscriptionManager) GetFilteredLogs(account *gethcommon.Address, filte
 		}
 	}
 
-	// We gather the logs across each block in the canonical chain.
+	// We gather the logs across all the blocks in the canonical chain.
 	logs := []*types.Log{}
 	for _, hash := range blockHashes {
 		blockLogs, found := s.storage.FetchLogs(hash)

--- a/go/enclave/events/subscription_manager.go
+++ b/go/enclave/events/subscription_manager.go
@@ -90,9 +90,10 @@ func (s *SubscriptionManager) RemoveSubscription(id gethrpc.ID) {
 	delete(s.subscriptions, id)
 }
 
-// FilterHeadBlockLogs returns the logs of the head block, filtered based on the provided account and filter.
-func (s *SubscriptionManager) FilterHeadBlockLogs(account *gethcommon.Address, filter *filters.FilterCriteria) ([]*types.Log, error) {
+// GetFilteredLogs returns the logs across the entire canonical chain that match the provided account and filter.
+func (s *SubscriptionManager) GetFilteredLogs(account *gethcommon.Address, filter *filters.FilterCriteria) ([]*types.Log, error) {
 	headBlockHash := s.storage.FetchHeadBlock().Hash()
+	// todo - joel - need to return all logs here, and not just the latest
 	_, logs, found := s.storage.FetchBlockState(headBlockHash)
 	if !found {
 		log.Error("could not retrieve logs for head state. Something is wrong")

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -445,10 +445,14 @@ func (rc *RollupChain) SubmitBlock(block types.Block, isLatest bool) common.Bloc
 		return rc.noBlockStateBlockSubmissionResponse(&block)
 	}
 
-	logs, found := rc.storage.FetchLogs(block.Hash())
-	if !found {
-		log.Panic("Could not retrieve logs for stored block state")
+	logs := []*types.Log{}
+	fetchedLogs, found := rc.storage.FetchLogs(block.Hash())
+	if found {
+		logs = fetchedLogs
+	} else {
+		log.Error("Could not retrieve logs for stored block state. Returning no logs")
 	}
+
 	encryptedLogs, err := rc.subscriptionManager.GetSubscribedLogsEncrypted(logs, blockState.HeadRollup)
 	if err != nil {
 		log.Panic("Could not get subscribed logs in encrypted form. Cause: %s", err)

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -180,19 +180,17 @@ func (rc *RollupChain) updateState(b *types.Block) (*obscurocore.BlockState, []*
 		// go back and calculate the Root of the Parent
 		parent, found := rc.storage.FetchBlock(b.ParentHash())
 		if !found {
-			common.LogWithID(rc.nodeID, "Could not find block parent. This should not happen.")
-			return nil, nil
+			log.Panic("Could not find parent block when calculating block state. This should not happen.")
 		}
 		parentState, _ = rc.updateState(parent)
 	}
 
 	if parentState == nil {
-		common.LogWithID(rc.nodeID, "Something went wrong. There should be a parent here, blockNum=%d. \n Block: %d, Block Parent: %d ",
+		log.Panic(fmt.Sprintf("Could not calculate parent block state when calculating block state. BlockNum=%d. \n Block: %d, Block Parent: %d ",
 			b.Number(),
 			common.ShortHash(b.Hash()),
 			common.ShortHash(b.Header().ParentHash),
-		)
-		return nil, nil
+		))
 	}
 
 	bs, head, receipts := rc.calculateBlockState(b, parentState, rollups)

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -227,7 +227,7 @@ func (rc *RollupChain) handleGenesisRollup(b *types.Block, rollups []*obscurocor
 			HeadRollup:     genesis.Hash(),
 			FoundNewRollup: true,
 		}
-		rc.storage.StoreNewHead(&bs, genesis, nil, nil)
+		rc.storage.StoreNewHead(&bs, genesis, nil, []*types.Log{})
 		err := rc.faucet.CalculateGenesisState(rc.storage)
 		if err != nil {
 			return nil, false

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -193,20 +193,19 @@ func (rc *RollupChain) updateState(b *types.Block) (*obscurocore.BlockState, []*
 		))
 	}
 
-	bs, head, receipts := rc.calculateBlockState(b, parentState, rollups)
+	blockState, head, receipts := rc.calculateBlockState(b, parentState, rollups)
 	common.TraceWithID(rc.nodeID, "Calc block state b_%d: Found: %t - r_%d, ",
 		common.ShortHash(b.Hash()),
-		bs.FoundNewRollup,
-		common.ShortHash(bs.HeadRollup))
+		blockState.FoundNewRollup,
+		common.ShortHash(blockState.HeadRollup))
 
-	newLogs := []*types.Log{}
+	logs := []*types.Log{}
 	for _, receipt := range receipts {
-		newLogs = append(newLogs, receipt.Logs...)
+		logs = append(logs, receipt.Logs...)
 	}
 
-	rc.storage.StoreNewHead(bs, head, receipts, newLogs)
-
-	return bs, newLogs
+	rc.storage.StoreNewHead(blockState, head, receipts, logs)
+	return blockState, logs
 }
 
 func (rc *RollupChain) handleGenesisRollup(b *types.Block, rollups []*obscurocore.Rollup, genesisRollup *obscurocore.Rollup) (genesisState *obscurocore.BlockState, isGenesis bool) {

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -150,12 +150,12 @@ func (rc *RollupChain) isGenesisBlock(block *types.Block) bool {
 
 //  STATE
 
-// Recursively calculates the block state, all the logs in the chain so far, and new logs for the given block.
-func (rc *RollupChain) updateState(b *types.Block) (*obscurocore.BlockState, []*types.Log, []*types.Log) {
+// Recursively calculates the block state and new logs for the given block.
+func (rc *RollupChain) updateState(b *types.Block) (*obscurocore.BlockState, []*types.Log) {
 	// This method is called recursively in case of re-orgs. Stop when state was calculated already.
 	blockState, _, found := rc.storage.FetchBlockState(b.Hash())
 	if found {
-		return blockState, nil, nil
+		return blockState, nil
 	}
 
 	rollups := rc.bridge.ExtractRollups(b, rc.storage)
@@ -163,14 +163,14 @@ func (rc *RollupChain) updateState(b *types.Block) (*obscurocore.BlockState, []*
 
 	// processing blocks before genesis, so there is nothing to do
 	if genesisRollup == nil && len(rollups) == 0 {
-		return nil, nil, nil
+		return nil, nil
 	}
 
 	// Detect if the incoming block contains the genesis rollup, and generate an updated state.
 	// Handles the case of the block containing the genesis being processed multiple times.
 	genesisState, isGenesis := rc.handleGenesisRollup(b, rollups, genesisRollup)
 	if isGenesis {
-		return genesisState, nil, nil
+		return genesisState, nil
 	}
 
 	// To calculate the state after the current block, we need the state after the parent.
@@ -181,9 +181,9 @@ func (rc *RollupChain) updateState(b *types.Block) (*obscurocore.BlockState, []*
 		parent, found := rc.storage.FetchBlock(b.ParentHash())
 		if !found {
 			common.LogWithID(rc.nodeID, "Could not find block parent. This should not happen.")
-			return nil, nil, nil
+			return nil, nil
 		}
-		parentState, allLogs, _ = rc.updateState(parent)
+		parentState, _ = rc.updateState(parent)
 	}
 
 	if parentState == nil {
@@ -192,7 +192,7 @@ func (rc *RollupChain) updateState(b *types.Block) (*obscurocore.BlockState, []*
 			common.ShortHash(b.Hash()),
 			common.ShortHash(b.Header().ParentHash),
 		)
-		return nil, nil, nil
+		return nil, nil
 	}
 
 	bs, head, receipts := rc.calculateBlockState(b, parentState, rollups)
@@ -205,11 +205,10 @@ func (rc *RollupChain) updateState(b *types.Block) (*obscurocore.BlockState, []*
 	for _, receipt := range receipts {
 		newLogs = append(newLogs, receipt.Logs...)
 	}
-	allLogs = append(allLogs, newLogs...)
 
 	rc.storage.SaveNewHead(bs, head, receipts, allLogs)
 
-	return bs, allLogs, newLogs
+	return bs, newLogs
 }
 
 func (rc *RollupChain) handleGenesisRollup(b *types.Block, rollups []*obscurocore.Rollup, genesisRollup *obscurocore.Rollup) (genesisState *obscurocore.BlockState, isGenesis bool) {
@@ -444,7 +443,7 @@ func (rc *RollupChain) SubmitBlock(block types.Block, isLatest bool) common.Bloc
 	}
 
 	common.TraceWithID(rc.nodeID, "Update state: b_%d", common.ShortHash(block.Hash()))
-	blockState, _, newLogs := rc.updateState(&block)
+	blockState, newLogs := rc.updateState(&block)
 	if blockState == nil {
 		return rc.noBlockStateBlockSubmissionResponse(&block)
 	}


### PR DESCRIPTION
### Why is this change needed?

Currently, for each block we store, we store all the logs from the entirety of the historical chain. This leads to major redundancy in how logs are stored.

### What changes were made as part of this PR:

- Provide a high level list of the changes made
- List key areas for the reviewer 

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
