### PR TITLE
fix check

### DIFF
--- a/go/host/main/main.go
+++ b/go/host/main/main.go
@@ -19,7 +19,7 @@ func main() {
 	}
 	addr := toAddress(config.PrivateKeyString)
 	if !bytes.Equal(hexutils.HexToBytes(config.PKAddress), addr.Bytes()) {
-		panic(fmt.Errorf("the address %s does not match the private key %s", config.PKAddress, config.PrivateKeyString))
+		fmt.Printf("WARN: the address: %s does not match the private key %s\n", config.PKAddress, config.PrivateKeyString)
 	}
 	hostrunner.RunHost(config)
 }


### PR DESCRIPTION
### Why is this change needed?

host fails to start when the address is not passed in.

### What changes were made as part of this PR:

Transform panic to warning 

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
