### PR TITLE
eturn balance of contract addresses to the deployer of the contract

### DIFF
--- a/go/enclave/db/interfaces.go
+++ b/go/enclave/db/interfaces.go
@@ -84,6 +84,8 @@ type TransactionStorage interface {
 	GetReceiptsByHash(hash gethcommon.Hash) types.Receipts
 	// GetSender returns the sender of the tx by hash
 	GetSender(txHash gethcommon.Hash) (gethcommon.Address, error)
+	// GetTxForContract returns the hash of the tx that created a contract
+	GetTxForContract(address gethcommon.Address) (gethcommon.Hash, error)
 }
 
 type AttestationStorage interface {

--- a/go/enclave/db/interfaces.go
+++ b/go/enclave/db/interfaces.go
@@ -84,8 +84,8 @@ type TransactionStorage interface {
 	GetReceiptsByHash(hash gethcommon.Hash) types.Receipts
 	// GetSender returns the sender of the tx by hash
 	GetSender(txHash gethcommon.Hash) (gethcommon.Address, error)
-	// GetTxForContract returns the hash of the tx that created a contract
-	GetTxForContract(address gethcommon.Address) (gethcommon.Hash, error)
+	// GetContractCreationTx returns the hash of the tx that created a contract
+	GetContractCreationTx(address gethcommon.Address) (gethcommon.Hash, error)
 }
 
 type AttestationStorage interface {

--- a/go/enclave/db/rawdb/accessors_receipts.go
+++ b/go/enclave/db/rawdb/accessors_receipts.go
@@ -1,6 +1,7 @@
 package rawdb
 
 import (
+	"bytes"
 	"errors"
 
 	"github.com/obscuronet/go-obscuro/go/common/log"
@@ -93,6 +94,28 @@ func WriteReceipts(db ethdb.KeyValueWriter, hash common.Hash, number uint64, rec
 	if err := db.Put(rollupReceiptsKey(number, hash), bytes); err != nil {
 		log.Panic("Failed to store block receipts. Cause: %s", err)
 	}
+}
+
+// WriteContractCreateReceipts stores a mapping between each contract and the receipt that created it
+func WriteContractCreateReceipts(db ethdb.KeyValueWriter, receipts types.Receipts) {
+	// Convert the receipts into their storage form and serialize them
+	for _, receipt := range receipts {
+		if !bytes.Equal(receipt.ContractAddress.Bytes(), (common.Address{}).Bytes()) {
+			// Store the flattened receipt slice
+			if err := db.Put(contractReceiptKey(receipt.ContractAddress), receipt.TxHash.Bytes()); err != nil {
+				log.Panic("Failed to store contract receipt. Cause: %s", err)
+			}
+		}
+	}
+}
+
+// ReadContractTransaction - returns the tx that created a contract
+func ReadContractTransaction(db ethdb.Reader, address common.Address) common.Hash {
+	value, err := db.Get(contractReceiptKey(address))
+	if err != nil {
+		log.Error("failed to read the contract receipt. %s", err)
+	}
+	return common.BytesToHash(value)
 }
 
 // DeleteReceipts removes all receipt data associated with a block hash.

--- a/go/enclave/db/rawdb/accessors_receipts.go
+++ b/go/enclave/db/rawdb/accessors_receipts.go
@@ -96,12 +96,11 @@ func WriteReceipts(db ethdb.KeyValueWriter, hash common.Hash, number uint64, rec
 	}
 }
 
-// WriteContractCreateReceipts stores a mapping between each contract and the receipt that created it
-func WriteContractCreateReceipts(db ethdb.KeyValueWriter, receipts types.Receipts) {
-	// Convert the receipts into their storage form and serialize them
+// WriteContractCreationTx stores a mapping between each contract and the tx that created it
+func WriteContractCreationTx(db ethdb.KeyValueWriter, receipts types.Receipts) {
 	for _, receipt := range receipts {
+		// determine receipts which create accounts and store the txHash
 		if !bytes.Equal(receipt.ContractAddress.Bytes(), (common.Address{}).Bytes()) {
-			// Store the flattened receipt slice
 			if err := db.Put(contractReceiptKey(receipt.ContractAddress), receipt.TxHash.Bytes()); err != nil {
 				log.Panic("Failed to store contract receipt. Cause: %s", err)
 			}

--- a/go/enclave/db/rawdb/schema.go
+++ b/go/enclave/db/rawdb/schema.go
@@ -19,6 +19,7 @@ var (
 	blockStatePrefix         = []byte("obs")         // blockStatePrefix + hash -> num (uint64 big endian)
 	logsPrefix               = []byte("olg")         // logsPrefix + hash -> block logs
 	rollupReceiptsPrefix     = []byte("or")          // rollupReceiptsPrefix + num (uint64 big endian) + hash -> block receipts
+	contractReceiptPrefix    = []byte("ocr")         // contractReceiptPrefix + address -> tx hash
 	txLookupPrefix           = []byte("ol")          // txLookupPrefix + hash -> transaction/receipt lookup metadata
 	bloomBitsPrefix          = []byte("oB")          // bloomBitsPrefix + bit (uint16 big endian) + section (uint64 big endian) + hash -> bloom bits
 	headRollupKey            = []byte("oLastBlock")  // headRollupKey tracks the latest known full block's hash.
@@ -65,6 +66,10 @@ func logsKey(hash common.Hash) []byte {
 // rollupReceiptsKey = rollupReceiptsPrefix + num (uint64 big endian) + hash
 func rollupReceiptsKey(number uint64, hash common.Hash) []byte {
 	return append(append(rollupReceiptsPrefix, encodeRollupNumber(number)...), hash.Bytes()...)
+}
+
+func contractReceiptKey(contractAddress common.Address) []byte {
+	return append(contractReceiptPrefix, contractAddress.Bytes()...)
 }
 
 // txLookupKey = txLookupPrefix + hash

--- a/go/enclave/db/storage.go
+++ b/go/enclave/db/storage.go
@@ -248,7 +248,7 @@ func (s *storageImpl) StoreNewHead(state *core.BlockState, rollup *core.Rollup, 
 		obscurorawdb.WriteTxLookupEntriesByBlock(batch, rollup)
 		obscurorawdb.WriteHeadRollupHash(batch, rollup.Hash())
 		obscurorawdb.WriteReceipts(batch, rollup.Hash(), rollup.NumberU64(), receipts)
-		obscurorawdb.WriteContractCreateReceipts(batch, receipts)
+		obscurorawdb.WriteContractCreationTx(batch, receipts)
 	}
 
 	obscurorawdb.WriteBlockState(batch, state)
@@ -322,7 +322,7 @@ func (s *storageImpl) GetSender(txHash gethcommon.Hash) (gethcommon.Address, err
 	return msg.From(), nil
 }
 
-func (s *storageImpl) GetTxForContract(address gethcommon.Address) (gethcommon.Hash, error) {
+func (s *storageImpl) GetContractCreationTx(address gethcommon.Address) (gethcommon.Hash, error) {
 	tx := obscurorawdb.ReadContractTransaction(s.db, address)
 	return tx, nil
 }

--- a/go/enclave/db/storage.go
+++ b/go/enclave/db/storage.go
@@ -248,6 +248,7 @@ func (s *storageImpl) StoreNewHead(state *core.BlockState, rollup *core.Rollup, 
 		obscurorawdb.WriteTxLookupEntriesByBlock(batch, rollup)
 		obscurorawdb.WriteHeadRollupHash(batch, rollup.Hash())
 		obscurorawdb.WriteReceipts(batch, rollup.Hash(), rollup.NumberU64(), receipts)
+		obscurorawdb.WriteContractCreateReceipts(batch, receipts)
 	}
 
 	obscurorawdb.WriteBlockState(batch, state)
@@ -319,6 +320,11 @@ func (s *storageImpl) GetSender(txHash gethcommon.Hash) (gethcommon.Address, err
 		return gethcommon.Address{}, fmt.Errorf("could not convert transaction to message to retrieve sender address in eth_getTransactionReceipt request. Cause: %w", err)
 	}
 	return msg.From(), nil
+}
+
+func (s *storageImpl) GetTxForContract(address gethcommon.Address) (gethcommon.Hash, error) {
+	tx := obscurorawdb.ReadContractTransaction(s.db, address)
+	return tx, nil
 }
 
 func (s *storageImpl) GetTransactionReceipt(txHash gethcommon.Hash) (*types.Receipt, error) {

--- a/go/enclave/evm/evm_facade.go
+++ b/go/enclave/evm/evm_facade.go
@@ -54,7 +54,6 @@ func executeTransaction(s *state.StateDB, cc *params.ChainConfig, chain *Obscuro
 	before := header.MixDigest
 	// calculate a random value per transaction
 	header.MixDigest = gethcommon.BytesToHash(crypto.PerTransactionRnd(before.Bytes(), tCount))
-	// todo - Author?
 	receipt, err := gethcore.ApplyTransaction(cc, chain, nil, gp, s, header, t, usedGas, vmCfg)
 	header.MixDigest = before
 	if err != nil {

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -711,7 +711,7 @@ func (rc *RollupChain) GetBalance(encryptedParams common.EncryptedParamsGetBalan
 	address := accountAddress
 	// If the accountAddress is a contract, encrypt with the address of the contract owner
 	code := blockchainState.GetCode(accountAddress)
-	if code != nil {
+	if len(code) != 0 {
 		txHash, err := rc.storage.GetTxForContract(accountAddress)
 		if err != nil {
 			return nil, fmt.Errorf("failed to retrieve tx that created contract %s. Cause %w", accountAddress.Hex(), err)

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -712,7 +712,7 @@ func (rc *RollupChain) GetBalance(encryptedParams common.EncryptedParamsGetBalan
 	// If the accountAddress is a contract, encrypt with the address of the contract owner
 	code := blockchainState.GetCode(accountAddress)
 	if len(code) != 0 {
-		txHash, err := rc.storage.GetTxForContract(accountAddress)
+		txHash, err := rc.storage.GetContractCreationTx(accountAddress)
 		if err != nil {
 			return nil, fmt.Errorf("failed to retrieve tx that created contract %s. Cause %w", accountAddress.Hex(), err)
 		}


### PR DESCRIPTION
### Why is this change needed?

- when deploying a contract in remix, it keeps polling the native balance of that address, and it fails because there is no encryption key

### What changes were made as part of this PR:

High level this makes the balance of a contract account relevant to the address who deployed that contract.

Implementation:
1. For each receipt, check whether it's a contract creation, and save a mapping from contract address to transaction hash that created it.
2. when reading the balance, check if the address is a contract, and if yes, fetch the transaction signer and use that viewing key.

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
