### PR TITLE
Allow node type to be configured in TN set up

### DIFF
--- a/.github/workflows/manual-deploy-dev-testnet.yml
+++ b/.github/workflows/manual-deploy-dev-testnet.yml
@@ -141,10 +141,15 @@ jobs:
             host_id: 0
           - node_pk_addr: GETHNETWORK_PREFUNDED_ADDR_1
             host_id: 1
-          # Ensure there is a genesis node
+          # Ensure there is a single genesis node
           - is_genesis: true
             host_id: 0
           - is_genesis: false
+            host_id: 1
+          # Ensure there is a single aggregator
+          - node_type: aggregator
+            host_id: 0
+          - node_type: validator
             host_id: 1
 
     steps:
@@ -201,6 +206,7 @@ jobs:
             && cd /home/obscuro/go-obscuro/testnet/ \
             && ./start-obscuro-node.sh \
                --is_genesis=${{ matrix.is_genesis }} \
+               --node_type=${{ matrix.node_type }} \
                --sgx_enabled=true \
                --host_id=${{ matrix.host_addr }} \
                --l1host=${{ github.event.inputs.L1HOST }} \

--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -94,10 +94,15 @@ jobs:
             host_id: 0
           - node_pk_addr: GETHNETWORK_PREFUNDED_ADDR_1
             host_id: 1
-          # Ensure there is a genesis node
+          # Ensure there is a single genesis node
           - is_genesis: true
             host_id: 0
           - is_genesis: false
+            host_id: 1
+          # Ensure there is a single aggregator
+          - node_type: aggregator
+            host_id: 0
+          - node_type: validator
             host_id: 1
 
     steps:
@@ -154,6 +159,7 @@ jobs:
             && cd /home/obscuro/go-obscuro/testnet/ \
             && ./start-obscuro-node.sh \
                --is_genesis=${{ matrix.is_genesis }} \
+               --node_type=${{ matrix.node_type }} \
                --sgx_enabled=true \
                --host_id=${{ matrix.host_addr }} \
                --l1host=${{ github.event.inputs.L1HOST }} \

--- a/README.md
+++ b/README.md
@@ -349,12 +349,12 @@ To start the test network locally run the below scripts. Note that it is recomme
 as detailed below. The arguments are set to correspond to valid pre-determined public / private key pair values for 
 contract deployment and roll up publishing. Using these values, and starting with a nonce of zero, means the addresses 
 of the contracts deployed are known a-priori, and so can be supplied in the `start-obscuro-node.sh` script as shown. As 
-only a single Obscuro node is started, it must be set as a genesis node. 
+only a single Obscuro node is started, it must be set as a genesis node and as an aggregator.
 
 ```
 ./testnet-local-gethnetwork.sh --pkaddresses=0x13E23Ca74DE0206C56ebaE8D51b5622EFF1E9944,0x0654D8B60033144D567f25bF41baC1FB0D60F23B
 ./testnet-deploy-contracts.sh --l1host=gethnetwork --pkstring=f52e5418e349dccdda29b6ac8b0abe6576bb7713886aa85abea6181ba731f9bb
-./start-obscuro-node.sh --sgx_enabled=false --host_id=0x0000000000000000000000000000000000000001 --l1host=gethnetwork --mgmtcontractaddr=0xeDa66Cc53bd2f26896f6Ba6b736B1Ca325DE04eF --hocerc20addr=0xC0370e0b5C1A41D447BDdA655079A1B977C71aA9 --pocerc20addr=0x51D43a3Ca257584E770B6188232b199E76B022A2 --is_genesis=true
+./start-obscuro-node.sh --sgx_enabled=false --host_id=0x0000000000000000000000000000000000000001 --l1host=gethnetwork --mgmtcontractaddr=0xeDa66Cc53bd2f26896f6Ba6b736B1Ca325DE04eF --hocerc20addr=0xC0370e0b5C1A41D447BDdA655079A1B977C71aA9 --pocerc20addr=0x51D43a3Ca257584E770B6188232b199E76B022A2 --is_genesis=true --node_type=aggregator
 ./testnet-deploy-l2-contracts.sh --l2host=testnet-host-1 
 ```
 

--- a/testnet/docker-compose.debug.yml
+++ b/testnet/docker-compose.debug.yml
@@ -18,6 +18,7 @@ services:
       L1PORT: some_port
       HOSTID: some_address
       ISGENESIS: some_bool
