### PR TITLE
Fix issues with submit block errors

### DIFF
--- a/go/enclave/rpc_server.go
+++ b/go/enclave/rpc_server.go
@@ -124,11 +124,11 @@ func (s *server) SubmitBlock(_ context.Context, request *generated.SubmitBlockRe
 	bl := s.decodeBlock(request.EncodedBlock)
 	blockSubmissionResponse, err := s.enclave.SubmitBlock(bl, request.IsLatest)
 	if err != nil {
-		var rejErr common.BlockRejectError
+		var rejErr *common.BlockRejectError
 		isReject := errors.As(err, &rejErr)
 		if isReject {
 			// todo: we should avoid errors in response messages and use the gRPC error objects for this stuff (standardized across all enclave responses)
-			msg, err := rpc.ToBlockSubmissionRejectionMsg(&rejErr)
+			msg, err := rpc.ToBlockSubmissionRejectionMsg(rejErr)
 			if err == nil {
 				// send back reject err response
 				return &generated.SubmitBlockResponse{BlockSubmissionResponse: &msg}, nil

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -385,8 +385,8 @@ func (h *host) waitForEnclave() {
 }
 
 // starts the host main processing loop
-func (h *host) startProcessing() {
-	h.logger.Info("§§§ Start processing...")
+// todo: matt to fix this complexity `nolint` in next PR with block provider
+func (h *host) startProcessing() { //nolint:gocognit
 	// Only open the p2p connection when the host is fully initialised
 	h.p2p.StartListening(h)
 

--- a/go/host/rpc/enclaverpc/enclave_client.go
+++ b/go/host/rpc/enclaverpc/enclave_client.go
@@ -177,13 +177,7 @@ func (c *Client) SubmitBlock(block types.Block, isLatest bool) (*common.BlockSub
 
 	blockSubmissionResponse, err := rpc.FromBlockSubmissionResponseMsg(response.BlockSubmissionResponse)
 	if err != nil {
-		return nil, fmt.Errorf("could not produce block submission response. Cause: %w", err)
-	}
-	if blockSubmissionResponse.RejectError != nil {
-		return nil, common.BlockRejectError{
-			L1Head:  blockSubmissionResponse.RejectError.L1Head,
-			Wrapped: blockSubmissionResponse.RejectError.Wrapped,
-		}
+		return nil, err
 	}
 	return blockSubmissionResponse, nil
 }


### PR DESCRIPTION
### Why is this change needed?

- The block feeding changes I'm making rely on the enclave reporting back what it knows as the L1 head with failures
- There were too many spammy logs from the parent block failures

### What changes were made as part of this PR:

- Fix the rpc conversion to produce the correct error type from the BlockSubmissionResponse object
- Change the log level to debug for those failures when they happen for 'parent' blocks in the main path (blocks that have usually already been processed and so will always fail as a duplicate)

I verified in the logs that I'm now seeing the hashes for the enclave's view of the L1 head and no longer seeing the spam of "could not submit block" "block already processed"

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
