### PR TITLE
Allow obcuroscan to be run against a local testnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ The above will perform all the relevant builds and ensure the images are ready f
 testnetobscuronet.azurecr.io/obscuronet/obscuro_enclave            # the enclave 
 testnetobscuronet.azurecr.io/obscuronet/obscuro_gethnetwork        # the L1 network 
 testnetobscuronet.azurecr.io/obscuronet/obscuro_host               # the host
+testnetobscuronet.azurecr.io/obscuronet/obscuroscan                # the obscuroscan server
 testnetobscuronet.azurecr.io/obscuronet/obscuro_contractdeployer   # deploys the management contract to the host
 ```
 
@@ -357,6 +358,7 @@ only a single Obscuro node is started, it must be set as a genesis node and as a
 ./testnet-deploy-contracts.sh --l1host=gethnetwork --pkstring=f52e5418e349dccdda29b6ac8b0abe6576bb7713886aa85abea6181ba731f9bb
 ./start-obscuro-node.sh --sgx_enabled=false --host_id=0x0000000000000000000000000000000000000001 --l1host=gethnetwork --mgmtcontractaddr=0xeDa66Cc53bd2f26896f6Ba6b736B1Ca325DE04eF --hocerc20addr=0xC0370e0b5C1A41D447BDdA655079A1B977C71aA9 --pocerc20addr=0x51D43a3Ca257584E770B6188232b199E76B022A2 --is_genesis=true --node_type=aggregator
 ./testnet-deploy-l2-contracts.sh --l2host=testnet-host-1 
+./start-obscuroscan.sh --rpcServerAddress=http://testnet-host-1:13000 
 ```
 
 where;

--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ only a single Obscuro node is started, it must be set as a genesis node and as a
 ./testnet-deploy-contracts.sh --l1host=gethnetwork --pkstring=f52e5418e349dccdda29b6ac8b0abe6576bb7713886aa85abea6181ba731f9bb
 ./start-obscuro-node.sh --sgx_enabled=false --host_id=0x0000000000000000000000000000000000000001 --l1host=gethnetwork --mgmtcontractaddr=0xeDa66Cc53bd2f26896f6Ba6b736B1Ca325DE04eF --hocerc20addr=0xC0370e0b5C1A41D447BDdA655079A1B977C71aA9 --pocerc20addr=0x51D43a3Ca257584E770B6188232b199E76B022A2 --is_genesis=true --node_type=aggregator
 ./testnet-deploy-l2-contracts.sh --l2host=testnet-host-1 
-./start-obscuroscan.sh --rpcServerAddress=http://testnet-host-1:13000 
+./start-obscuroscan.sh --rpcServerAddress=http://testnet-host-1:13000 --receivingPort=8098
 ```
 
 where;
@@ -373,6 +373,8 @@ account on the L1 network used to deploy the Obscuro Management and the ERC20 co
 - `0xeDa66Cc53bd2f26896f6Ba6b736B1Ca325DE04eF` is the address of the Obscuro Management contract which is known a-priori as a nonce of 0 is used 
 - `0xC0370e0b5C1A41D447BDdA655079A1B977C71aA9` is the address of the ERC20 contract which represents OBX and is known a-priori as a nonce of 1 is used
 - `0x51D43a3Ca257584E770B6188232b199E76B022A2` is the address of the ERC20 contract which represents ETH and is known a-priori as a nonce of 2 is used
+
+Once started Obscurscan is available on `http://0.0.0.0:8098`.
 
 
 ### Building and running a local faucet

--- a/testnet/start-obscuroscan.sh
+++ b/testnet/start-obscuroscan.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+#
+# This script starts up the obscuroscan server
+#
+
+help_and_exit() {
+    echo ""
+    echo "Usage: $(basename "${0}")"
+    echo ""
+    echo "  rpcServerAddress        *Optional* Set the rpc server address (defaults to http://testnet.obscu.ro:13000)"
+    echo ""
+    echo "  address                 *Optional* Set the obscuroscan endpoint address (defaults to 0.0.0.0:80)"
+    echo ""
+    echo ""
+    echo ""
+    exit 1  # Exit with error explicitly
+}
+# Ensure any fail is loud and explicit
+set -euo pipefail
+
+# Define local usage vars
+start_path="$(cd "$(dirname "${0}")" && pwd)"
+testnet_path="${start_path}"
+
+# Define defaults
+rpcServerAddress='http://testnet-host-1:13000'
+address='0.0.0.0:80'
+docker_image="testnetobscuronet.azurecr.io/obscuronet/obscuroscan:latest"
+
+# Fetch options
+for argument in "$@"
+do
+    key=$(echo $argument | cut -f1 -d=)
+    value=$(echo $argument | cut -f2 -d=)
+
+    case "$key" in
+            --rpcServerAddress)         rpcServerAddress=${value} ;;
+            --address)                  address=${value} ;;
+            --help)                     help_and_exit ;;
+            *)
+    esac
+done
+
+# ensure required fields
+if [[ -z ${rpcServerAddress:-} || -z ${address:-} ]];
+then
+    help_and_exit
+fi
+
+# start the container
+echo "Starting the obscuroscan server..."
+docker network create --driver bridge node_network || true
+docker run --name=obscuroscan \
+    --network=node_network \
+    -p 80:80 \
+    --entrypoint /home/go-obscuro/tools/obscuroscan/main/main \
+    "${docker_image}" \
+    --rpcServerAddress=${rpcServerAddress} \
+    --address=${address}
+echo ""

