### PR TITLE
Clean up ahead of light-batch work

### DIFF
--- a/go/common/types.go
+++ b/go/common/types.go
@@ -123,7 +123,7 @@ type AttestationReport struct {
 	HostAddress string         // the IP address on which the host can be contacted by other Obscuro hosts for peer-to-peer communication
 }
 
-func (er ExtRollup) ToRollup() *EncryptedRollup {
+func (er ExtRollup) ToEncryptedRollup() *EncryptedRollup {
 	return &EncryptedRollup{
 		Header:       er.Header,
 		TxHashes:     er.TxHashes,

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -244,7 +244,7 @@ func (e *enclaveImpl) SubmitBlock(block types.Block, isLatest bool) (common.Bloc
 }
 
 func (e *enclaveImpl) SubmitRollup(rollup common.ExtRollup) error {
-	r := core.ToEnclaveRollup(rollup.ToRollup(), e.transactionBlobCrypto)
+	r := core.ToEnclaveRollup(rollup.ToEncryptedRollup(), e.transactionBlobCrypto)
 
 	// only store if the parent exists
 	_, found := e.storage.FetchRollup(r.Header.ParentHash)

--- a/go/host/db/hostdb.go
+++ b/go/host/db/hostdb.go
@@ -121,6 +121,7 @@ func (db *DB) AddRollupHeader(headerWithHashes *common.HeaderWithTxHashes) {
 	}
 }
 
+// AddSubmittedRollup adds a rollup hash to the list of rollup hashes already submitted to the enclave.
 func (db *DB) AddSubmittedRollup(hash gethcommon.Hash) {
 	err := db.kvStore.Put(submittedRollupHeaderKey(hash), []byte{})
 	if err != nil {
@@ -128,6 +129,7 @@ func (db *DB) AddSubmittedRollup(hash gethcommon.Hash) {
 	}
 }
 
+// WasSubmitted checks whether a rollup has already been submitted to the enclave.
 func (db *DB) WasSubmitted(hash gethcommon.Hash) bool {
 	f, err := db.kvStore.Has(submittedRollupHeaderKey(hash))
 	if err != nil {

--- a/go/host/db/hostdb.go
+++ b/go/host/db/hostdb.go
@@ -121,7 +121,7 @@ func (db *DB) AddRollupHeader(headerWithHashes *common.HeaderWithTxHashes) {
 	}
 }
 
-// AddSubmittedRollup adds a rollup hash to the list of rollup hashes already submitted to the enclave.
+// AddSubmittedRollup adds a rollup hash to the list of rollup hashes already submitted to the L1.
 func (db *DB) AddSubmittedRollup(hash gethcommon.Hash) {
 	err := db.kvStore.Put(submittedRollupHeaderKey(hash), []byte{})
 	if err != nil {
@@ -129,7 +129,7 @@ func (db *DB) AddSubmittedRollup(hash gethcommon.Hash) {
 	}
 }
 
-// WasSubmitted checks whether a rollup has already been submitted to the enclave.
+// WasSubmitted checks whether a rollup has already been submitted to the L1.
 func (db *DB) WasSubmitted(hash gethcommon.Hash) bool {
 	f, err := db.kvStore.Has(submittedRollupHeaderKey(hash))
 	if err != nil {

--- a/go/host/node/node.go
+++ b/go/host/node/node.go
@@ -86,8 +86,8 @@ func NewHost(config config.HostConfig, stats host.StatsCollector, p2p host.P2P, 
 	node := &Node{
 		// config
 		config:      config,
-		isSequencer: config.IsGenesis && config.NodeType == common.Aggregator,
 		shortID:     common.ShortAddress(config.ID),
+		isSequencer: config.IsGenesis && config.NodeType == common.Aggregator,
 
 		// Communication layers.
 		p2p:           p2p,

--- a/go/host/node/node.go
+++ b/go/host/node/node.go
@@ -83,13 +83,6 @@ type Node struct {
 }
 
 func NewHost(config config.HostConfig, stats host.StatsCollector, p2p host.P2P, ethClient ethadapter.EthClient, enclaveClient common.Enclave, ethWallet wallet.Wallet, mgmtContractLib mgmtcontractlib.MgmtContractLib, logger gethlog.Logger) host.MockHost {
-	if config.IsGenesis && config.NodeType != common.Aggregator {
-		logger.Crit("genesis node must be an aggregator")
-	}
-	if !config.IsGenesis && config.NodeType == common.Aggregator {
-		logger.Crit("only the genesis node can be an aggregator")
-	}
-
 	node := &Node{
 		// config
 		config:      config,
@@ -184,6 +177,8 @@ func NewHost(config config.HostConfig, stats host.StatsCollector, p2p host.P2P, 
 }
 
 func (a *Node) Start() {
+	a.validateConfig()
+
 	tomlConfig, err := toml.Marshal(a.config)
 	if err != nil {
 		a.logger.Crit("could not print host config")
@@ -1001,6 +996,16 @@ func (a *Node) checkBlockForSecretResponse(block *types.Block) bool {
 	}
 	// response not found
 	return false
+}
+
+// Checks the node config is valid.
+func (a *Node) validateConfig() {
+	if a.config.IsGenesis && a.config.NodeType != common.Aggregator {
+		a.logger.Crit("genesis node must be an aggregator")
+	}
+	if !a.config.IsGenesis && a.config.NodeType == common.Aggregator {
+		a.logger.Crit("only the genesis node can be an aggregator")
+	}
 }
 
 // We retry calling `funcToRetry`, with a pause in between that starts at one second and doubles on each retry.

--- a/go/host/node/node.go
+++ b/go/host/node/node.go
@@ -959,7 +959,7 @@ func (a *Node) awaitSecret() error {
 				return fmt.Errorf("failed to retrieve block. Cause: %w", err)
 			}
 			if a.checkBlockForSecretResponse(block) {
-				// todo this should be defered when the errors are upstreamed instead of panic'd
+				// todo this should be deferred when the errors are upstreamed instead of panic'd
 				subs.Unsubscribe()
 				return nil
 			}
@@ -975,7 +975,7 @@ func (a *Node) awaitSecret() error {
 			}
 
 		case <-time.After(time.Second * 10):
-			// This will provide useful feedback if things are stuck (and in tests if any goroutines got stranded on this select
+			// This will provide useful feedback if things are stuck (and in tests if any goroutines got stranded on this select)
 			a.logger.Info("Still waiting for secret from the L1...")
 
 		case <-a.exitNodeCh:

--- a/go/host/node/node.go
+++ b/go/host/node/node.go
@@ -1006,6 +1006,10 @@ func (a *Node) validateConfig() {
 	if !a.config.IsGenesis && a.config.NodeType == common.Aggregator {
 		a.logger.Crit("only the genesis node can be an aggregator")
 	}
+
+	if a.config.P2PPublicAddress == "" {
+		a.logger.Crit("the node must specify a public P2P address")
+	}
 }
 
 // We retry calling `funcToRetry`, with a pause in between that starts at one second and doubles on each retry.

--- a/go/host/node/node.go
+++ b/go/host/node/node.go
@@ -86,6 +86,9 @@ func NewHost(config config.HostConfig, stats host.StatsCollector, p2p host.P2P, 
 	if config.IsGenesis && config.NodeType != common.Aggregator {
 		logger.Crit("genesis node must be an aggregator")
 	}
+	if !config.IsGenesis && config.NodeType == common.Aggregator {
+		logger.Crit("only the genesis node can be an aggregator")
+	}
 
 	node := &Node{
 		// config

--- a/go/host/node/node.go
+++ b/go/host/node/node.go
@@ -637,11 +637,15 @@ func (a *Node) signAndBroadcastL1Tx(tx types.TxData, tries int) error {
 		return err
 	}
 
-	funcBroadcastTx := func() error { return a.ethClient.SendTransaction(signedTx) }
+	funcBroadcastTx := func() error {
+		// TODO - #1089 - Await transaction receipt after sending the transaction.
+		return a.ethClient.SendTransaction(signedTx)
+	}
 	err = retryWithBackoff(tries, funcBroadcastTx)
 	if err == nil {
 		return nil
 	}
+
 	return fmt.Errorf("broadcasting L1 transaction failed after %d tries. Cause: %w", tries, err)
 }
 

--- a/go/host/node/node.go
+++ b/go/host/node/node.go
@@ -515,7 +515,7 @@ func (a *Node) processBlocks(blocks []common.EncodedBlock, interrupt *int32) err
 		return nil
 	}
 
-	encodedRollup, err := common.EncodeRollup(result.ProducedRollup.ToRollup())
+	encodedRollup, err := common.EncodeRollup(result.ProducedRollup.ToEncryptedRollup())
 	if err != nil {
 		return fmt.Errorf("could not encode rollup. Cause: %w", err)
 	}
@@ -567,7 +567,7 @@ func (a *Node) handleRoundWinner(result common.BlockSubmissionResponse) func() {
 				winnerRollup.Header.Number,
 			))
 
-		encodedRollup, err := common.EncodeRollup(winnerRollup.ToRollup())
+		encodedRollup, err := common.EncodeRollup(winnerRollup.ToEncryptedRollup())
 		if err != nil {
 			a.logger.Crit("could not encode rollup.", log.ErrKey, err)
 		}
@@ -613,7 +613,7 @@ func (a *Node) initialiseProtocol(block *types.Block) (common.L2RootHash, error)
 		fmt.Sprintf("Initialising network. Genesis rollup r_%d.",
 			common.ShortHash(genesisResponse.ProducedRollup.Header.Hash()),
 		))
-	encodedRollup, err := common.EncodeRollup(genesisResponse.ProducedRollup.ToRollup())
+	encodedRollup, err := common.EncodeRollup(genesisResponse.ProducedRollup.ToEncryptedRollup())
 	if err != nil {
 		return common.L2RootHash{}, fmt.Errorf("could not encode rollup. Cause: %w", err)
 	}

--- a/integration/common/utils.go
+++ b/integration/common/utils.go
@@ -49,7 +49,7 @@ func AwaitReceipt(ctx context.Context, client *obsclient.AuthObsClient, txHash g
 
 			counter += 100
 			if counter > receiptTimeoutMillis {
-				return fmt.Errorf("could not retrieve transaction after timeout")
+				return fmt.Errorf("could not retrieve transaction %s after timeout", txHash.Hex())
 			}
 			time.Sleep(100 * time.Millisecond)
 			continue

--- a/integration/simulation/network/network_utils.go
+++ b/integration/simulation/network/network_utils.go
@@ -79,6 +79,7 @@ func createInMemObscuroNode(
 		NodeType:            nodeType,
 		GossipRoundDuration: avgGossipPeriod,
 		HasClientRPCHTTP:    false,
+		P2PPublicAddress:    "dummy_address", // Required because the node sanity-checks that this field is not empty at start-up.
 	}
 
 	enclaveConfig := config.EnclaveConfig{

--- a/integration/simulation/network/network_utils.go
+++ b/integration/simulation/network/network_utils.go
@@ -132,6 +132,7 @@ func createSocketObscuroNode(
 		EnclaveRPCTimeout:      ClientRPCTimeout,
 		EnclaveRPCAddress:      enclaveAddr,
 		P2PBindAddress:         p2pAddr,
+		P2PPublicAddress:       p2pAddr,
 		L1ChainID:              integration.EthereumChainID,
 		ObscuroChainID:         integration.ObscuroChainID,
 	}

--- a/integration/simulation/network/obscuro_node_utils.go
+++ b/integration/simulation/network/obscuro_node_utils.go
@@ -286,8 +286,8 @@ func isAddressAvailable(address string) bool {
 
 // GetNodeType returns the type of the node based on its ID.
 func GetNodeType(i int) common.NodeType {
-	// We assign every other node the role of aggregator.
-	if i%2 == 0 {
+	// Only the genesis node is assigned the role of aggregator.
+	if i == 0 {
 		return common.Aggregator
 	}
 	return common.Validator

--- a/integration/simulation/network/obscuro_node_utils.go
+++ b/integration/simulation/network/obscuro_node_utils.go
@@ -171,8 +171,8 @@ func createAuthClients(clients []rpc.Client, wal wallet.Wallet) []*obsclient.Aut
 	return authClients
 }
 
-func startRemoteEnclaveServers(startAt int, params *params.SimParams) {
-	for i := startAt; i < params.NumberOfNodes; i++ {
+func startRemoteEnclaveServers(params *params.SimParams) {
+	for i := 0; i < params.NumberOfNodes; i++ {
 		// create a remote enclave server
 		enclaveAddr := fmt.Sprintf("%s:%d", Localhost, params.StartPort+DefaultEnclaveOffset+i)
 		hostAddr := fmt.Sprintf("%s:%d", Localhost, params.StartPort+DefaultHostP2pOffset+i)

--- a/integration/simulation/network/socket.go
+++ b/integration/simulation/network/socket.go
@@ -49,7 +49,7 @@ func (n *networkOfSocketNodes) Create(params *params.SimParams, stats *stats.Sta
 	params.ERC20ContractLib = erc20contractlib.NewERC20ContractLib(params.MgmtContractAddr, params.ObxErc20Address, params.EthErc20Address)
 
 	// Start the enclaves
-	startRemoteEnclaveServers(0, params)
+	startRemoteEnclaveServers(params)
 
 	n.enclaveAddresses = make([]string, params.NumberOfNodes)
 	for i := 0; i < params.NumberOfNodes; i++ {

--- a/tools/walletextension/accountmanager/account_manager.go
+++ b/tools/walletextension/accountmanager/account_manager.go
@@ -244,7 +244,7 @@ func (m *AccountManager) executeSubscribe(client *rpc.EncRPCClient, req *RPCRequ
 					continue
 				}
 
-				m.logger.Info(fmt.Sprintf("Forwarding log from Obscuro noe: %s", jsonResponse), log.SubIDKey, idAndLog.SubID)
+				m.logger.Info(fmt.Sprintf("Forwarding log from Obscuro node: %s", jsonResponse), log.SubIDKey, idAndLog.SubID)
 				err = userConn.WriteResponse(jsonResponse)
 				if err != nil {
 					m.logger.Error("could not write the JSON log to the websocket on subscription %", log.SubIDKey, idAndLog.SubID, log.ErrKey, err)


### PR DESCRIPTION
### Why is this change needed?

Just some clean-up I wanted to do and TODOs I wanted to add. Also a bug fix in how the full-network sim nodes were created.

### What changes were made as part of this PR:

- Documents the `DB.AddSubmittedRollup` and `DB.WasSubmitted` methods
- Provides a node field to indicate whether we're the sequencer
- Adds some todos
- Fixes bug whereby full-network sim node addresses were empty

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
