### PR TITLE
Watch for receipts to confirm L1 transactions

### DIFF
--- a/go/common/retry/retry.go
+++ b/go/common/retry/retry.go
@@ -17,10 +17,13 @@ func Do(fn func() error, retryStrat Strategy) error {
 			return nil
 		}
 
+		// calling NextRetryInterval() marks the end of an attempt for the retry strategy, so we call it before checking Done()
+		nextInterval := retryStrat.NextRetryInterval()
+
 		if retryStrat.Done() {
 			return fmt.Errorf("%s - latest error: %w", retryStrat.Summary(), err)
 		}
 
-		time.Sleep(retryStrat.NextRetryInterval())
+		time.Sleep(nextInterval)
 	}
 }

--- a/go/common/retry/retry_strategy.go
+++ b/go/common/retry/retry_strategy.go
@@ -2,6 +2,7 @@ package retry
 
 import (
 	"fmt"
+	"math"
 	"time"
 )
 
@@ -14,6 +15,7 @@ type Strategy interface {
 	Reset()                           // reset is called before the first attempt is made, can be used for recording start time or setting attempts to zero
 }
 
+// NewTimeoutStrategy retries at the provided (fixed) interval until the timeout duration has elapsed
 func NewTimeoutStrategy(timeout time.Duration, interval time.Duration) Strategy {
 	return &timeoutStrategy{
 		timeout:  timeout,
@@ -47,4 +49,44 @@ func (t *timeoutStrategy) Summary() string {
 func (t *timeoutStrategy) Reset() {
 	t.attempts = 0
 	t.startTime = time.Now()
+}
+
+// NewDoublingBackoffStrategy keeps retrying until successful or until it reaches maxRetries, doubling the initialInterval
+// wait period after each additional retry to avoid exacerbating problems with failing traffic
+func NewDoublingBackoffStrategy(initialInterval time.Duration, maxRetries uint64) Strategy {
+	return &backoffStrategy{
+		initialInterval:        initialInterval,
+		maxRetries:             maxRetries,
+		intervalIncreaseFactor: 2,
+	}
+}
+
+type backoffStrategy struct {
+	maxRetries             uint64
+	initialInterval        time.Duration
+	intervalIncreaseFactor float64
+
+	startTime time.Time
+	attempts  uint64
+}
+
+func (b *backoffStrategy) NextRetryInterval() time.Duration {
+	b.attempts++
+	return b.initialInterval * time.Duration(math.Pow(b.intervalIncreaseFactor, float64(b.attempts-1)))
+}
+
+func (b *backoffStrategy) Done() bool {
+	return b.attempts >= b.maxRetries
+}
+
+func (b *backoffStrategy) Summary() string {
+	if b.Done() {
+		return fmt.Sprintf("completed maximum permitted retries (%d) over %s", b.attempts, time.Since(b.startTime))
+	}
+	return fmt.Sprintf("retrying after %d attempts", b.attempts)
+}
+
+func (b *backoffStrategy) Reset() {
+	b.attempts = 0
+	b.startTime = time.Now()
 }

--- a/go/common/retry/retry_test.go
+++ b/go/common/retry/retry_test.go
@@ -40,3 +40,26 @@ func TestDoWithTimeoutStrategy_UnsuccessfulAfterTimeout(t *testing.T) {
 
 	assert.Greater(t, count, 5, "expected function to be called at least 5 times before timing out")
 }
+
+func TestDoublingBackoffStrategy_DoublingIntervalsAndRespectMaxRetries(t *testing.T) {
+	var count int
+	prevAttempt := time.Now()
+	expectedInterval := 20
+	testFunc := func() error {
+		count = count + 1
+		if count > 1 {
+			// we check it waited at least long enough (not checking for too long as that could be flaky)
+			assert.Greater(t, time.Since(prevAttempt), time.Duration(expectedInterval)*time.Millisecond)
+			expectedInterval = 2 * expectedInterval
+		}
+		prevAttempt = time.Now()
+		return fmt.Errorf("attempt number %d", count)
+	}
+
+	err := Do(testFunc, NewDoublingBackoffStrategy(20*time.Millisecond, 5))
+	if err == nil {
+		assert.Fail(t, "expected failure from hitting max retries but no err found")
+	}
+
+	assert.Equal(t, 6, count, "expected function to be called exactly 5 times before failing")
+}

--- a/go/common/retry/retry_test.go
+++ b/go/common/retry/retry_test.go
@@ -61,5 +61,5 @@ func TestDoublingBackoffStrategy_DoublingIntervalsAndRespectMaxRetries(t *testin
 		assert.Fail(t, "expected failure from hitting max retries but no err found")
 	}
 
-	assert.Equal(t, 6, count, "expected function to be called exactly 5 times before failing")
+	assert.Equal(t, 5, count, "expected function to be called exactly 5 times before failing")
 }

--- a/go/host/node/node.go
+++ b/go/host/node/node.go
@@ -8,6 +8,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/obscuronet/go-obscuro/go/common/retry"
+
 	gethlog "github.com/ethereum/go-ethereum/log"
 
 	"github.com/obscuronet/go-obscuro/go/host/events"
@@ -48,6 +50,9 @@ const (
 	l1TxTriesRollup = 3
 	// Attempts to send secret initialisation, request or response transactions to the L1. Worst-case, equates to 63 seconds, plus time per request.
 	l1TxTriesSecret = 7
+
+	maxWaitForL1Receipt       = time.Minute
+	retryIntervalForL1Receipt = time.Second
 )
 
 // Node is an implementation of host.Host.
@@ -629,22 +634,32 @@ func (a *Node) initialiseProtocol(block *types.Block) (common.L2RootHash, error)
 }
 
 // `tries` is the number of times to attempt broadcasting the transaction.
-func (a *Node) signAndBroadcastL1Tx(tx types.TxData, tries int) error {
+func (a *Node) signAndBroadcastL1Tx(tx types.TxData, tries uint64) error {
 	signedTx, err := a.ethWallet.SignTransaction(tx)
 	if err != nil {
 		return err
 	}
 
-	funcBroadcastTx := func() error {
-		// TODO - #1089 - Await transaction receipt after sending the transaction.
+	err = retry.Do(func() error {
 		return a.ethClient.SendTransaction(signedTx)
-	}
-	err = retryWithBackoff(tries, funcBroadcastTx)
-	if err == nil {
-		return nil
+	}, retry.NewDoublingBackoffStrategy(time.Second, tries)) // doubling retry wait (3 tries = 7sec, 7 tries = 63sec)
+	if err != nil {
+		return fmt.Errorf("broadcasting L1 transaction failed after %d tries. Cause: %w", tries, err)
 	}
 
-	return fmt.Errorf("broadcasting L1 transaction failed after %d tries. Cause: %w", tries, err)
+	var receipt *types.Receipt
+	err = retry.Do(func() error {
+		receipt, err = a.ethClient.TransactionReceipt(signedTx.Hash())
+		return err
+	}, retry.NewTimeoutStrategy(maxWaitForL1Receipt, retryIntervalForL1Receipt))
+	if err != nil {
+		return fmt.Errorf("receipt for L1 transaction never found despite 'successful' broadcast - %w", err)
+	}
+	if err == nil && receipt.Status != types.ReceiptStatusSuccessful {
+		return fmt.Errorf("unsuccessful receipt found for published L1 transaction, status=%d", receipt.Status)
+	}
+
+	return nil
 }
 
 // This method implements the procedure by which a node obtains the secret
@@ -1009,28 +1024,5 @@ func (a *Node) validateConfig() {
 
 	if a.config.P2PPublicAddress == "" {
 		a.logger.Crit("the node must specify a public P2P address")
-	}
-}
-
-// We retry calling `funcToRetry`, with a pause in between that starts at one second and doubles on each retry.
-// This is equal to 7 seconds for 3 tries, and 63 seconds for 7 tries.
-func retryWithBackoff(tries int, funcToRetry func() error) error {
-	pause := time.Second
-	var err error
-
-	for i := 0; ; i++ {
-		if i >= tries {
-			// We've performed all the tries, so we return the (possibly nil) error.
-			return err
-		}
-
-		err = funcToRetry()
-		if err == nil {
-			// If the transaction sent successfully, we break out.
-			return nil
-		}
-
-		time.Sleep(pause)
-		pause = pause * 2
 	}
 }

--- a/go/host/node/node.go
+++ b/go/host/node/node.go
@@ -647,7 +647,7 @@ func (a *Node) signAndBroadcastL1Tx(tx types.TxData, tries uint64) error {
 		return fmt.Errorf("broadcasting L1 transaction failed after %d tries. Cause: %w", tries, err)
 	}
 
-	// asynchronously watch for a successful receipt, panic if transaction ends up failing
+	// asynchronously watch for a successful receipt
 	// todo: consider how to handle the various ways that L1 transactions could fail to improve node operator QoL
 	go a.watchForReceipt(signedTx.Hash())
 

--- a/go/host/node/node.go
+++ b/go/host/node/node.go
@@ -51,8 +51,8 @@ const (
 	// Attempts to send secret initialisation, request or response transactions to the L1. Worst-case, equates to 63 seconds, plus time per request.
 	l1TxTriesSecret = 7
 
-	maxWaitForL1Receipt       = time.Minute
-	retryIntervalForL1Receipt = time.Second
+	maxWaitForL1Receipt       = 100 * time.Second
+	retryIntervalForL1Receipt = 10 * time.Second
 )
 
 // Node is an implementation of host.Host.

--- a/go/host/node/node.go
+++ b/go/host/node/node.go
@@ -662,10 +662,10 @@ func (a *Node) watchForReceipt(txHash common.TxHash) {
 		return err
 	}, retry.NewTimeoutStrategy(maxWaitForL1Receipt, retryIntervalForL1Receipt))
 	if err != nil {
-		panic(fmt.Sprintf("receipt for L1 transaction never found despite 'successful' broadcast - %s", err))
+		a.logger.Error("receipt for L1 transaction never found despite 'successful' broadcast", "err", err)
 	}
 	if err == nil && receipt.Status != types.ReceiptStatusSuccessful {
-		panic(fmt.Sprintf("unsuccessful receipt found for published L1 transaction, status=%d", receipt.Status))
+		a.logger.Error("unsuccessful receipt found for published L1 transaction", "status", receipt.Status)
 	}
 }
 


### PR DESCRIPTION
### Why is this change needed?

- We sometimes have failures where secrets haven't exchanged or rollups get lost because L1 transaction never got mined
- These can be hard to diagnose and also we need to be provide visibility for this issue for node operators

### What changes were made as part of this PR:

- Add a watch for receipt part to the L1 transaction submission in the host
- Move the backing-off retry strategy to the retry package
- Fix minor bug in the retry logic where we checked if Done before recording the latest retry attempt (didn't matter in the timeout strategy)

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
