### PR TITLE
Fix EVM error casting to use pointer variable

### DIFF
--- a/go/enclave/rpc_server.go
+++ b/go/enclave/rpc_server.go
@@ -286,7 +286,7 @@ func serializeEVMError(err error) ([]byte, error) {
 	var errReturn interface{}
 
 	// check if it's a serialized error and handle any error wrapping that might have occurred
-	var e evm.SerialisableError
+	var e *evm.SerialisableError
 	if ok := errors.As(err, &e); ok {
 		errReturn = e
 	} else {


### PR DESCRIPTION
### Why is this change needed?

- We discovered while looking at `errors.As()` docs and examples that errors are typically returned as pointers and that the `errors.As` target should be a pointer to the pointer variable.

E.g. from official docs https://pkg.go.dev/errors
```
var perr *fs.PathError
if errors.As(err, &perr) {
	fmt.Println(perr.Path)
}
```
- I fixed a couple of these issues that I introduced recently
- this EVM error casting seems to be another case where it would not be casting successfully

### What changes were made as part of this PR:

- cast evm error to a pointer

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
