### PR TITLE
Fix testnet configs

### DIFF
--- a/.github/workflows/manual-deploy-dev-testnet.yml
+++ b/.github/workflows/manual-deploy-dev-testnet.yml
@@ -53,7 +53,7 @@ jobs:
           name: dev-testnet-gethnetwork
           location: 'uksouth'
           restart-policy: 'Never'
-          command-line: /home/go-obscuro/integration/gethnetwork/main/main --blockTimeSecs=15 --numNodes=2 --startPort=8000 --websocketStartPort=9000 --prefundedAddrs=${{ secrets.GETHNETWORK_PREFUNDED_ADDR_WORKER }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_0 }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_1 }}
+          command-line: /home/go-obscuro/integration/gethnetwork/main/main --blockTimeSecs=15 --numNodes=2 --startPort=8000 --websocketStartPort=9000 --prefundedAddrs="${{ secrets.GETHNETWORK_PREFUNDED_ADDR_WORKER }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_0 }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_1 }}"
           # Ports start at 9000 for Websockets and 8000 for Start port and 8025 for Http Port
           # Each node has Port + id
           ports: '8025 8026 9000 9001'

--- a/.github/workflows/manual-deploy-dev-testnet.yml
+++ b/.github/workflows/manual-deploy-dev-testnet.yml
@@ -213,7 +213,7 @@ jobs:
                --mgmtcontractaddr=${{needs.build-l2.outputs.mgmtContractAddr}} \
                --hocerc20addr=${{needs.build-l2.outputs.hocErc20Addr}} \
                --pocerc20addr=${{needs.build-l2.outputs.pocErc20Addr}} \
-               --pkaddr=${{ secrets[matrix.node_pk_addr] }} \
+               --pkaddress=${{ secrets[matrix.node_pk_addr] }} \
                --pkstring=${{ secrets[matrix.node_pk_str] }} \
                --dev_testnet=true \
                --p2p_public_address=dev-obscuronode-${{ matrix.host_id }}-testnet-${{ GITHUB.RUN_NUMBER }}.uksouth.cloudapp.azure.com:10000'

--- a/.github/workflows/manual-deploy-dev-testnet.yml
+++ b/.github/workflows/manual-deploy-dev-testnet.yml
@@ -53,7 +53,7 @@ jobs:
           name: dev-testnet-gethnetwork
           location: 'uksouth'
           restart-policy: 'Never'
-          command-line: /home/go-obscuro/integration/gethnetwork/main/main --blockTimeSecs=15 --numNodes=2 --startPort=8000 --websocketStartPort=9000 --prefundedAddrs="${{ secrets.GETHNETWORK_PREFUNDED_ADDR_WORKER }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_0 }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_1 }}"
+          command-line: /home/go-obscuro/integration/gethnetwork/main/main --blockTimeSecs=15 --numNodes=2 --startPort=8000 --websocketStartPort=9000 --prefundedAddrs='${{ secrets.GETHNETWORK_PREFUNDED_ADDR_WORKER }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_0 }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_1 }}'
           # Ports start at 9000 for Websockets and 8000 for Start port and 8025 for Http Port
           # Each node has Port + id
           ports: '8025 8026 9000 9001'

--- a/.github/workflows/manual-deploy-dev-testnet.yml
+++ b/.github/workflows/manual-deploy-dev-testnet.yml
@@ -53,7 +53,19 @@ jobs:
           name: dev-testnet-gethnetwork
           location: 'uksouth'
           restart-policy: 'Never'
-          command-line: /home/go-obscuro/integration/gethnetwork/main/main --blockTimeSecs 15 --numNodes=2 --startPort=8000 --websocketStartPort=9000 --prefundedAddrs=${{ secrets.GETHNETWORK_PREFUNDED_ADDR_WORKER }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_0 }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_1 }}
+          inlineScript: |
+            docker run -d --name datadog-agent \
+            -e DD_API_KEY=${{ secrets.DD_API_KEY }} \
+            -e DD_LOGS_ENABLED=true \
+            -e DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true \
+            -e DD_CONTAINER_EXCLUDE_LOGS="name:datadog-agent" \
+            -e DD_SITE="datadoghq.eu"  \
+            -v /var/run/docker.sock:/var/run/docker.sock:ro \
+            -v /proc/:/host/proc/:ro \
+            -v /opt/datadog-agent/run:/opt/datadog-agent/run:rw \
+            -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
+            datadog/agent:latest \
+            && /home/go-obscuro/integration/gethnetwork/main/main --blockTimeSecs 15 --numNodes=2 --startPort=8000 --websocketStartPort=9000 --prefundedAddrs=${{ secrets.GETHNETWORK_PREFUNDED_ADDR_WORKER }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_0 }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_1 }}
           # Ports start at 9000 for Websockets and 8000 for Start port and 8025 for Http Port
           # Each node has Port + id
           ports: '8025 8026 9000 9001'