+      NODETYPE: some_bool
       PROFILERENABLED: some_bool
       P2PPUBLICADDRESS: some_string
       LOGLEVEL: some_int
@@ -32,6 +33,7 @@ services:
       "--privateKey=$PKSTRING",
       "--clientRPCHost=0.0.0.0",
       "--isGenesis=$ISGENESIS",
+      "--nodeType=$NODETYPE",
       "--logLevel=$LOGLEVEL",
       "--logPath=sys_out",
       "--profilerEnabled=$PROFILERENABLED",
@@ -49,6 +51,7 @@ services:
       HOCERC20ADDR: some_address
       POCERC20ADDR: some_address
       HOSTID: some_address
+      NODETYPE: some_bool
       PROFILERENABLED: some_bool
       P2PPUBLICADDRESS: some_string
       LOGLEVEL: some_int
@@ -64,6 +67,7 @@ services:
       "--",
       "--hostID=$HOSTID",
       "--address=:11000",
+      "--nodeType=$NODETYPE"
       "--useInMemoryDB=false",
       "--sqliteDBPath=/data/sqlite.db",
       "--managementContractAddress=$MGMTCONTRACTADDR",

--- a/testnet/docker-compose.debug.yml
+++ b/testnet/docker-compose.debug.yml
@@ -18,7 +18,7 @@ services:
       L1PORT: some_port
       HOSTID: some_address
       ISGENESIS: some_bool
-      NODETYPE: some_bool
+      NODETYPE: some_string
       PROFILERENABLED: some_bool
       P2PPUBLICADDRESS: some_string
       LOGLEVEL: some_int
@@ -51,7 +51,7 @@ services:
       HOCERC20ADDR: some_address
       POCERC20ADDR: some_address
       HOSTID: some_address
-      NODETYPE: some_bool
+      NODETYPE: some_string
       PROFILERENABLED: some_bool
       P2PPUBLICADDRESS: some_string
       LOGLEVEL: some_int

--- a/testnet/docker-compose.dev-testnet.yml
+++ b/testnet/docker-compose.dev-testnet.yml
@@ -20,7 +20,7 @@ services:
       L1PORT: some_port
       HOSTID: some_address
       ISGENESIS: some_bool
-      NODETYPE: some_bool
+      NODETYPE: some_string
       PROFILERENABLED: some_bool
       P2PPUBLICADDRESS: some_string
       LOGLEVEL: some_int
@@ -55,7 +55,7 @@ services:
       HOCERC20ADDR: some_address
       POCERC20ADDR: some_address
       HOSTID: some_address
-      NODETYPE: some_bool
+      NODETYPE: some_string
       OE_SIMULATION: 0
       PROFILERENABLED: some_bool
       P2PPUBLICADDRESS: some_string

--- a/testnet/docker-compose.dev-testnet.yml
+++ b/testnet/docker-compose.dev-testnet.yml
@@ -20,6 +20,7 @@ services:
       L1PORT: some_port
       HOSTID: some_address
       ISGENESIS: some_bool
+      NODETYPE: some_bool
       PROFILERENABLED: some_bool
       P2PPUBLICADDRESS: some_string
       LOGLEVEL: some_int
@@ -34,6 +35,7 @@ services:
       "--privateKey=$PKSTRING",
       "--clientRPCHost=0.0.0.0",
       "--isGenesis=$ISGENESIS",
+      "--nodeType=$NODETYPE",
       "--logLevel=$LOGLEVEL",
       "--logPath=sys_out",
       "--profilerEnabled=$PROFILERENABLED",
@@ -53,6 +55,7 @@ services:
       HOCERC20ADDR: some_address
       POCERC20ADDR: some_address
       HOSTID: some_address
+      NODETYPE: some_bool
       OE_SIMULATION: 0
       PROFILERENABLED: some_bool
       P2PPUBLICADDRESS: some_string
@@ -62,6 +65,7 @@ services:
                  "ego", "run", "/home/obscuro/go-obscuro/go/enclave/main/main",
                  "--hostID=$HOSTID",
                  "--address=:11000",
+                 "--nodeType=$NODETYPE"
                  "--managementContractAddress=$MGMTCONTRACTADDR",
                  "--erc20ContractAddresses=$HOCERC20ADDR,$POCERC20ADDR",
                  "--hostAddress=host:10000",

