### PR TITLE
Distribute and store batches

### DIFF
--- a/go/common/host/host.go
+++ b/go/common/host/host.go
@@ -23,6 +23,8 @@ type Host interface {
 	SubmitAndBroadcastTx(encryptedParams common.EncryptedParamsSendRawTx) (common.EncryptedResponseSendRawTx, error)
 	// ReceiveTx processes a transaction received from a peer host.
 	ReceiveTx(tx common.EncryptedTx)
+	// ReceiveBatch processes a batch received from a peer host.
+	ReceiveBatch(batch common.EncodedBatch)
 	// Subscribe feeds logs matching the encrypted log subscription to the matchedLogs channel.
 	Subscribe(id rpc.ID, encryptedLogSubscription common.EncryptedParamsLogSubscription, matchedLogs chan []byte) error
 	// Unsubscribe terminates a log subscription between the host and the enclave.

--- a/go/common/host/host.go
+++ b/go/common/host/host.go
@@ -52,6 +52,7 @@ type P2P interface {
 	StopListening() error
 	UpdatePeerList([]string)
 	BroadcastTx(tx common.EncryptedTx) error
+	BroadcastBatch(batch *common.ExtBatch) error
 }
 
 // ReconnectingBlockProvider interface allows host to monitor and await L1 blocks.

--- a/go/common/types.go
+++ b/go/common/types.go
@@ -38,6 +38,7 @@ type (
 
 	Nonce         = uint64
 	EncodedRollup []byte
+	EncodedBatch  []byte
 )
 
 const (

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -231,12 +231,10 @@ func (e *enclaveImpl) ProduceGenesis(blkHash gethcommon.Hash) (*common.BlockSubm
 func (e *enclaveImpl) SubmitBlock(block types.Block, isLatest bool) (*common.BlockSubmissionResponse, error) {
 	bsr, err := e.chain.SubmitBlock(block, isLatest)
 	if err != nil {
-		e.logger.Trace("SubmitBlock failed",
-			"blk", block.Number(), "blkHash", block.Hash(), "err", err)
+		e.logger.Trace("SubmitBlock failed", "blk", block.Number(), "blkHash", block.Hash(), "err", err)
 		return nil, err
 	}
-	e.logger.Trace("SubmitBlock successful",
-		"blk", block.Number(), "blkHash", block.Hash())
+	e.logger.Trace("SubmitBlock successful", "blk", block.Number(), "blkHash", block.Hash())
 
 	if bsr.IngestedRollupHeader != nil {
 		hr, f := e.storage.FetchRollup(bsr.IngestedRollupHeader.Hash())

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -558,7 +558,10 @@ func (h *host) distributeBatch(producedRollup common.ExtRollup) {
 		h.logger.Error("could not store batch", log.ErrKey, err)
 	}
 
-	// TODO - #718 - Distribute batch
+	err = h.p2p.BroadcastBatch(&batch)
+	if err != nil {
+		h.logger.Error("could not broadcast batch", log.ErrKey, err)
+	}
 }
 
 func (h *host) storeBlockProcessingResult(result *common.BlockSubmissionResponse) error {

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -308,6 +308,11 @@ func (h *host) ReceiveTx(tx common.EncryptedTx) {
 	h.txP2PCh <- tx
 }
 
+// ReceiveBatch receives a new batch
+func (h *host) ReceiveBatch(batch common.EncodedBatch) {
+	panic("not implemented")
+}
+
 func (h *host) Subscribe(id rpc.ID, encryptedLogSubscription common.EncryptedParamsLogSubscription, matchedLogsCh chan []byte) error {
 	err := h.EnclaveClient().Subscribe(id, encryptedLogSubscription)
 	if err != nil {

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -547,7 +547,17 @@ func (h *host) publishRollup(producedRollup common.ExtRollup) {
 
 // Creates a batch based on the rollup and distributes it to all other nodes.
 func (h *host) distributeBatch(producedRollup common.ExtRollup) {
-	// TODO - #718 - Store batch
+	batch := common.ExtBatch{
+		Header:          producedRollup.Header,
+		TxHashes:        producedRollup.TxHashes,
+		EncryptedTxBlob: producedRollup.EncryptedTxBlob,
+	}
+
+	err := h.db.AddBatchHeader(batch.Header, batch.TxHashes)
+	if err != nil {
+		h.logger.Error("could not store batch", log.ErrKey, err)
+	}
+
 	// TODO - #718 - Distribute batch
 }
 

--- a/go/host/p2p/p2p.go
+++ b/go/host/p2p/p2p.go
@@ -29,6 +29,7 @@ type msgType uint8
 
 const (
 	msgTypeTx msgType = iota
+	msgTypeBatch
 )
 
 // Message associates an encoded message to its type.
@@ -93,7 +94,13 @@ func (p *p2pImpl) BroadcastTx(tx common.EncryptedTx) error {
 }
 
 func (p *p2pImpl) BroadcastBatch(batch *common.ExtBatch) error {
-	panic("not implemented")
+	encodedBatch, err := rlp.EncodeToBytes(batch)
+	if err != nil {
+		return fmt.Errorf("could not encode batch using RLP. Cause: %w", err)
+	}
+
+	msg := Message{Type: msgTypeBatch, Contents: encodedBatch}
+	return p.broadcast(msg)
 }
 
 // Listens for connections and handles them in a separate goroutine.
@@ -133,6 +140,8 @@ func (p *p2pImpl) handle(conn net.Conn, callback host.Host) {
 	case msgTypeTx:
 		// The transaction is encrypted, so we cannot check that it's correctly formed.
 		callback.ReceiveTx(msg.Contents)
+	case msgTypeBatch:
+		panic("bad bad bad")
 	}
 }
 

--- a/go/host/p2p/p2p.go
+++ b/go/host/p2p/p2p.go
@@ -141,7 +141,7 @@ func (p *p2pImpl) handle(conn net.Conn, callback host.Host) {
 		// The transaction is encrypted, so we cannot check that it's correctly formed.
 		callback.ReceiveTx(msg.Contents)
 	case msgTypeBatch:
-		panic("bad bad bad")
+		callback.ReceiveBatch(msg.Contents)
 	}
 }
 

--- a/go/host/p2p/p2p.go
+++ b/go/host/p2p/p2p.go
@@ -92,6 +92,10 @@ func (p *p2pImpl) BroadcastTx(tx common.EncryptedTx) error {
 	return p.broadcast(msg)
 }
 
+func (p *p2pImpl) BroadcastBatch(batch *common.ExtBatch) error {
+	panic("not implemented")
+}
+
 // Listens for connections and handles them in a separate goroutine.
 func (p *p2pImpl) handleConnections(callback host.Host) {
 	for {

--- a/go/host/rpc/clientapi/client_api_eth.go
+++ b/go/host/rpc/clientapi/client_api_eth.go
@@ -38,17 +38,17 @@ func (api *EthereumAPI) ChainId() (*hexutil.Big, error) { //nolint:stylecheck,re
 	return (*hexutil.Big)(big.NewInt(api.host.Config().ObscuroChainID)), nil
 }
 
-// BlockNumber returns the height of the current head rollup.
-// TODO - #718 - Switch to returning height based on current batch.
+// BlockNumber returns the height of the current head batch.
 func (api *EthereumAPI) BlockNumber() hexutil.Uint64 {
-	header, err := api.host.DB().GetHeadRollupHeader()
+	header, err := api.host.DB().GetHeadBatchHeader()
 	if err != nil {
 		// This error may be nefarious, but unfortunately the Eth API doesn't allow us to return an error.
 		api.logger.Error("could not retrieve head rollup header", log.ErrKey, err)
 		return 0
 	}
 
-	number := header.Number.Uint64()
+	// TODO - #718 - Temp fix due to off-by-one error in `writeRollupNumber`.
+	number := header.Number.Uint64() - 1
 	return hexutil.Uint64(number)
 }
 

--- a/go/host/rpc/clientapi/client_api_eth.go
+++ b/go/host/rpc/clientapi/client_api_eth.go
@@ -39,7 +39,7 @@ func (api *EthereumAPI) ChainId() (*hexutil.Big, error) { //nolint:stylecheck,re
 }
 
 // BlockNumber returns the height of the current head rollup.
-// # TODO - #718 - Switch to returning height based on current batch.
+// TODO - #718 - Switch to returning height based on current batch.
 func (api *EthereumAPI) BlockNumber() hexutil.Uint64 {
 	header, err := api.host.DB().GetHeadRollupHeader()
 	if err != nil {
@@ -63,6 +63,7 @@ func (api *EthereumAPI) GetBalance(_ context.Context, encryptedParams common.Enc
 }
 
 // GetBlockByNumber returns the header of the rollup with the given height.
+// TODO - #718 - Switch to retrieving batch header.
 func (api *EthereumAPI) GetBlockByNumber(ctx context.Context, number rpc.BlockNumber, _ bool) (map[string]interface{}, error) {
 	rollupHash, err := api.rollupNumberToRollupHash(number)
 	if err != nil {

--- a/integration/simulation/p2p/mock_l2_network.go
+++ b/integration/simulation/p2p/mock_l2_network.go
@@ -63,6 +63,10 @@ func (netw *MockP2P) BroadcastTx(tx common.EncryptedTx) error {
 	return nil
 }
 
+func (netw *MockP2P) BroadcastBatch(batch *common.ExtBatch) error {
+	panic("not implemented")
+}
+
 // delay returns an expected delay on the l2
 func (netw *MockP2P) delay() time.Duration {
 	return testcommon.RndBtwTime(netw.avgLatency/10, 2*netw.avgLatency)

--- a/integration/simulation/p2p/mock_l2_network.go
+++ b/integration/simulation/p2p/mock_l2_network.go
@@ -1,7 +1,6 @@
 package p2p
 
 import (
-	"bytes"
 	"fmt"
 	"sync/atomic"
 	"time"
@@ -57,8 +56,7 @@ func (netw *MockP2P) BroadcastTx(tx common.EncryptedTx) error {
 	}
 
 	for _, node := range netw.Nodes {
-		// todo - joel - can this check be cleaned up?
-		if !bytes.Equal(node.Config().ID.Bytes(), netw.CurrentNode.Config().ID.Bytes()) {
+		if node.Config().ID.Hex() != netw.CurrentNode.Config().ID.Hex() {
 			tempNode := node
 			common.Schedule(netw.delay()/2, func() { tempNode.ReceiveTx(tx) })
 		}
@@ -78,8 +76,7 @@ func (netw *MockP2P) BroadcastBatch(batch *common.ExtBatch) error {
 	}
 
 	for _, node := range netw.Nodes {
-		// todo - joel - can this check be cleaned up?
-		if !bytes.Equal(node.Config().ID.Bytes(), netw.CurrentNode.Config().ID.Bytes()) {
+		if node.Config().ID.Hex() != netw.CurrentNode.Config().ID.Hex() {
 			tempNode := node
 			common.Schedule(netw.delay()/2, func() { tempNode.ReceiveBatch(encodedBatch) })
 		}


### PR DESCRIPTION
### Why is this change needed?

We are now producing batches alongside rollups, but they're not being distributed or stored.

### What changes were made as part of this PR:

- Stores the batch on the sequencer
- Distributes the batch to all other nodes
- Stores the batches on the other nodes

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
