### PR TITLE
Checks whether the head rollup is nil.

### DIFF
--- a/go/enclave/events/subscription_manager.go
+++ b/go/enclave/events/subscription_manager.go
@@ -75,10 +75,14 @@ func (s *SubscriptionManager) AddSubscription(id gethrpc.ID, encryptedSubscripti
 	// For subscriptions, only the Topics and Addresses fields of the filter are applied.
 	subscription.Filter.BlockHash = nil
 	subscription.Filter.ToBlock = nil
-	// We set this to the current rollup height, so that historical logs aren't returned.
+
+	// We set the FromBlock to the current rollup height, so that historical logs aren't returned.
 	rollup, err := s.storage.FetchHeadRollup()
 	if err != nil {
-		return fmt.Errorf("unable to fetch head rollup - %w", err)
+		return fmt.Errorf("unable to fetch head rollup. Cause: %w", err)
+	}
+	if rollup == nil {
+		return fmt.Errorf("no head rollup is stored")
 	}
 	subscription.Filter.FromBlock = big.NewInt(0).Add(rollup.Number(), big.NewInt(1))
 


### PR DESCRIPTION
### Why is this change needed?

We don't check whether the head rollup is nil before trying to get its number.

### What changes were made as part of this PR:

- Provide a high level list of the changes made
- List key areas for the reviewer 

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
