### PR TITLE
fix the bridge address to pass the checksums

### DIFF
--- a/go/enclave/bridge/bridge.go
+++ b/go/enclave/bridge/bridge.go
@@ -41,7 +41,7 @@ const (
 	POC            ERC20 = "POC"
 	HOCAddr              = "f3a8bd422097bFdd9B3519Eaeb533393a1c561aC"
 	pocAddr              = "9802F661d17c65527D7ABB59DAAD5439cb125a67"
-	bridgeAddr           = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+	bridgeAddr           = "deB34A740ECa1eC42C8b8204CBEC0bA34FDD27f3"
 	hocOwnerKeyHex       = "6e384a07a01263518a09a5424c7b6bbfc3604ba7d93f47e3a455cbdd7f9f0682"
 	pocOwnerKeyHex       = "4bfe14725e685901c062ccd4e220c61cf9c189897b6c78bd18d7f51291b2b8f8"
 )


### PR DESCRIPTION
### Why is this change needed?

it is hard to test the bridge because the address was not passing the checksum

### What changes were made as part of this PR:

- change the address 
- 
### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
