### PR TITLE
Removes ExtRollup/ExtRollupWithHash split.

### DIFF
--- a/go/common/encoding.go
+++ b/go/common/encoding.go
@@ -26,12 +26,12 @@ func (eb EncodedBlock) DecodeBlock() (*types.Block, error) {
 	return &b, nil
 }
 
-func EncodeRollup(r *ExtRollupWithHash) (EncodedRollup, error) {
+func EncodeRollup(r *ExtRollup) (EncodedRollup, error) {
 	return rlp.EncodeToBytes(r)
 }
 
-func DecodeRollup(encoded EncodedRollup) (*ExtRollupWithHash, error) {
-	r := new(ExtRollupWithHash)
+func DecodeRollup(encoded EncodedRollup) (*ExtRollup, error) {
+	r := new(ExtRollup)
 	err := rlp.DecodeBytes(encoded, r)
 	return r, err
 }

--- a/go/common/headers.go
+++ b/go/common/headers.go
@@ -17,7 +17,7 @@ var hasherPool = sync.Pool{
 	New: func() interface{} { return sha3.NewLegacyKeccak256() },
 }
 
-// Header is a public / plaintext struct that holds common properties of rollups batches.
+// Header is a public / plaintext struct that holds common properties of rollups..
 // Making changes to this struct will require GRPC + GRPC Converters regen
 type Header struct {
 	// The fields present in Geth's `types/Header` struct.

--- a/go/common/rollups.go
+++ b/go/common/rollups.go
@@ -9,34 +9,24 @@ type ExtRollup struct {
 	Header          *Header
 	TxHashes        []TxHash // The hashes of the transactions included in the rollup
 	EncryptedTxBlob EncryptedTransactions
+	hash            atomic.Value
 }
 
-// ExtRollupWithHash extends ExtRollup with additional fields.
-// This parallels the Block/extblock split in Geth.
-type ExtRollupWithHash struct {
-	ExtRollup
-	hash atomic.Value
-}
-
-func (er ExtRollup) ToExtRollupWithHash() *ExtRollupWithHash {
-	extRollup := ExtRollup{
-		Header:          er.Header,
-		TxHashes:        er.TxHashes,
-		EncryptedTxBlob: er.EncryptedTxBlob,
-	}
-	return &ExtRollupWithHash{
-		ExtRollup: extRollup,
+func (r ExtRollup) ToExtRollup() *ExtRollup {
+	return &ExtRollup{
+		Header:          r.Header,
+		TxHashes:        r.TxHashes,
+		EncryptedTxBlob: r.EncryptedTxBlob,
 	}
 }
 
-// Hash returns the keccak256 hash of b's header.
+// Hash returns the keccak256 hash of the rollup's header.
 // The hash is computed on the first call and cached thereafter.
-func (r *ExtRollupWithHash) Hash() L2RootHash {
+func (r *ExtRollup) Hash() L2RootHash {
 	if hash := r.hash.Load(); hash != nil {
 		return hash.(L2RootHash)
 	}
 	v := r.Header.Hash()
 	r.hash.Store(v)
-
 	return v
 }

--- a/go/enclave/core/rollup.go
+++ b/go/enclave/core/rollup.go
@@ -53,7 +53,7 @@ func (r *Rollup) ToExtRollup(transactionBlobCrypto crypto.TransactionBlobCrypto)
 	}
 }
 
-func ToEnclaveRollup(encryptedRollup *common.ExtRollupWithHash, transactionBlobCrypto crypto.TransactionBlobCrypto) *Rollup {
+func ToEnclaveRollup(encryptedRollup *common.ExtRollup, transactionBlobCrypto crypto.TransactionBlobCrypto) *Rollup {
 	return &Rollup{
 		Header:       encryptedRollup.Header,
 		Transactions: transactionBlobCrypto.Decrypt(encryptedRollup.EncryptedTxBlob),

--- a/go/enclave/core/rollup_serialisation_test.go
+++ b/go/enclave/core/rollup_serialisation_test.go
@@ -33,7 +33,7 @@ func TestSerialiseRollup(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	r1 := common.ExtRollupWithHash{}
+	r1 := common.ExtRollup{}
 
 	err = rlp.Decode(read, &r1)
 	if err != nil {

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -506,7 +506,7 @@ func (h *host) processBlockTransactions(b *types.Block) {
 
 // Publishes a rollup to the L1.
 func (h *host) publishRollup(producedRollup common.ExtRollup) {
-	encodedRollup, err := common.EncodeRollup(producedRollup.ToExtRollupWithHash())
+	encodedRollup, err := common.EncodeRollup(producedRollup.ToExtRollup())
 	if err != nil {
 		h.logger.Crit("could not encode rollup.", log.ErrKey, err)
 	}
@@ -550,7 +550,7 @@ func (h *host) initialiseProtocol(block *types.Block) (common.L2RootHash, error)
 		fmt.Sprintf("Initialising network. Genesis rollup r_%d.",
 			common.ShortHash(genesisResponse.ProducedRollup.Header.Hash()),
 		))
-	encodedRollup, err := common.EncodeRollup(genesisResponse.ProducedRollup.ToExtRollupWithHash())
+	encodedRollup, err := common.EncodeRollup(genesisResponse.ProducedRollup.ToExtRollup())
 	if err != nil {
 		return common.L2RootHash{}, fmt.Errorf("could not encode rollup. Cause: %w", err)
 	}

--- a/integration/datagenerator/rollup.go
+++ b/integration/datagenerator/rollup.go
@@ -8,7 +8,7 @@ import (
 	"github.com/obscuronet/go-obscuro/go/common"
 )
 
-func RandomRollup() common.ExtRollupWithHash {
+func RandomRollup() common.ExtRollup {
 	extRollup := common.ExtRollup{
 		Header: &common.Header{
 			ParentHash:  randomHash(),
@@ -21,7 +21,5 @@ func RandomRollup() common.ExtRollupWithHash {
 		TxHashes:        []gethcommon.Hash{randomHash()},
 		EncryptedTxBlob: RandomBytes(10),
 	}
-	return common.ExtRollupWithHash{
-		ExtRollup: extRollup,
-	}
+	return extRollup
 }

--- a/integration/simulation/utils.go
+++ b/integration/simulation/utils.go
@@ -101,7 +101,7 @@ func findHashDups(list []gethcommon.Hash) map[gethcommon.Hash]int {
 }
 
 // FindRollupDups - returns a map of all L2 root hashes that appear multiple times, and how many times
-func findRollupDups(list []*common.ExtRollupWithHash) map[common.L2RootHash]int {
+func findRollupDups(list []*common.ExtRollup) map[common.L2RootHash]int {
 	elementCount := make(map[common.L2RootHash]int)
 
 	for _, item := range list {

--- a/integration/simulation/validate_chain.go
+++ b/integration/simulation/validate_chain.go
@@ -168,9 +168,9 @@ func checkBlockchainOfEthereumNode(t *testing.T, node ethadapter.EthClient, minH
 
 // ExtractDataFromEthereumChain returns the deposits, rollups, total amount deposited and length of the blockchain
 // between the start block and the end block.
-func ExtractDataFromEthereumChain(startBlock *types.Block, endBlock *types.Block, node ethadapter.EthClient, s *Simulation, nodeIdx int) ([]gethcommon.Hash, []*common.ExtRollupWithHash, *big.Int, int) {
+func ExtractDataFromEthereumChain(startBlock *types.Block, endBlock *types.Block, node ethadapter.EthClient, s *Simulation, nodeIdx int) ([]gethcommon.Hash, []*common.ExtRollup, *big.Int, int) {
 	deposits := make([]gethcommon.Hash, 0)
-	rollups := make([]*common.ExtRollupWithHash, 0)
+	rollups := make([]*common.ExtRollup, 0)
 	totalDeposited := big.NewInt(0)
 
 	blockchain := node.BlocksBetween(startBlock, endBlock)

--- a/integration/smartcontract/debug_mgmt_contract_lib.go
+++ b/integration/smartcontract/debug_mgmt_contract_lib.go
@@ -36,7 +36,7 @@ func newDebugMgmtContractLib(address gethcommon.Address, client *ethereumclient.
 }
 
 // AwaitedIssueRollup speeds ups the issuance of rollup, await of tx to be minted and makes sure the values are correctly stored
-func (d *debugMgmtContractLib) AwaitedIssueRollup(rollup common.ExtRollupWithHash, client ethadapter.EthClient, w *debugWallet) error {
+func (d *debugMgmtContractLib) AwaitedIssueRollup(rollup common.ExtRollup, client ethadapter.EthClient, w *debugWallet) error {
 	encodedRollup, err := common.EncodeRollup(&rollup)
 	if err != nil {
 		return err

--- a/integration/smartcontract/smartcontracts_test.go
+++ b/integration/smartcontract/smartcontracts_test.go
@@ -596,7 +596,7 @@ func detectSimpleFork(t *testing.T, mgmtContractLib *debugMgmtContractLib, w *de
 	}
 
 	// inserts a fork ( two rollups at same height / same parent )
-	splitPoint := make([]common.ExtRollupWithHash, 2)
+	splitPoint := make([]common.ExtRollup, 2)
 	for i := 0; i < 2; i++ {
 		r := datagenerator.RandomRollup()
 		r.Header.Agg = aggAID
@@ -616,7 +616,7 @@ func detectSimpleFork(t *testing.T, mgmtContractLib *debugMgmtContractLib, w *de
 	}
 
 	// create the fork
-	forks := make([]common.ExtRollupWithHash, 2)
+	forks := make([]common.ExtRollup, 2)
 	for i, parentRollup := range splitPoint {
 		r := datagenerator.RandomRollup()
 		r.Header.Agg = aggAID


### PR DESCRIPTION
### Why is this change needed?

There was no reason for this split, which just complicated things.

### What changes were made as part of this PR:

- Provide a high level list of the changes made
- List key areas for the reviewer 

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