--- a/.github/workflows/manual-deploy-dev-testnet.yml
+++ b/.github/workflows/manual-deploy-dev-testnet.yml
@@ -59,8 +59,6 @@ jobs:
           ports: '8025 8026 9000 9001'
           cpu: 2
           memory: 4
-      - run:
-          echo "prefundedAddrs=${{ secrets.GETHNETWORK_PREFUNDED_ADDR_WORKER }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_0 }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_1 }}"
 
   build-l2:
     needs: deploy-l1

--- a/.github/workflows/manual-deploy-dev-testnet.yml
+++ b/.github/workflows/manual-deploy-dev-testnet.yml
@@ -53,7 +53,7 @@ jobs:
           name: dev-testnet-gethnetwork
           location: 'uksouth'
           restart-policy: 'Never'
-          command-line: /home/go-obscuro/integration/gethnetwork/main/main --blockTimeSecs 15 --numNodes=2 --startPort=8000 --websocketStartPort=9000 --prefundedAddrs=${{ secrets.GETHNETWORK_PREFUNDED_ADDR_WORKER }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_0 }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_1 }}
+          command-line: /home/go-obscuro/integration/gethnetwork/main/main --blockTimeSecs=15 --numNodes=2 --startPort=8000 --websocketStartPort=9000 --prefundedAddrs=${{ secrets.GETHNETWORK_PREFUNDED_ADDR_WORKER }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_0 }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_1 }}
           # Ports start at 9000 for Websockets and 8000 for Start port and 8025 for Http Port
           # Each node has Port + id
           ports: '8025 8026 9000 9001'

--- a/.github/workflows/manual-deploy-dev-testnet.yml
+++ b/.github/workflows/manual-deploy-dev-testnet.yml
@@ -53,19 +53,7 @@ jobs:
           name: dev-testnet-gethnetwork
           location: 'uksouth'
           restart-policy: 'Never'
-          inlineScript: |
-            docker run -d --name datadog-agent \
-            -e DD_API_KEY=${{ secrets.DD_API_KEY }} \
-            -e DD_LOGS_ENABLED=true \
-            -e DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true \
-            -e DD_CONTAINER_EXCLUDE_LOGS="name:datadog-agent" \
-            -e DD_SITE="datadoghq.eu"  \
-            -v /var/run/docker.sock:/var/run/docker.sock:ro \
-            -v /proc/:/host/proc/:ro \
-            -v /opt/datadog-agent/run:/opt/datadog-agent/run:rw \
-            -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
-            datadog/agent:latest \
-            && /home/go-obscuro/integration/gethnetwork/main/main --blockTimeSecs 15 --numNodes=2 --startPort=8000 --websocketStartPort=9000 --prefundedAddrs=${{ secrets.GETHNETWORK_PREFUNDED_ADDR_WORKER }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_0 }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_1 }}
+          command-line: /home/go-obscuro/integration/gethnetwork/main/main --blockTimeSecs 15 --numNodes=2 --startPort=8000 --websocketStartPort=9000 --prefundedAddrs=${{ secrets.GETHNETWORK_PREFUNDED_ADDR_WORKER }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_0 }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_1 }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_2 }}
           # Ports start at 9000 for Websockets and 8000 for Start port and 8025 for Http Port
           # Each node has Port + id
           ports: '8025 8026 9000 9001'

--- a/.github/workflows/manual-deploy-dev-testnet.yml
+++ b/.github/workflows/manual-deploy-dev-testnet.yml
@@ -53,7 +53,7 @@ jobs:
           name: dev-testnet-gethnetwork
           location: 'uksouth'
           restart-policy: 'Never'
-          command-line: /home/go-obscuro/integration/gethnetwork/main/main --blockTimeSecs 15 --numNodes=2 --startPort=8000 --websocketStartPort=9000 --prefundedAddrs=${{ secrets.GETHNETWORK_PREFUNDED_ADDR_WORKER }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_0 }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_1 }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_2 }}
+          command-line: /home/go-obscuro/integration/gethnetwork/main/main --blockTimeSecs 15 --numNodes=2 --startPort=8000 --websocketStartPort=9000 --prefundedAddrs=${{ secrets.GETHNETWORK_PREFUNDED_ADDR_WORKER }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_0 }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_1 }}
           # Ports start at 9000 for Websockets and 8000 for Start port and 8025 for Http Port
           # Each node has Port + id
           ports: '8025 8026 9000 9001'

--- a/.github/workflows/manual-deploy-dev-testnet.yml
+++ b/.github/workflows/manual-deploy-dev-testnet.yml
@@ -59,6 +59,8 @@ jobs:
           ports: '8025 8026 9000 9001'
           cpu: 2
           memory: 4
+      - run:
+          echo "prefundedAddrs=${{ secrets.GETHNETWORK_PREFUNDED_ADDR_WORKER }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_0 }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_1 }}"
 
   build-l2:
     needs: deploy-l1

--- a/.github/workflows/manual-deploy-testnet-l1.yml
+++ b/.github/workflows/manual-deploy-testnet-l1.yml
@@ -64,7 +64,7 @@ jobs:
           name: testnet-gethnetwork
           location: 'uksouth'
           restart-policy: 'Never'
