### PR TITLE
Return errors from enclave DB, instead of ignoring or using a critical log message

### DIFF
--- a/go/enclave/db/interfaces.go
+++ b/go/enclave/db/interfaces.go
@@ -69,8 +69,8 @@ type BlockStateStorage interface {
 }
 
 type SharedSecretStorage interface {
-	// FetchSecret returns the enclave's secret, returns (nil, false) if not found
-	FetchSecret() (*crypto.SharedEnclaveSecret, bool)
+	// FetchSecret returns the enclave's secret.
+	FetchSecret() (*crypto.SharedEnclaveSecret, error)
 	// StoreSecret stores a secret in the enclave
 	StoreSecret(secret crypto.SharedEnclaveSecret)
 }

--- a/go/enclave/db/interfaces.go
+++ b/go/enclave/db/interfaces.go
@@ -63,7 +63,7 @@ type BlockStateStorage interface {
 	// StoreNewHead saves the block state alongside its rollup, receipts and logs.
 	StoreNewHead(state *core.BlockState, rollup *core.Rollup, receipts []*types.Receipt, logs []*types.Log)
 	// CreateStateDB creates a database that can be used to execute transactions
-	CreateStateDB(hash common.L2RootHash) *state.StateDB
+	CreateStateDB(hash common.L2RootHash) (*state.StateDB, error)
 	// EmptyStateDB creates the original empty StateDB
 	EmptyStateDB() *state.StateDB
 }
