### PR TITLE
Adds integration test of getTotalTxs.

### DIFF
--- a/go/host/rpc/clientapi/client_api_obscuroscan.go
+++ b/go/host/rpc/clientapi/client_api_obscuroscan.go
@@ -27,7 +27,7 @@ func NewObscuroScanAPI(host host.Host) *ObscuroScanAPI {
 	}
 }
 
-// GetBlockHeaderByHash returns the header for the block with the given number.
+// GetBlockHeaderByHash returns the header for the block with the given hash.
 func (api *ObscuroScanAPI) GetBlockHeaderByHash(blockHash gethcommon.Hash) (*types.Header, error) {
 	blockHeader, err := api.host.DB().GetBlockHeader(blockHash)
 	if err != nil {

--- a/integration/simulation/network/geth_network.go
+++ b/integration/simulation/network/geth_network.go
@@ -52,6 +52,7 @@ func (n *networkInMemGeth) Create(params *params.SimParams, stats *stats.Stats) 
 	return &RPCHandles{
 		EthClients:     n.gethClients,
 		ObscuroClients: obscuroClients,
+		RPCClients:     n.l2Clients,
 		AuthObsClients: walletClients,
 	}, nil
 }

--- a/integration/simulation/network/inmemory.go
+++ b/integration/simulation/network/inmemory.go
@@ -112,6 +112,7 @@ func (n *basicNetworkOfInMemoryNodes) Create(params *params.SimParams, stats *st
 	return &RPCHandles{
 		EthClients:     l1Clients,
 		ObscuroClients: obscuroClients,
+		RPCClients:     n.l2Clients,
 		AuthObsClients: walletClients,
 	}, nil
 }

--- a/integration/simulation/network/network.go
+++ b/integration/simulation/network/network.go
@@ -36,7 +36,6 @@ type RPCHandles struct {
 	// An Obscuro client per Obscuro node in the network.
 	ObscuroClients []*obsclient.ObsClient
 	// An RPC client per Obscuro node in the network (used for APIs that don't have methods on `ObsClient`.
-	// TDOO - Switch to a pointer.
 	RPCClients []rpc.Client
 
 	// an RPC client per node per wallet, with a viewing key set up (on the client and registered on its corresponding host enclave),

--- a/integration/simulation/network/network.go
+++ b/integration/simulation/network/network.go
@@ -3,6 +3,8 @@ package network
 import (
 	"math/rand"
 
+	"github.com/obscuronet/go-obscuro/go/rpc"
+
 	"github.com/obscuronet/go-obscuro/go/obsclient"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -31,8 +33,11 @@ type RPCHandles struct {
 	// an eth client per eth node in the network
 	EthClients []ethadapter.EthClient
 
-	// an obscuro client per obscuro node in the network (used for things like validation rather than transactions on behalf of sim accounts)
+	// An Obscuro client per Obscuro node in the network.
 	ObscuroClients []*obsclient.ObsClient
+	// An RPC client per Obscuro node in the network (used for APIs that don't have methods on `ObsClient`.
+	// TDOO - Switch to a pointer.
+	RPCClients []rpc.Client
 
 	// an RPC client per node per wallet, with a viewing key set up (on the client and registered on its corresponding host enclave),
 	//	to mimic user acc interaction via a wallet extension

--- a/integration/simulation/network/socket.go
+++ b/integration/simulation/network/socket.go
@@ -71,6 +71,7 @@ func (n *networkOfSocketNodes) Create(params *params.SimParams, stats *stats.Sta
 	return &RPCHandles{
 		EthClients:     n.gethClients,
 		ObscuroClients: obscuroClients,
+		RPCClients:     n.l2Clients,
 		AuthObsClients: walletClients,
 	}, nil
 }

--- a/integration/simulation/p2p/in_mem_obscuro_client.go
+++ b/integration/simulation/p2p/in_mem_obscuro_client.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math/big"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 
@@ -111,6 +112,9 @@ func (c *inMemObscuroClient) Call(result interface{}, method string, args ...int
 
 	case rpc.Health:
 		return c.health(result)
+
+	case rpc.GetTotalTxs:
+		return c.getTotalTransactions(result)
 
 	default:
 		return fmt.Errorf("RPC method %s is unknown", method)
@@ -297,6 +301,16 @@ func (c *inMemObscuroClient) addViewingKey(args []interface{}) error {
 func (c *inMemObscuroClient) health(result interface{}) error {
 	healty := true
 	*result.(**bool) = &healty
+	return nil
+}
+
+func (c *inMemObscuroClient) getTotalTransactions(result interface{}) error {
+	totalTxs, err := c.obscuroScanAPI.GetTotalTransactions()
+	if err != nil {
+		return fmt.Errorf("`%s` call failed. Cause: %w", rpc.GetTotalTxs, err)
+	}
+
+	*result.(**big.Int) = totalTxs
 	return nil
 }
 


### PR DESCRIPTION
### Why is this change needed?

We need integration tests of the Obscuroscan APIs to stop Obscuroscan from breaking silently.

### What changes were made as part of this PR:

- Provide a high level list of the changes made
- List key areas for the reviewer 

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