-          command-line: /home/go-obscuro/integration/gethnetwork/main/main --blockTimeSecs=15 --numNodes=2 --startPort=8000 --websocketStartPort=9000 --prefundedAddrs=${{ secrets.GETHNETWORK_PREFUNDED_ADDR_WORKER }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_0 }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_1 }}
+          command-line: /home/go-obscuro/integration/gethnetwork/main/main --blockTimeSecs=15 --numNodes=2 --startPort=8000 --websocketStartPort=9000 --prefundedAddrs="${{ secrets.GETHNETWORK_PREFUNDED_ADDR_WORKER }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_0 }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_1 }}"
           # Ports start at 9000 for Websockets and 8000 for Start port and 80025 for Http Port
           # Each node has Port + id
           ports: '8025 8026 9000 9001'

--- a/.github/workflows/manual-deploy-testnet-l1.yml
+++ b/.github/workflows/manual-deploy-testnet-l1.yml
@@ -64,7 +64,7 @@ jobs:
           name: testnet-gethnetwork
           location: 'uksouth'
           restart-policy: 'Never'
-          command-line: /home/go-obscuro/integration/gethnetwork/main/main --blockTimeSecs 15 --numNodes=2 --startPort=8000 --websocketStartPort=9000 --prefundedAddrs=${{ secrets.GETHNETWORK_PREFUNDED_ADDR_WORKER }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_0 }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_1 }}
+          command-line: /home/go-obscuro/integration/gethnetwork/main/main --blockTimeSecs=15 --numNodes=2 --startPort=8000 --websocketStartPort=9000 --prefundedAddrs=${{ secrets.GETHNETWORK_PREFUNDED_ADDR_WORKER }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_0 }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_1 }}
           # Ports start at 9000 for Websockets and 8000 for Start port and 80025 for Http Port
           # Each node has Port + id
           ports: '8025 8026 9000 9001'

--- a/.github/workflows/manual-deploy-testnet-l1.yml
+++ b/.github/workflows/manual-deploy-testnet-l1.yml
@@ -64,7 +64,7 @@ jobs:
           name: testnet-gethnetwork
           location: 'uksouth'
           restart-policy: 'Never'
-          command-line: /home/go-obscuro/integration/gethnetwork/main/main --blockTimeSecs=15 --numNodes=2 --startPort=8000 --websocketStartPort=9000 --prefundedAddrs="${{ secrets.GETHNETWORK_PREFUNDED_ADDR_WORKER }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_0 }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_1 }}"
+          command-line: /home/go-obscuro/integration/gethnetwork/main/main --blockTimeSecs=15 --numNodes=2 --startPort=8000 --websocketStartPort=9000 --prefundedAddrs='${{ secrets.GETHNETWORK_PREFUNDED_ADDR_WORKER }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_0 }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_1 }}'
           # Ports start at 9000 for Websockets and 8000 for Start port and 80025 for Http Port
           # Each node has Port + id
           ports: '8025 8026 9000 9001'

--- a/.github/workflows/manual-deploy-testnet-l1.yml
+++ b/.github/workflows/manual-deploy-testnet-l1.yml
@@ -64,7 +64,7 @@ jobs:
           name: testnet-gethnetwork
           location: 'uksouth'
           restart-policy: 'Never'
-          command-line: /home/go-obscuro/integration/gethnetwork/main/main --blockTimeSecs 15 --numNodes=2 --startPort=8000 --websocketStartPort=9000 --prefundedAddrs=${{ secrets.GETHNETWORK_PREFUNDED_ADDR_WORKER }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_0 }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_1 }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_2 }}
+          command-line: /home/go-obscuro/integration/gethnetwork/main/main --blockTimeSecs 15 --numNodes=2 --startPort=8000 --websocketStartPort=9000 --prefundedAddrs=${{ secrets.GETHNETWORK_PREFUNDED_ADDR_WORKER }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_0 }},${{ secrets.GETHNETWORK_PREFUNDED_ADDR_1 }}
           # Ports start at 9000 for Websockets and 8000 for Start port and 80025 for Http Port
           # Each node has Port + id
           ports: '8025 8026 9000 9001'

--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -166,7 +166,7 @@ jobs:
                --mgmtcontractaddr=${{needs.build.outputs.mgmtContractAddr}} \
                --hocerc20addr=${{needs.build.outputs.hocErc20Addr}} \
                --pocerc20addr=${{needs.build.outputs.pocErc20Addr}} \
-               --pkaddr=${{ secrets[matrix.node_pk_addr] }} \
+               --pkaddress=${{ secrets[matrix.node_pk_addr] }} \
                --pkstring=${{ secrets[matrix.node_pk_str] }} \
                --p2p_public_address=obscuronode-${{ matrix.host_id }}-testnet-${{ GITHUB.RUN_NUMBER }}.uksouth.cloudapp.azure.com:10000'
 

