### PR TITLE
Fixing node start out of sync

### DIFF
--- a/.github/workflows/manual-deploy-dev-testnet.yml
+++ b/.github/workflows/manual-deploy-dev-testnet.yml
@@ -181,6 +181,10 @@ jobs:
           inlineScript: |
             az vm open-port -g Testnet -n "Dev-ObscuroNodeTestnet-${{ matrix.host_id }}-${{ GITHUB.RUN_NUMBER }}"  --port 13000,13001,6060,6061,10000
 
+      - name: 'Wait for Obscuro sequencer to start'
+        shell: bash
+        run: if [ 1==${{ matrix.host_id }} ]; then sleep 60; fi
+
       - name: 'Start Obscuro node-${{ matrix.host_id }} on Azure'
         uses: azure/CLI@v1
         with:

--- a/.github/workflows/manual-deploy-dev-testnet.yml
+++ b/.github/workflows/manual-deploy-dev-testnet.yml
@@ -183,7 +183,7 @@ jobs:
 
       - name: 'Wait for Obscuro sequencer to start'
         shell: bash
-        run: if [ 1==${{ matrix.host_id }} ]; then sleep 60; fi
+        run: if [ 1 = ${{ matrix.host_id }} ]; then sleep 60; fi
 
       - name: 'Start Obscuro node-${{ matrix.host_id }} on Azure'
         uses: azure/CLI@v1

--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -136,7 +136,7 @@ jobs:
 
       - name: 'Wait for Obscuro sequencer to start'
         shell: bash
-        run: if [ 0!=${{ matrix.host_id }} ]; then sleep 60; fi
+        run: if [ 0! = ${{ matrix.host_id }} ]; then sleep 60; fi
 
       - name: 'Start Obscuro node-${{ matrix.host_id }} on Azure'
         uses: azure/CLI@v1

--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -134,6 +134,10 @@ jobs:
           inlineScript: |
             az vm open-port -g Testnet -n "ObscuroNodeTestnet-${{ matrix.host_id }}-${{ GITHUB.RUN_NUMBER }}"  --port 13000,13001,6060,6061,10000
 
+      - name: 'Wait for Obscuro sequencer to start'
+        shell: bash
+        run: if [ 0!=${{ matrix.host_id }} ]; then sleep 60; fi
+
       - name: 'Start Obscuro node-${{ matrix.host_id }} on Azure'
         uses: azure/CLI@v1
         with:

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -478,11 +478,11 @@ func (e *enclaveImpl) verifyAttestationAndEncryptSecret(att *common.AttestationR
 	// First we verify the attestation report has come from a valid obscuro enclave running in a verified TEE.
 	data, err := e.attestationProvider.VerifyReport(att)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to verify report - %w", err)
 	}
 	// Then we verify the public key provided has come from the same enclave as that attestation report
 	if err = VerifyIdentity(data, att); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to verify identity - %w", err)
 	}
 	e.logger.Info(fmt.Sprintf("Successfully verified attestation and identity. Owner: %s", att.Owner))
 
@@ -836,6 +836,7 @@ func (e *enclaveImpl) processSecretRequest(req *ethadapter.L1RequestSecretTx) (*
 		return nil, fmt.Errorf("failed to decode attestation - %w", err)
 	}
 
+	e.logger.Info("received attestation", "attestation", att)
 	secret, err := e.verifyAttestationAndEncryptSecret(att)
 	if err != nil {
 		return nil, fmt.Errorf("secret request failed, no response will be published - %w", err)


### PR DESCRIPTION
### Why is this change needed?

- https://github.com/obscuronet/obscuro-internal/issues/1182
- Adding more logs to figure out what's happening
- Non-sequencer nodes start is now delayed by 1 minute in testnet / dev testnet deployments

### What changes were made as part of this PR:

- Provide a high level list of the changes made
- List key areas for the reviewer 

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
