### PR TITLE
Modified README to add notice of problematic Docker behaviour.

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,12 +280,13 @@ written in [go](https://go.dev). Unless otherwise stated, all paths stated herei
 The following dependencies are required to be installed locally;
 
 - [go](https://go.dev) (version > 1.18)
-- [docker](https://docs.docker.com/get-docker/) (recommend latest version)
+- [docker](https://docs.docker.com/get-docker/) (recommend latest version*)
 - [docker compose](https://docs.docker.com/compose/install/) (recommend latest version)
 
 Whilst the recommended version of go is > 1.18, the reference implementation uses _only_ language features up to and 
 including 1.17. Using 1.18 is recommended for easier setup and installation and is backwards compatible with all 1.17 
 language features. 
+> :warning: Docker Desktop version 4.13 is known to have issues on ARM64 systems. If you experience daemon crashes and segmentation faults when running inside containers it is recommended to downgrade. Version 4.12 is the latest known to work.
 
 
 ### Building


### PR DESCRIPTION
### Why is this change needed?

[Docker Issue](https://github.com/docker/for-mac/issues/6539)

The steps to build and run the project in the current README do not work with the latest version of docker

### What changes were made as part of this PR:

Added a warning notice

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
