### PR TITLE
fix host startup

### DIFF
--- a/go/host/main/main.go
+++ b/go/host/main/main.go
@@ -3,10 +3,10 @@ package main
 import (
 	"bytes"
 	"fmt"
-
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/status-im/keycard-go/hexutils"
+	"strings"
 
 	"github.com/obscuronet/go-obscuro/go/host/hostrunner"
 )
@@ -18,14 +18,23 @@ func main() {
 		panic(fmt.Errorf("could not parse config. Cause: %w", err))
 	}
 	addr := toAddress(config.PrivateKeyString)
-	if config.PKAddress != "" && !bytes.Equal(hexutils.HexToBytes(config.PKAddress), addr.Bytes()) {
+	pkadd := config.PKAddress
+	if strings.HasPrefix(config.PKAddress, "0x") {
+		pkadd = config.PKAddress[2:]
+	}
+
+	if config.PKAddress != "" && !bytes.Equal(hexutils.HexToBytes(pkadd), addr.Bytes()) {
 		fmt.Printf("WARN: the address: %s does not match the private key %s\n", config.PKAddress, config.PrivateKeyString)
 	}
 	hostrunner.RunHost(config)
 }
 
 func toAddress(privateKey string) gethcommon.Address {
-	privateKeyA, err := crypto.ToECDSA(hexutils.HexToBytes(privateKey))
+	k := privateKey
+	if strings.HasPrefix(privateKey, "0x") {
+		k = privateKey[2:]
+	}
+	privateKeyA, err := crypto.ToECDSA(hexutils.HexToBytes(k))
 	if err != nil {
 		panic(err)
 	}

--- a/go/host/main/main.go
+++ b/go/host/main/main.go
@@ -3,10 +3,11 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"strings"
+
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/status-im/keycard-go/hexutils"
-	"strings"
 
 	"github.com/obscuronet/go-obscuro/go/host/hostrunner"
 )
@@ -18,26 +19,26 @@ func main() {
 		panic(fmt.Errorf("could not parse config. Cause: %w", err))
 	}
 	addr := toAddress(config.PrivateKeyString)
-	pkadd := config.PKAddress
-	if strings.HasPrefix(config.PKAddress, "0x") {
-		pkadd = config.PKAddress[2:]
-	}
 
-	if config.PKAddress != "" && !bytes.Equal(hexutils.HexToBytes(pkadd), addr.Bytes()) {
+	if config.PKAddress != "" && !bytes.Equal(hexutils.HexToBytes(removeHexPrefix(config.PKAddress)), addr.Bytes()) {
 		fmt.Printf("WARN: the address: %s does not match the private key %s\n", config.PKAddress, config.PrivateKeyString)
 	}
 	hostrunner.RunHost(config)
 }
 
 func toAddress(privateKey string) gethcommon.Address {
-	k := privateKey
-	if strings.HasPrefix(privateKey, "0x") {
-		k = privateKey[2:]
-	}
-	privateKeyA, err := crypto.ToECDSA(hexutils.HexToBytes(k))
+	privateKeyA, err := crypto.ToECDSA(hexutils.HexToBytes(removeHexPrefix(privateKey)))
 	if err != nil {
 		panic(err)
 	}
 	pubKeyA := privateKeyA.PublicKey
 	return crypto.PubkeyToAddress(pubKeyA)
+}
+
+func removeHexPrefix(hex string) string {
+	result := hex
+	if strings.HasPrefix(hex, "0x") {
+		result = hex[2:]
+	}
+	return result
 }

--- a/go/host/main/main.go
+++ b/go/host/main/main.go
@@ -18,7 +18,7 @@ func main() {
 		panic(fmt.Errorf("could not parse config. Cause: %w", err))
 	}
 	addr := toAddress(config.PrivateKeyString)
-	if !bytes.Equal(hexutils.HexToBytes(config.PKAddress), addr.Bytes()) {
+	if config.PKAddress != "" && !bytes.Equal(hexutils.HexToBytes(config.PKAddress), addr.Bytes()) {
 		fmt.Printf("WARN: the address: %s does not match the private key %s\n", config.PKAddress, config.PrivateKeyString)
 	}
 	hostrunner.RunHost(config)

--- a/testnet/start-obscuro-node.sh
+++ b/testnet/start-obscuro-node.sh
@@ -149,3 +149,6 @@ fi
 echo "Starting enclave with DISABLED SGX and host..."
 docker compose -f docker-compose.non-sgx.yml up enclave host -d
 
+echo "Waiting 20s for the node to be up..."
+sleep 20
+echo "Node should be up and running"

--- a/testnet/testnet-deploy-contracts.sh
+++ b/testnet/testnet-deploy-contracts.sh
@@ -82,7 +82,7 @@ docker run --name=hocerc20deployer \
     --nodeHost=${l1host} \
     --nodePort=${l1port} \
     --l1Deployment \
-    --contractName="L1ERC20" \
+    --contractName="Layer1ERC20" \
     --privateKey=${pkstring}\
     --constructorParams="Hocus,HOC,1000000000000000000000000000000"
 # storing the contract address to the .env file
@@ -99,7 +99,7 @@ docker run --name=pocerc20deployer \
     --nodeHost=${l1host} \
     --nodePort=${l1port} \
     --l1Deployment \
-    --contractName="L1ERC20" \
+    --contractName="Layer1ERC20" \
     --privateKey=${pkstring}\
     --constructorParams="Pocus,POC,1000000000000000000000000000000"
 # storing the contract address to the .env file


### PR DESCRIPTION
### Why is this change needed?

in the testnet configs, we pass in binary values prefixed with 0x, which broke a new check added to the host, that prevented it from starting

### What changes were made as part of this PR:

- strip the 0x prefix if it exists

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
