### PR TITLE
Using transaction args to form api request object

### DIFF
--- a/go/common/gethapi/transaction_args.go
+++ b/go/common/gethapi/transaction_args.go
@@ -1,19 +1,3 @@
-// Copyright 2021 The go-ethereum Authors
-// This file is part of the go-ethereum library.
-//
-// The go-ethereum library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The go-ethereum library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
-
 package gethapi
 
 import (

--- a/go/common/gethapi/transaction_args.go
+++ b/go/common/gethapi/transaction_args.go
@@ -1,0 +1,315 @@
+// Copyright 2021 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package gethapi
+
+import (
+	"errors"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/common/math"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+// TransactionArgs represents the arguments to construct a new transaction
+// or a message call.
+type TransactionArgs struct {
+	From                 *common.Address `json:"from"`
+	To                   *common.Address `json:"to"`
+	Gas                  *hexutil.Uint64 `json:"gas"`
+	GasPrice             *hexutil.Big    `json:"gasPrice"`
+	MaxFeePerGas         *hexutil.Big    `json:"maxFeePerGas"`
+	MaxPriorityFeePerGas *hexutil.Big    `json:"maxPriorityFeePerGas"`
+	Value                *hexutil.Big    `json:"value"`
+	Nonce                *hexutil.Uint64 `json:"nonce"`
+
+	// We accept "data" and "input" for backwards-compatibility reasons.
+	// "input" is the newer name and should be preferred by clients.
+	// Issue detail: https://github.com/ethereum/go-ethereum/issues/15628
+	Data  *hexutil.Bytes `json:"data"`
+	Input *hexutil.Bytes `json:"input"`
+
+	// Introduced by AccessListTxType transaction.
+	AccessList *types.AccessList `json:"accessList,omitempty"`
+	ChainID    *hexutil.Big      `json:"chainId,omitempty"`
+}
+
+// from retrieves the transaction sender address.
+func (args *TransactionArgs) from() common.Address {
+	if args.From == nil {
+		return common.Address{}
+	}
+	return *args.From
+}
+
+// data retrieves the transaction calldata. Input field is preferred.
+func (args *TransactionArgs) data() []byte {
+	if args.Input != nil {
+		return *args.Input
+	}
+	if args.Data != nil {
+		return *args.Data
+	}
+	return nil
+}
+
+//// setDefaults fills in default values for unspecified tx fields.
+//func (args *TransactionArgs) setDefaults(ctx context.Context, b Backend) error {
+//	if err := args.setFeeDefaults(ctx, b); err != nil {
+//		return err
+//	}
+//	if args.Value == nil {
+//		args.Value = new(hexutil.Big)
+//	}
+//	if args.Nonce == nil {
+//		nonce, err := b.GetPoolNonce(ctx, args.from())
+//		if err != nil {
+//			return err
+//		}
+//		args.Nonce = (*hexutil.Uint64)(&nonce)
+//	}
+//	if args.Data != nil && args.Input != nil && !bytes.Equal(*args.Data, *args.Input) {
+//		return errors.New(`both "data" and "input" are set and not equal. Please use "input" to pass transaction call data`)
+//	}
+//	if args.To == nil && len(args.data()) == 0 {
+//		return errors.New(`contract creation without any data provided`)
+//	}
+//	// Estimate the gas usage if necessary.
+//	if args.Gas == nil {
+//		// These fields are immutable during the estimation, safe to
+//		// pass the pointer directly.
+//		data := args.data()
+//		callArgs := TransactionArgs{
+//			From:                 args.From,
+//			To:                   args.To,
+//			GasPrice:             args.GasPrice,
+//			MaxFeePerGas:         args.MaxFeePerGas,
+//			MaxPriorityFeePerGas: args.MaxPriorityFeePerGas,
+//			Value:                args.Value,
+//			Data:                 (*hexutil.Bytes)(&data),
+//			AccessList:           args.AccessList,
+//		}
+//		pendingBlockNr := rpc.BlockNumberOrHashWithNumber(rpc.PendingBlockNumber)
+//		estimated, err := DoEstimateGas(ctx, b, callArgs, pendingBlockNr, b.RPCGasCap())
+//		if err != nil {
+//			return err
+//		}
+//		args.Gas = &estimated
+//		log.Trace("Estimate gas usage automatically", "gas", args.Gas)
+//	}
+//	// If chain id is provided, ensure it matches the local chain id. Otherwise, set the local
+//	// chain id as the default.
+//	want := b.ChainConfig().ChainID
+//	if args.ChainID != nil {
+//		if have := (*big.Int)(args.ChainID); have.Cmp(want) != 0 {
+//			return fmt.Errorf("chainId does not match node's (have=%v, want=%v)", have, want)
+//		}
+//	} else {
+//		args.ChainID = (*hexutil.Big)(want)
+//	}
+//	return nil
+//}
+//
+//// setFeeDefaults fills in default fee values for unspecified tx fields.
+//func (args *TransactionArgs) setFeeDefaults(ctx context.Context, b Backend) error {
+//	// If both gasPrice and at least one of the EIP-1559 fee parameters are specified, error.
+//	if args.GasPrice != nil && (args.MaxFeePerGas != nil || args.MaxPriorityFeePerGas != nil) {
+//		return errors.New("both gasPrice and (maxFeePerGas or maxPriorityFeePerGas) specified")
+//	}
+//	// If the tx has completely specified a fee mechanism, no default is needed. This allows users
+//	// who are not yet synced past London to get defaults for other tx values. See
+//	// https://github.com/ethereum/go-ethereum/pull/23274 for more information.
+//	eip1559ParamsSet := args.MaxFeePerGas != nil && args.MaxPriorityFeePerGas != nil
+//	if (args.GasPrice != nil && !eip1559ParamsSet) || (args.GasPrice == nil && eip1559ParamsSet) {
+//		// Sanity check the EIP-1559 fee parameters if present.
+//		if args.GasPrice == nil && args.MaxFeePerGas.ToInt().Cmp(args.MaxPriorityFeePerGas.ToInt()) < 0 {
+//			return fmt.Errorf("maxFeePerGas (%v) < maxPriorityFeePerGas (%v)", args.MaxFeePerGas, args.MaxPriorityFeePerGas)
+//		}
+//		return nil
+//	}
+//	// Now attempt to fill in default value depending on whether London is active or not.
+//	head := b.CurrentHeader()
+//	if b.ChainConfig().IsLondon(head.Number) {
+//		// London is active, set maxPriorityFeePerGas and maxFeePerGas.
+//		if err := args.setLondonFeeDefaults(ctx, head, b); err != nil {
+//			return err
+//		}
+//	} else {
+//		if args.MaxFeePerGas != nil || args.MaxPriorityFeePerGas != nil {
+//			return fmt.Errorf("maxFeePerGas and maxPriorityFeePerGas are not valid before London is active")
+//		}
+//		// London not active, set gas price.
+//		price, err := b.SuggestGasTipCap(ctx)
+//		if err != nil {
+//			return err
+//		}
+//		args.GasPrice = (*hexutil.Big)(price)
+//	}
+//	return nil
+//}
+//
+//// setLondonFeeDefaults fills in reasonable default fee values for unspecified fields.
+//func (args *TransactionArgs) setLondonFeeDefaults(ctx context.Context, head *types.Header, b Backend) error {
+//	// Set maxPriorityFeePerGas if it is missing.
+//	if args.MaxPriorityFeePerGas == nil {
+//		tip, err := b.SuggestGasTipCap(ctx)
+//		if err != nil {
+//			return err
+//		}
+//		args.MaxPriorityFeePerGas = (*hexutil.Big)(tip)
+//	}
+//	// Set maxFeePerGas if it is missing.
+//	if args.MaxFeePerGas == nil {
+//		// Set the max fee to be 2 times larger than the previous block's base fee.
+//		// The additional slack allows the tx to not become invalidated if the base
+//		// fee is rising.
+//		val := new(big.Int).Add(
+//			args.MaxPriorityFeePerGas.ToInt(),
+//			new(big.Int).Mul(head.BaseFee, big.NewInt(2)),
+//		)
+//		args.MaxFeePerGas = (*hexutil.Big)(val)
+//	}
+//	// Both EIP-1559 fee parameters are now set; sanity check them.
+//	if args.MaxFeePerGas.ToInt().Cmp(args.MaxPriorityFeePerGas.ToInt()) < 0 {
+//		return fmt.Errorf("maxFeePerGas (%v) < maxPriorityFeePerGas (%v)", args.MaxFeePerGas, args.MaxPriorityFeePerGas)
+//	}
+//	return nil
+//}
+
+// ToMessage converts the transaction arguments to the Message type used by the
+// core evm. This method is used in calls and traces that do not require a real
+// live transaction.
+func (args *TransactionArgs) ToMessage(globalGasCap uint64, baseFee *big.Int) (types.Message, error) {
+	// Reject invalid combinations of pre- and post-1559 fee styles
+	if args.GasPrice != nil && (args.MaxFeePerGas != nil || args.MaxPriorityFeePerGas != nil) {
+		return types.Message{}, errors.New("both gasPrice and (maxFeePerGas or maxPriorityFeePerGas) specified")
+	}
+	// Set sender address or use zero address if none specified.
+	addr := args.from()
+
+	// Set default gas & gas price if none were set
+	gas := globalGasCap
+	if gas == 0 {
+		gas = uint64(math.MaxUint64 / 2)
+	}
+	if args.Gas != nil {
+		gas = uint64(*args.Gas)
+	}
+	if globalGasCap != 0 && globalGasCap < gas {
+		log.Warn("Caller gas above allowance, capping", "requested", gas, "cap", globalGasCap)
+		gas = globalGasCap
+	}
+	var (
+		gasPrice  *big.Int
+		gasFeeCap *big.Int
+		gasTipCap *big.Int
+	)
+	if baseFee == nil {
+		// If there's no basefee, then it must be a non-1559 execution
+		gasPrice = new(big.Int)
+		if args.GasPrice != nil {
+			gasPrice = args.GasPrice.ToInt()
+		}
+		gasFeeCap, gasTipCap = gasPrice, gasPrice
+	} else {
+		// A basefee is provided, necessitating 1559-type execution
+		if args.GasPrice != nil {
+			// User specified the legacy gas field, convert to 1559 gas typing
+			gasPrice = args.GasPrice.ToInt()
+			gasFeeCap, gasTipCap = gasPrice, gasPrice
+		} else {
+			// User specified 1559 gas fields (or none), use those
+			gasFeeCap = new(big.Int)
+			if args.MaxFeePerGas != nil {
+				gasFeeCap = args.MaxFeePerGas.ToInt()
+			}
+			gasTipCap = new(big.Int)
+			if args.MaxPriorityFeePerGas != nil {
+				gasTipCap = args.MaxPriorityFeePerGas.ToInt()
+			}
+			// Backfill the legacy gasPrice for EVM execution, unless we're all zeroes
+			gasPrice = new(big.Int)
+			if gasFeeCap.BitLen() > 0 || gasTipCap.BitLen() > 0 {
+				gasPrice = math.BigMin(new(big.Int).Add(gasTipCap, baseFee), gasFeeCap)
+			}
+		}
+	}
+	value := new(big.Int)
+	if args.Value != nil {
+		value = args.Value.ToInt()
+	}
+	data := args.data()
+	var accessList types.AccessList
+	if args.AccessList != nil {
+		accessList = *args.AccessList
+	}
+	msg := types.NewMessage(addr, args.To, 0, value, gas, gasPrice, gasFeeCap, gasTipCap, data, accessList, true)
+	return msg, nil
+}
+
+// toTransaction converts the arguments to a transaction.
+// This assumes that setDefaults has been called.
+func (args *TransactionArgs) toTransaction() *types.Transaction {
+	var data types.TxData
+	switch {
+	case args.MaxFeePerGas != nil:
+		al := types.AccessList{}
+		if args.AccessList != nil {
+			al = *args.AccessList
+		}
+		data = &types.DynamicFeeTx{
+			To:         args.To,
+			ChainID:    (*big.Int)(args.ChainID),
+			Nonce:      uint64(*args.Nonce),
+			Gas:        uint64(*args.Gas),
+			GasFeeCap:  (*big.Int)(args.MaxFeePerGas),
+			GasTipCap:  (*big.Int)(args.MaxPriorityFeePerGas),
+			Value:      (*big.Int)(args.Value),
+			Data:       args.data(),
+			AccessList: al,
+		}
+	case args.AccessList != nil:
+		data = &types.AccessListTx{
+			To:         args.To,
+			ChainID:    (*big.Int)(args.ChainID),
+			Nonce:      uint64(*args.Nonce),
+			Gas:        uint64(*args.Gas),
+			GasPrice:   (*big.Int)(args.GasPrice),
+			Value:      (*big.Int)(args.Value),
+			Data:       args.data(),
+			AccessList: *args.AccessList,
+		}
+	default:
+		data = &types.LegacyTx{
+			To:       args.To,
+			Nonce:    uint64(*args.Nonce),
+			Gas:      uint64(*args.Gas),
+			GasPrice: (*big.Int)(args.GasPrice),
+			Value:    (*big.Int)(args.Value),
+			Data:     args.data(),
+		}
+	}
+	return types.NewTx(data)
+}
+
+// ToTransaction converts the arguments to a transaction.
+// This assumes that setDefaults has been called.
+func (args *TransactionArgs) ToTransaction() *types.Transaction {
+	return args.toTransaction()
+}

--- a/go/common/gethapi/transaction_args.go
+++ b/go/common/gethapi/transaction_args.go
@@ -220,7 +220,7 @@ func (args *TransactionArgs) ToMessage(globalGasCap uint64, baseFee *big.Int) (t
 		gasFeeCap *big.Int
 		gasTipCap *big.Int
 	)
-	if baseFee == nil {
+	if baseFee == nil { //nolint:nestif
 		// If there's no basefee, then it must be a non-1559 execution
 		gasPrice = new(big.Int)
 		if args.GasPrice != nil {

--- a/go/common/gethapi/transaction_args.go
+++ b/go/common/gethapi/transaction_args.go
@@ -1,5 +1,7 @@
 package gethapi
 
+// This file is a direct copy of geth @ go-ethereum/internal/ethapi/transaction_args.go
+//
 import (
 	"errors"
 	"math/big"

--- a/go/common/gethencoding/geth_encoding.go
+++ b/go/common/gethencoding/geth_encoding.go
@@ -2,10 +2,9 @@ package gethencoding
 
 import (
 	"fmt"
-	"math/big"
+	"github.com/obscuronet/go-obscuro/go/common/gethapi"
 	"strings"
 
-	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
@@ -13,10 +12,14 @@ import (
 
 const (
 	// The relevant fields in an eth_call request's params.
-	callFieldTo    = "to"
-	CallFieldFrom  = "from"
-	callFieldData  = "data"
-	callFieldValue = "value"
+	callFieldTo                   = "to"
+	CallFieldFrom                 = "from"
+	callFieldData                 = "data"
+	callFieldValue                = "value"
+	callFieldGas                  = "gas"
+	callFieldGasPrice             = "gasprice"
+	callFieldMaxFeePerGas         = "maxfeepergas"
+	callFieldMaxPriorityFeePerGas = "maxpriorityfeepergas"
 )
 
 // ExtractEthCallMapString extracts the eth_call ethereum.CallMsg from an interface{}
@@ -53,6 +56,12 @@ func ExtractEthCallMapString(paramBytes interface{}) (map[string]string, error) 
 			callMsg[callFieldData] = valString
 		case callFieldValue:
 			callMsg[callFieldValue] = valString
+		case callFieldGas:
+			callMsg[callFieldGas] = valString
+		case callFieldMaxFeePerGas:
+			callMsg[callFieldMaxFeePerGas] = valString
+		case callFieldMaxPriorityFeePerGas:
+			callMsg[callFieldMaxPriorityFeePerGas] = valString
 		default:
 			callMsg[field] = valString
 		}
@@ -62,14 +71,15 @@ func ExtractEthCallMapString(paramBytes interface{}) (map[string]string, error) 
 }
 
 // ExtractEthCall extracts the eth_call ethereum.CallMsg from an interface{}
-func ExtractEthCall(paramBytes interface{}) (*ethereum.CallMsg, error) {
+func ExtractEthCall(paramBytes interface{}) (*gethapi.TransactionArgs, error) {
 	// geth lowercases the field name and uses the last seen value
 	var valString string
 	var to, from gethcommon.Address
-	var data []byte
-	var value *big.Int
+	var data *hexutil.Bytes
+	var value, gasPrice, maxFeePerGas, maxPriorityFeePerGas *hexutil.Big
 	var ok bool
-	var err error
+	var gas *hexutil.Uint64
+
 	for field, val := range paramBytes.(map[string]interface{}) {
 		if val == nil {
 			continue
@@ -87,29 +97,59 @@ func ExtractEthCall(paramBytes interface{}) (*ethereum.CallMsg, error) {
 		case CallFieldFrom:
 			from = gethcommon.HexToAddress(valString)
 		case callFieldData:
-			data, err = hexutil.Decode(valString)
+			dataVal, err := hexutil.Decode(valString)
 			if err != nil {
 				return nil, fmt.Errorf("could not decode data in CallMsg - %w", err)
 			}
+			data = (*hexutil.Bytes)(&dataVal)
 		case callFieldValue:
-			value, err = hexutil.DecodeBig(valString)
+			valueVal, err := hexutil.DecodeBig(valString)
 			if err != nil {
 				return nil, fmt.Errorf("could not decode value in CallMsg - %w", err)
 			}
+			value = (*hexutil.Big)(valueVal)
+		case callFieldGas:
+			gasVal, err := hexutil.DecodeUint64(valString)
+			if err != nil {
+				return nil, fmt.Errorf("could not decode value in CallMsg - %w", err)
+			}
+			gas = (*hexutil.Uint64)(&gasVal)
+
+		case callFieldGasPrice:
+			valueVal, err := hexutil.DecodeBig(valString)
+			if err != nil {
+				return nil, fmt.Errorf("could not decode value in CallMsg - %w", err)
+			}
+			value = (*hexutil.Big)(valueVal)
+
+		case callFieldMaxFeePerGas:
+			maxFeePerGasVal, err := hexutil.DecodeBig(valString)
+			if err != nil {
+				return nil, fmt.Errorf("could not decode value in CallMsg - %w", err)
+			}
+			maxFeePerGas = (*hexutil.Big)(maxFeePerGasVal)
+
+		case callFieldMaxPriorityFeePerGas:
+			maxPriorityFeePerGasVal, err := hexutil.DecodeBig(valString)
+			if err != nil {
+				return nil, fmt.Errorf("could not decode value in CallMsg - %w", err)
+			}
+			maxPriorityFeePerGas = (*hexutil.Big)(maxPriorityFeePerGasVal)
 		}
+
 	}
 
 	// convert the params[0] into an ethereum.CallMsg
-	callMsg := &ethereum.CallMsg{
-		From:       from,
-		To:         &to,
-		Gas:        0,
-		GasPrice:   nil,
-		GasFeeCap:  nil,
-		GasTipCap:  nil,
-		Value:      value,
-		Data:       data,
-		AccessList: nil,
+	callMsg := &gethapi.TransactionArgs{
+		From:                 &from,
+		To:                   &to,
+		Gas:                  gas,
+		GasPrice:             gasPrice,
+		MaxFeePerGas:         maxFeePerGas,
+		MaxPriorityFeePerGas: maxPriorityFeePerGas,
+		Value:                value,
+		Data:                 data,
+		AccessList:           nil,
 	}
 
 	return callMsg, nil

--- a/go/common/gethencoding/geth_encoding.go
+++ b/go/common/gethencoding/geth_encoding.go
@@ -22,7 +22,7 @@ const (
 	callFieldMaxPriorityFeePerGas = "maxpriorityfeepergas"
 )
 
-// ExtractEthCallMapString extracts the eth_call ethereum.CallMsg from an interface{}
+// ExtractEthCallMapString extracts the eth_call gethapi.TransactionArgs from an interface{}
 // it ensures that :
 // - All types are string
 // - All keys are lowercase
@@ -70,7 +70,7 @@ func ExtractEthCallMapString(paramBytes interface{}) (map[string]string, error) 
 	return callMsg, nil
 }
 
-// ExtractEthCall extracts the eth_call ethereum.CallMsg from an interface{}
+// ExtractEthCall extracts the eth_call gethapi.TransactionArgs from an interface{}
 func ExtractEthCall(paramBytes interface{}) (*gethapi.TransactionArgs, error) {
 	// geth lowercases the field name and uses the last seen value
 	var valString string

--- a/go/common/gethencoding/geth_encoding.go
+++ b/go/common/gethencoding/geth_encoding.go
@@ -4,9 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/obscuronet/go-obscuro/go/common/gethapi"
-
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/obscuronet/go-obscuro/go/common/gethapi"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
 )

--- a/go/common/gethencoding/geth_encoding.go
+++ b/go/common/gethencoding/geth_encoding.go
@@ -2,8 +2,9 @@ package gethencoding
 
 import (
 	"fmt"
-	"github.com/obscuronet/go-obscuro/go/common/gethapi"
 	"strings"
+
+	"github.com/obscuronet/go-obscuro/go/common/gethapi"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 
@@ -136,7 +137,6 @@ func ExtractEthCall(paramBytes interface{}) (*gethapi.TransactionArgs, error) {
 			}
 			maxPriorityFeePerGas = (*hexutil.Big)(maxPriorityFeePerGasVal)
 		}
-
 	}
 
 	// convert the params[0] into an ethereum.CallMsg

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -562,7 +562,7 @@ func (e *enclaveImpl) EstimateGas(encryptedParams common.EncryptedParamsEstimate
 
 	// encrypt the gas cost with the callMsg.From viewing key
 	// TODO hook up the evm gas estimation
-	encryptedGasCost, err := e.rpcEncryptionManager.EncryptWithViewingKey(callMsg.From, []byte(hexutil.EncodeUint64(5_000_000_000)))
+	encryptedGasCost, err := e.rpcEncryptionManager.EncryptWithViewingKey(*callMsg.From, []byte(hexutil.EncodeUint64(5_000_000_000)))
 	if err != nil {
 		return nil, fmt.Errorf("enclave could not respond securely to eth_estimateGas request. Cause: %w", err)
 	}

--- a/go/enclave/evm/evm_facade.go
+++ b/go/enclave/evm/evm_facade.go
@@ -83,14 +83,11 @@ func logReceipt(r *types.Receipt, logger gethlog.Logger) {
 	}
 }
 
-// ExecuteOffChainCall - executes the "data" command against the "to" smart contract
-func ExecuteOffChainCall(from gethcommon.Address, to *gethcommon.Address, data []byte, s *state.StateDB, header *common.Header, storage db.Storage, chainConfig *params.ChainConfig, logger gethlog.Logger) (*gethcore.ExecutionResult, error) {
+// ExecuteOffChainCall - executes the eth_call call
+func ExecuteOffChainCall(msg *types.Message, s *state.StateDB, header *common.Header, storage db.Storage, chainConfig *params.ChainConfig, logger gethlog.Logger) (*gethcore.ExecutionResult, error) {
 	chain, vmCfg, gp := initParams(storage, true)
 
 	blockContext := gethcore.NewEVMBlockContext(convertToEthHeader(header, secret(storage)), chain, &header.Agg)
-	// todo use ToMessage
-	// 100_000_000_000 is just a huge number gasLimit for making sure the local tx doesn't fail with lack of gas
-	msg := types.NewMessage(from, to, 0, gethcommon.Big0, 100_000_000_000, gethcommon.Big0, gethcommon.Big0, gethcommon.Big0, data, nil, true)
 
 	// sets TxKey.origin
 	txContext := gethcore.NewEVMTxContext(msg)

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -593,7 +593,7 @@ func (rc *RollupChain) ExecuteOffChainTransaction(encryptedParams common.Encrypt
 
 	rc.logger.Trace(fmt.Sprintf("!OffChain call: contractAddress=%s, from=%s, data=%s, rollup=r_%d, state=%s", callMsg.To(), callMsg.From(), hexutils.BytesToHex(callMsg.Data()), common.ShortHash(r.Hash()), r.Header.Root.Hex()))
 	s := rc.storage.CreateStateDB(hs.HeadRollup)
-	result, err := evm.ExecuteOffChainCall(callMsg.From(), callMsg.To(), callMsg.Data(), s, r.Header, rc.storage, rc.chainConfig, rc.logger)
+	result, err := evm.ExecuteOffChainCall(&callMsg, s, r.Header, rc.storage, rc.chainConfig, rc.logger)
 	// todo - clarify this error handling
 	if err != nil {
 		return nil, err

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -571,9 +571,14 @@ func (rc *RollupChain) ExecuteOffChainTransaction(encryptedParams common.Encrypt
 		return nil, fmt.Errorf("required at least 1 params, but received %d", len(paramList))
 	}
 
-	callMsg, err := gethencoding.ExtractEthCall(paramList[0])
+	apiArgs, err := gethencoding.ExtractEthCall(paramList[0])
 	if err != nil {
 		return nil, fmt.Errorf("unable to decode EthCall Params - %w", err)
+	}
+
+	callMsg, err := apiArgs.ToMessage(0, gethcommon.Big0)
+	if err != nil {
+		return nil, fmt.Errorf("unable to convert TransactionArgs to Message - %w", err)
 	}
 
 	hs := rc.storage.FetchHeadState()
@@ -586,15 +591,15 @@ func (rc *RollupChain) ExecuteOffChainTransaction(encryptedParams common.Encrypt
 		panic("not found")
 	}
 
-	rc.logger.Trace(fmt.Sprintf("!OffChain call: contractAddress=%s, from=%s, data=%s, rollup=r_%d, state=%s", callMsg.To.Hex(), callMsg.From.Hex(), hexutils.BytesToHex(callMsg.Data), common.ShortHash(r.Hash()), r.Header.Root.Hex()))
+	rc.logger.Trace(fmt.Sprintf("!OffChain call: contractAddress=%s, from=%s, data=%s, rollup=r_%d, state=%s", callMsg.To(), callMsg.From(), hexutils.BytesToHex(callMsg.Data()), common.ShortHash(r.Hash()), r.Header.Root.Hex()))
 	s := rc.storage.CreateStateDB(hs.HeadRollup)
-	result, err := evm.ExecuteOffChainCall(callMsg.From, callMsg.To, callMsg.Data, s, r.Header, rc.storage, rc.chainConfig, rc.logger)
+	result, err := evm.ExecuteOffChainCall(callMsg.From(), callMsg.To(), callMsg.Data(), s, r.Header, rc.storage, rc.chainConfig, rc.logger)
 	// todo - clarify this error handling
 	if err != nil {
 		return nil, err
 	}
 	if result.Failed() {
-		rc.logger.Error(fmt.Sprintf("!OffChain: Failed to execute contract %s.", callMsg.To.Hex()), log.ErrKey, result.Err)
+		rc.logger.Error(fmt.Sprintf("!OffChain: Failed to execute contract %s.", callMsg.To()), log.ErrKey, result.Err)
 		return nil, result.Err
 	}
 
@@ -604,7 +609,7 @@ func (rc *RollupChain) ExecuteOffChainTransaction(encryptedParams common.Encrypt
 	if len(result.ReturnData) != 0 {
 		encodedResult = hexutil.Encode(result.ReturnData)
 	}
-	encryptedResult, err := rc.rpcEncryptionManager.EncryptWithViewingKey(callMsg.From, []byte(encodedResult))
+	encryptedResult, err := rc.rpcEncryptionManager.EncryptWithViewingKey(callMsg.From(), []byte(encodedResult))
 	if err != nil {
 		return nil, fmt.Errorf("enclave could not respond securely to eth_call request. Cause: %w", err)
 	}


### PR DESCRIPTION
### Why is this change needed?

- Required for https://github.com/obscuronet/obscuro-internal/issues/929
- Uses https://geth.ethereum.org/docs/rpc/objects#transaction-call-object call object to ensure obscuro respects the same params as geth
- Uses the https://github.com/ethereum/go-ethereum/blob/fa1305f8bf1b1e6c4eadf4d12c9dd8ce7ddc4c6c/internal/ethapi/transaction_args.go#L202 ToMessage to ensure the same gas logic as geth uses.

### What changes were made as part of this PR:

- Added Transactions args between the Encoding of API params and the EVM .

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
