### PR TITLE
send coinbase to hardcoded pool address 

### DIFF
--- a/go/enclave/evm/no_op_engine.go
+++ b/go/enclave/evm/no_op_engine.go
@@ -10,13 +10,17 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
+// PoolAddress - address of the pool where the gas will go
+// TODO - this has to be reworked when the gas/fee work starts
+var PoolAddress = common.HexToAddress("0x0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A")
+
 // ObscuroNoOpConsensusEngine - implements the geth consensus.Engine, but doesn't do anything
 // This is needed for running evm transactions
 type ObscuroNoOpConsensusEngine struct{}
 
+// Author is used to determine where to send the gas collected from the fees.
 func (e *ObscuroNoOpConsensusEngine) Author(header *types.Header) (common.Address, error) {
-	h := convertFromEthHeader(header)
-	return h.Agg, nil
+	return PoolAddress, nil
 }
 
 func (e *ObscuroNoOpConsensusEngine) VerifyHeader(chain consensus.ChainHeaderReader, header *types.Header, seal bool) error {

--- a/go/enclave/evm/utils.go
+++ b/go/enclave/evm/utils.go
@@ -40,6 +40,7 @@ func convertToEthHeader(h *common.Header, secret []byte) *types.Header {
 	}
 }
 
+/*
 func convertFromEthHeader(header *types.Header) *common.Header {
 	h := new(common.Header)
 	err := rlp.DecodeBytes(header.Extra, h)
@@ -48,3 +49,4 @@ func convertFromEthHeader(header *types.Header) *common.Header {
 	}
 	return h
 }
+*/

--- a/integration/simulation/simulation.go
+++ b/integration/simulation/simulation.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	allocObsWallets = 750000000000000 // The amount the faucet allocates to each Obscuro wallet.
+	allocObsWallets = 750_000_000_000_000 // The amount the faucet allocates to each Obscuro wallet.
 )
 
 var initialBalance = common.ValueInWei(big.NewInt(5000))


### PR DESCRIPTION
### Why is this change needed?

We were seeing some mysterious balances in the state, which turned out to be the coinbase transaction applied by default by the evm.
This is not expected behaviour, as that gas will have to go into a pool.

### What changes were made as part of this PR:

Just use a hardcoded pool for now, with a todo to be addressed when the fee work starts

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
