### PR TITLE
Locks the subscription list in LogEventManager for threadsafety

### DIFF
--- a/go/host/events/logs.go
+++ b/go/host/events/logs.go
@@ -12,14 +12,14 @@ import (
 type LogEventManager struct {
 	subscriptions     map[rpc.ID]*subscription // The channels that logs are sent to, one per subscription
 	subscriptionMutex *sync.RWMutex
-
-	logger gethlog.Logger
+	logger            gethlog.Logger
 }
 
 func NewLogEventManager(logger gethlog.Logger) LogEventManager {
 	return LogEventManager{
-		subscriptions: map[rpc.ID]*subscription{},
-		logger:        logger,
+		subscriptions:     map[rpc.ID]*subscription{},
+		subscriptionMutex: &sync.RWMutex{},
+		logger:            logger,
 	}
 }
 

--- a/go/host/events/logs.go
+++ b/go/host/events/logs.go
@@ -33,10 +33,14 @@ func (l *LogEventManager) AddSubscription(id rpc.ID, matchedLogsCh chan []byte) 
 
 // RemoveSubscription removes a subscription from the set of managed subscriptions.
 func (l *LogEventManager) RemoveSubscription(id rpc.ID) {
-	l.subscriptionMutex.RLock()
-	defer l.subscriptionMutex.RUnlock()
+	logSubscription, found := l.getSubscriptionThreadsafe(id)
+	if found {
+		close(logSubscription.ch)
 
-	delete(l.subscriptions, id)
+		l.subscriptionMutex.RLock()
+		defer l.subscriptionMutex.RUnlock()
+		delete(l.subscriptions, id)
+	}
 }
 
 // SendLogsToSubscribers distributes logs to subscribed clients.

--- a/go/host/events/logs.go
+++ b/go/host/events/logs.go
@@ -1,6 +1,8 @@
 package events
 
 import (
+	"sync"
+
 	gethlog "github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/obscuronet/go-obscuro/go/common"
@@ -8,8 +10,10 @@ import (
 
 // LogEventManager manages the routing of logs back to their subscribers.
 type LogEventManager struct {
-	subscriptions map[rpc.ID]*subscription // The channels that logs are sent to, one per subscription
-	logger        gethlog.Logger
+	subscriptions     map[rpc.ID]*subscription // The channels that logs are sent to, one per subscription
+	subscriptionMutex *sync.RWMutex
+
+	logger gethlog.Logger
 }
 
 func NewLogEventManager(logger gethlog.Logger) LogEventManager {
@@ -21,27 +25,38 @@ func NewLogEventManager(logger gethlog.Logger) LogEventManager {
 
 // AddSubscription adds a subscription to the set of managed subscriptions.
 func (l *LogEventManager) AddSubscription(id rpc.ID, matchedLogsCh chan []byte) {
+	l.subscriptionMutex.Lock()
+	defer l.subscriptionMutex.Unlock()
+
 	l.subscriptions[id] = &subscription{ch: matchedLogsCh}
 }
 
 // RemoveSubscription removes a subscription from the set of managed subscriptions.
 func (l *LogEventManager) RemoveSubscription(id rpc.ID) {
-	logSubscription, found := l.subscriptions[id]
-	if found {
-		close(logSubscription.ch)
-		delete(l.subscriptions, id)
-	}
+	l.subscriptionMutex.RLock()
+	defer l.subscriptionMutex.RUnlock()
+
+	delete(l.subscriptions, id)
 }
 
 // SendLogsToSubscribers distributes logs to subscribed clients.
 func (l *LogEventManager) SendLogsToSubscribers(result *common.BlockSubmissionResponse) {
-	for subscriptionID, encryptedLogs := range result.SubscribedLogs {
-		logSub, found := l.subscriptions[subscriptionID]
+	for id, encryptedLogs := range result.SubscribedLogs {
+		logSub, found := l.getSubscriptionThreadsafe(id)
 		if !found {
 			continue
 		}
 		logSub.ch <- encryptedLogs
 	}
+}
+
+// Locks the subscription map and retrieves the subscription with subID, or (nil, false) if so such subscription is found.
+func (l *LogEventManager) getSubscriptionThreadsafe(subID rpc.ID) (*subscription, bool) {
+	l.subscriptionMutex.RLock()
+	defer l.subscriptionMutex.RUnlock()
+
+	sub, found := l.subscriptions[subID]
+	return sub, found
 }
 
 // Pairs the latest seen rollup for a log subscription with the channel on which new logs should be sent.


### PR DESCRIPTION
### Why is this change needed?

Getting concurrent access exceptions.

### What changes were made as part of this PR:

- Provide a high level list of the changes made
- List key areas for the reviewer 

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
