### PR TITLE
eth_getBlockByNumber and eth_getBlockByHash responds based on the batches, not the rollups

### DIFF
--- a/go/host/db/batches.go
+++ b/go/host/db/batches.go
@@ -35,8 +35,7 @@ func (db *DB) GetBatchHeader(hash gethcommon.Hash) (*common.Header, error) {
 func (db *DB) AddBatchHeader(header *common.Header, txHashes []common.TxHash) error {
 	b := db.kvStore.NewBatch()
 
-	err := db.writeBatchHeader(header)
-	if err != nil {
+	if err := db.writeBatchHeader(header); err != nil {
 		return fmt.Errorf("could not write batch header. Cause: %w", err)
 	}
 	if err := db.writeBatchHash(b, header); err != nil {

--- a/go/host/db/batches.go
+++ b/go/host/db/batches.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/ethdb"
 
 	"github.com/obscuronet/go-obscuro/go/common/errutil"
 
@@ -23,15 +26,24 @@ func (db *DB) GetHeadBatchHeader() (*common.Header, error) {
 	return db.readBatchHeader(*headBatchHash)
 }
 
+// GetBatchHeader returns the batch header given the hash, or (nil, false) if no such header is found.
+func (db *DB) GetBatchHeader(hash gethcommon.Hash) (*common.Header, error) {
+	return db.readBatchHeader(hash)
+}
+
 // AddBatchHeader adds a batch's header to the known headers
 func (db *DB) AddBatchHeader(header *common.Header, txHashes []common.TxHash) error {
 	b := db.kvStore.NewBatch()
+
 	err := db.writeBatchHeader(header)
 	if err != nil {
 		return fmt.Errorf("could not write batch header. Cause: %w", err)
 	}
+	if err := db.writeBatchHash(b, header); err != nil {
+		return fmt.Errorf("could not write batch hash. Cause: %w", err)
+	}
 
-	// TODO - #718 - Store the batch txs, batch hash, and batch number per transaction hash, if needed (see `AddRollupHeader`).
+	// TODO - #718 - Store the batch txs and batch number per transaction hash, if needed (see `AddRollupHeader`).
 
 	// TODO - #718 - Update the total transactions, once we no longer do this in `AddRollupHeader`.
 
@@ -54,9 +66,19 @@ func (db *DB) AddBatchHeader(header *common.Header, txHashes []common.TxHash) er
 	return nil
 }
 
+// GetBatchHash returns the hash of a batch given its number, or (nil, false) if no such batch is found.
+func (db *DB) GetBatchHash(number *big.Int) (*gethcommon.Hash, error) {
+	return db.readBatchHash(number)
+}
+
 // headerKey = batchHeaderPrefix  + hash
 func batchHeaderKey(hash gethcommon.Hash) []byte {
 	return append(batchHeaderPrefix, hash.Bytes()...)
+}
+
+// headerKey = batchHashPrefix + number
+func batchHashKey(num *big.Int) []byte {
+	return append(batchHashPrefix, []byte(num.String())...)
 }
 
 // Retrieves the batch header corresponding to the hash.
@@ -121,4 +143,33 @@ func (db *DB) writeHeadBatchHash(val gethcommon.Hash) error {
 		return err
 	}
 	return nil
+}
+
+// Stores a batch's hash in the database, keyed by the batch's number.
+func (db *DB) writeBatchHash(w ethdb.KeyValueWriter, header *common.Header) error {
+	key := batchHashKey(header.Number)
+	if err := w.Put(key, header.Hash().Bytes()); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Retrieves the hash for the batch with the given number, or (nil, false) if no such batch is found.
+func (db *DB) readBatchHash(number *big.Int) (*gethcommon.Hash, error) {
+	f, err := db.kvStore.Has(batchHashKey(number))
+	if err != nil {
+		return nil, err
+	}
+	if !f {
+		return nil, errutil.ErrNotFound
+	}
+	data, err := db.kvStore.Get(batchHashKey(number))
+	if err != nil {
+		return nil, err
+	}
+	if len(data) == 0 {
+		return nil, errutil.ErrNotFound
+	}
+	hash := gethcommon.BytesToHash(data)
+	return &hash, nil
 }

--- a/go/host/db/hostdb.go
+++ b/go/host/db/hostdb.go
@@ -20,6 +20,7 @@ var (
 	headBatch            = []byte("hba")
 	blockHeaderPrefix    = []byte("b")
 	batchHeaderPrefix    = []byte("ba")
+	batchHashPrefix      = []byte("bh")
 	rollupHeaderPrefix   = []byte("r")
 	rollupTxHashesPrefix = []byte("rt")
 	rollupHashPrefix     = []byte("rh")

--- a/go/host/db/rollups.go
+++ b/go/host/db/rollups.go
@@ -27,7 +27,7 @@ func (db *DB) GetHeadRollupHeader() (*common.Header, error) {
 	return db.readRollupHeader(*headRollupHash)
 }
 
-// GetRollupHeader returns the rollup header given the Hash, or (nil, false) if no such header is found.
+// GetRollupHeader returns the rollup header given the hash, or (nil, false) if no such header is found.
 func (db *DB) GetRollupHeader(hash gethcommon.Hash) (*common.Header, error) {
 	return db.readRollupHeader(hash)
 }
@@ -35,6 +35,7 @@ func (db *DB) GetRollupHeader(hash gethcommon.Hash) (*common.Header, error) {
 // AddRollupHeader adds a rollup's header to the known headers
 func (db *DB) AddRollupHeader(header *common.Header, txHashes []common.TxHash) error {
 	b := db.kvStore.NewBatch()
+
 	if err := db.writeRollupHeader(b, header); err != nil {
 		return fmt.Errorf("could not write rollup header. Cause: %w", err)
 	}

--- a/go/host/rpc/clientapi/client_api_eth.go
+++ b/go/host/rpc/clientapi/client_api_eth.go
@@ -62,7 +62,7 @@ func (api *EthereumAPI) GetBalance(_ context.Context, encryptedParams common.Enc
 	return gethcommon.Bytes2Hex(encryptedBalance), nil
 }
 
-// GetBlockByNumber returns the header of the rollup with the given height.
+// GetBlockByNumber returns the header of the batch with the given height.
 func (api *EthereumAPI) GetBlockByNumber(ctx context.Context, number rpc.BlockNumber, _ bool) (map[string]interface{}, error) {
 	batchHash, err := api.batchNumberToBatchHash(number)
 	if err != nil {
@@ -73,11 +73,11 @@ func (api *EthereumAPI) GetBlockByNumber(ctx context.Context, number rpc.BlockNu
 
 // GetBlockByHash returns the header of the batch with the given hash.
 func (api *EthereumAPI) GetBlockByHash(_ context.Context, hash gethcommon.Hash, _ bool) (map[string]interface{}, error) {
-	rollupHeader, err := api.host.DB().GetBatchHeader(hash)
+	batchHeader, err := api.host.DB().GetBatchHeader(hash)
 	if err != nil {
 		return nil, err
 	}
-	return headerToMap(rollupHeader), nil
+	return headerToMap(batchHeader), nil
 }
 
 // GasPrice is a placeholder for an RPC method required by MetaMask/Remix.

--- a/integration/noderunner/noderunner_test.go
+++ b/integration/noderunner/noderunner_test.go
@@ -114,9 +114,9 @@ func TestCanStartStandaloneObscuroHostAndEnclave(t *testing.T) {
 		counter++
 		time.Sleep(500 * time.Millisecond)
 
-		var result hexutil.Uint64
-		err = obscuroClient.Call(&result, rpc.RollupNumber)
-		if err == nil && result > 0 {
+		var rollupNumber hexutil.Uint64
+		err = obscuroClient.Call(&rollupNumber, rpc.RollupNumber)
+		if err == nil && rollupNumber > 0 {
 			return
 		}
 	}

--- a/integration/simulation/validate_chain.go
+++ b/integration/simulation/validate_chain.go
@@ -415,6 +415,7 @@ func extractWithdrawals(t *testing.T, obscuroClient *obsclient.ObsClient, nodeId
 		header, err = obscuroClient.RollupHeaderByHash(header.ParentHash)
 		if err != nil {
 			t.Errorf(fmt.Sprintf("Node %d: Could not retrieve rollup header by hash", nodeIdx))
+			return
 		}
 	}
 }


### PR DESCRIPTION
### Why is this change needed?

- Provide a description and a link to the underlying ticket

### What changes were made as part of this PR:

- Provide a high level list of the changes made
- List key areas for the reviewer 

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
