### PR TITLE
Rename Testnet Obscuroscan workflow to be consistent

### DIFF
--- a/.github/workflows/manual-deploy-obscuroscan.yml
+++ b/.github/workflows/manual-deploy-obscuroscan.yml
@@ -8,7 +8,7 @@
 # Exposes the following addresses: (only accessible internally)
 #  testnet-obscuroscan.uksouth.azurecontainer.io
 
-name: '[M] Deploy Obscuroscan'
+name: '[M] Deploy Testnet Obscuroscan'
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
### Why is this change needed?

- Provides consistency in the naming of deploying obscuroscan. 