--- a/testnet/docker-compose.non-sgx.yml
+++ b/testnet/docker-compose.non-sgx.yml
@@ -18,6 +18,7 @@ services:
       L1PORT: some_port
       HOSTID: some_address
       ISGENESIS: some_bool
+      NODETYPE: some_bool
       PROFILERENABLED: some_bool
       P2PPUBLICADDRESS: some_string
       LOGLEVEL: some_int
@@ -32,6 +33,7 @@ services:
       "--privateKey=$PKSTRING",
       "--clientRPCHost=0.0.0.0",
       "--isGenesis=$ISGENESIS",
+      "--nodeType=$NODETYPE",
       "--logPath=sys_out",
       "--logLevel=$LOGLEVEL",
       "--profilerEnabled=$PROFILERENABLED",
@@ -48,6 +50,7 @@ services:
       HOCERC20ADDR: some_address
       POCERC20ADDR: some_address
       HOSTID: some_address
+      NODETYPE: some_bool
       PROFILERENABLED: some_bool
       P2PPUBLICADDRESS: some_string
       LOGLEVEL: some_int
@@ -56,6 +59,7 @@ services:
                  "ego", "run", "/home/obscuro/go-obscuro/go/enclave/main/main",
                  "--hostID=$HOSTID",
                  "--address=:11000",
+                 "--nodeType=$NODETYPE"
                  "--useInMemoryDB=false",
                  "--sqliteDBPath=/data/sqlite.db",
                  "--managementContractAddress=$MGMTCONTRACTADDR",

--- a/testnet/docker-compose.non-sgx.yml
+++ b/testnet/docker-compose.non-sgx.yml
@@ -18,7 +18,7 @@ services:
       L1PORT: some_port
       HOSTID: some_address
       ISGENESIS: some_bool
-      NODETYPE: some_bool
+      NODETYPE: some_string
       PROFILERENABLED: some_bool
       P2PPUBLICADDRESS: some_string
       LOGLEVEL: some_int
@@ -50,7 +50,7 @@ services:
       HOCERC20ADDR: some_address
       POCERC20ADDR: some_address
       HOSTID: some_address
-      NODETYPE: some_bool
+      NODETYPE: some_string
       PROFILERENABLED: some_bool
       P2PPUBLICADDRESS: some_string
       LOGLEVEL: some_int

--- a/testnet/docker-compose.yml
+++ b/testnet/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       L1PORT: some_port
       HOSTID: some_address
       ISGENESIS: some_bool
-      NODETYPE: some_bool
+      NODETYPE: some_string
       PROFILERENABLED: some_bool
       P2PPUBLICADDRESS: some_string
       LOGLEVEL: some_int
@@ -55,7 +55,7 @@ services:
       HOCERC20ADDR: some_address
       POCERC20ADDR: some_address
       HOSTID: some_address
-      NODETYPE: some_bool
+      NODETYPE: some_string
       OE_SIMULATION: 0
       PROFILERENABLED: some_bool
       P2PPUBLICADDRESS: some_string

--- a/testnet/docker-compose.yml
+++ b/testnet/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       L1PORT: some_port
       HOSTID: some_address
       ISGENESIS: some_bool
+      NODETYPE: some_bool
       PROFILERENABLED: some_bool
       P2PPUBLICADDRESS: some_string
       LOGLEVEL: some_int
@@ -34,6 +35,7 @@ services:
       "--privateKey=$PKSTRING",
       "--clientRPCHost=0.0.0.0",
       "--isGenesis=$ISGENESIS",
+      "--nodeType=$NODETYPE",
       "--logLevel=$LOGLEVEL",
       "--logPath=sys_out",
       "--profilerEnabled=$PROFILERENABLED",
@@ -53,6 +55,7 @@ services:
       HOCERC20ADDR: some_address
       POCERC20ADDR: some_address
       HOSTID: some_address
+      NODETYPE: some_bool
       OE_SIMULATION: 0
       PROFILERENABLED: some_bool
       P2PPUBLICADDRESS: some_string
@@ -62,6 +65,7 @@ services:
                  "ego", "run", "/home/obscuro/go-obscuro/go/enclave/main/main",
                  "--hostID=$HOSTID",
                  "--address=:11000",
