### PR TITLE
Only aggregators produce rollups

### DIFF
--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -166,7 +166,7 @@ func NewEnclave(config config.EnclaveConfig, mgmtContractLib mgmtcontractlib.Mgm
 	memp := mempool.New(config.ObscuroChainID)
 
 	subscriptionManager := events.NewSubscriptionManager(&rpcEncryptionManager, storage, logger)
-	chain := rollupchain.New(config.HostID, storage, l1Blockchain, obscuroBridge, subscriptionManager, transactionBlobCrypto, memp, rpcEncryptionManager, enclaveKey, config.L1ChainID, &chainConfig, logger)
+	chain := rollupchain.New(config.HostID, config.NodeType, storage, l1Blockchain, obscuroBridge, subscriptionManager, transactionBlobCrypto, memp, rpcEncryptionManager, enclaveKey, config.L1ChainID, &chainConfig, logger)
 
 	jsonConfig, _ := json.MarshalIndent(config, "", "  ")
 	logger.Info("Enclave service created with following config", log.CfgKey, string(jsonConfig))

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -462,8 +462,8 @@ func (rc *RollupChain) SubmitBlock(block types.Block, isLatest bool) common.Bloc
 		rc.logger.Crit("Could not get subscribed logs in encrypted form. ", log.ErrKey, err)
 	}
 
-	// We do not produce a rollup if we're a validator, or we're behind the L1 (in which case the rollup will be outdated).
-	if !isLatest || rc.nodeType == common.Validator {
+	// We do not produce a rollup if we're not an aggregator, or we're behind the L1 (in which case the rollup will be outdated).
+	if !isLatest || rc.nodeType != common.Aggregator {
 		return rc.newBlockSubmissionResponse(blockState, common.ExtRollup{}, encryptedLogs)
 	}
 

--- a/go/host/node/node.go
+++ b/go/host/node/node.go
@@ -500,7 +500,7 @@ func (a *Node) processBlocks(blocks []common.EncodedBlock, interrupt *int32) err
 	if result.ProducedRollup.Header == nil {
 		return nil
 	}
-
+	// We check that a rollup wasn't somehow produced by a non-aggregator.
 	if a.config.NodeType != common.Aggregator {
 		panic("node produced a rollup but was not an aggregator")
 	}

--- a/go/host/node/node.go
+++ b/go/host/node/node.go
@@ -497,12 +497,12 @@ func (a *Node) processBlocks(blocks []common.EncodedBlock, interrupt *int32) err
 		}
 	}
 
-	// Nodes can start before the genesis was published, and it makes no sense to enter the protocol.
-	if result.ProducedRollup.Header == nil {
+	// The first part of this check is redundant - if the node is configured correctly, a validator's enclave will
+	// never produce a rollup anyway. However, we include it here for resiliency.
+	if a.config.NodeType == common.Validator || result.ProducedRollup.Header == nil {
 		return nil
 	}
 
-	// TODO - #718 - Handle the validator case, where no rollup is produced.
 	encodedRollup, err := common.EncodeRollup(result.ProducedRollup.ToRollup())
 	if err != nil {
 		return fmt.Errorf("could not encode rollup. Cause: %w", err)

--- a/go/host/node/node.go
+++ b/go/host/node/node.go
@@ -499,7 +499,7 @@ func (a *Node) processBlocks(blocks []common.EncodedBlock, interrupt *int32) err
 
 	// The first part of this check is redundant - if the node is configured correctly, a validator's enclave will
 	// never produce a rollup anyway. However, we include it here for resiliency.
-	if a.config.NodeType == common.Validator || result.ProducedRollup.Header == nil {
+	if a.config.NodeType != common.Aggregator || result.ProducedRollup.Header == nil {
 		return nil
 	}
 

--- a/go/host/node/node.go
+++ b/go/host/node/node.go
@@ -502,7 +502,7 @@ func (a *Node) processBlocks(blocks []common.EncodedBlock, interrupt *int32) err
 	}
 	// We check that a rollup wasn't somehow produced by a non-aggregator.
 	if a.config.NodeType != common.Aggregator {
-		panic("node produced a rollup but was not an aggregator")
+		a.logger.Crit("node produced a rollup but was not an aggregator")
 	}
 
 	encodedRollup, err := common.EncodeRollup(result.ProducedRollup.ToRollup())

--- a/go/host/node/node.go
+++ b/go/host/node/node.go
@@ -497,10 +497,12 @@ func (a *Node) processBlocks(blocks []common.EncodedBlock, interrupt *int32) err
 		}
 	}
 