--- a/testnet/start-obscuroscan.sh
+++ b/testnet/start-obscuroscan.sh
@@ -6,11 +6,11 @@
 
 help_and_exit() {
     echo ""
-    echo "Usage: $(basename "${0}")"
+    echo "Usage: $(basename "${0}") --rpcServerAddress=http://testnet-host-1:13000 --receivingPort=80"
     echo ""
-    echo "  rpcServerAddress        *Optional* Set the rpc server address (defaults to http://testnet.obscu.ro:13000)"
+    echo "  rpcServerAddress        *Optional* Set the rpc server address (defaults to http://testnet-host-1:13000)"
     echo ""
-    echo "  address                 *Optional* Set the obscuroscan endpoint address (defaults to 0.0.0.0:80)"
+    echo "  receivingPort           *Optional* Set the ObscuroScan server receiving port (defaults to 80)"
     echo ""
     echo ""
     echo ""
@@ -24,8 +24,8 @@ start_path="$(cd "$(dirname "${0}")" && pwd)"
 testnet_path="${start_path}"
 
 # Define defaults
+receivingPort=80
 rpcServerAddress='http://testnet-host-1:13000'
-address='0.0.0.0:80'
 docker_image="testnetobscuronet.azurecr.io/obscuronet/obscuroscan:latest"
 
 # Fetch options
@@ -36,14 +36,14 @@ do
 
     case "$key" in
             --rpcServerAddress)         rpcServerAddress=${value} ;;
-            --address)                  address=${value} ;;
+            --receivingPort)            receivingPort=${value} ;;
             --help)                     help_and_exit ;;
             *)
     esac
 done
 
 # ensure required fields
-if [[ -z ${rpcServerAddress:-} || -z ${address:-} ]];
+if [[ -z ${rpcServerAddress:-} || -z ${receivingPort:-} ]];
 then
     help_and_exit
 fi
@@ -53,9 +53,9 @@ echo "Starting the obscuroscan server..."
 docker network create --driver bridge node_network || true
 docker run --name=obscuroscan \
     --network=node_network \
-    -p 80:80 \
+    -p $receivingPort:$receivingPort \
     --entrypoint /home/go-obscuro/tools/obscuroscan/main/main \
     "${docker_image}" \
-    --rpcServerAddress=${rpcServerAddress} \
-    --address=${address}
+    --address='0.0.0.0:'$receivingPort \
+    --rpcServerAddress=${rpcServerAddress}
 echo ""

--- a/testnet/start-obscuroscan.sh
+++ b/testnet/start-obscuroscan.sh
@@ -52,6 +52,7 @@ fi
 echo "Starting the obscuroscan server..."
 docker network create --driver bridge node_network || true
 docker run --name=obscuroscan \
+    --detach \
     --network=node_network \
     -p $receivingPort:$receivingPort \
     --entrypoint /home/go-obscuro/tools/obscuroscan/main/main \

--- a/testnet/testnet-local-build_images.sh
+++ b/testnet/testnet-local-build_images.sh
@@ -25,5 +25,7 @@ command docker build -t testnetobscuronet.azurecr.io/obscuronet/obscuro_host:lat
 command docker build -t testnetobscuronet.azurecr.io/obscuronet/obscuro_contractdeployer:latest -f "${testnet_path}/contractdeployer.Dockerfile" "${root_path}" &
 command docker build -t testnetobscuronet.azurecr.io/obscuronet/obscuro_enclave:latest -f "${root_path}/dockerfiles/enclave.Dockerfile" "${root_path}" &
 command docker build -t testnetobscuronet.azurecr.io/obscuronet/obscuro_enclave_debug:latest -f "${root_path}/dockerfiles/enclave.debug.Dockerfile" "${root_path}" &
+command docker build -t testnetobscuronet.azurecr.io/obscuronet/obscuroscan:latest -f "${testnet_path}/obscuroscan.Dockerfile" "${root_path}" &
 
 wait
+


### PR DESCRIPTION
### Why is this change needed?

- Adds the build of the obscuroscan image into the local testnet build, provides a script to start up obscuroscan locally, and updates the readme accordingly. 

### What changes were made as part of this PR:

- The top level readme, and build and runs script in the testnet folder