### PR TITLE
Make our ErrNotFound match Ethereum's

### DIFF
--- a/go/common/errutil/errors_util.go
+++ b/go/common/errutil/errors_util.go
@@ -1,8 +1,12 @@
 package errutil
 
-import "errors"
+import (
+	"errors"
+
+	"github.com/ethereum/go-ethereum"
+)
 
 var (
-	ErrNotFound = errors.New("not found")
+	ErrNotFound = ethereum.NotFound
 	ErrNoImpl   = errors.New("not implemented")
 )

--- a/go/common/errutil/errors_util.go
+++ b/go/common/errutil/errors_util.go
@@ -7,6 +7,8 @@ import (
 )
 
 var (
+	// ErrNotFound must equal Geth's not-found error. This is because some Geth components we use throw the latter, and
+	// we want to be able to catch both types in a single error-check.
 	ErrNotFound = ethereum.NotFound
 	ErrNoImpl   = errors.New("not implemented")
 )


### PR DESCRIPTION
### Why is this change needed?

Currently, we use a lot of Ethereum components. Some of these may be throwing out their own `ethereum.NotFound` errors which we are failing to convert to `errutil.ErrNotFound`. This is a potential source of bugs, as we may have an `errutil.ErrNotFound` check that misses an unconverted `ethereum.NotFound` error.

### What changes were made as part of this PR:

- Provide a high level list of the changes made
- List key areas for the reviewer 

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