+                 "--nodeType=$NODETYPE"
                  "--managementContractAddress=$MGMTCONTRACTADDR",
                  "--erc20ContractAddresses=$HOCERC20ADDR,$POCERC20ADDR",
                  "--hostAddress=host:10000",

--- a/testnet/start-obscuro-node.sh
+++ b/testnet/start-obscuro-node.sh
@@ -3,8 +3,9 @@
 #
 # This script downloads and builds the obscuro node
 #
-# Note: Be aware that a network MUST always have AT LEAST ONE Genesis node -> Flag is_genesis=true
-#       Otherwise you might see your node getting stuck in waiting for a secret
+# Note: Be aware that a network MUST always have:
+#  * EXACTLY ONE genesis node -> Flag is_genesis=true (otherwise your node wil spin forever waiting for the network secret)
+#  * AT LEAST ONE aggregator  -> Flag node_type=aggregator (otherwise no rollups will be produced)
 #
 
 help_and_exit() {
@@ -36,6 +37,8 @@ help_and_exit() {
     echo ""
     echo "  is_genesis         *Optional* Set the node as genesis node. Defaults to false"
     echo ""
+    echo "  node_type          *Optional* Set the node's type. Defaults to validator"
+    echo ""
     echo "  log_level          *Optional* Sets the log level. Defaults to 2 (warn)."
     echo ""
     echo "  p2p_public_address *Optional* Set host p2p public address. Defaults to 127.0.0.1:10000"
@@ -60,6 +63,7 @@ testnet_path="${start_path}"
 # Define defaults
 l1_port=9000
 is_genesis=false
+node_type=aggregator
 profiler_enabled=false
 p2p_public_address="127.0.0.1:10000"
 debug_enclave=false
@@ -86,6 +90,7 @@ do
             --pkstring)                 pk_string=${value} ;;
             --sgx_enabled)              sgx_enabled=${value} ;;
             --is_genesis)               is_genesis=${value} ;;
+            --node_type)                node_type=${value} ;;
             --log_level)                log_level=${value} ;;
             --profiler_enabled)         profiler_enabled=${value} ;;
             --p2p_public_address)       p2p_public_address=${value} ;;
@@ -113,6 +118,7 @@ echo "POCERC20ADDR=${poc_erc20_addr}"  >> "${testnet_path}/.env"
 echo "L1HOST=${l1_host}" >> "${testnet_path}/.env"
 echo "L1PORT=${l1_port}" >> "${testnet_path}/.env"
 echo "ISGENESIS=${is_genesis}" >> "${testnet_path}/.env"
+echo "NODETYPE=${node_type}" >> "${testnet_path}/.env"
 echo "LOGLEVEL=${log_level}" >> "${testnet_path}/.env"
 echo "PROFILERENABLED=${profiler_enabled}" >> "${testnet_path}/.env"
 echo "P2PPUBLICADDRESS=${p2p_public_address}" >> "${testnet_path}/.env"

--- a/testnet/start-obscuro-node.sh
+++ b/testnet/start-obscuro-node.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 
 #
-# This script downloads and builds the obscuro node
+# This script downloads and builds the Obscuro node.
 #
-# Note: Be aware that a network MUST always have:
-#  * EXACTLY ONE genesis node -> Flag is_genesis=true (otherwise your node wil spin forever waiting for the network secret)
-#  * AT LEAST ONE aggregator  -> Flag node_type=aggregator (otherwise no rollups will be produced)
+# Note: Be aware that a network MUST always have EXACTLY ONE genesis node (i.e. with flag `is_genesis=true`);
+# otherwise, your node wil spin forever waiting for the network secret. In addition, a network MUST always have AT
+# LEAST ONE aggregator (i.e. with flag `node_type=aggregator`); otherwise no rollups will be produced. In addition, the
+# genesis node MUST be one of the aggregators.
 #
 
 help_and_exit() {

--- a/testnet/start-obscuro-node.sh
+++ b/testnet/start-obscuro-node.sh
@@ -63,7 +63,7 @@ testnet_path="${start_path}"
 # Define defaults
 l1_port=9000
 is_genesis=false
-node_type=aggregator
+node_type=validator
 profiler_enabled=false
 p2p_public_address="127.0.0.1:10000"
 debug_enclave=false


### PR DESCRIPTION
### Why is this change needed?

Currently, all the nodes of testnet default to being aggregators. We want only a single aggregator.

### What changes were made as part of this PR:

- Updates testnet scripts
- Updates readme

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
