### PR TITLE
Remove double parenthesis

### DIFF
--- a/docs/testnet/changelog.md
+++ b/docs/testnet/changelog.md
@@ -4,7 +4,7 @@
 * Event Subscriptions:
   * Event subscriptions for logs are now supported via the eth_subscribe and eth_getLogs approaches. This has been 
     tested using both the ethers and web3js libraries. Note that eth_newFilter is not currently supported. For more 
-    information see [the events design]((https://github.com/obscuronet/go-obscuro/blob/main/design/Events_design.md)).
+    information see [the events design](https://github.com/obscuronet/go-obscuro/blob/main/design/Events_design.md).
 
 ## September 2022-09-22 (v0.4)
 * Wallet extension:


### PR DESCRIPTION
### Why is this change needed?

- Small fix to the changelog to remove a double parenthesis. 

### What changes were made as part of this PR:

- The changelog. 


