### PR TITLE
Set correct timeout for giving up on L1 reconnection

### DIFF
--- a/go/ethadapter/geth_rpc_client.go
+++ b/go/ethadapter/geth_rpc_client.go
@@ -23,6 +23,7 @@ import (
 )
 
 const (
+	connRetryMaxWait  = 10 * time.Minute // after this duration, we will stop retrying to connect and return the failure
 	connRetryInterval = 500 * time.Millisecond
 )
 
@@ -146,10 +147,10 @@ func (e *gethRPCClient) BlockListener() (chan *types.Header, ethereum.Subscripti
 	err = retry.Do(func() error {
 		sub, err = e.client.SubscribeNewHead(ctx, ch)
 		if err != nil {
-			e.logger.Warn("could not subscribe for new head blocks, retrying...")
+			e.logger.Warn("could not subscribe for new head blocks")
 		}
 		return err
-	}, retry.NewTimeoutStrategy(e.timeout, connRetryInterval))
+	}, retry.NewTimeoutStrategy(connRetryMaxWait, connRetryInterval))
 	if err != nil {
 		// todo: handle this scenario better after refactor of node.go (health monitor report L1 unavailable, be able to recover without restarting host)
 		// couldn't connect after timeout period, cannot continue

--- a/go/ethadapter/geth_rpc_client.go
+++ b/go/ethadapter/geth_rpc_client.go
@@ -136,7 +136,7 @@ func (e *gethRPCClient) Nonce(account gethcommon.Address) (uint64, error) {
 }
 
 func (e *gethRPCClient) BlockListener() (chan *types.Header, ethereum.Subscription) {
-	ctx, cancel := context.WithTimeout(context.Background(), e.timeout)
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	// this channel holds blocks that have been received from the geth network but not yet processed by the host,


### PR DESCRIPTION
### Why is this change needed?

- We were using the context timeouts as the max time before giving up so gave up after 10-15s instead of a longer period
- This should help us reconnect if there are L1 "blips" but won't help with recovery for more serious issues

### What changes were made as part of this PR:

- Fix timeout

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