--- a/go/config/host_config.go
+++ b/go/config/host_config.go
@@ -61,7 +61,7 @@ type HostConfig struct {
 	LogPath string
 	// The stringified private key for the host's L1 wallet
 	PrivateKeyString string
-	// The address of the host's L1 wallet
+	// The address of the host's L1 wallet. The only purpose for this address is to sanity check compare it against the PrivateKeyString.
 	PKAddress string
 	// The ID of the L1 chain
 	L1ChainID int64

--- a/go/config/host_config.go
+++ b/go/config/host_config.go
@@ -61,6 +61,8 @@ type HostConfig struct {
 	LogPath string
 	// The stringified private key for the host's L1 wallet
 	PrivateKeyString string
+	// The address of the host's L1 wallet
+	PKAddress string
 	// The ID of the L1 chain
 	L1ChainID int64
 	// The ID of the Obscuro chain

--- a/go/host/hostrunner/cli.go
+++ b/go/host/hostrunner/cli.go
@@ -73,6 +73,7 @@ func ParseConfig() (config.HostConfig, error) {
 	l1ChainID := flag.Int64(l1ChainIDName, cfg.L1ChainID, flagUsageMap[l1ChainIDName])
 	obscuroChainID := flag.Int64(obscuroChainIDName, cfg.ObscuroChainID, flagUsageMap[obscuroChainIDName])
 	privateKeyStr := flag.String(privateKeyName, cfg.PrivateKeyString, flagUsageMap[privateKeyName])
+	pkAddress := flag.String(pkAddressName, cfg.PKAddress, flagUsageMap[pkAddressName])
 	profilerEnabled := flag.Bool(profilerEnabledName, cfg.ProfilerEnabled, flagUsageMap[profilerEnabledName])
 
 	flag.Parse()
@@ -106,6 +107,7 @@ func ParseConfig() (config.HostConfig, error) {
 	cfg.P2PConnectionTimeout = time.Duration(*p2pConnectionTimeoutSecs) * time.Second
 	cfg.RollupContractAddress = gethcommon.HexToAddress(*rollupContractAddress)
 	cfg.PrivateKeyString = *privateKeyStr
+	cfg.PKAddress = *pkAddress
 	cfg.LogLevel = *logLevel
 	cfg.LogPath = *logPath
 	cfg.L1ChainID = *l1ChainID

--- a/go/host/hostrunner/cli.go
+++ b/go/host/hostrunner/cli.go
@@ -39,6 +39,7 @@ type HostConfigToml struct {
 	LogLevel               int
 	LogPath                string
 	PrivateKeyString       string
+	PKAddress              string
 	L1ChainID              int64
 	ObscuroChainID         int64
 	ProfilerEnabled        bool
@@ -158,6 +159,7 @@ func fileBasedConfig(configPath string) (config.HostConfig, error) {
 		LogLevel:               tomlConfig.LogLevel,
 		LogPath:                tomlConfig.LogPath,
 		PrivateKeyString:       tomlConfig.PrivateKeyString,
+		PKAddress:              tomlConfig.PKAddress,
 		L1ChainID:              tomlConfig.L1ChainID,
 		ObscuroChainID:         tomlConfig.ObscuroChainID,
 		ProfilerEnabled:        tomlConfig.ProfilerEnabled,

--- a/go/host/hostrunner/cli_flags.go
+++ b/go/host/hostrunner/cli_flags.go
@@ -23,6 +23,7 @@ const (
 	logLevelName                 = "logLevel"
 	logPathName                  = "logPath"
 	privateKeyName               = "privateKey"
+	pkAddressName                = "pkAddress"
 	l1ChainIDName                = "l1ChainID"
 	obscuroChainIDName           = "obscuroChainID"
 	profilerEnabledName          = "profilerEnabled"
@@ -53,6 +54,7 @@ func getFlagUsageMap() map[string]string {
 		logLevelName:                 "The verbosity level of logs. (Defaults to Info)",
 		logPathName:                  "The path to use for the host's log file",
 		privateKeyName:               "The private key for the L1 host account",
+		pkAddressName:                "The address of the L1 host account",
 		l1ChainIDName:                "An integer representing the unique chain id of the Ethereum chain used as an L1 (default 1337)",
 		obscuroChainIDName:           "An integer representing the unique chain id of the Obscuro chain (default 777)",
 		profilerEnabledName:          "Runs a profiler instance (Defaults to false)",

--- a/go/host/hostrunner/host_runner.go
+++ b/go/host/hostrunner/host_runner.go
@@ -27,6 +27,7 @@ import (
 func RunHost(config config.HostConfig) {
 	logger := log.New(log.HostCmp, config.LogLevel, config.LogPath, log.NodeIDKey, config.ID)
 
+	logger.Info(fmt.Sprintf("Starting node with config: %+v", config))
 	mgmtContractLib := mgmtcontractlib.NewMgmtContractLib(&config.RollupContractAddress, logger)
 
 	fmt.Println("Connecting to L1 network...")

--- a/go/host/hostrunner/host_runner.go
+++ b/go/host/hostrunner/host_runner.go
@@ -27,6 +27,7 @@ import (
 func RunHost(config config.HostConfig) {
 	logger := log.New(log.HostCmp, config.LogLevel, config.LogPath, log.NodeIDKey, config.ID)
 
+	fmt.Printf("Starting host with config: %+v", config)
 	logger.Info(fmt.Sprintf("Starting node with config: %+v", config))
 	mgmtContractLib := mgmtcontractlib.NewMgmtContractLib(&config.RollupContractAddress, logger)
 

--- a/go/host/main/main.go
+++ b/go/host/main/main.go
@@ -1,7 +1,12 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
+
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/status-im/keycard-go/hexutils"
 
 	"github.com/obscuronet/go-obscuro/go/host/hostrunner"
 )
@@ -12,5 +17,18 @@ func main() {
 	if err != nil {
 		panic(fmt.Errorf("could not parse config. Cause: %w", err))
 	}
+	addr := toAddress(config.PrivateKeyString)
+	if !bytes.Equal(hexutils.HexToBytes(config.PKAddress), addr.Bytes()) {
+		panic(fmt.Errorf("the address %s does not match the private key %s", config.PKAddress, config.PrivateKeyString))
+	}
 	hostrunner.RunHost(config)
+}
+
+func toAddress(privateKey string) gethcommon.Address {
+	privateKeyA, err := crypto.ToECDSA(hexutils.HexToBytes(privateKey))
+	if err != nil {
+		panic(err)
+	}
+	pubKeyA := privateKeyA.PublicKey
+	return crypto.PubkeyToAddress(pubKeyA)
 }

--- a/go/host/node/node.go
+++ b/go/host/node/node.go
@@ -644,7 +644,7 @@ func (a *Node) signAndBroadcastL1Tx(tx types.TxData, tries int) error {
 		return nil
 	}
 
-	return fmt.Errorf("broadcasting L1 transaction failed after %d tries. Cause: %w", tries, err)
+	return fmt.Errorf("broadcasting L1 transaction failed after %d tries. Signer %s. Cause: %w", tries, a.ethWallet.Address().Hex(), err)
 }
 
 // This method implements the procedure by which a node obtains the secret

--- a/integration/gethnetwork/geth_network.go
+++ b/integration/gethnetwork/geth_network.go
@@ -211,9 +211,12 @@ func NewGethNetwork(portStart int, websocketPortStart int, gethBinaryPath string
 	wg.Wait()
 
 	// We generate the genesis config file based on the accounts above and the prefunded addresses.
-	allocs := make([]string, numNodes+len(preFundedAddrs))
-	for i, addr := range append(network.addresses, preFundedAddrs...) {
-		allocs[i] = fmt.Sprintf(addrBlockTemplate, addr)
+	allocs := make([]string, 0)
+	for _, addr := range network.addresses {
+		allocs = append(allocs, fmt.Sprintf(addrBlockTemplate, addr))
+	}
+	for _, addr := range preFundedAddrs {
+		allocs = append(allocs, fmt.Sprintf(addrBlockTemplate, addr))
 	}
 	network.GenesisJSON = []byte(
 		fmt.Sprintf(genesisJSONTemplate, blockTimeSecs, strings.Join(allocs, ",\r\n"), strings.Join(network.addresses, "")),

--- a/integration/gethnetwork/geth_network.go
+++ b/integration/gethnetwork/geth_network.go
@@ -158,8 +158,15 @@ func NewGethNetwork(portStart int, websocketPortStart int, gethBinaryPath string
 
 	logPath := log.SysOut
 	logFile := os.Stdout
+	// In case there is no `logPathParam` passed in, logging defaults to a standard file in the current folder
 	if logPathParam == "" {
 		logPath = path.Join(buildDir, logFileName)
+		logFile, err = os.Create(logPath)
+		if err != nil {
+			panic(err)
+		}
+	} else if logPathParam != log.SysOut {
+		logPath = logPathParam
 		logFile, err = os.Create(logPath)
 		if err != nil {
 			panic(err)

--- a/integration/gethnetwork/geth_network.go
+++ b/integration/gethnetwork/geth_network.go
@@ -88,7 +88,7 @@ const (
 	  },
 	  "alloc": {
 		"0x323AefbFC16159655514846a9e5433C457de9389": {
-		  "balance": "1000000000000000000000"
+		  "balance": "1000000000000000000000000"
 		},
 %s
 	  },
@@ -102,7 +102,7 @@ const (
 	  "timestamp": "0x00"
   }`
 	addrBlockTemplate = `		"%s": {
-		  "balance": "1000000000000000000000"
+		  "balance": "1000000000000000000000000"
 		}`
 	genesisJSONAddrKey = "address"
 )

--- a/integration/gethnetwork/geth_network.go
+++ b/integration/gethnetwork/geth_network.go
@@ -160,7 +160,7 @@ func NewGethNetwork(portStart int, websocketPortStart int, gethBinaryPath string
 	logFile := os.Stdout
 	if logPathParam == "" {
 		logPath = path.Join(buildDir, logFileName)
-		logFile, err = os.Create(logPathParam)
+		logFile, err = os.Create(logPath)
 		if err != nil {
 			panic(err)
 		}

--- a/integration/gethnetwork/geth_network_test.go
+++ b/integration/gethnetwork/geth_network_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	gethlog "github.com/ethereum/go-ethereum/log"
 	"math/big"
 	"strconv"
 	"testing"
@@ -55,7 +56,7 @@ func TestGethAllNodesJoinSameNetwork(t *testing.T) {
 	}
 
 	startPort := int(integration.StartPortGethNetworkTest)
-	network := NewGethNetwork(startPort, startPort+defaultWsPortOffset, gethBinaryPath, numNodes, 1, nil)
+	network := NewGethNetwork(startPort, startPort+defaultWsPortOffset, gethBinaryPath, numNodes, 1, nil, "", int(gethlog.LvlDebug))
 	defer network.StopNodes()
 
 	peerCountStr := network.IssueCommand(0, peerCountCmd)
@@ -74,7 +75,7 @@ func TestGethGenesisParamsAreUsed(t *testing.T) {
 	}
 
 	startPort := int(integration.StartPortGethNetworkTest) + numNodes
-	network := NewGethNetwork(startPort, startPort+defaultWsPortOffset, gethBinaryPath, numNodes, 1, nil)
+	network := NewGethNetwork(startPort, startPort+defaultWsPortOffset, gethBinaryPath, numNodes, 1, nil, "", int(gethlog.LvlDebug))
 	defer network.StopNodes()
 
 	chainID := network.IssueCommand(0, chainIDCmd)
@@ -90,7 +91,7 @@ func TestGethTransactionCanBeSubmitted(t *testing.T) {
 	}
 
 	startPort := int(integration.StartPortGethNetworkTest) + numNodes*2
-	network := NewGethNetwork(startPort, startPort+defaultWsPortOffset, gethBinaryPath, numNodes, 1, nil)
+	network := NewGethNetwork(startPort, startPort+defaultWsPortOffset, gethBinaryPath, numNodes, 1, nil, "", int(gethlog.LvlDebug))
 	defer network.StopNodes()
 
 	account := network.addresses[0]
@@ -119,7 +120,7 @@ func TestGethTransactionIsMintedOverRPC(t *testing.T) {
 	// wallet should be prefunded
 	w := datagenerator.RandomWallet(genesisChainID)
 	startPort := int(integration.StartPortGethNetworkTest) + numNodes*3
-	network := NewGethNetwork(startPort, startPort+defaultWsPortOffset, gethBinaryPath, numNodes, 1, []string{w.Address().String()})
+	network := NewGethNetwork(startPort, startPort+defaultWsPortOffset, gethBinaryPath, numNodes, 1, []string{w.Address().String()}, "", int(gethlog.LvlDebug))
 	defer network.StopNodes()
 
 	ethClient, err := ethadapter.NewEthClient(localhost, network.WebSocketPorts[0], defaultL1RPCTimeout, common.HexToAddress("0x0"), testlog.Logger())

--- a/integration/gethnetwork/geth_network_test.go
+++ b/integration/gethnetwork/geth_network_test.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	gethlog "github.com/ethereum/go-ethereum/log"
 	"math/big"
 	"strconv"
 	"testing"
 	"time"
+
+	gethlog "github.com/ethereum/go-ethereum/log"
 
 	"github.com/obscuronet/go-obscuro/integration/common/testlog"
 

--- a/integration/gethnetwork/main/cli.go
+++ b/integration/gethnetwork/main/cli.go
@@ -68,6 +68,8 @@ func parseCLIArgs() gethConfig {
 	flag.Parse()
 
 	addrs := *prefundedAddrs
+	// When running locally, we don't have to add the quotes around the prefunded addresses.
+	// This is stripping them away in case they were added.
 	if strings.HasPrefix(addrs, "'") {
 		addrs = addrs[1 : len(addrs)-1]
 	}

--- a/integration/gethnetwork/main/cli.go
+++ b/integration/gethnetwork/main/cli.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"flag"
+	"strings"
+
 	gethlog "github.com/ethereum/go-ethereum/log"
 	"github.com/obscuronet/go-obscuro/go/common/log"
-	"strings"
 )
 
 const (

--- a/integration/gethnetwork/main/cli.go
+++ b/integration/gethnetwork/main/cli.go
@@ -67,8 +67,12 @@ func parseCLIArgs() gethConfig {
 
 	flag.Parse()
 
-	parsedPrefundedAddrs := strings.Split(*prefundedAddrs, ",")
-	if *prefundedAddrs == "" {
+	addrs := *prefundedAddrs
+	if strings.HasPrefix(addrs, "'") {
+		addrs = addrs[1 : len(addrs)-1]
+	}
+	parsedPrefundedAddrs := strings.Split(addrs, ",")
+	if addrs == "" {
 		// We handle the special case of an empty list.
 		parsedPrefundedAddrs = []string{}
 	}

--- a/integration/gethnetwork/main/cli.go
+++ b/integration/gethnetwork/main/cli.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"flag"
+	gethlog "github.com/ethereum/go-ethereum/log"
+	"github.com/obscuronet/go-obscuro/go/common/log"
 	"strings"
 )
 
@@ -21,6 +23,12 @@ const (
 
 	blockTimeSecsName  = "blockTimeSecs"
 	blockTimeSecsUsage = "The block time in seconds"
+
+	logLevelName  = "logLevel"
+	logLevelUsage = "logLevel"
+
+	logPathName  = "logPath"
+	logPathUsage = "logPath"
 )
 
 type gethConfig struct {
@@ -29,6 +37,8 @@ type gethConfig struct {
 	websocketStartPort int
 	prefundedAddrs     []string
 	blockTimeSecs      int
+	logLevel           int
+	logPath            string
 }
 
 func defaultHostConfig() gethConfig {
@@ -38,6 +48,8 @@ func defaultHostConfig() gethConfig {
 		websocketStartPort: 12100,
 		prefundedAddrs:     []string{},
 		blockTimeSecs:      1,
+		logPath:            log.SysOut,
+		logLevel:           int(gethlog.LvlDebug),
 	}
 }
 
@@ -49,6 +61,8 @@ func parseCLIArgs() gethConfig {
 	websocketStartPort := flag.Int(websocketStartPortName, defaultConfig.websocketStartPort, websocketStartPortUsage)
 	prefundedAddrs := flag.String(prefundedAddrsName, "", prefundedAddrsUsage)
 	blockTimeSecs := flag.Int(blockTimeSecsName, defaultConfig.blockTimeSecs, blockTimeSecsUsage)
+	logLevel := flag.Int(logLevelName, defaultConfig.logLevel, logLevelUsage)
+	logPath := flag.String(logPathName, defaultConfig.logPath, logPathUsage)
 
 	flag.Parse()
 
@@ -64,5 +78,7 @@ func parseCLIArgs() gethConfig {
 		websocketStartPort: *websocketStartPort,
 		prefundedAddrs:     parsedPrefundedAddrs,
 		blockTimeSecs:      *blockTimeSecs,
+		logLevel:           *logLevel,
+		logPath:            *logPath,
 	}
 }

--- a/integration/gethnetwork/main/main.go
+++ b/integration/gethnetwork/main/main.go
@@ -17,7 +17,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	gethNetwork := gethnetwork.NewGethNetwork(config.startPort, config.websocketStartPort, gethBinaryPath, config.numNodes, config.blockTimeSecs, config.prefundedAddrs)
+	gethNetwork := gethnetwork.NewGethNetwork(config.startPort, config.websocketStartPort, gethBinaryPath, config.numNodes, config.blockTimeSecs, config.prefundedAddrs, config.logPath, config.logLevel)
 	fmt.Println("Geth network started.")
 
 	handleInterrupt(gethNetwork)

--- a/integration/noderunner/noderunner_test.go
+++ b/integration/noderunner/noderunner_test.go
@@ -3,11 +3,12 @@ package noderunner
 import (
 	"encoding/hex"
 	"fmt"
-	gethlog "github.com/ethereum/go-ethereum/log"
 	"net"
 	"net/http"
 	"testing"
 	"time"
+
+	gethlog "github.com/ethereum/go-ethereum/log"
 
 	"github.com/obscuronet/go-obscuro/go/common/profiler"
 	"github.com/obscuronet/go-obscuro/integration/common/testlog"

--- a/integration/noderunner/noderunner_test.go
+++ b/integration/noderunner/noderunner_test.go
@@ -3,6 +3,7 @@ package noderunner
 import (
 	"encoding/hex"
 	"fmt"
+	gethlog "github.com/ethereum/go-ethereum/log"
 	"net"
 	"net/http"
 	"testing"
@@ -73,7 +74,7 @@ func TestCanStartStandaloneObscuroHostAndEnclave(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	network := gethnetwork.NewGethNetwork(int(gethPort), int(gethWebsocketPort), gethBinaryPath, 1, 1, []string{address.String()})
+	network := gethnetwork.NewGethNetwork(int(gethPort), int(gethWebsocketPort), gethBinaryPath, 1, 1, []string{address.String()}, "", int(gethlog.LvlDebug))
 	defer network.StopNodes()
 
 	go enclaverunner.RunEnclave(enclaveConfig)

--- a/integration/simulation/network/geth_utils.go
+++ b/integration/simulation/network/geth_utils.go
@@ -3,9 +3,10 @@ package network
 import (
 	"errors"
 	"fmt"
-	gethlog "github.com/ethereum/go-ethereum/log"
 	"math/big"
 	"time"
+
+	gethlog "github.com/ethereum/go-ethereum/log"
 
 	"github.com/obscuronet/go-obscuro/integration/common/testlog"
 

--- a/integration/simulation/network/geth_utils.go
+++ b/integration/simulation/network/geth_utils.go
@@ -3,6 +3,7 @@ package network
 import (
 	"errors"
 	"fmt"
+	gethlog "github.com/ethereum/go-ethereum/log"
 	"math/big"
 	"time"
 
@@ -41,14 +42,7 @@ func SetUpGethNetwork(wallets *params.SimWallets, StartPort int, nrNodes int, bl
 	}
 
 	// kickoff the network with the prefunded wallet addresses
-	gethNetwork := gethnetwork.NewGethNetwork(
-		StartPort,
-		StartPort+DefaultWsPortOffset,
-		path,
-		nrNodes,
-		blockDurationSeconds,
-		walletAddresses,
-	)
+	gethNetwork := gethnetwork.NewGethNetwork(StartPort, StartPort+DefaultWsPortOffset, path, nrNodes, blockDurationSeconds, walletAddresses, "", int(gethlog.LvlDebug))
 
 	// connect to the first host to deploy
 	tmpEthClient, err := ethadapter.NewEthClient(Localhost, gethNetwork.WebSocketPorts[0], DefaultL1RPCTimeout, common.HexToAddress("0x0"), testlog.Logger())

--- a/integration/smartcontract/smartcontracts_test.go
+++ b/integration/smartcontract/smartcontracts_test.go
@@ -1,10 +1,11 @@
 package smartcontract
 
 import (
-	"github.com/ethereum/go-ethereum/log"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/obscuronet/go-obscuro/integration/common/testlog"
 

--- a/integration/smartcontract/smartcontracts_test.go
+++ b/integration/smartcontract/smartcontracts_test.go
@@ -1,6 +1,7 @@
 package smartcontract
 
 import (
+	"github.com/ethereum/go-ethereum/log"
 	"reflect"
 	"testing"
 	"time"
@@ -53,14 +54,7 @@ func runGethNetwork(t *testing.T) *netInfo {
 	workerWallet := datagenerator.RandomWallet(integration.EthereumChainID)
 
 	// define + run the network
-	gethNetwork := gethnetwork.NewGethNetwork(
-		integration.StartPortSmartContractTests,
-		integration.StartPortSmartContractTests+100,
-		path,
-		3,
-		1,
-		[]string{workerWallet.Address().String()},
-	)
+	gethNetwork := gethnetwork.NewGethNetwork(integration.StartPortSmartContractTests, integration.StartPortSmartContractTests+100, path, 3, 1, []string{workerWallet.Address().String()}, "", int(log.LvlInfo))
 
 	// create a client that is connected to node 0 of the network
 	client, err := ethadapter.NewEthClient("127.0.0.1", gethNetwork.WebSocketPorts[0], 30*time.Second, gethcommon.HexToAddress("0x0"), testlog.Logger())

--- a/testnet/docker-compose.dev-testnet.yml
+++ b/testnet/docker-compose.dev-testnet.yml
@@ -33,6 +33,7 @@ services:
       "--enclaveRPCAddress=enclave:11000",
       "--rollupContractAddress=$MGMTCONTRACTADDR",
       "--privateKey=$PKSTRING",
+      "--pkAddress=$PKADDR",
       "--clientRPCHost=0.0.0.0",
       "--isGenesis=$ISGENESIS",
       "--nodeType=$NODETYPE",

--- a/testnet/start-obscuro-node.sh
+++ b/testnet/start-obscuro-node.sh
@@ -71,7 +71,7 @@ debug_enclave=false
 dev_testnet=false
 pk_address=0x0654D8B60033144D567f25bF41baC1FB0D60F23B
 pk_string=8ead642ca80dadb0f346a66cd6aa13e08a8ac7b5c6f7578d4bac96f5db01ac99
-log_level=2
+log_level=4
 
 
 # Fetch options

--- a/testnet/start-obscuro-node.sh
+++ b/testnet/start-obscuro-node.sh
@@ -110,7 +110,7 @@ fi
 
 
 # set the data in the env file
-echo "PKSTRING=${pk_string}" > "${testnet_path}/.env"
+echo "PKSTRING=${pk_string}" >> "${testnet_path}/.env"
 echo "PKADDR=${pk_address}" >> "${testnet_path}/.env"
 echo "HOSTID=${host_id}"  >> "${testnet_path}/.env"
 echo "MGMTCONTRACTADDR=${mgmt_contract_addr}"  >> "${testnet_path}/.env"


### PR DESCRIPTION
### Why is this change needed?

Dev testnet was not starting because of l1 gas errors. Captured in bug ticket https://github.com/obscuronet/obscuro-internal/issues/1097

### What changes were made as part of this PR:

After investigations ( which are reflected in different changes), it turned out the problem was in parsing the start l1 command line on the azure docker setup. 

This PR also contains fixes along the way:
- adding support to the gethnetwork util for sending logging params
- passing the wallet address to the obscuro host ( not strictly necessary, but can be used for debugging)


### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
