### PR TITLE
Splits `types.go` into a few different files

### DIFF
--- a/go/common/headers.go
+++ b/go/common/headers.go
@@ -1,0 +1,95 @@
+package common
+
+import (
+	"fmt"
+	"math/big"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/rlp"
+	"golang.org/x/crypto/sha3"
+)
+
+// Used to hash headers.
+var hasherPool = sync.Pool{
+	New: func() interface{} { return sha3.NewLegacyKeccak256() },
+}
+
+// Header is a public / plaintext struct that holds common properties of rollups batches.
+// Making changes to this struct will require GRPC + GRPC Converters regen
+type Header struct {
+	ParentHash  L2RootHash
+	Agg         common.Address
+	RollupNonce Nonce            // RollupNonce holds the lottery rollup nonce
+	Nonce       types.BlockNonce // Nonce ensure compatibility with ethereum
+	L1Proof     L1RootHash       // the L1 block where the Parent was published
+	Root        StateRoot
+	TxHash      common.Hash // todo - include the synthetic deposits
+	Number      *big.Int    // the rollup height
+	Bloom       types.Bloom
+	ReceiptHash common.Hash
+	Extra       []byte
+	R, S        *big.Int // signature values
+	Withdrawals []Withdrawal
+
+	// Specification fields - not used for now but are expected to be available
+	UncleHash  common.Hash    `json:"sha3Uncles"`
+	Coinbase   common.Address `json:"miner"      `
+	Difficulty *big.Int       `json:"difficulty" `
+	GasLimit   uint64         `json:"gasLimit"  `
+	GasUsed    uint64         `json:"gasUsed"    `
+	Time       uint64         `json:"timestamp"   `
+	MixDigest  common.Hash    `json:"mixHash"`
+	// BaseFee was added by EIP-1559 and is ignored in legacy headers.
+	BaseFee *big.Int `json:"baseFeePerGas"`
+}
+
+// Withdrawal - this is the withdrawal instruction that is included in the rollup header.
+type Withdrawal struct {
+	// Type      uint8 // the type of withdrawal. For now only ERC20. Todo - add this once more ERCs are supported
+	Amount    *big.Int
+	Recipient common.Address // the user account that will receive the money
+	Contract  common.Address // the contract
+}
+
+// HeaderWithTxHashes pairs a header with the hashes of the transactions in that rollup.
+type HeaderWithTxHashes struct {
+	Header   *Header
+	TxHashes []TxHash
+}
+
+// Hash returns the block hash of the header, which is simply the keccak256 hash of its
+// RLP encoding excluding the signature.
+func (h *Header) Hash() L2RootHash {
+	cp := *h
+	cp.R = nil
+	cp.S = nil
+	hash, err := rlpHash(cp)
+	if err != nil {
+		panic("err hashing a rollup header")
+	}
+	return hash
+}
+
+// Encodes value, hashes the encoded bytes and returns the hash.
+func rlpHash(value interface{}) (common.Hash, error) {
+	var hash common.Hash
+
+	sha := hasherPool.Get().(crypto.KeccakState)
+	defer hasherPool.Put(sha)
+	sha.Reset()
+
+	err := rlp.Encode(sha, value)
+	if err != nil {
+		return hash, fmt.Errorf("unable to encode Value. %w", err)
+	}
+
+	_, err = sha.Read(hash[:])
+	if err != nil {
+		return hash, fmt.Errorf("unable to read encoded value. %w", err)
+	}
+
+	return hash, nil
+}

