### PR TITLE
Uses a write lock instead of a read lock.

### DIFF
--- a/go/host/events/logs.go
+++ b/go/host/events/logs.go
@@ -37,8 +37,8 @@ func (l *LogEventManager) RemoveSubscription(id rpc.ID) {
 	if found {
 		close(logSubscription.ch)
 
-		l.subscriptionMutex.RLock()
-		defer l.subscriptionMutex.RUnlock()
+		l.subscriptionMutex.Lock()
+		defer l.subscriptionMutex.Unlock()
 		delete(l.subscriptions, id)
 	}
 }


### PR DESCRIPTION
### Why is this change needed?

- Provide a description and a link to the underlying ticket

### What changes were made as part of this PR:

- Provide a high level list of the changes made
- List key areas for the reviewer 

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
