### PR TITLE
Fix dead links in docs

### DIFF
--- a/docs/_docs/api/sensitive-apis.md
+++ b/docs/_docs/api/sensitive-apis.md
@@ -7,7 +7,7 @@ Obscuro supports a subset of Ethereum's [JSON-RPC API](https://ethereum.org/en/d
 Some of these methods deal with sensitive information. For example, the response to an `eth_getBalance` request will 
 contain the balance of an account. An attacker could intercept this response to discover a user's balance. To avoid 
 this, the requests and responses for methods deemed sensitive are encrypted and decrypted by the 
-[wallet extension](../wallet-extension/wallet-extension.md). To ensure a good user experience, this process is 
+[wallet extension](https://docs.obscu.ro/wallet-extension/wallet-extension). To ensure a good user experience, this process is 
 invisible to the end user.
 
 This page details which JSON-RPC API methods are deemed sensitive, and the rules governing who is able to decrypt the 

--- a/docs/_docs/community/contributions.md
+++ b/docs/_docs/community/contributions.md
@@ -8,7 +8,7 @@ As detailed in the [whitepaper](https://whitepaper.obscu.ro), Obscuro is powered
 
 2% of tokens are set aside for early contributors. Each contributor's allocation is a percentage of their total contributions against the entire community contribution.
 
-For example, suppose you contribute work worth 10 'task points' and the community as a whole contributes 200 'task points'. In that case, you'll be allocated 5% of the contributor tokens or 0.1% of all available OBX tokens. These tokens will be held and distributed to you according to the vesting schedule detailed in the [tokenomics](https://docs.obscu.ro/tokenomics/overview.html). Upon vesting, they will be sent to your wallet.
+For example, suppose you contribute work worth 10 'task points' and the community as a whole contributes 200 'task points'. In that case, you'll be allocated 5% of the contributor tokens or 0.1% of all available OBX tokens. These tokens will be held and distributed to you according to the vesting schedule detailed in the [tokenomics](https://github.com/obscuronet/foundation/blob/main/token-utility-whitepaper.md). Upon vesting, they will be sent to your wallet.
 
 To help manage contributions, we use DeWork. It's a lot like Trello but crypto-native. The DeWork board has a load of suggested tasks. Anyone can add additional tasks and manage the lifecycle through to completion. 
 Anyone in the community can suggest a task that will benefit the project and community by adding it to the community suggestions group.

--- a/docs/_docs/testnet/Introduction.md
+++ b/docs/_docs/testnet/Introduction.md
@@ -5,11 +5,11 @@ This section contains detailed on how to connect, build and deploy on Evan's Cat
 
 Evan's Cat can also be used by end users to help test Obscuro and test developer dApps. Evan's Cat does not focus on node operators. Support for node operators will arrive in the next version of testnet. 
 
-Developers can expect frequent updates which will be communicated [here](https://docs.obscu.ro/testnet/changelog.html). The trade-off is that in the early days Testnet will have some sharp edges and unexpected surprises. More specifically, whilst Testnet is in its infancy:
+Developers can expect frequent updates which will be communicated [here](https://docs.obscu.ro/testnet/changelog). The trade-off is that in the early days Testnet will have some sharp edges and unexpected surprises. More specifically, whilst Testnet is in its infancy:
 * Obscuro Testnet will crash from time to time, and will frequently be updated with new features.
 * When Obscuro Testnet restarts expect to lose everything.
 * Obscuro Testnet code has not been optimised or audited yet. (Mainnet code will be audited prior to launch.)
-* The [Wallet extension](https://docs.obscu.ro/wallet-extension/wallet-extension.html) is still being improved.
+* The [Wallet extension](https://docs.obscu.ro/wallet-extension/wallet-extension) is still being improved.
 * The decryption key is known by all allowing you to decrypt and view everything. This also allows the wider community to support you in development.
 
 All Obscuro code is under an open source licence. If you see something you think could be improved or reworked feel free to submit a PR in the [go-obscuro repo](https://github.com/obscuronet/go-obscuro), or to let us know about your suggestion on [Discord](https://discord.com/channels/916052669955727371/945360340613484684). 

--- a/docs/_docs/testnet/changelog.md
+++ b/docs/_docs/testnet/changelog.md
@@ -84,7 +84,7 @@
 * Wallet extension:
   * The wallet extension now supports separate ports for HTTP and WebSocket connections. Use the `--port` and `--portWS` 
     command line options respectively for each. For more information see the
-    [Wallet extension](https://docs.obscu.ro/wallet-extension/wallet-extension.html) documentation. 
+    [Wallet extension](https://docs.obscu.ro/wallet-extension/wallet-extension) documentation. 
 * Event subscription:
   * An early preview of event subscriptions is available in this release, though note that this is still undergoing 
     testing and feature enhancements and therefore is liable to issues and instability. For more information on the 

--- a/docs/_docs/testnet/changelog.md
+++ b/docs/_docs/testnet/changelog.md
@@ -72,7 +72,7 @@
 * ObscuroScan:
   * ObscuroScan supports a single API at [/rollup/](http://testnet.obscuroscan.io/rollup/) which allows web clients to 
     access a JSON representation of rollups and encrypted transactions. Further details 
-    [here](https://docs.obscu.ro/testnet/obscuroscan.html)
+    [here](https://docs.obscu.ro/testnet/obscuroscan)
 
 ## October 2022-10-21 (v0.5)
 * Event Subscriptions:

--- a/docs/_docs/testnet/deploying-a-smart-contract-programmatically.md
+++ b/docs/_docs/testnet/deploying-a-smart-contract-programmatically.md
@@ -13,7 +13,7 @@ the local host with default values `WHOST=127.0.0.1` and `WPORT=3000`.
 A walk through and explanation of the steps performed is given below;
 
 ## Connect to the network and create a local private key
-The [wallet extension](../wallet-extension/wallet-extension.md) acts as an HTTP server to mediate RPC requests. In the 
+The [wallet extension](https://docs.obscu.ro/wallet-extension/wallet-extension/) acts as an HTTP server to mediate RPC requests. In the 
 below a connection is made on the wallet extension host and port, a private key is locally created and the associated 
 account stored for later usage.
 

--- a/docs/_docs/testnet/deploying-a-smart-contract.md
+++ b/docs/_docs/testnet/deploying-a-smart-contract.md
@@ -5,12 +5,12 @@ Using the steps below you will add an extension to your MetaMask wallet so it ca
 
 ## Prerequisites
 * [MetaMask](https://metamask.io/) wallet installed in your browser.
-* A local copy of the [Obscuro MetaMask wallet extension](../wallet-extension/wallet-extension.md)
+* A local copy of the [Obscuro MetaMask wallet extension](https://docs.obscu.ro/wallet-extension/wallet-extension/)
 
 ## Prepare Your MetaMask Wallet for Obscuro Testnet
 An essential part of how Obscuro provides full privacy is the encryption of communication between an Obscuro application and Obscuro nodes on the network.
 
-Follow the steps [here](../wallet-extension/wallet-extension.md) to configure and start the wallet extension and 
+Follow the steps [here](https://docs.obscu.ro/wallet-extension/wallet-extension/) to configure and start the wallet extension and 
 generate a viewing key. 
 
 
@@ -32,7 +32,7 @@ You can now go ahead and deploy your smart contract to the Obscuro Testnet.
 
 1. Compile your smart contract using the Remix Solidity Compiler.
 
-1. Log in to MetaMask and confirm you are connected to Obscuro Testnet network. The parameters for the Obscuro Testnet can be found [here](./essentials.md).
+1. Log in to MetaMask and confirm you are connected to Obscuro Testnet network. The parameters for the Obscuro Testnet can be found [here](https://docs.obscu.ro/testnet/essentials/).
 
 1. In the _Deploy & Run Transactions_ section of Remix change the Environment to _Injected Web3_. This tells Remix to use the network settings currently configured in your MetaMask wallet, which in this case is the Obscuro Testnet. If the connection to Obscuro Testnet is successful you will see the text _Custom (777) network_ displayed under _Injected Web3_.
 
@@ -48,4 +48,4 @@ Congratulations, your smart contract is now deployed to Obscuro Testnet!
 
 Because Obscuro provides full privacy, the details of your transaction are encrypted and only visible to you, as the holder of your wallet's private key.
 
-Now head over to the [ObscuroScan page](./obscuroscan.md) to see how you can view the transaction details.
+Now head over to the [ObscuroScan page](https://docs.obscu.ro/testnet/obscuroscan/) to see how you can view the transaction details.

--- a/docs/_docs/testnet/example-dapps.md
+++ b/docs/_docs/testnet/example-dapps.md
@@ -11,7 +11,7 @@ Consider for a moment how a secret number could be created without divulging it.
 Building the guessing game in Obscuro addresses both scenarios described above. The guessing game smart contract generates a random secret number when it is deployed. This number is never revealed to a player or node operator, or indeed anybody because it is generated within a Trusted Execution Environment. And when players make their guesses the transactions carrying the guesses are encrypted and therefore obscured in a block explorer.
 
 ### How to Play
-1. Start up the wallet extension. Follow instructions [here](https://docs.obscu.ro/wallet-extension/wallet-extension.html).
+1. Start up the wallet extension. Follow instructions [here](https://docs.obscu.ro/wallet-extension/wallet-extension).
 1. For the moment, the Guessing Game includes an ERC20 token (called OGG, short for Obscuro Guessing Game). This is partly because OGG is modified to have a built-in faucet: It allocates tokens to addresses as they make a request to allow other addresses to take tokens from their account.
 1. If you want to see this balance in your wallet, you have to import a new Token with the address: ``0x5FbDB2315678afecb367f032d93F642f64180aa3``
 1. Browse to [the number guessing game](http://obscuronet.github.io/sample-applications/number-guessing-game). Check you see `Network ID: 777` at the top of the game window to confirm you are connected to Obscuro Testnet.
@@ -36,4 +36,4 @@ Once the guess transaction is completed you can check the guess transaction on O
 ### Next Steps
 
 Now you have enjoyed playing the guessing game you are invited to make it even better! Go ahead and fork the guessing game code in this [GitHub repository](https://github.com/obscuronet/number-guessing-game) and bring your own contributions to Obscuro Testnet.
-Of course, you are free to [deploy any smart contract](https://docs.obscu.ro/testnet/deploying-a-smart-contract.html) to the testnet.   
+Of course, you are free to [deploy any smart contract](https://docs.obscu.ro/testnet/deploying-a-smart-contract) to the testnet.   

--- a/docs/_docs/testnet/faucet.md
+++ b/docs/_docs/testnet/faucet.md
@@ -7,7 +7,7 @@ Using the steps below you will request testnet OBX tokens from the faucet availa
 * Your wallet address.
 * Access to the [Obscuro Discord server](https://discord.gg/yQfmKeNzNd).
 * (Optional) [MetaMask](https://metamask.io/) wallet installed in your browser.
-* (Optional) A local copy of the [Obscuro MetaMask wallet extension](../wallet-extension/wallet-extension.md).
+* (Optional) A local copy of the [Obscuro MetaMask wallet extension](https://docs.obscu.ro/wallet-extension/wallet-extension/).
 
 ## Requesting Testnet OBX Tokens
 1. Make a note of your wallet address or copy it to your clipboard.
@@ -22,4 +22,4 @@ Using the steps below you will request testnet OBX tokens from the faucet availa
 ## Viewing Your Wallet Balance
 To view the balance of your wallet you will need to establish a connection from your wallet to the Obscuro Testnet. An essential part of how Obscuro provides full privacy is the encryption of communication between an Obscuro application and Obscuro nodes on the network. As a result, you will need to use the wallet extension to allow your wallet to communication with the Obscuro Testnet.
 
-Use the steps [here](../testnet/deploying-a-smart-contract.md#prepare-your-metamask-wallet-for-obscuro-testnet) to prepare your MetaMask wallet for Obscuro Testnet.
+Use the steps [here](https://docs.obscu.ro/testnet/deploying-a-smart-contract/#prepare-your-metamask-wallet-for-obscuro-testnet) to prepare your MetaMask wallet for Obscuro Testnet.

--- a/docs/_docs/testnet/faucet.md
+++ b/docs/_docs/testnet/faucet.md
@@ -11,13 +11,16 @@ Using the steps below you will request testnet OBX tokens from the faucet availa
 
 ## Requesting Testnet OBX Tokens
 1. Make a note of your wallet address or copy it to your clipboard.
-1. Open the [_faucet-requests_ channel](https://discord.gg/5qyj3qraaH) on Obscuro Discord.
-1. Request OBX using the `/faucet` command. The faucet will credit 100,000 OBX by default:
-![faucet command](../assets/images/faucet-cmd.png)
-1. Provide your wallet address and hit Enter. The faucet will acknowledge your request:
-![faucet ack](../assets/images/faucet-ack.png)
-1. After a short period of time the faucet will confirm the Testnet OBX tokens have been credited to your wallet:
-![faucet complete](../assets/images/faucet-done.png)
+2. Open the [_faucet-requests_ channel](https://discord.gg/5qyj3qraaH) on Obscuro Discord.
+3. Request OBX using the `/faucet` command. The faucet will credit 100,000 OBX by default:
+
+    ![faucet command](../../assets/images/faucet-cmd.png)
+4. Provide your wallet address and hit Enter. The faucet will acknowledge your request:
+
+    ![faucet ack](../../assets/images/faucet-ack.png)
+5. After a short period of time the faucet will confirm the Testnet OBX tokens have been credited to your wallet:
+
+    ![faucet complete](../.../assets/images/faucet-done.png)
 
 ## Viewing Your Wallet Balance
 To view the balance of your wallet you will need to establish a connection from your wallet to the Obscuro Testnet. An essential part of how Obscuro provides full privacy is the encryption of communication between an Obscuro application and Obscuro nodes on the network. As a result, you will need to use the wallet extension to allow your wallet to communication with the Obscuro Testnet.

--- a/docs/_docs/testnet/tutorial.md
+++ b/docs/_docs/testnet/tutorial.md
@@ -27,8 +27,8 @@ The dApp has many of the features that you'd expect to find, including:
 
 # Set up your environment
 - You'll need to install MetaMask following the instructions [here](https://metamask.io/)
-- Then download and run the Obscuro Wallet extension following the instructions [here](https://docs.obscu.ro/wallet-extension/wallet-extension.html)
-- Now connect MetaMask to the Obscuro testnet following the instructions [here](https://docs.obscu.ro/wallet-extension/configure-metamask.html)
+- Then download and run the Obscuro Wallet extension following the instructions [here](https://docs.obscu.ro/wallet-extension/wallet-extension)
+- Now connect MetaMask to the Obscuro testnet following the instructions [here](https://docs.obscu.ro/wallet-extension/configure-metamask)
 - Finally, check you can open the Remix IDE by visiting the following URL in your browser https://remix.ethereum.org
 
 That's it. You're all set to start building your first dApp on Obscuro.
@@ -156,7 +156,7 @@ Our function to return the prize pool is:
 
 And that's it! Congratulations on writing your first Obscuro smart contract!
 
-You can now go ahead and deploy the contract following the instructions [here](https://docs.obscu.ro/testnet/deploying-a-smart-contract.html)
+You can now go ahead and deploy the contract following the instructions [here](https://docs.obscu.ro/testnet/deploying-a-smart-contract)
 
 With that done, why not have a go at extending the contract to include warmer/colder functionality. Then, when a returning player plays again for the same again, if their new guess is closer to the previous guess, they're told they're *warmer*, and if it's further, they're *colder*.
 

--- a/docs/_docs/wallet-extension/wallet-extension.md
+++ b/docs/_docs/wallet-extension/wallet-extension.md
@@ -64,7 +64,7 @@ tools.
    The wallet extension is now listening on the specified host and port. For the remainder of this document, we'll 
    assume that the default ports of `3000` and `3001` were selected.
 
-3. Sign in to MetaMask and add the Obscuro Testnet network following the instructions [here](/wallet-extension/configure-metamask.html)
+3. Sign in to MetaMask and add the Obscuro Testnet network following the instructions [here](https://docs.obscu.ro/wallet-extension/configure-metamask).
 
 4. At this stage, no viewing key has been set up. The enclave will refuse to respond to sensitive RPC requests such 
    as `eth_getBalance`, `eth_call` and `eth_getTransactionReceipt`. As a result, your balance in MetaMask will not be 


### PR DESCRIPTION
### Why is this change needed?

- Some of the docs pages were pointing to .html pages however when the docs search fix was applied all md files lost their .html suffix when the html pages are constructed by Jekyll

### What changes were made as part of this PR:

- links embedded in the md files with .html have ".html" removed from the URL
- reference links replaced with FQDN links

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
