### PR TITLE
Provides logger for Obscuroscan.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ tools/obscuroscan/main/main
 **/enclave_logs.txt
 **/host_logs.txt
 **/wallet_extension_logs.txt
+**/obscuroscan_logs.txt
 
 # Temp env files
 testnet/.env

--- a/go/common/log/log.go
+++ b/go/common/log/log.go
@@ -31,6 +31,7 @@ const (
 	WalletExtCmp    = "wallet_extension"
 	TestGethNetwCmp = "test_geth_network"
 	EthereumL1Cmp   = "l1_host"
+	ObscuroscanCmp  = "obscuroscan"
 )
 
 // Used when the logger has to write to Sys.out

--- a/tools/obscuroscan/main/cli.go
+++ b/tools/obscuroscan/main/cli.go
@@ -14,12 +14,16 @@ const (
 
 	addressName  = "address"
 	addressUsage = "The address to serve Obscuroscan on"
+
+	logPathName  = "logPath"
+	logPathUsage = "The path to use for Obscuroscan's log file"
 )
 
 type obscuroscanConfig struct {
 	nodeID        string
 	rpcServerAddr string
 	address       string
+	logPath       string
 }
 
 func defaultObscuroClientConfig() obscuroscanConfig {
@@ -27,6 +31,7 @@ func defaultObscuroClientConfig() obscuroscanConfig {
 		nodeID:        "",
 		rpcServerAddr: "http://testnet.obscu.ro:13000",
 		address:       "127.0.0.1:3000",
+		logPath:       "obscuroscan_logs.txt",
 	}
 }
 
@@ -36,6 +41,7 @@ func parseCLIArgs() obscuroscanConfig {
 	nodeID := flag.String(nodeIDName, defaultConfig.nodeID, nodeIDUsage)
 	rpcServerAddr := flag.String(rpcServerAddrName, defaultConfig.rpcServerAddr, rpcServerAddrUsage)
 	address := flag.String(addressName, defaultConfig.address, addressUsage)
+	logPath := flag.String(logPathName, defaultConfig.logPath, logPathUsage)
 
 	flag.Parse()
 
@@ -43,5 +49,6 @@ func parseCLIArgs() obscuroscanConfig {
 		nodeID:        *nodeID,
 		rpcServerAddr: *rpcServerAddr,
 		address:       *address,
+		logPath:       *logPath,
 	}
 }

--- a/tools/obscuroscan/main/main.go
+++ b/tools/obscuroscan/main/main.go
@@ -3,13 +3,19 @@ package main
 import (
 	"fmt"
 
+	gethlog "github.com/ethereum/go-ethereum/log"
+	"github.com/obscuronet/go-obscuro/go/common/log"
+
 	"github.com/obscuronet/go-obscuro/tools/obscuroscan"
 )
 
 func main() {
 	config := parseCLIArgs()
 
-	server := obscuroscan.NewObscuroscan(config.rpcServerAddr)
+	server := obscuroscan.NewObscuroscan(
+		config.rpcServerAddr,
+		log.New(log.ObscuroscanCmp, int(gethlog.LvlInfo), config.logPath),
+	)
 	go server.Serve(config.address)
 	fmt.Printf("Obscuroscan started.\n💡 Visit %s to monitor the Obscuro network.\n", config.address)
 

--- a/tools/obscuroscan/obscuroscan.go
+++ b/tools/obscuroscan/obscuroscan.go
@@ -81,7 +81,7 @@ type attestationReportExternal struct {
 	TCBStatus       string
 }
 
-func NewObscuroscan(address string) *Obscuroscan {
+func NewObscuroscan(address string, logger gethlog.Logger) *Obscuroscan {
 	client, err := rpc.NewNetworkClient(address)
 	if err != nil {
 		panic(err)
@@ -93,6 +93,7 @@ func NewObscuroscan(address string) *Obscuroscan {
 	return &Obscuroscan{
 		client:      client,
 		contractABI: contractABI,
+		logger:      logger,
 	}
 }
 


### PR DESCRIPTION
### Why is this change needed?

Obscuroscan was using a logger, but it was never actually set, causing an NPE.

### What changes were made as part of this PR:

- Provide a high level list of the changes made
- List key areas for the reviewer 

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