--- a/go/common/rollups.go
+++ b/go/common/rollups.go
@@ -1,0 +1,131 @@
+package common
+
+import (
+	"fmt"
+	"math/big"
+	"sync"
+	"sync/atomic"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/rlp"
+	"golang.org/x/crypto/sha3"
+)
+
+// Header is a public / plaintext struct that holds common properties of rollups batches.
+// Making changes to this struct will require GRPC + GRPC Converters regen
+type Header struct {
+	ParentHash  L2RootHash
+	Agg         common.Address
+	RollupNonce Nonce            // RollupNonce holds the lottery rollup nonce
+	Nonce       types.BlockNonce // Nonce ensure compatibility with ethereum
+	L1Proof     L1RootHash       // the L1 block where the Parent was published
+	Root        StateRoot
+	TxHash      common.Hash // todo - include the synthetic deposits
+	Number      *big.Int    // the rollup height
+	Bloom       types.Bloom
+	ReceiptHash common.Hash
+	Extra       []byte
+	R, S        *big.Int // signature values
+	Withdrawals []Withdrawal
+
+	// Specification fields - not used for now but are expected to be available
+	UncleHash  common.Hash    `json:"sha3Uncles"`
+	Coinbase   common.Address `json:"miner"      `
+	Difficulty *big.Int       `json:"difficulty" `
+	GasLimit   uint64         `json:"gasLimit"  `
+	GasUsed    uint64         `json:"gasUsed"    `
+	Time       uint64         `json:"timestamp"   `
+	MixDigest  common.Hash    `json:"mixHash"`
+	// BaseFee was added by EIP-1559 and is ignored in legacy headers.
+	BaseFee *big.Int `json:"baseFeePerGas"`
+}
+
+// HeaderWithTxHashes pairs a header with the hashes of the transactions in that rollup.
+type HeaderWithTxHashes struct {
+	Header   *Header
+	TxHashes []TxHash
+}
+
+// Withdrawal - this is the withdrawal instruction that is included in the rollup header.
+type Withdrawal struct {
+	// Type      uint8 // the type of withdrawal. For now only ERC20. Todo - add this once more ERCs are supported
+	Amount    *big.Int
+	Recipient common.Address // the user account that will receive the money
+	Contract  common.Address // the contract
+}
+
+// ExtRollup is an encrypted form of rollup used when passing the rollup around outside of an enclave.
+type ExtRollup struct {
+	Header          *Header
+	TxHashes        []TxHash // The hashes of the transactions included in the rollup
+	EncryptedTxBlob EncryptedTransactions
+}
+
+// EncryptedRollup extends ExtRollup with additional fields.
+// This parallels the Block/extblock split in Geth.
+type EncryptedRollup struct {
+	Header       *Header
+	TxHashes     []TxHash // The hashes of the transactions included in the rollup
+	Transactions EncryptedTransactions
+	hash         atomic.Value
+}
+
+func (er ExtRollup) ToEncryptedRollup() *EncryptedRollup {
+	return &EncryptedRollup{
+		Header:       er.Header,
+		TxHashes:     er.TxHashes,
+		Transactions: er.EncryptedTxBlob,
+	}
+}
+
+var hasherPool = sync.Pool{
+	New: func() interface{} { return sha3.NewLegacyKeccak256() },
+}
+
+// Encodes value, hashes the encoded bytes and returns the hash.
+func rlpHash(value interface{}) (common.Hash, error) {
+	var hash common.Hash
+
+	sha := hasherPool.Get().(crypto.KeccakState)
+	defer hasherPool.Put(sha)
+	sha.Reset()
+
+	err := rlp.Encode(sha, value)
+	if err != nil {
+		return hash, fmt.Errorf("unable to encode Value. %w", err)
+	}
+
+	_, err = sha.Read(hash[:])
+	if err != nil {
+		return hash, fmt.Errorf("unable to read encoded value. %w", err)
+	}
+
+	return hash, nil
+}
+
+// Hash returns the keccak256 hash of b's header.
+// The hash is computed on the first call and cached thereafter.
+func (r *EncryptedRollup) Hash() L2RootHash {
+	if hash := r.hash.Load(); hash != nil {
+		return hash.(L2RootHash)
+	}
+	v := r.Header.Hash()
+	r.hash.Store(v)
+
+	return v
+}
+
+// Hash returns the block hash of the header, which is simply the keccak256 hash of its
+// RLP encoding excluding the signature.
+func (h *Header) Hash() L2RootHash {
+	cp := *h
+	cp.R = nil
+	cp.S = nil
+	hash, err := rlpHash(cp)
+	if err != nil {
+		panic("err hashing a rollup header")
+	}
+	return hash
+}

--- a/go/common/rollups.go
+++ b/go/common/rollups.go
@@ -1,60 +1,8 @@
 package common
 
 import (
-	"fmt"
-	"math/big"
-	"sync"
 	"sync/atomic"
-
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/rlp"
-	"golang.org/x/crypto/sha3"
 )
