### PR TITLE
Replace panics with logger.Crit in the enclave

### DIFF
--- a/go/enclave/bridge/bridge.go
+++ b/go/enclave/bridge/bridge.go
@@ -190,7 +190,7 @@ func (bridge *Bridge) NewDepositTx(contract *gethcommon.Address, address gethcom
 
 	token := bridge.GetMapping(contract)
 	if token == nil {
-		panic("This should not happen as we don't generate deposits on unsupported tokens.")
+		bridge.logger.Crit("This should not happen as we don't generate deposits on unsupported tokens.")
 	}
 
 	// The nonce is adjusted with the number of deposits added to the rollup already.
@@ -277,7 +277,7 @@ func (bridge *Bridge) RollupPostProcessingWithdrawals(newHeadRollup *obscurocore
 				signer := types.NewLondonSigner(big.NewInt(bridge.ObscuroChainID))
 				from, err := types.Sender(signer, t)
 				if err != nil {
-					panic(err)
+					bridge.logger.Crit("Error retrieving the sender from the signature", log.ErrKey, err)
 				}
 				state.Logs()
 				w = append(w, common.Withdrawal{

--- a/go/enclave/core/rollup.go
+++ b/go/enclave/core/rollup.go
@@ -60,7 +60,11 @@ func ToEnclaveRollup(encryptedRollup *common.ExtRollup, transactionBlobCrypto cr
 	}
 }
 
-func EmptyRollup(agg gethcommon.Address, parent *common.Header, blkHash gethcommon.Hash, nonce common.Nonce) *Rollup {
+func EmptyRollup(agg gethcommon.Address, parent *common.Header, blkHash gethcommon.Hash, nonce common.Nonce) (*Rollup, error) {
+	rand, err := crypto.GeneratePublicRandomness()
+	if err != nil {
+		return nil, err
+	}
 	h := common.Header{
 		Agg:        agg,
 		ParentHash: parent.Hash(),
@@ -71,12 +75,12 @@ func EmptyRollup(agg gethcommon.Address, parent *common.Header, blkHash gethcomm
 		// generate true randomness inside the enclave.
 		// note that this randomness will be published in the header of the rollup.
 		// the randomness exposed to smart contract is combining this with the shared secret.
-		MixDigest: gethcommon.BytesToHash(crypto.GeneratePublicRandomness()),
+		MixDigest: gethcommon.BytesToHash(rand),
 	}
 	r := Rollup{
 		Header: &h,
 	}
-	return &r
+	return &r, nil
 }
 
 // NewRollup - produces a new rollup. only used for genesis. todo - review

--- a/go/enclave/crypto/crypto.go
+++ b/go/enclave/crypto/crypto.go
@@ -92,7 +92,7 @@ func decryptWithPrivateKey(ciphertext []byte, priv *ecdsa.PrivateKey) ([]byte, e
 }
 
 // GeneratePublicRandomness - generate 32 bytes of randomness, which will be exposed in the rollup header.
-func GeneratePublicRandomness() []byte {
+func GeneratePublicRandomness() ([]byte, error) {
 	return randomBytes(gethcommon.HashLength)
 }
 
@@ -101,13 +101,12 @@ func PrivateRollupRnd(publicRnd []byte, secret []byte) []byte {
 	return crypto.Keccak256Hash(publicRnd, secret).Bytes()
 }
 
-func randomBytes(length int) []byte {
+func randomBytes(length int) ([]byte, error) {
 	byteArr := make([]byte, length)
 	if _, err := rand.Read(byteArr); err != nil {
-		// todo - what should happen?
-		panic(err)
+		return nil, err
 	}
-	return byteArr
+	return byteArr, nil
 }
 
 // PerTransactionRnd - calculates a per tx random value

--- a/go/enclave/db/rawdb/accessors_indexes.go
+++ b/go/enclave/db/rawdb/accessors_indexes.go
@@ -18,7 +18,7 @@ import (
 
 // ReadTxLookupEntry retrieves the positional metadata associated with a transaction
 // hash to allow retrieving the transaction or receipt by hash.
-func ReadTxLookupEntry(db ethdb.Reader, hash common.Hash) *uint64 {
+func ReadTxLookupEntry(db ethdb.Reader, hash common.Hash, logger gethlog.Logger) *uint64 {
 	data, _ := db.Get(txLookupKey(hash))
 	if len(data) == 0 {
 		return nil
@@ -28,7 +28,8 @@ func ReadTxLookupEntry(db ethdb.Reader, hash common.Hash) *uint64 {
 		number := new(big.Int).SetBytes(data).Uint64()
 		return &number
 	}
-	panic("Should not be here")
+	logger.Crit("Should not be here")
+	return nil
 }
 
 // writeTxLookupEntry stores a positional metadata for a transaction,
@@ -74,7 +75,7 @@ func DeleteTxLookupEntries(db ethdb.KeyValueWriter, hashes []common.Hash, logger
 // ReadTransaction retrieves a specific transaction from the database, along with
 // its added positional metadata.
 func ReadTransaction(db ethdb.Reader, hash common.Hash, logger gethlog.Logger) (*types.Transaction, common.Hash, uint64, uint64) {
-	blockNumber := ReadTxLookupEntry(db, hash)
+	blockNumber := ReadTxLookupEntry(db, hash, logger)
 	if blockNumber == nil {
 		return nil, common.Hash{}, 0, 0
 	}
@@ -100,7 +101,7 @@ func ReadTransaction(db ethdb.Reader, hash common.Hash, logger gethlog.Logger) (
 // its added positional metadata.
 func ReadReceipt(db ethdb.Reader, hash common.Hash, config *params.ChainConfig, logger gethlog.Logger) (*types.Receipt, common.Hash, uint64, uint64) {
 	// Retrieve the context of the receipt based on the transaction hash
-	blockNumber := ReadTxLookupEntry(db, hash)
+	blockNumber := ReadTxLookupEntry(db, hash, logger)
 	if blockNumber == nil {
 		return nil, common.Hash{}, 0, 0
 	}

--- a/go/enclave/db/sql/edgelessdb.go
+++ b/go/enclave/db/sql/edgelessdb.go
@@ -148,7 +148,7 @@ func EdgelessDBConnector(edbCfg *EdgelessDBConfig, logger gethlog.Logger) (ethdb
 	}
 
 	// wrap it in our eth-compatible key-value store layer
-	return CreateSQLEthDatabase(sqlDB)
+	return CreateSQLEthDatabase(sqlDB, logger)
 }
 
 func waitForEdgelessDBToStart(edbHost string, logger gethlog.Logger) error {

--- a/go/enclave/db/sql/sql.go
+++ b/go/enclave/db/sql/sql.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 
+	gethlog "github.com/ethereum/go-ethereum/log"
+
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/obscuronet/go-obscuro/go/common/errutil"
 )
@@ -19,11 +21,12 @@ const (
 
 // sqlEthDatabase implements ethdb.Database
 type sqlEthDatabase struct {
-	db *sql.DB
+	db     *sql.DB
+	logger gethlog.Logger
 }
 
-func CreateSQLEthDatabase(db *sql.DB) (ethdb.Database, error) {
-	return &sqlEthDatabase{db: db}, nil
+func CreateSQLEthDatabase(db *sql.DB, logger gethlog.Logger) (ethdb.Database, error) {
+	return &sqlEthDatabase{db: db, logger: logger}, nil
 }
 
 func (m *sqlEthDatabase) Has(key []byte) (bool, error) {
@@ -96,12 +99,14 @@ func (m *sqlEthDatabase) NewIterator(prefix []byte, start []byte) ethdb.Iterator
 
 func (m *sqlEthDatabase) Stat(property string) (string, error) {
 	// TODO implement me
-	panic("implement me")
+	m.logger.Crit("implement me")
+	return "", nil
 }
 
 func (m *sqlEthDatabase) Compact(start []byte, limit []byte) error {
 	// TODO implement me
-	panic("implement me")
+	m.logger.Crit("implement me")
+	return nil
 }
 
 // no-freeze! Copied from the geth in-memory db implementation these ancient method implementations disable the 'freezer'

--- a/go/enclave/db/sql/sql_test.go
+++ b/go/enclave/db/sql/sql_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/obscuronet/go-obscuro/integration/common/testlog"
+
 	"github.com/status-im/keycard-go/hexutils"
 
 	"github.com/ethereum/go-ethereum/ethdb"
@@ -115,7 +117,7 @@ func createDB(t *testing.T) ethdb.Database {
 	lite := setupSQLite(t)
 	_, err := lite.Exec(createQry)
 	failIfError(t, err, "Failed to create key-value table in test db")
-	s, err := CreateSQLEthDatabase(lite)
+	s, err := CreateSQLEthDatabase(lite, testlog.Logger())
 	failIfError(t, err, "Failed to create SQLEthDatabase for test")
 	return s
 }

--- a/go/enclave/db/sql/sqlite.go
+++ b/go/enclave/db/sql/sqlite.go
@@ -46,7 +46,7 @@ func CreateTemporarySQLiteDB(dbPath string, logger gethlog.Logger) (ethdb.Databa
 		desc = "new"
 	}
 	logger.Info(fmt.Sprintf("Opened %s sqlite db file at %s", desc, dbPath))
-	return CreateSQLEthDatabase(db)
+	return CreateSQLEthDatabase(db, logger)
 }
 
 func getTempDBFile() (string, error) {

--- a/go/enclave/evm/chain_context.go
+++ b/go/enclave/evm/chain_context.go
@@ -29,6 +29,7 @@ func (occ *ObscuroChainContext) GetHeader(hash common.Hash, height uint64) *type
 	h, err := convertToEthHeader(rol.Header, secret(occ.storage))
 	if err != nil {
 		occ.logger.Crit("Could not convert to eth header", log.ErrKey, err)
+		return nil
 	}
 	return h
 }

--- a/go/enclave/evm/chain_context.go
+++ b/go/enclave/evm/chain_context.go
@@ -4,16 +4,19 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/core/types"
+	gethlog "github.com/ethereum/go-ethereum/log"
+	"github.com/obscuronet/go-obscuro/go/common/log"
 	"github.com/obscuronet/go-obscuro/go/enclave/db"
 )
 
 // ObscuroChainContext - basic implementation of the ChainContext needed for the EVM integration
 type ObscuroChainContext struct {
 	storage db.Storage
+	logger  gethlog.Logger
 }
 
-func (*ObscuroChainContext) Engine() consensus.Engine {
-	return &ObscuroNoOpConsensusEngine{}
+func (occ *ObscuroChainContext) Engine() consensus.Engine {
+	return &ObscuroNoOpConsensusEngine{logger: occ.logger}
 }
 
 func (occ *ObscuroChainContext) GetHeader(hash common.Hash, height uint64) *types.Header {
@@ -22,5 +25,10 @@ func (occ *ObscuroChainContext) GetHeader(hash common.Hash, height uint64) *type
 	if !f {
 		return nil
 	}
-	return convertToEthHeader(rol.Header, secret(occ.storage))
+
+	h, err := convertToEthHeader(rol.Header, secret(occ.storage))
+	if err != nil {
+		occ.logger.Crit("Could not convert to eth header", log.ErrKey, err)
+	}
+	return h
 }

--- a/go/enclave/evm/evm_facade.go
+++ b/go/enclave/evm/evm_facade.go
@@ -35,6 +35,7 @@ func ExecuteTransactions(txs []*common.L2Tx, s *state.StateDB, header *common.He
 	ethHeader, err := convertToEthHeader(header, secret(storage))
 	if err != nil {
 		logger.Crit("Could not convert to eth header", log.ErrKey, err)
+		return nil
 	}
 
 	for i, t := range txs {

--- a/go/enclave/evm/evm_facade.go
+++ b/go/enclave/evm/evm_facade.go
@@ -27,12 +27,15 @@ import (
 // header - the header of the rollup where this transaction will be included
 // fromTxIndex - for the receipts and events, the evm needs to know for each transaction the order in which it was executed in the block.
 func ExecuteTransactions(txs []*common.L2Tx, s *state.StateDB, header *common.Header, storage db.Storage, chainConfig *params.ChainConfig, fromTxIndex int, logger gethlog.Logger) map[common.TxHash]interface{} {
-	chain, vmCfg, gp := initParams(storage, true)
+	chain, vmCfg, gp := initParams(storage, true, logger)
 	zero := uint64(0)
 	usedGas := &zero
 	result := map[common.TxHash]interface{}{}
 
-	ethHeader := convertToEthHeader(header, secret(storage))
+	ethHeader, err := convertToEthHeader(header, secret(storage))
+	if err != nil {
+		logger.Crit("Could not convert to eth header", log.ErrKey, err)
+	}
 
 	for i, t := range txs {
 		r, err := executeTransaction(s, chainConfig, chain, gp, ethHeader, t, usedGas, vmCfg, fromTxIndex+i)
@@ -84,9 +87,12 @@ func logReceipt(r *types.Receipt, logger gethlog.Logger) {
 
 // ExecuteOffChainCall - executes the eth_call call
 func ExecuteOffChainCall(msg *types.Message, s *state.StateDB, header *common.Header, storage db.Storage, chainConfig *params.ChainConfig, logger gethlog.Logger) (*gethcore.ExecutionResult, error) {
-	chain, vmCfg, gp := initParams(storage, true)
-
-	blockContext := gethcore.NewEVMBlockContext(convertToEthHeader(header, secret(storage)), chain, &header.Agg)
+	chain, vmCfg, gp := initParams(storage, true, nil)
+	ethHeader, err := convertToEthHeader(header, secret(storage))
+	if err != nil {
+		return nil, err
+	}
+	blockContext := gethcore.NewEVMBlockContext(ethHeader, chain, &header.Agg)
 
 	// sets TxKey.origin
 	txContext := gethcore.NewEVMTxContext(msg)
@@ -117,8 +123,8 @@ func ExecuteOffChainCall(msg *types.Message, s *state.StateDB, header *common.He
 	return result, nil
 }
 
-func initParams(storage db.Storage, noBaseFee bool) (*ObscuroChainContext, vm.Config, *gethcore.GasPool) {
-	chain := &ObscuroChainContext{storage: storage}
+func initParams(storage db.Storage, noBaseFee bool, l gethlog.Logger) (*ObscuroChainContext, vm.Config, *gethcore.GasPool) {
+	chain := &ObscuroChainContext{storage: storage, logger: l}
 
 	// Todo - temporarily enable the evm tracer to check what sort of extra info we receive
 	tracer := logger.NewStructLogger(&logger.Config{Debug: true})

--- a/go/enclave/evm/no_op_engine.go
+++ b/go/enclave/evm/no_op_engine.go
@@ -55,7 +55,7 @@ func (e *ObscuroNoOpConsensusEngine) FinalizeAndAssemble(chain consensus.ChainHe
 	uncles []*types.Header, receipts []*types.Receipt,
 ) (*types.Block, error) {
 	e.logger.Crit("noop")
-	return nil, nil
+	return nil, nil // nolint:nilnil
 }
 
 func (e *ObscuroNoOpConsensusEngine) Seal(chain consensus.ChainHeaderReader, block *types.Block, results chan<- *types.Block, stop <-chan struct{}) error {

--- a/go/enclave/evm/no_op_engine.go
+++ b/go/enclave/evm/no_op_engine.go
@@ -3,6 +3,8 @@ package evm
 import (
 	"math/big"
 
+	gethlog "github.com/ethereum/go-ethereum/log"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/core/state"
@@ -16,7 +18,9 @@ var PoolAddress = common.HexToAddress("0x0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0
 
 // ObscuroNoOpConsensusEngine - implements the geth consensus.Engine, but doesn't do anything
 // This is needed for running evm transactions
-type ObscuroNoOpConsensusEngine struct{}
+type ObscuroNoOpConsensusEngine struct {
+	logger gethlog.Logger
+}
 
 // Author is used to determine where to send the gas collected from the fees.
 func (e *ObscuroNoOpConsensusEngine) Author(header *types.Header) (common.Address, error) {
@@ -24,49 +28,57 @@ func (e *ObscuroNoOpConsensusEngine) Author(header *types.Header) (common.Addres
 }
 
 func (e *ObscuroNoOpConsensusEngine) VerifyHeader(chain consensus.ChainHeaderReader, header *types.Header, seal bool) error {
-	panic("noop")
+	e.logger.Crit("noop")
+	return nil
 }
 
 func (e *ObscuroNoOpConsensusEngine) VerifyHeaders(chain consensus.ChainHeaderReader, headers []*types.Header, seals []bool) (chan<- struct{}, <-chan error) {
-	panic("noop")
+	e.logger.Crit("noop")
+	return nil, nil
 }
 
 func (e *ObscuroNoOpConsensusEngine) VerifyUncles(chain consensus.ChainReader, block *types.Block) error {
-	panic("noop")
+	e.logger.Crit("noop")
+	return nil
 }
 
 func (e *ObscuroNoOpConsensusEngine) Prepare(chain consensus.ChainHeaderReader, header *types.Header) error {
-	panic("noop")
+	e.logger.Crit("noop")
+	return nil
 }
 
-func (e *ObscuroNoOpConsensusEngine) Finalize(chain consensus.ChainHeaderReader, header *types.Header, state *state.StateDB, txs []*types.Transaction,
-	uncles []*types.Header,
-) {
-	panic("noop")
+func (e *ObscuroNoOpConsensusEngine) Finalize(chain consensus.ChainHeaderReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header) {
+	e.logger.Crit("noop")
 }
 
 func (e *ObscuroNoOpConsensusEngine) FinalizeAndAssemble(chain consensus.ChainHeaderReader, header *types.Header, state *state.StateDB, txs []*types.Transaction,
 	uncles []*types.Header, receipts []*types.Receipt,
 ) (*types.Block, error) {
-	panic("noop")
+	e.logger.Crit("noop")
+	return nil, nil
 }
 
 func (e *ObscuroNoOpConsensusEngine) Seal(chain consensus.ChainHeaderReader, block *types.Block, results chan<- *types.Block, stop <-chan struct{}) error {
-	panic("noop")
+	e.logger.Crit("noop")
+	return nil
 }
 
 func (e *ObscuroNoOpConsensusEngine) SealHash(header *types.Header) common.Hash {
-	panic("noop")
+	e.logger.Crit("noop")
+	return common.Hash{}
 }
 
 func (e *ObscuroNoOpConsensusEngine) CalcDifficulty(chain consensus.ChainHeaderReader, time uint64, parent *types.Header) *big.Int {
-	panic("noop")
+	e.logger.Crit("noop")
+	return nil
 }
 
 func (e *ObscuroNoOpConsensusEngine) APIs(chain consensus.ChainHeaderReader) []rpc.API {
-	panic("noop")
+	e.logger.Crit("noop")
+	return nil
 }
 
 func (e *ObscuroNoOpConsensusEngine) Close() error {
-	panic("noop")
+	e.logger.Crit("noop")
+	return nil
 }

--- a/go/enclave/evm/no_op_engine.go
+++ b/go/enclave/evm/no_op_engine.go
@@ -55,7 +55,7 @@ func (e *ObscuroNoOpConsensusEngine) FinalizeAndAssemble(chain consensus.ChainHe
 	uncles []*types.Header, receipts []*types.Receipt,
 ) (*types.Block, error) {
 	e.logger.Crit("noop")
-	return nil, nil // nolint:nilnil
+	return nil, nil //nolint:nilnil
 }
 
 func (e *ObscuroNoOpConsensusEngine) Seal(chain consensus.ChainHeaderReader, block *types.Block, results chan<- *types.Block, stop <-chan struct{}) error {

--- a/go/enclave/evm/utils.go
+++ b/go/enclave/evm/utils.go
@@ -13,10 +13,10 @@ import (
 // Perform the conversion between an Obscuro header and an Ethereum header that the EVM understands
 // in the first stage we just encode the obscuro header in the Extra field
 // todo - find a better way
-func convertToEthHeader(h *common.Header, secret []byte) *types.Header {
+func convertToEthHeader(h *common.Header, secret []byte) (*types.Header, error) {
 	obscuroHeader, err := rlp.EncodeToBytes(h)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
 	// deterministically calculate private randomness that will be exposed to the evm
@@ -37,7 +37,7 @@ func convertToEthHeader(h *common.Header, secret []byte) *types.Header {
 		MixDigest:   gethcommon.BytesToHash(randomness),
 		Nonce:       types.BlockNonce{},
 		BaseFee:     gethcommon.Big0,
-	}
+	}, nil
 }
 
 /*


### PR DESCRIPTION
### Why is this change needed?

The enclave is sometimes crashing with segmentation faults which are hard to debug.
One theory is that these are caused by panics.

### What changes were made as part of this PR:

- Remove panics thrown during the enclave runtime, and replace them with `logger.Crit`, which logs and exits
- in some methods return an error, which is handled in the caller

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