-	// The first part of this check is redundant - if the node is configured correctly, a validator's enclave will
-	// never produce a rollup anyway. However, we include it here for resiliency.
-	if a.config.NodeType != common.Aggregator || result.ProducedRollup.Header == nil {
+	if result.ProducedRollup.Header == nil {
 		return nil
+	}
+
+	if a.config.NodeType != common.Aggregator {
+		panic("node produced a rollup but was not an aggregator")
 	}
 
 	encodedRollup, err := common.EncodeRollup(result.ProducedRollup.ToRollup())

--- a/integration/simulation/network/inmemory.go
+++ b/integration/simulation/network/inmemory.go
@@ -3,8 +3,6 @@ package network
 import (
 	"time"
 
-	"github.com/obscuronet/go-obscuro/go/common"
-
 	"github.com/obscuronet/go-obscuro/integration/datagenerator"
 
 	"github.com/obscuronet/go-obscuro/go/host"
@@ -53,16 +51,11 @@ func (n *basicNetworkOfInMemoryNodes) Create(params *params.SimParams, stats *st
 		// create the in memory l1 and l2 node
 		miner := createMockEthNode(int64(i), params.NumberOfNodes, params.AvgBlockDuration, params.AvgNetworkLatency, stats)
 		p2pLayers[i] = p2p.NewMockP2P(params.AvgBlockDuration, params.AvgNetworkLatency)
-		// We assign every other node the role of aggregator.
-		nodeType := common.Aggregator
-		if i%2 == 0 {
-			nodeType = common.Validator
-		}
 
 		agg := createInMemObscuroNode(
 			int64(i),
 			isGenesis,
-			nodeType,
+			GetNodeType(i),
 			params.MgmtContractLib,
 			params.ERC20ContractLib,
 			params.AvgGossipPeriod,

--- a/integration/simulation/utils.go
+++ b/integration/simulation/utils.go
@@ -132,16 +132,16 @@ func findHashDups(list []gethcommon.Hash) map[gethcommon.Hash]int {
 }
 
 // FindRollupDups - returns a map of all L2 root hashes that appear multiple times, and how many times
-func findRollupDups(list []common.L2RootHash) map[common.L2RootHash]int {
+func findRollupDups(list []*common.EncryptedRollup) map[common.L2RootHash]int {
 	elementCount := make(map[common.L2RootHash]int)
 
 	for _, item := range list {
 		// check if the item/element exist in the duplicate_frequency map
-		_, exist := elementCount[item]
+		_, exist := elementCount[item.Hash()]
 		if exist {
-			elementCount[item]++ // increase counter by 1 if already in the map
+			elementCount[item.Hash()]++ // increase counter by 1 if already in the map
 		} else {
-			elementCount[item] = 1 // else start counting from 1
+			elementCount[item.Hash()] = 1 // else start counting from 1
 		}
 	}
 	dups := make(map[common.L2RootHash]int)


### PR DESCRIPTION
### Why is this change needed?

Currently, nodes can be configured to be either aggregators or validators, but both types produce rollups. We change this so that only aggregators produce rollups.

### What changes were made as part of this PR:

- Have only aggregators produce rollups
- Check in sims that only aggregators produce rollups

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