-
-// Header is a public / plaintext struct that holds common properties of rollups batches.
-// Making changes to this struct will require GRPC + GRPC Converters regen
-type Header struct {
-	ParentHash  L2RootHash
-	Agg         common.Address
-	RollupNonce Nonce            // RollupNonce holds the lottery rollup nonce
-	Nonce       types.BlockNonce // Nonce ensure compatibility with ethereum
-	L1Proof     L1RootHash       // the L1 block where the Parent was published
-	Root        StateRoot
-	TxHash      common.Hash // todo - include the synthetic deposits
-	Number      *big.Int    // the rollup height
-	Bloom       types.Bloom
-	ReceiptHash common.Hash
-	Extra       []byte
-	R, S        *big.Int // signature values
-	Withdrawals []Withdrawal
-
-	// Specification fields - not used for now but are expected to be available
-	UncleHash  common.Hash    `json:"sha3Uncles"`
-	Coinbase   common.Address `json:"miner"      `
-	Difficulty *big.Int       `json:"difficulty" `
-	GasLimit   uint64         `json:"gasLimit"  `
-	GasUsed    uint64         `json:"gasUsed"    `
-	Time       uint64         `json:"timestamp"   `
-	MixDigest  common.Hash    `json:"mixHash"`
-	// BaseFee was added by EIP-1559 and is ignored in legacy headers.
-	BaseFee *big.Int `json:"baseFeePerGas"`
-}
-
-// HeaderWithTxHashes pairs a header with the hashes of the transactions in that rollup.
-type HeaderWithTxHashes struct {
-	Header   *Header
-	TxHashes []TxHash
-}
-
-// Withdrawal - this is the withdrawal instruction that is included in the rollup header.
-type Withdrawal struct {
-	// Type      uint8 // the type of withdrawal. For now only ERC20. Todo - add this once more ERCs are supported
-	Amount    *big.Int
-	Recipient common.Address // the user account that will receive the money
-	Contract  common.Address // the contract
-}
 
 // ExtRollup is an encrypted form of rollup used when passing the rollup around outside of an enclave.
 type ExtRollup struct {
@@ -80,31 +28,6 @@ func (er ExtRollup) ToEncryptedRollup() *EncryptedRollup {
 	}
 }
 
