### PR TITLE
Fixes eth call error propagation

### DIFF
--- a/go/enclave/evm/evm_facade.go
+++ b/go/enclave/evm/evm_facade.go
@@ -113,7 +113,7 @@ func ExecuteOffChainCall(msg *types.Message, s *state.StateDB, header *common.He
 		logger.Error("ErrKey applying msg:", log.ErrKey, err)
 		return result, err
 	}
-	
+
 	return result, nil
 }
 

--- a/go/enclave/evm/evm_facade.go
+++ b/go/enclave/evm/evm_facade.go
@@ -103,16 +103,17 @@ func ExecuteOffChainCall(msg *types.Message, s *state.StateDB, header *common.He
 		return nil, newErrorWithReasonAndCode(dbErr)
 	}
 
+	// If the result contains a revert reason, try to unpack and return it.
+	if result != nil && len(result.Revert()) > 0 {
+		return nil, newRevertError(result)
+	}
+
 	if err != nil {
 		// also return the result as the result can be evaluated on some errors like ErrIntrinsicGas
 		logger.Error("ErrKey applying msg:", log.ErrKey, err)
 		return result, err
 	}
-
-	// If the result contains a revert reason, try to unpack and return it.
-	if len(result.Revert()) > 0 {
-		return nil, newRevertError(result)
-	}
+	
 	return result, nil
 }
 

--- a/go/enclave/evm/evm_facade.go
+++ b/go/enclave/evm/evm_facade.go
@@ -97,10 +97,10 @@ func ExecuteOffChainCall(msg *types.Message, s *state.StateDB, header *common.He
 	// 1 - vmError / stateDB err check
 	// 2 - evm.Cancelled() TODO
 	// 3 - error check the ApplyMessage
+
 	// Read the error stored in the database.
-	err = s.Error()
-	if err != nil {
-		return nil, newErrorWithReasonAndCode(err)
+	if dbErr := s.Error(); dbErr != nil {
+		return nil, newErrorWithReasonAndCode(dbErr)
 	}
 
 	if err != nil {

--- a/go/enclave/evm/evm_facade.go
+++ b/go/enclave/evm/evm_facade.go
@@ -5,14 +5,8 @@ import (
 	"fmt"
 	"math"
 
-	gethlog "github.com/ethereum/go-ethereum/log"
-
-	gethrpc "github.com/ethereum/go-ethereum/rpc"
-
 	"github.com/ethereum/go-ethereum/accounts/abi"
-	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	gethcore "github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
@@ -22,6 +16,11 @@ import (
 	"github.com/obscuronet/go-obscuro/go/common/log"
 	"github.com/obscuronet/go-obscuro/go/enclave/crypto"
 	"github.com/obscuronet/go-obscuro/go/enclave/db"
+
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	gethcore "github.com/ethereum/go-ethereum/core"
+	gethlog "github.com/ethereum/go-ethereum/log"
+	gethrpc "github.com/ethereum/go-ethereum/rpc"
 )
 
 // ExecuteTransactions
@@ -94,16 +93,20 @@ func ExecuteOffChainCall(msg *types.Message, s *state.StateDB, header *common.He
 	vmenv := vm.NewEVM(blockContext, txContext, s, chainConfig, vmCfg)
 
 	result, err := gethcore.ApplyMessage(vmenv, msg, gp)
-	if err != nil {
-		// also return the result as the result can be evaluated on some errors like ErrIntrinsicGas
-		logger.Error("ErrKey applying msg:", log.ErrKey, err)
-		return result, fmt.Errorf("unable to ApplyMessage - %w", err)
-	}
-
+	// Follow the same error check structure as in geth
+	// 1 - vmError / stateDB err check
+	// 2 - evm.Cancelled() TODO
+	// 3 - error check the ApplyMessage
 	// Read the error stored in the database.
 	err = s.Error()
 	if err != nil {
 		return nil, newErrorWithReasonAndCode(err)
+	}
+
+	if err != nil {
+		// also return the result as the result can be evaluated on some errors like ErrIntrinsicGas
+		logger.Error("ErrKey applying msg:", log.ErrKey, err)
+		return result, err
 	}
 
 	// If the result contains a revert reason, try to unpack and return it.

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -623,7 +623,13 @@ func (rc *RollupChain) ExecuteOffChainTransaction(encryptedParams common.Encrypt
 	// TODO Hook up the blockNumber
 	result, err := rc.ExecuteOffChainTransactionAtBlock(apiArgs, gethrpc.BlockNumber(0))
 	if err != nil {
-		return nil, fmt.Errorf("failed when executing eth_call transaction - %w", err)
+		rc.logger.Error(fmt.Sprintf("!OffChain: Failed to execute contract %s.", apiArgs.To), log.ErrKey, err.Error())
+		return nil, err
+	}
+	// the execution might have succeeded but the evm contract logic might have failed
+	if result.Failed() {
+		rc.logger.Error(fmt.Sprintf("!OffChain: Failed to execute contract %s.", apiArgs.To), log.ErrKey, result.Err)
+		return nil, result.Err
 	}
 
 	rc.logger.Trace(fmt.Sprintf("!OffChain result: %s", hexutils.BytesToHex(result.ReturnData)))

--- a/go/enclave/rpc_server.go
+++ b/go/enclave/rpc_server.go
@@ -7,23 +7,20 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/obscuronet/go-obscuro/go/common/log"
-
-	gethlog "github.com/ethereum/go-ethereum/log"
-
-	gethrpc "github.com/ethereum/go-ethereum/rpc"
-
-	"github.com/obscuronet/go-obscuro/go/config"
-
-	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/obscuronet/go-obscuro/go/common"
+	"github.com/obscuronet/go-obscuro/go/common/log"
 	"github.com/obscuronet/go-obscuro/go/common/rpc"
 	"github.com/obscuronet/go-obscuro/go/common/rpc/generated"
+	"github.com/obscuronet/go-obscuro/go/config"
 	"github.com/obscuronet/go-obscuro/go/ethadapter/erc20contractlib"
 	"github.com/obscuronet/go-obscuro/go/ethadapter/mgmtcontractlib"
 	"google.golang.org/grpc"
+
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	gethlog "github.com/ethereum/go-ethereum/log"
+	gethrpc "github.com/ethereum/go-ethereum/rpc"
 )
 
 // Receives RPC calls to the enclave process and relays them to the enclave.Enclave.


### PR DESCRIPTION
### Why is this change needed?

- Errors were not being correctly propagated from the EVM to the user

### What changes were made as part of this PR:

- Removed error wrapping

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