@@ -89,7 +89,7 @@ type TransactionStorage interface {
 }
 
 type AttestationStorage interface {
-	// FetchAttestedKey returns the public key of an attested aggregator, returns nil if not found
+	// FetchAttestedKey returns the public key of an attested aggregator
 	FetchAttestedKey(aggregator gethcommon.Address) (*ecdsa.PublicKey, error)
 	// StoreAttestedKey - store the public key of an attested aggregator
 	StoreAttestedKey(aggregator gethcommon.Address, key *ecdsa.PublicKey)

--- a/go/enclave/db/interfaces.go
+++ b/go/enclave/db/interfaces.go
@@ -90,7 +90,7 @@ type TransactionStorage interface {
 
 type AttestationStorage interface {
 	// FetchAttestedKey returns the public key of an attested aggregator, returns nil if not found
-	FetchAttestedKey(aggregator gethcommon.Address) *ecdsa.PublicKey
+	FetchAttestedKey(aggregator gethcommon.Address) (*ecdsa.PublicKey, error)
 	// StoreAttestedKey - store the public key of an attested aggregator
 	StoreAttestedKey(aggregator gethcommon.Address, key *ecdsa.PublicKey)
 }

--- a/go/enclave/db/interfaces.go
+++ b/go/enclave/db/interfaces.go
@@ -40,7 +40,7 @@ type RollupResolver interface {
 	// FetchRollupByHeight returns the rollup with the given height and true, or (nil, false) if no such rollup is stored.
 	FetchRollupByHeight(height uint64) (*core.Rollup, bool)
 	// FetchRollups returns all the proposed rollups with the given height
-	FetchRollups(height uint64) []*core.Rollup
+	FetchRollups(height uint64) ([]*core.Rollup, error)
 	// StoreRollup persists the rollup
 	StoreRollup(rollup *core.Rollup)
 	// ParentRollup returns the rollup's parent rollup, or (nil, false) if no such rollup was found.
@@ -72,7 +72,7 @@ type SharedSecretStorage interface {
 	// FetchSecret returns the enclave's secret.
 	FetchSecret() (*crypto.SharedEnclaveSecret, error)
 	// StoreSecret stores a secret in the enclave
-	StoreSecret(secret crypto.SharedEnclaveSecret)
+	StoreSecret(secret crypto.SharedEnclaveSecret) error
 }
 
 type TransactionStorage interface {
@@ -81,7 +81,7 @@ type TransactionStorage interface {
 	// GetTransactionReceipt - returns the receipt of a tx by tx hash
 	GetTransactionReceipt(txHash gethcommon.Hash) (*types.Receipt, error)
 	// GetReceiptsByHash retrieves the receipts for all transactions in a given rollup.
-	GetReceiptsByHash(hash gethcommon.Hash) types.Receipts
+	GetReceiptsByHash(hash gethcommon.Hash) (types.Receipts, error)
 	// GetSender returns the sender of the tx by hash
 	GetSender(txHash gethcommon.Hash) (gethcommon.Address, error)
 	// GetContractCreationTx returns the hash of the tx that created a contract

--- a/go/enclave/db/interfaces.go
+++ b/go/enclave/db/interfaces.go
@@ -58,10 +58,10 @@ type BlockStateStorage interface {
 	FetchBlockState(blockHash common.L1RootHash) (*core.BlockState, bool)
 	// FetchLogs returns the block's logs, or (nil, false) if no such block was found.
 	FetchLogs(blockHash common.L1RootHash) ([]*types.Log, bool)
-	// FetchHeadState returns the head block state. Returns nil if nothing recorded yet
-	FetchHeadState() *core.BlockState
+	// FetchHeadState returns the head block state.
+	FetchHeadState() (*core.BlockState, error)
 	// StoreNewHead saves the block state alongside its rollup, receipts and logs.
-	StoreNewHead(state *core.BlockState, rollup *core.Rollup, receipts []*types.Receipt, logs []*types.Log)
+	StoreNewHead(state *core.BlockState, rollup *core.Rollup, receipts []*types.Receipt, logs []*types.Log) error
 	// CreateStateDB creates a database that can be used to execute transactions
 	CreateStateDB(hash common.L2RootHash) (*state.StateDB, error)
 	// EmptyStateDB creates the original empty StateDB

--- a/go/enclave/db/interfaces.go
+++ b/go/enclave/db/interfaces.go
@@ -85,7 +85,7 @@ type TransactionStorage interface {
 	// GetSender returns the sender of the tx by hash
 	GetSender(txHash gethcommon.Hash) (gethcommon.Address, error)
 	// GetContractCreationTx returns the hash of the tx that created a contract
-	GetContractCreationTx(address gethcommon.Address) (gethcommon.Hash, error)
+	GetContractCreationTx(address gethcommon.Address) (*gethcommon.Hash, error)
 }
 
 type AttestationStorage interface {

--- a/go/enclave/db/interfaces.go
+++ b/go/enclave/db/interfaces.go
@@ -92,7 +92,7 @@ type AttestationStorage interface {
 	// FetchAttestedKey returns the public key of an attested aggregator
 	FetchAttestedKey(aggregator gethcommon.Address) (*ecdsa.PublicKey, error)
 	// StoreAttestedKey - store the public key of an attested aggregator
-	StoreAttestedKey(aggregator gethcommon.Address, key *ecdsa.PublicKey)
+	StoreAttestedKey(aggregator gethcommon.Address, key *ecdsa.PublicKey) error
 }
 
 // Storage is the enclave's interface for interacting with the enclave's datastore

--- a/go/enclave/db/rawdb/accessors_attestation.go
+++ b/go/enclave/db/rawdb/accessors_attestation.go
@@ -2,10 +2,7 @@ package rawdb
 
 import (
 	"crypto/ecdsa"
-	"errors"
 	"fmt"
-
-	"github.com/obscuronet/go-obscuro/go/common/errutil"
 
 	gethlog "github.com/ethereum/go-ethereum/log"
 
@@ -17,9 +14,6 @@ import (
 func ReadAttestationKey(db ethdb.KeyValueReader, address gethcommon.Address) (*ecdsa.PublicKey, error) {
 	key, err := db.Get(attestationPkKey(address))
 	if err != nil {
-		if errors.Is(err, errutil.ErrNotFound) {
-			return nil, errutil.ErrNotFound
-		}
 		return nil, fmt.Errorf("could not retrieve attestation key for address %s. Cause: %w", address, err)
 	}
 

--- a/go/enclave/db/rawdb/accessors_attestation.go
+++ b/go/enclave/db/rawdb/accessors_attestation.go
@@ -12,7 +12,6 @@ import (
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
-	"github.com/obscuronet/go-obscuro/go/common/log"
 )
 
 func ReadAttestationKey(db ethdb.KeyValueReader, address gethcommon.Address) (*ecdsa.PublicKey, error) {
@@ -32,8 +31,9 @@ func ReadAttestationKey(db ethdb.KeyValueReader, address gethcommon.Address) (*e
 	return publicKey, nil
 }
 
-func WriteAttestationKey(db ethdb.KeyValueWriter, address gethcommon.Address, key *ecdsa.PublicKey, logger gethlog.Logger) {
+func WriteAttestationKey(db ethdb.KeyValueWriter, address gethcommon.Address, key *ecdsa.PublicKey, logger gethlog.Logger) error {
 	if err := db.Put(attestationPkKey(address), crypto.CompressPubkey(key)); err != nil {
-		logger.Crit("Failed to store the attested key. ", log.ErrKey, err)
+		return fmt.Errorf("could not write attestation key. Cause: %w", err)
 	}
+	return nil
 }

--- a/go/enclave/db/rawdb/accessors_metadata.go
+++ b/go/enclave/db/rawdb/accessors_metadata.go
@@ -26,14 +26,15 @@ func ReadSharedSecret(db ethdb.KeyValueReader) (*crypto.SharedEnclaveSecret, err
 	return &ss, nil
 }
 
-func WriteSharedSecret(db ethdb.KeyValueWriter, ss crypto.SharedEnclaveSecret, logger gethlog.Logger) {
+func WriteSharedSecret(db ethdb.KeyValueWriter, ss crypto.SharedEnclaveSecret) error {
 	enc, err := rlp.EncodeToBytes(ss)
 	if err != nil {
-		logger.Crit("could not encode shared secret. ", log.ErrKey, err)
+		return fmt.Errorf("could not encode shared secret. Cause: %w", err)
 	}
 	if err = db.Put(sharedSecret, enc); err != nil {
-		logger.Crit("could not put shared secret in DB. ", log.ErrKey, err)
+		return fmt.Errorf("could not shared secret in DB. Cause: %w", err)
 	}
+	return nil
 }
 
 func ReadGenesisHash(db ethdb.KeyValueReader) (*common.Hash, bool) {

--- a/go/enclave/db/rawdb/accessors_metadata.go
+++ b/go/enclave/db/rawdb/accessors_metadata.go
@@ -1,26 +1,29 @@
 package rawdb
 
 import (
+	"fmt"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethdb"
 	gethlog "github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/obscuronet/go-obscuro/go/common/errutil"
 	"github.com/obscuronet/go-obscuro/go/common/log"
 	"github.com/obscuronet/go-obscuro/go/enclave/crypto"
 )
 
-func ReadSharedSecret(db ethdb.KeyValueReader) (*crypto.SharedEnclaveSecret, bool) {
+func ReadSharedSecret(db ethdb.KeyValueReader) (*crypto.SharedEnclaveSecret, error) {
 	var ss crypto.SharedEnclaveSecret
 
 	enc, _ := db.Get(sharedSecret)
 	if len(enc) == 0 {
-		return nil, false
+		return nil, errutil.ErrNotFound
 	}
 	if err := rlp.DecodeBytes(enc, &ss); err != nil {
-		return nil, false
+		return nil, fmt.Errorf("could not decode shared secret")
 	}
 
-	return &ss, true
+	return &ss, nil
 }
 
 func WriteSharedSecret(db ethdb.KeyValueWriter, ss crypto.SharedEnclaveSecret, logger gethlog.Logger) {

--- a/go/enclave/db/rawdb/accessors_metadata.go
+++ b/go/enclave/db/rawdb/accessors_metadata.go
@@ -15,6 +15,7 @@ import (
 func ReadSharedSecret(db ethdb.KeyValueReader) (*crypto.SharedEnclaveSecret, error) {
 	var ss crypto.SharedEnclaveSecret
 
+	// TODO - Handle error.
 	enc, _ := db.Get(sharedSecret)
 	if len(enc) == 0 {
 		return nil, errutil.ErrNotFound

--- a/go/enclave/db/rawdb/accessors_receipts.go
+++ b/go/enclave/db/rawdb/accessors_receipts.go
@@ -112,12 +112,12 @@ func WriteContractCreationTx(db ethdb.KeyValueWriter, receipts types.Receipts, l
 }
 
 // ReadContractTransaction - returns the tx that created a contract
-func ReadContractTransaction(db ethdb.Reader, address common.Address, logger gethlog.Logger) common.Hash {
+func ReadContractTransaction(db ethdb.Reader, address common.Address, logger gethlog.Logger) (common.Hash, error) {
 	value, err := db.Get(contractReceiptKey(address))
 	if err != nil {
-		logger.Error("failed to read the contract receipt.", log.ErrKey, err)
+		return common.Hash{}, err
 	}
-	return common.BytesToHash(value)
+	return common.BytesToHash(value), nil
 }
 
 // DeleteReceipts removes all receipt data associated with a block hash.

--- a/go/enclave/db/rawdb/accessors_receipts.go
+++ b/go/enclave/db/rawdb/accessors_receipts.go
@@ -112,12 +112,13 @@ func WriteContractCreationTx(db ethdb.KeyValueWriter, receipts types.Receipts, l
 }
 
 // ReadContractTransaction - returns the tx that created a contract
-func ReadContractTransaction(db ethdb.Reader, address common.Address, logger gethlog.Logger) (common.Hash, error) {
+func ReadContractTransaction(db ethdb.Reader, address common.Address) (*common.Hash, error) {
 	value, err := db.Get(contractReceiptKey(address))
 	if err != nil {
-		return common.Hash{}, err
+		return nil, err
 	}
-	return common.BytesToHash(value), nil
+	hash := common.BytesToHash(value)
+	return &hash, nil
 }
 
 // DeleteReceipts removes all receipt data associated with a block hash.

--- a/go/enclave/db/storage.go
+++ b/go/enclave/db/storage.go
@@ -263,17 +263,19 @@ func (s *storageImpl) StoreNewHead(state *core.BlockState, rollup *core.Rollup, 
 	}
 }
 
-func (s *storageImpl) CreateStateDB(hash common.L2RootHash) *state.StateDB {
+func (s *storageImpl) CreateStateDB(hash common.L2RootHash) (*state.StateDB, error) {
 	rollup, f := s.FetchRollup(hash)
 	if !f {
-		s.logger.Crit("could not retrieve rollup for hash %s", hash.String())
+		return nil, errutil.ErrNotFound
 	}
+
 	// todo - snapshots?
 	statedb, err := state.New(rollup.Header.Root, s.stateDB, nil)
 	if err != nil {
-		s.logger.Crit("could not create state DB. ", log.ErrKey, err)
+		return nil, fmt.Errorf("could not create state DB. Cause: %w", err)
 	}
-	return statedb
+
+	return statedb, nil
 }
 
 func (s *storageImpl) EmptyStateDB() *state.StateDB {

--- a/go/enclave/db/storage.go
+++ b/go/enclave/db/storage.go
@@ -131,7 +131,7 @@ func (s *storageImpl) StoreSecret(secret crypto.SharedEnclaveSecret) {
 	obscurorawdb.WriteSharedSecret(s.db, secret, s.logger)
 }
 
-func (s *storageImpl) FetchSecret() (*crypto.SharedEnclaveSecret, bool) {
+func (s *storageImpl) FetchSecret() (*crypto.SharedEnclaveSecret, error) {
 	return obscurorawdb.ReadSharedSecret(s.db)
 }
 

--- a/go/enclave/db/storage.go
+++ b/go/enclave/db/storage.go
@@ -346,8 +346,8 @@ func (s *storageImpl) GetTransactionReceipt(txHash gethcommon.Hash) (*types.Rece
 	return receipt, nil
 }
 
-func (s *storageImpl) FetchAttestedKey(aggregator gethcommon.Address) *ecdsa.PublicKey {
-	return obscurorawdb.ReadAttestationKey(s.db, aggregator, s.logger)
+func (s *storageImpl) FetchAttestedKey(aggregator gethcommon.Address) (*ecdsa.PublicKey, error) {
+	return obscurorawdb.ReadAttestationKey(s.db, aggregator)
 }
 
 func (s *storageImpl) StoreAttestedKey(aggregator gethcommon.Address, key *ecdsa.PublicKey) {

--- a/go/enclave/db/storage.go
+++ b/go/enclave/db/storage.go
@@ -79,6 +79,7 @@ func (s *storageImpl) FetchRollup(hash common.L2RootHash) (*core.Rollup, bool) {
 	s.assertSecretAvailable()
 	rollup, err := obscurorawdb.ReadRollup(s.db, hash, s.logger)
 	if err != nil {
+		// TODO - Return this error.
 		return nil, false
 	}
 	return rollup, true
@@ -331,8 +332,8 @@ func (s *storageImpl) GetSender(txHash gethcommon.Hash) (gethcommon.Address, err
 	return msg.From(), nil
 }
 
-func (s *storageImpl) GetContractCreationTx(address gethcommon.Address) (gethcommon.Hash, error) {
-	return obscurorawdb.ReadContractTransaction(s.db, address, s.logger)
+func (s *storageImpl) GetContractCreationTx(address gethcommon.Address) (*gethcommon.Hash, error) {
+	return obscurorawdb.ReadContractTransaction(s.db, address)
 }
 
 func (s *storageImpl) GetTransactionReceipt(txHash gethcommon.Hash) (*types.Receipt, error) {

--- a/go/enclave/db/storage.go
+++ b/go/enclave/db/storage.go
@@ -3,9 +3,10 @@ package db
 import (
 	"bytes"
 	"crypto/ecdsa"
-	"errors"
 	"fmt"
 	"math/big"
+
+	"github.com/obscuronet/go-obscuro/go/common/errutil"
 
 	gethlog "github.com/ethereum/go-ethereum/log"
 
@@ -32,9 +33,6 @@ type storageImpl struct {
 	chainConfig *params.ChainConfig
 	logger      gethlog.Logger
 }
-
-// ErrTxNotFound indicates that a transaction could not be found.
-var ErrTxNotFound = errors.New("transaction not found")
 
 func NewStorage(backingDB ethdb.Database, chainConfig *params.ChainConfig, logger gethlog.Logger) Storage {
 	return &storageImpl{
@@ -308,7 +306,7 @@ func (s *storageImpl) GetReceiptsByHash(hash gethcommon.Hash) types.Receipts {
 func (s *storageImpl) GetTransaction(txHash gethcommon.Hash) (*types.Transaction, gethcommon.Hash, uint64, uint64, error) {
 	tx, blockHash, blockNumber, index := obscurorawdb.ReadTransaction(s.db, txHash, s.logger)
 	if tx == nil {
-		return nil, gethcommon.Hash{}, 0, 0, ErrTxNotFound
+		return nil, gethcommon.Hash{}, 0, 0, errutil.ErrNotFound
 	}
 	return tx, blockHash, blockNumber, index, nil
 }
@@ -327,8 +325,7 @@ func (s *storageImpl) GetSender(txHash gethcommon.Hash) (gethcommon.Address, err
 }
 
 func (s *storageImpl) GetContractCreationTx(address gethcommon.Address) (gethcommon.Hash, error) {
-	tx := obscurorawdb.ReadContractTransaction(s.db, address, s.logger)
-	return tx, nil
+	return obscurorawdb.ReadContractTransaction(s.db, address, s.logger)
 }
 
 func (s *storageImpl) GetTransactionReceipt(txHash gethcommon.Hash) (*types.Receipt, error) {

--- a/go/enclave/db/storage.go
+++ b/go/enclave/db/storage.go
@@ -355,6 +355,6 @@ func (s *storageImpl) FetchAttestedKey(aggregator gethcommon.Address) (*ecdsa.Pu
 	return obscurorawdb.ReadAttestationKey(s.db, aggregator)
 }
 
-func (s *storageImpl) StoreAttestedKey(aggregator gethcommon.Address, key *ecdsa.PublicKey) {
-	obscurorawdb.WriteAttestationKey(s.db, aggregator, key, s.logger)
+func (s *storageImpl) StoreAttestedKey(aggregator gethcommon.Address, key *ecdsa.PublicKey) error {
+	return obscurorawdb.WriteAttestationKey(s.db, aggregator, key, s.logger)
 }

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -463,7 +463,10 @@ func (e *enclaveImpl) Attestation() (*common.AttestationReport, error) {
 // GenerateSecret - the genesis enclave is responsible with generating the secret entropy
 func (e *enclaveImpl) GenerateSecret() (common.EncryptedSharedEnclaveSecret, error) {
 	secret := crypto.GenerateEntropy(e.logger)
-	e.storage.StoreSecret(secret)
+	err := e.storage.StoreSecret(secret)
+	if err != nil {
+		return nil, fmt.Errorf("could not store secret. Cause: %w", err)
+	}
 	encSec, err := crypto.EncryptSecret(e.enclavePubKey, secret, e.logger)
 	if err != nil {
 		e.logger.Error("failed to encrypt secret.", log.ErrKey, err)
@@ -478,7 +481,10 @@ func (e *enclaveImpl) InitEnclave(s common.EncryptedSharedEnclaveSecret) error {
 	if err != nil {
 		return err
 	}
-	e.storage.StoreSecret(*secret)
+	err = e.storage.StoreSecret(*secret)
+	if err != nil {
+		return fmt.Errorf("could not store secret. Cause: %w", err)
+	}
 	e.logger.Trace(fmt.Sprintf("Secret decrypted and stored. Secret: %v", secret))
 	return nil
 }

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/obscuronet/go-obscuro/go/common/errutil"
+
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/obscuronet/go-obscuro/go/common/gethapi"
@@ -197,9 +199,12 @@ func NewEnclave(config config.EnclaveConfig, mgmtContractLib mgmtcontractlib.Mgm
 
 // Status is only implemented by the RPC wrapper
 func (e *enclaveImpl) Status() (common.Status, error) {
-	_, found := e.storage.FetchSecret()
-	if !found {
-		return common.AwaitingSecret, nil
+	_, err := e.storage.FetchSecret()
+	if err != nil {
+		if errors.Is(err, errutil.ErrNotFound) {
+			return common.AwaitingSecret, nil
+		}
+		return common.Unavailable, err
 	}
 	return common.Running, nil // The enclave is local so it is always ready
 }
@@ -485,9 +490,9 @@ func (e *enclaveImpl) verifyAttestationAndEncryptSecret(att *common.AttestationR
 	}
 	e.logger.Info(fmt.Sprintf("Successfully verified attestation and identity. Owner: %s", att.Owner))
 
-	secret, found := e.storage.FetchSecret()
-	if !found {
-		return nil, errors.New("secret was nil, no secret to share - this shouldn't happen")
+	secret, err := e.storage.FetchSecret()
+	if err != nil {
+		return nil, fmt.Errorf("could not retrieve secret; this should not happen. Cause: %w", err)
 	}
 	return crypto.EncryptSecret(att.PubKey, *secret, e.logger)
 }

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -314,8 +314,8 @@ func (e *enclaveImpl) GetTransactionCount(encryptedParams common.EncryptedParams
 	if err != nil {
 		return nil, err
 	}
-	hs := e.storage.FetchHeadState()
-	if hs != nil {
+	hs, err := e.storage.FetchHeadState()
+	if err == nil {
 		// todo: we should return an error when head state is not available, but for current test situations with race
 		// 		conditions we allow it to return zero while head state is uninitialized
 		s, err := e.storage.CreateStateDB(hs.HeadRollup)

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -347,7 +347,7 @@ func (e *enclaveImpl) GetTransaction(encryptedParams common.EncryptedParamsGetTx
 	// Unlike in the Geth impl, we do not try and retrieve unconfirmed transactions from the mempool.
 	tx, blockHash, blockNumber, index, err := e.storage.GetTransaction(txHash)
 	if err != nil {
-		if errors.Is(err, db.ErrTxNotFound) {
+		if errors.Is(err, errutil.ErrNotFound) {
 			return nil, nil
 		}
 		return nil, err
@@ -384,7 +384,7 @@ func (e *enclaveImpl) GetTransactionReceipt(encryptedParams common.EncryptedPara
 	// We retrieve the transaction.
 	tx, txRollupHash, txRollupHeight, _, err := e.storage.GetTransaction(txHash)
 	if err != nil {
-		if errors.Is(err, db.ErrTxNotFound) {
+		if errors.Is(err, errutil.ErrNotFound) {
 			return nil, nil
 		}
 		return nil, err
@@ -402,7 +402,7 @@ func (e *enclaveImpl) GetTransactionReceipt(encryptedParams common.EncryptedPara
 	// We retrieve the transaction receipt.
 	txReceipt, err := e.storage.GetTransactionReceipt(txHash)
 	if err != nil {
-		if errors.Is(err, db.ErrTxNotFound) {
+		if errors.Is(err, errutil.ErrNotFound) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("could not retrieve transaction receipt in eth_getTransactionReceipt request. Cause: %w", err)

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -515,7 +515,10 @@ func (e *enclaveImpl) storeAttestation(att *common.AttestationReport) error {
 	if err != nil {
 		return fmt.Errorf("failed to parse public key %w", err)
 	}
-	e.storage.StoreAttestedKey(att.Owner, key)
+	err = e.storage.StoreAttestedKey(att.Owner, key)
+	if err != nil {
+		return fmt.Errorf("could not store attested key. Cause: %w", err)
+	}
 	return nil
 }
 

--- a/go/enclave/events/subscription_manager.go
+++ b/go/enclave/events/subscription_manager.go
@@ -142,14 +142,17 @@ func (s *SubscriptionManager) GetFilteredLogs(account *gethcommon.Address, filte
 	if !found {
 		return nil, fmt.Errorf("could not filter logs as block state for head block could not be found")
 	}
-	return s.FilterLogs(logs, headBlockState.HeadRollup, account, filter), nil
+	return s.FilterLogs(logs, headBlockState.HeadRollup, account, filter)
 }
 
 // FilterLogs takes a list of logs and the hash of the rollup to use to create the state DB. It returns the logs
 // filtered based on the provided account and filter.
-func (s *SubscriptionManager) FilterLogs(logs []*types.Log, rollupHash common.L2RootHash, account *gethcommon.Address, filter *filters.FilterCriteria) []*types.Log {
+func (s *SubscriptionManager) FilterLogs(logs []*types.Log, rollupHash common.L2RootHash, account *gethcommon.Address, filter *filters.FilterCriteria) ([]*types.Log, error) {
 	filteredLogs := []*types.Log{}
-	stateDB := s.storage.CreateStateDB(rollupHash)
+	stateDB, err := s.storage.CreateStateDB(rollupHash)
+	if err != nil {
+		return nil, fmt.Errorf("could not create state DB to filter logs. Cause: %w", err)
+	}
 
 	for _, logItem := range logs {
 		userAddrs := getUserAddrsFromLogTopics(logItem, stateDB)
@@ -158,33 +161,40 @@ func (s *SubscriptionManager) FilterLogs(logs []*types.Log, rollupHash common.L2
 		}
 	}
 
-	return filteredLogs
+	return filteredLogs, nil
 }
 
 // GetSubscribedLogsEncrypted returns, for each subscription, the logs filtered and encrypted with the appropriate
 // viewing key.
 func (s *SubscriptionManager) GetSubscribedLogsEncrypted(logs []*types.Log, rollupHash common.L2RootHash) (map[gethrpc.ID][]byte, error) {
-	filteredLogs := s.getSubscribedLogs(logs, rollupHash)
+	filteredLogs, err := s.getSubscribedLogs(logs, rollupHash)
+	if err != nil {
+		return nil, fmt.Errorf("could not get subscribed logs. Cause: %w", err)
+	}
 	return s.encryptLogs(filteredLogs)
 }
 
 // Filters out irrelevant logs, those that are not subscribed to, and those the subscription has seen before, and
 // organises them by their subscribing ID.
-func (s *SubscriptionManager) getSubscribedLogs(logs []*types.Log, rollupHash common.L2RootHash) map[gethrpc.ID][]*types.Log {
+func (s *SubscriptionManager) getSubscribedLogs(logs []*types.Log, rollupHash common.L2RootHash) (map[gethrpc.ID][]*types.Log, error) {
 	relevantLogsByID := map[gethrpc.ID][]*types.Log{}
 
 	// If there are no subscriptions, we return early, to avoid the overhead of creating the state DB.
 	if s.getNumberOfSubsThreadsafe() == 0 {
-		return map[gethrpc.ID][]*types.Log{}
+		return map[gethrpc.ID][]*types.Log{}, nil
 	}
 
-	stateDB := s.storage.CreateStateDB(rollupHash)
+	stateDB, err := s.storage.CreateStateDB(rollupHash)
+	if err != nil {
+		return nil, fmt.Errorf("could not create stateDB to extract user addresses. Cause: %w", err)
+	}
+
 	for _, logItem := range logs {
 		userAddrs := getUserAddrsFromLogTopics(logItem, stateDB)
 		s.updateRelevantLogs(logItem, userAddrs, relevantLogsByID)
 	}
 
-	return relevantLogsByID
+	return relevantLogsByID, nil
 }
 
 // Encrypts each log with the appropriate viewing key.

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -724,7 +724,7 @@ func (rc *RollupChain) GetBalance(encryptedParams common.EncryptedParamsGetBalan
 		if err != nil {
 			return nil, fmt.Errorf("failed to retrieve tx that created contract %s. Cause %w", accountAddress.Hex(), err)
 		}
-		transaction, _, _, _, err := rc.storage.GetTransaction(txHash)
+		transaction, _, _, _, err := rc.storage.GetTransaction(*txHash)
 		if err != nil {
 			return nil, fmt.Errorf("failed to retrieve tx that created contract %s. Cause %w", accountAddress.Hex(), err)
 		}

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -825,7 +825,13 @@ func (rc *RollupChain) verifySig(r *obscurocore.Rollup) bool {
 		rc.logger.Error("Missing signature on rollup")
 		return false
 	}
-	pubKey := rc.storage.FetchAttestedKey(r.Header.Agg)
+
+	pubKey, err := rc.storage.FetchAttestedKey(r.Header.Agg)
+	if err != nil {
+		rc.logger.Error("Could not retrieve attested key for aggregator %s. Cause: %w", r.Header.Agg, err)
+		return false
+	}
+
 	return ecdsa.Verify(pubKey, h[:], r.Header.R, r.Header.S)
 }
 


### PR DESCRIPTION
### Why is this change needed?

The enclave DB swallows a lot of errors, and uses a critical logger message for others. For resilience, we should return errors and handle those.

This is just the first step - there's too much to change to do it all in one PR.

### What changes were made as part of this PR:

- Provide a high level list of the changes made
- List key areas for the reviewer 

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
