### PR TITLE
Profiler - address gosec warning on new versions of golangci-lint

### DIFF
--- a/go/common/profiler/profiler.go
+++ b/go/common/profiler/profiler.go
@@ -3,6 +3,7 @@ package profiler
 import (
 	"fmt"
 	"net/http"
+	"time"
 
 	gethlog "github.com/ethereum/go-ethereum/log"
 
@@ -29,8 +30,13 @@ func NewProfiler(port int, logger gethlog.Logger) *Profiler {
 func (p *Profiler) Start() error {
 	go func() {
 		address := fmt.Sprintf("0.0.0.0:%d", p.port)
+		server := &http.Server{
+			Addr:              address,
+			ReadHeaderTimeout: 3 * time.Second,
+		}
+
 		p.logger.Info(fmt.Sprintf("Profiler started @%s ", address))
-		p.logger.Info(fmt.Sprintf("%v", http.ListenAndServe(address, nil)))
+		p.logger.Info(fmt.Sprintf("%v", server.ListenAndServe()))
 	}()
 	return nil
 }


### PR DESCRIPTION
### Why is this change needed?

The current impl of the profiler doesn't cause any linting issues on the version of golangci-lint used in CI, but it does on more recent versions. This change avoids that linting issue.

### What changes were made as part of this PR:

- Provide a high level list of the changes made
- List key areas for the reviewer 

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