-var hasherPool = sync.Pool{
-	New: func() interface{} { return sha3.NewLegacyKeccak256() },
-}
-
-// Encodes value, hashes the encoded bytes and returns the hash.
-func rlpHash(value interface{}) (common.Hash, error) {
-	var hash common.Hash
-
-	sha := hasherPool.Get().(crypto.KeccakState)
-	defer hasherPool.Put(sha)
-	sha.Reset()
-
-	err := rlp.Encode(sha, value)
-	if err != nil {
-		return hash, fmt.Errorf("unable to encode Value. %w", err)
-	}
-
-	_, err = sha.Read(hash[:])
-	if err != nil {
-		return hash, fmt.Errorf("unable to read encoded value. %w", err)
-	}
-
-	return hash, nil
-}
-
 // Hash returns the keccak256 hash of b's header.
 // The hash is computed on the first call and cached thereafter.
 func (r *EncryptedRollup) Hash() L2RootHash {
@@ -115,17 +38,4 @@ func (r *EncryptedRollup) Hash() L2RootHash {
 	r.hash.Store(v)
 
 	return v
-}
-
-// Hash returns the block hash of the header, which is simply the keccak256 hash of its
-// RLP encoding excluding the signature.
-func (h *Header) Hash() L2RootHash {
-	cp := *h
-	cp.R = nil
-	cp.S = nil
-	hash, err := rlpHash(cp)
-	if err != nil {
-		panic("err hashing a rollup header")
-	}
-	return hash
 }

--- a/go/common/types.go
+++ b/go/common/types.go
@@ -1,16 +1,7 @@
 package common
 
 import (
-	"fmt"
-	"math/big"
-	"sync"
-	"sync/atomic"
-
 	"github.com/ethereum/go-ethereum/common"
-
-	gethcrypto "github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/rlp"
-	"golang.org/x/crypto/sha3"
 
 	"github.com/ethereum/go-ethereum/core/types"
 )
@@ -56,65 +47,6 @@ const (
 	HeightCommittedBlocks = 15
 )
 
-// Header is a public / plaintext struct that holds common properties of the Rollup
-// Making changes to this struct will require GRPC + GRPC Converters regen
-type Header struct {
-	ParentHash  L2RootHash
-	Agg         common.Address
-	RollupNonce Nonce            // RollupNonce holds the lottery rollup nonce
-	Nonce       types.BlockNonce // Nonce ensure compatibility with ethereum
-	L1Proof     L1RootHash       // the L1 block where the Parent was published
-	Root        StateRoot
-	TxHash      common.Hash // todo - include the synthetic deposits
-	Number      *big.Int    // the rollup height
-	Bloom       types.Bloom
-	ReceiptHash common.Hash
-	Extra       []byte
-	R, S        *big.Int // signature values
-	Withdrawals []Withdrawal
-
-	// Specification fields - not used for now but are expected to be available
-	UncleHash  common.Hash    `json:"sha3Uncles"`
-	Coinbase   common.Address `json:"miner"      `
-	Difficulty *big.Int       `json:"difficulty" `
-	GasLimit   uint64         `json:"gasLimit"  `
-	GasUsed    uint64         `json:"gasUsed"    `
-	Time       uint64         `json:"timestamp"   `
-	MixDigest  common.Hash    `json:"mixHash"`
-	// BaseFee was added by EIP-1559 and is ignored in legacy headers.
-	BaseFee *big.Int `json:"baseFeePerGas"`
-}
-
-// HeaderWithTxHashes represents a rollup header and the hashes of the transactions in the rollup.
-type HeaderWithTxHashes struct {
-	Header   *Header
-	TxHashes []TxHash
-}
-
-// Withdrawal - this is the withdrawal instruction that is included in the rollup header
-type Withdrawal struct {
-	// Type      uint8 // the type of withdrawal. For now only ERC20. Todo - add this once more ERCs are supported
-	Amount    *big.Int
-	Recipient common.Address // the user account that will receive the money
-	Contract  common.Address // the contract
-}
-
-// ExtRollup is used for communication between the enclave and the outside world.
-type ExtRollup struct {
-	Header          *Header
-	TxHashes        []TxHash // The hashes of the transactions included in the rollup
-	EncryptedTxBlob EncryptedTransactions
-}
-
-// EncryptedRollup extends ExtRollup with additional fields.
-// This parallels the Block/extblock split in Go Ethereum.
-type EncryptedRollup struct {
-	Header       *Header
-	TxHashes     []TxHash // The hashes of the transactions included in the rollup
-	Transactions EncryptedTransactions
-	hash         atomic.Value
-}
-
 // AttestationReport represents a signed attestation report from a TEE and some metadata about the source of it to verify it
 type AttestationReport struct {
 	Report      []byte         // the signed bytes of the report which includes some encrypted identifying data
@@ -123,65 +55,7 @@ type AttestationReport struct {
 	HostAddress string         // the IP address on which the host can be contacted by other Obscuro hosts for peer-to-peer communication
 }
 
-func (er ExtRollup) ToEncryptedRollup() *EncryptedRollup {
-	return &EncryptedRollup{
-		Header:       er.Header,
-		TxHashes:     er.TxHashes,
-		Transactions: er.EncryptedTxBlob,
-	}
-}
-
 type (
 	EncryptedSharedEnclaveSecret []byte
 	EncodedAttestationReport     []byte
 )
-
-var hasherPool = sync.Pool{
-	New: func() interface{} { return sha3.NewLegacyKeccak256() },
-}
-
-// RLPHash encodes value, hashes the encoded bytes and returns the hash.
-func RLPHash(value interface{}) (common.Hash, error) {
-	var hash common.Hash
-
-	sha := hasherPool.Get().(gethcrypto.KeccakState)
-	defer hasherPool.Put(sha)
-	sha.Reset()
-
-	err := rlp.Encode(sha, value)
-	if err != nil {
-		return hash, fmt.Errorf("unable to encode Value. %w", err)
-	}
-
-	_, err = sha.Read(hash[:])
-	if err != nil {
-		return hash, fmt.Errorf("unable to read encoded value. %w", err)
-	}
-
-	return hash, nil
-}
-
-// Hash returns the keccak256 hash of b's header.
-// The hash is computed on the first call and cached thereafter.
-func (r *EncryptedRollup) Hash() L2RootHash {
-	if hash := r.hash.Load(); hash != nil {
-		return hash.(L2RootHash)
-	}
-	v := r.Header.Hash()
-	r.hash.Store(v)
-
-	return v
-}
-
-// Hash returns the block hash of the header, which is simply the keccak256 hash of its
-// RLP encoding excluding the signature.
-func (h *Header) Hash() L2RootHash {
-	cp := *h
-	cp.R = nil
-	cp.S = nil
-	hash, err := RLPHash(cp)
-	if err != nil {
-		panic("err hashing a rollup header")
-	}
-	return hash
-}


### PR DESCRIPTION
### Why is this change needed?

`common/types.go` was getting messy (shock!).

So I pulled the rollup stuff into a separate file, and the header stuff into a separate file too.

### What changes were made as part of this PR:

- Provide a high level list of the changes made
- List key areas for the reviewer 

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
