### PR TITLE
HeaderWithHashes is in the `common` module, but it's specific to the host DB

### DIFF
--- a/go/common/headers.go
+++ b/go/common/headers.go
@@ -53,12 +53,6 @@ type Withdrawal struct {
 	Contract  common.Address // the contract
 }
 
-// HeaderWithTxHashes pairs a header with the hashes of the transactions in that rollup.
-type HeaderWithTxHashes struct {
-	Header   *Header
-	TxHashes []TxHash
-}
-
 // Hash returns the block hash of the header, which is simply the keccak256 hash of its
 // RLP encoding excluding the signature.
 func (h *Header) Hash() L2RootHash {

--- a/go/host/db/hostdb.go
+++ b/go/host/db/hostdb.go
@@ -108,6 +108,7 @@ func (db *DB) AddRollupHeader(header *common.Header, txHashes []common.TxHash) {
 	b := db.kvStore.NewBatch()
 	headerWithHashes := &HeaderWithTxHashes{Header: header, TxHashes: txHashes}
 	db.writeRollupHeader(b, headerWithHashes)
+	db.writeRollupTxHashes(b, header.Hash(), txHashes) // Required by ObscuroScan, to display a list of recent transactions.
 	db.writeRollupHash(b, headerWithHashes.Header)
 	for _, txHash := range headerWithHashes.TxHashes {
 		db.writeRollupNumber(b, headerWithHashes.Header, txHash)
@@ -139,6 +140,11 @@ func (db *DB) GetRollupNumber(txHash gethcommon.Hash) (*big.Int, bool) {
 	return db.readRollupNumber(db.kvStore, txHash)
 }
 
+// GetRollupTxs returns the transaction hashes of the rollup with the given hash, or (nil, false) if no such rollup is found.
+func (db *DB) GetRollupTxs(rollupHash gethcommon.Hash) ([]gethcommon.Hash, bool) {
+	return db.readRollupTxHashes(db.kvStore, rollupHash)
+}
+
 // GetTotalTransactions returns the total number of rolled-up transactions.
 func (db *DB) GetTotalTransactions() *big.Int {
 	return db.readTotalTransactions(db.kvStore)
@@ -148,6 +154,7 @@ func (db *DB) GetTotalTransactions() *big.Int {
 var (
 	blockHeaderPrefix    = []byte("b")
 	rollupHeaderPrefix   = []byte("r")
+	rollupTxHashesPrefix = []byte("rt")
 	headBlock            = []byte("hb")
 	headRollup           = []byte("hr")
 	rollupHashPrefix     = []byte("rh")
@@ -158,6 +165,11 @@ var (
 // headerKey = rollupHeaderPrefix  + hash
 func rollupHeaderKey(hash gethcommon.Hash) []byte {
 	return append(rollupHeaderPrefix, hash.Bytes()...)
+}
+
+// headerKey = rollupTxHashesPrefix + rollup hash
+func rollupTxHashesKey(hash gethcommon.Hash) []byte {
+	return append(rollupTxHashesPrefix, hash.Bytes()...)
 }
 
 // headerKey = blockHeaderPrefix  + hash
@@ -245,6 +257,41 @@ func (db *DB) readRollupHeader(r ethdb.KeyValueReader, hash gethcommon.Hash) (*H
 		db.logger.Crit("could not decode rollup header.", log.ErrKey, err)
 	}
 	return header, true
+}
+
+// Writes the transaction hashes against the rollup containing them.
+func (db *DB) writeRollupTxHashes(w ethdb.KeyValueWriter, rollupHash common.L2RootHash, txHashes []gethcommon.Hash) {
+	data, err := rlp.EncodeToBytes(txHashes)
+	if err != nil {
+		db.logger.Crit("could not encode rollup transaction hashes.", log.ErrKey, err)
+	}
+	key := rollupTxHashesKey(rollupHash)
+	if err := w.Put(key, data); err != nil {
+		db.logger.Crit("could not put rollup transaction hashes in DB.", log.ErrKey, err)
+	}
+}
+
+// Returns the transaction hashes in the rollup with the given hash, or (nil, false) if no such header is found.
+func (db *DB) readRollupTxHashes(r ethdb.KeyValueReader, hash gethcommon.Hash) ([]gethcommon.Hash, bool) {
+	f, err := r.Has(rollupTxHashesKey(hash))
+	if err != nil {
+		db.logger.Crit("could not retrieve rollup tx hashes.", log.ErrKey, err)
+	}
+	if !f {
+		return nil, false
+	}
+	data, err := r.Get(rollupTxHashesKey(hash))
+	if err != nil {
+		db.logger.Crit("could not retrieve rollup tx hashes.", log.ErrKey, err)
+	}
+	if len(data) == 0 {
+		return nil, false
+	}
+	txHashes := []gethcommon.Hash{}
+	if err := rlp.Decode(bytes.NewReader(data), &txHashes); err != nil {
+		db.logger.Crit("could not decode tx hashes.", log.ErrKey, err)
+	}
+	return txHashes, true
 }
 
 func (db *DB) readHeadBlock(r ethdb.KeyValueReader) *gethcommon.Hash {

--- a/go/host/db/hostdb.go
+++ b/go/host/db/hostdb.go
@@ -89,12 +89,13 @@ func (db *DB) AddBlockHeader(header *types.Header) {
 }
 
 // GetHeadRollupHeader returns the header of the current rollup (head) of the Node, or (nil, false) if no such header is found.
-func (db *DB) GetHeadRollupHeader() (*HeaderWithTxHashes, bool) {
+func (db *DB) GetHeadRollupHeader() (*common.Header, bool) {
 	headRollupHash := db.readHeadRollup(db.kvStore)
 	if headRollupHash == nil {
 		return nil, false
 	}
-	return db.readRollupHeader(db.kvStore, *headRollupHash)
+	headerWithHashes, found := db.readRollupHeader(db.kvStore, *headRollupHash)
+	return headerWithHashes.Header, found
 }
 
 // GetRollupHeader returns the rollup header given the Hash, or (nil, false) if no such header is found.
@@ -118,8 +119,8 @@ func (db *DB) AddRollupHeader(header *common.Header, txHashes []common.TxHash) {
 	db.writeTotalTransactions(b, newTotal)
 
 	// update the head if the new height is greater than the existing one
-	currentRollupHeaderWithHashes, found := db.GetHeadRollupHeader()
-	if !found || currentRollupHeaderWithHashes.Header.Number.Int64() <= headerWithHashes.Header.Number.Int64() {
+	headRollupHeader, found := db.GetHeadRollupHeader()
+	if !found || headRollupHeader.Number.Int64() <= headerWithHashes.Header.Number.Int64() {
 		db.writeHeadRollup(b, headerWithHashes.Header.Hash())
 	}
 

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -531,8 +531,7 @@ func (h *host) storeBlockProcessingResult(result *common.BlockSubmissionResponse
 	// only update the host rollup headers if the enclave has found a new rollup head
 	if result.FoundNewHead {
 		// adding a header will update the head if it has a higher height
-		headerWithHashes := common.HeaderWithTxHashes{Header: result.IngestedRollupHeader, TxHashes: result.ProducedRollup.TxHashes}
-		h.db.AddRollupHeader(&headerWithHashes)
+		h.db.AddRollupHeader(result.IngestedRollupHeader, result.ProducedRollup.TxHashes)
 	}
 
 	// adding a header will update the head if it has a higher height

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -531,6 +531,7 @@ func (h *host) storeBlockProcessingResult(result *common.BlockSubmissionResponse
 	// only update the host rollup headers if the enclave has found a new rollup head
 	if result.FoundNewHead {
 		// adding a header will update the head if it has a higher height
+		// TODO - Fix bug here where tx hashes are being stored against the wrong rollup.
 		h.db.AddRollupHeader(result.IngestedRollupHeader, result.ProducedRollup.TxHashes)
 	}
 

--- a/go/host/rpc/clientapi/client_api_eth.go
+++ b/go/host/rpc/clientapi/client_api_eth.go
@@ -65,11 +65,11 @@ func (api *EthereumAPI) GetBlockByNumber(ctx context.Context, number rpc.BlockNu
 // GetBlockByHash returns the header of the rollup with the given hash.
 // TODO - #718 - Switch to retrieving batch header.
 func (api *EthereumAPI) GetBlockByHash(_ context.Context, hash gethcommon.Hash, _ bool) (map[string]interface{}, error) {
-	rollupHeaderWithHashes, found := api.host.DB().GetRollupHeader(hash)
+	rollupHeader, found := api.host.DB().GetRollupHeader(hash)
 	if !found {
 		return nil, nil //nolint:nilnil
 	}
-	return headerToMap(rollupHeaderWithHashes.Header), nil
+	return headerToMap(rollupHeader), nil
 }
 
 // GasPrice is a placeholder for an RPC method required by MetaMask/Remix.

--- a/go/host/rpc/clientapi/client_api_eth.go
+++ b/go/host/rpc/clientapi/client_api_eth.go
@@ -34,12 +34,12 @@ func (api *EthereumAPI) ChainId() (*hexutil.Big, error) { //nolint:stylecheck,re
 // BlockNumber returns the height of the current head rollup.
 // # TODO - #718 - Switch to returning height based on current batch.
 func (api *EthereumAPI) BlockNumber() hexutil.Uint64 {
-	head, found := api.host.DB().GetHeadRollupHeader()
+	header, found := api.host.DB().GetHeadRollupHeader()
 	if !found {
 		return 0
 	}
 
-	number := head.Header.Number.Uint64()
+	number := header.Number.Uint64()
 	return hexutil.Uint64(number)
 }
 
@@ -222,7 +222,7 @@ func (api *EthereumAPI) rollupNumberToRollupHash(blockNumber rpc.BlockNumber) (*
 		if !found {
 			return nil, false
 		}
-		hash := header.Header.Hash()
+		hash := header.Hash()
 		return &hash, true
 	}
 

--- a/go/host/rpc/clientapi/client_api_obscuroscan.go
+++ b/go/host/rpc/clientapi/client_api_obscuroscan.go
@@ -86,12 +86,12 @@ func (api *ObscuroScanAPI) GetLatestTransactions(num int) ([]gethcommon.Hash, er
 	// We walk the chain until we've collected the requested number of transactions.
 	var txHashes []gethcommon.Hash
 	for {
-		rollupHeaderWithHashes, found := api.host.DB().GetRollupHeader(currentRollupHash)
+		rollupHeader, found := api.host.DB().GetRollupHeader(currentRollupHash)
 		if !found {
 			return nil, fmt.Errorf("could not retrieve rollup for hash %s", currentRollupHash)
 		}
 
-		rollupTxHashes, found := api.host.DB().GetRollupTxs(rollupHeaderWithHashes.Header.Hash())
+		rollupTxHashes, found := api.host.DB().GetRollupTxs(rollupHeader.Hash())
 		if !found {
 			return nil, fmt.Errorf("could not retrieve transaction hashes for rollup hash %s", currentRollupHash)
 		}
@@ -104,10 +104,10 @@ func (api *ObscuroScanAPI) GetLatestTransactions(num int) ([]gethcommon.Hash, er
 		}
 
 		// If we've reached the top of the chain, we stop walking.
-		if rollupHeaderWithHashes.Header.Number.Uint64() == common.L2GenesisHeight {
+		if rollupHeader.Number.Uint64() == common.L2GenesisHeight {
 			break
 		}
-		currentRollupHash = rollupHeaderWithHashes.Header.ParentHash
+		currentRollupHash = rollupHeader.ParentHash
 	}
 
 	return txHashes, nil

--- a/go/host/rpc/clientapi/client_api_obscuroscan.go
+++ b/go/host/rpc/clientapi/client_api_obscuroscan.go
@@ -91,7 +91,12 @@ func (api *ObscuroScanAPI) GetLatestTransactions(num int) ([]gethcommon.Hash, er
 			return nil, fmt.Errorf("could not retrieve rollup for hash %s", currentRollupHash)
 		}
 
-		for _, txHash := range rollupHeaderWithHashes.TxHashes {
+		rollupTxHashes, found := api.host.DB().GetRollupTxs(rollupHeaderWithHashes.Header.Hash())
+		if !found {
+			return nil, fmt.Errorf("could not retrieve transaction hashes for rollup hash %s", currentRollupHash)
+		}
+
+		for _, txHash := range rollupTxHashes {
 			txHashes = append(txHashes, txHash)
 			if len(txHashes) >= num {
 				break

--- a/go/host/rpc/clientapi/client_api_obscuroscan.go
+++ b/go/host/rpc/clientapi/client_api_obscuroscan.go
@@ -36,11 +36,11 @@ func (api *ObscuroScanAPI) GetBlockHeaderByHash(blockHash gethcommon.Hash) (*typ
 // GetHeadRollupHeader returns the current head rollup's header.
 // TODO - #718 - Switch to reading batch header.
 func (api *ObscuroScanAPI) GetHeadRollupHeader() *common.Header {
-	headerWithHashes, found := api.host.DB().GetHeadRollupHeader()
+	header, found := api.host.DB().GetHeadRollupHeader()
 	if !found {
 		return nil
 	}
-	return headerWithHashes.Header
+	return header
 }
 
 // GetRollup returns the rollup with the given hash.
@@ -77,11 +77,11 @@ func (api *ObscuroScanAPI) GetLatestTransactions(num int) ([]gethcommon.Hash, er
 		return nil, fmt.Errorf("cannot request more than 100 latest transactions")
 	}
 
-	currentRollupHeaderWithHashes, found := api.host.DB().GetHeadRollupHeader()
+	headRollupHeader, found := api.host.DB().GetHeadRollupHeader()
 	if !found {
 		return nil, nil
 	}
-	currentRollupHash := currentRollupHeaderWithHashes.Header.Hash()
+	currentRollupHash := headRollupHeader.Hash()
 
 	// We walk the chain until we've collected the requested number of transactions.
 	var txHashes []gethcommon.Hash

--- a/tools/obscuroscan/obscuroscan.go
+++ b/tools/obscuroscan/obscuroscan.go
@@ -172,7 +172,7 @@ func (o *Obscuroscan) getNumTransactions(resp http.ResponseWriter, _ *http.Reque
 	var numTransactions *big.Int
 	err := o.client.Call(&numTransactions, rpc.GetTotalTxs)
 	if err != nil {
-		o.logger.Error("Could not fetch latest transactions.", log.ErrKey, err)
+		o.logger.Error("Could not fetch total transactions.", log.ErrKey, err)
 		logAndSendErr(resp, "Could not fetch total transactions.")
 		return
 	}


### PR DESCRIPTION
### Why is this change needed?

HeaderWithHashes is in the `common` module, but it's specific to the host DB. I've moved it across for clarity.

### What changes were made as part of this PR:

- Provide a high level list of the changes made
- List key areas for the reviewer 

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
