### PR TITLE
Allow hosts to catch up on missed batches

### DIFF
--- a/go/common/batches.go
+++ b/go/common/batches.go
@@ -14,9 +14,8 @@ type ExtBatch struct {
 
 // TODO - #718 - Cache hash calculation.
 
-// BatchRequest is used when request a range of batches from a peer.
+// BatchRequest is used when requesting a range of batches from a peer.
 type BatchRequest struct {
-	Requester string
-	From      *big.Int
-	To        *big.Int
+	Requester            string
+	EarliestMissingBatch *big.Int
 }

--- a/go/common/batches.go
+++ b/go/common/batches.go
@@ -2,8 +2,6 @@ package common
 
 import (
 	"math/big"
-
-	gethcommon "github.com/ethereum/go-ethereum/common"
 )
 
 // ExtBatch is an encrypted form of batch used when passing the batch around outside of an enclave.
@@ -18,7 +16,7 @@ type ExtBatch struct {
 
 // BatchRequest is used when request a range of batches from a peer.
 type BatchRequest struct {
-	Requester *gethcommon.Address
+	Requester string
 	From      *big.Int
 	To        *big.Int
 }

--- a/go/common/batches.go
+++ b/go/common/batches.go
@@ -1,5 +1,11 @@
 package common
 
+import (
+	"math/big"
+
+	gethcommon "github.com/ethereum/go-ethereum/common"
+)
+
 // ExtBatch is an encrypted form of batch used when passing the batch around outside of an enclave.
 // TODO - #718 - Expand this structure to contain the required fields.
 type ExtBatch struct {
@@ -9,3 +15,10 @@ type ExtBatch struct {
 }
 
 // TODO - #718 - Cache hash calculation.
+
+// BatchRequest is used when request a range of batches from a peer.
+type BatchRequest struct {
+	Requester *gethcommon.Address
+	From      *big.Int
+	To        *big.Int
+}

--- a/go/common/host/host.go
+++ b/go/common/host/host.go
@@ -55,7 +55,7 @@ type P2P interface {
 	UpdatePeerList([]string)
 	BroadcastTx(tx common.EncryptedTx) error
 	BroadcastBatch(batch *common.ExtBatch) error
-	RequestBatchesSince(batchNumber *big.Int) ([]*common.ExtBatch, error)
+	RequestBatches(from *big.Int, to *big.Int) ([]*common.ExtBatch, error)
 }
 
 // ReconnectingBlockProvider interface allows host to monitor and await L1 blocks.

--- a/go/common/host/host.go
+++ b/go/common/host/host.go
@@ -23,8 +23,8 @@ type Host interface {
 	SubmitAndBroadcastTx(encryptedParams common.EncryptedParamsSendRawTx) (common.EncryptedResponseSendRawTx, error)
 	// ReceiveTx processes a transaction received from a peer host.
 	ReceiveTx(tx common.EncryptedTx)
-	// ReceiveBatch processes a batch received from a peer host.
-	ReceiveBatch(batch common.EncodedBatch)
+	// ReceiveBatches receives a set of batches from a peer host.
+	ReceiveBatches(batches common.EncodedBatches)
 	// Subscribe feeds logs matching the encrypted log subscription to the matchedLogs channel.
 	Subscribe(id rpc.ID, encryptedLogSubscription common.EncryptedParamsLogSubscription, matchedLogs chan []byte) error
 	// Unsubscribe terminates a log subscription between the host and the enclave.

--- a/go/common/host/host.go
+++ b/go/common/host/host.go
@@ -57,7 +57,7 @@ type P2P interface {
 	UpdatePeerList([]string)
 	BroadcastTx(tx common.EncryptedTx) error
 	BroadcastBatch(batch *common.ExtBatch) error
-	RequestBatches(from *big.Int, to *big.Int) error
+	RequestBatches(batchRequest *common.BatchRequest) error
 }
 
 // ReconnectingBlockProvider interface allows host to monitor and await L1 blocks.

--- a/go/common/host/host.go
+++ b/go/common/host/host.go
@@ -61,8 +61,8 @@ type P2P interface {
 	BroadcastBatch(batch *common.ExtBatch) error
 	// RequestBatches requests batches from the sequencer.
 	RequestBatches(batchRequest *common.BatchRequest) error
-	// SendBatch sends batches to a specific node, in response to a batch request.
-	SendBatch(batches []*common.ExtBatch, to *gethcommon.Address) error
+	// SendBatches sends batches to a specific node, in response to a batch request.
+	SendBatches(batches []*common.ExtBatch, to string) error
 }
 
 // ReconnectingBlockProvider interface allows host to monitor and await L1 blocks.

--- a/go/common/host/host.go
+++ b/go/common/host/host.go
@@ -25,6 +25,8 @@ type Host interface {
 	ReceiveTx(tx common.EncryptedTx)
 	// ReceiveBatches receives a set of batches from a peer host.
 	ReceiveBatches(batches common.EncodedBatches)
+	// SendBatches sends a set of batches to a peer host. Used during catch-up.
+	SendBatches(batchRequest common.EncodedBatchRequest)
 	// Subscribe feeds logs matching the encrypted log subscription to the matchedLogs channel.
 	Subscribe(id rpc.ID, encryptedLogSubscription common.EncryptedParamsLogSubscription, matchedLogs chan []byte) error
 	// Unsubscribe terminates a log subscription between the host and the enclave.

--- a/go/common/host/host.go
+++ b/go/common/host/host.go
@@ -55,9 +55,14 @@ type P2P interface {
 	StartListening(callback Host)
 	StopListening() error
 	UpdatePeerList([]string)
+	// BroadcastTx sends the encrypted transaction to every other node on the network.
 	BroadcastTx(tx common.EncryptedTx) error
+	// BroadcastBatch sends the batch to every other node on the network.
 	BroadcastBatch(batch *common.ExtBatch) error
+	// RequestBatches requests batches from the sequencer.
 	RequestBatches(batchRequest *common.BatchRequest) error
+	// SendBatch sends batches to a specific node, in response to a batch request.
+	SendBatch(batches []*common.ExtBatch, to *gethcommon.Address) error
 }
 
 // ReconnectingBlockProvider interface allows host to monitor and await L1 blocks.

--- a/go/common/host/host.go
+++ b/go/common/host/host.go
@@ -55,6 +55,7 @@ type P2P interface {
 	UpdatePeerList([]string)
 	BroadcastTx(tx common.EncryptedTx) error
 	BroadcastBatch(batch *common.ExtBatch) error
+	RequestBatchesSince(batchNumber *big.Int) ([]*common.ExtBatch, error)
 }
 
 // ReconnectingBlockProvider interface allows host to monitor and await L1 blocks.

--- a/go/common/host/host.go
+++ b/go/common/host/host.go
@@ -55,7 +55,7 @@ type P2P interface {
 	UpdatePeerList([]string)
 	BroadcastTx(tx common.EncryptedTx) error
 	BroadcastBatch(batch *common.ExtBatch) error
-	RequestBatches(from *big.Int, to *big.Int) ([]*common.ExtBatch, error)
+	RequestBatches(from *big.Int, to *big.Int) error
 }
 
 // ReconnectingBlockProvider interface allows host to monitor and await L1 blocks.

--- a/go/common/host/host.go
+++ b/go/common/host/host.go
@@ -25,8 +25,8 @@ type Host interface {
 	ReceiveTx(tx common.EncryptedTx)
 	// ReceiveBatches receives a set of batches from a peer host.
 	ReceiveBatches(batches common.EncodedBatches)
-	// SendBatches sends a set of batches to a peer host. Used during catch-up.
-	SendBatches(batchRequest common.EncodedBatchRequest)
+	// ReceiveBatchRequest receives a batch request from a peer host. Used during catch-up.
+	ReceiveBatchRequest(batchRequest common.EncodedBatchRequest)
 	// Subscribe feeds logs matching the encrypted log subscription to the matchedLogs channel.
 	Subscribe(id rpc.ID, encryptedLogSubscription common.EncryptedParamsLogSubscription, matchedLogs chan []byte) error
 	// Unsubscribe terminates a log subscription between the host and the enclave.

--- a/go/common/types.go
+++ b/go/common/types.go
@@ -36,9 +36,9 @@ type (
 	EncryptedResponseEstimateGas  []byte // As above, but for an RPC estimateGas response.
 	EncryptedResponseGetLogs      []byte // As above, but for an RPC getLogs request.
 
-	Nonce         = uint64
-	EncodedRollup []byte
-	EncodedBatch  []byte
+	Nonce          = uint64
+	EncodedRollup  []byte
+	EncodedBatches []byte
 )
 
 const (

--- a/go/common/types.go
+++ b/go/common/types.go
@@ -36,9 +36,10 @@ type (
 	EncryptedResponseEstimateGas  []byte // As above, but for an RPC estimateGas response.
 	EncryptedResponseGetLogs      []byte // As above, but for an RPC getLogs request.
 
-	Nonce          = uint64
-	EncodedRollup  []byte
-	EncodedBatches []byte
+	Nonce               = uint64
+	EncodedRollup       []byte
+	EncodedBatches      []byte
+	EncodedBatchRequest []byte
 )
 
 const (

--- a/go/host/batchmanager/batch_manager.go
+++ b/go/host/batchmanager/batch_manager.go
@@ -37,7 +37,7 @@ func (b *BatchManager) StoreBatches(batches []*common.ExtBatch) error {
 		parentBatchNumber := big.NewInt(0).Sub(batch.Header.Number, big.NewInt(1))
 		_, err := b.db.GetBatchHash(parentBatchNumber)
 
-		// We have stored the parent, or this is the genesis batch, so we store the batch.
+		// We have stored the batch's parent, or this batch is the genesis batch, so we store the batch.
 		if err == nil || batch.Header.Number.Uint64() == common.L2GenesisHeight {
 			err = b.db.AddBatchHeader(batch)
 			if err != nil {

--- a/go/host/batchmanager/batch_manager.go
+++ b/go/host/batchmanager/batch_manager.go
@@ -22,7 +22,7 @@ func NewBatchManager(db *db.DB) *BatchManager {
 	}
 }
 
-// IsMissingBatches retruns a bool indicating whether any historical batches are missing, given the state of the host's
+// IsMissingBatches returns a bool indicating whether any historical batches are missing, given the state of the host's
 // database and the batches provided. If batches are missing, it creates a corresponding batch request.
 func (b *BatchManager) IsMissingBatches(batches []*common.ExtBatch) (bool, *common.BatchRequest, error) {
 	// We sort the batches, then check for duplicates or gaps. If we don't identify gaps first, there's a risk that

--- a/go/host/batchmanager/batch_manager.go
+++ b/go/host/batchmanager/batch_manager.go
@@ -70,7 +70,7 @@ func (b *BatchManager) CheckForGapsAndDupes(batches []*common.ExtBatch) error {
 }
 
 // todo - joel - comment
-func (b *BatchManager) EarliestMissingBatch(batch *common.ExtBatch) (*big.Int, error) {
+func (b *BatchManager) CreateBatchRequest(batch *common.ExtBatch) (*common.BatchRequest, error) {
 	var earliestMissingBatch *big.Int
 	parentBatchNumber := big.NewInt(0).Sub(batch.Header.Number, big.NewInt(1))
 	for {
@@ -93,7 +93,13 @@ func (b *BatchManager) EarliestMissingBatch(batch *common.ExtBatch) (*big.Int, e
 		// If there was no error, we have reach a stored batch.
 		break
 	}
-	return earliestMissingBatch, nil
+
+	if earliestMissingBatch == nil {
+		// There are no missing batches to request.
+		return nil, nil //nolint:nilnil
+	}
+
+	return &common.BatchRequest{From: earliestMissingBatch, To: batch.Header.Number}, nil
 }
 
 // todo - joel - comment

--- a/go/host/batchmanager/batch_manager.go
+++ b/go/host/batchmanager/batch_manager.go
@@ -1,0 +1,96 @@
+package batchmanager
+
+import (
+	"errors"
+	"fmt"
+	"github.com/obscuronet/go-obscuro/go/common"
+	"github.com/obscuronet/go-obscuro/go/common/errutil"
+	"github.com/obscuronet/go-obscuro/go/host/db"
+	"math/big"
+	"sort"
+)
+
+// BatchManager handles the creation and processing of batches for the host.
+type BatchManager struct {
+	db *db.DB
+}
+
+func NewBatchManager(db *db.DB) *BatchManager {
+	return &BatchManager{
+		db: db,
+	}
+}
+
+// todo - joel - comment
+func (b *BatchManager) RetrieveBatches(batchRequest *common.BatchRequest) ([]*common.ExtBatch, error) {
+	var batches []*common.ExtBatch
+	currentBatchToRetrieve := batchRequest.From
+	for currentBatchToRetrieve.Cmp(batchRequest.To) != 1 {
+		batchHash, err := b.db.GetBatchHash(currentBatchToRetrieve)
+		if err != nil {
+			return nil, fmt.Errorf("could not retrieve batch hash for batch number %d. Cause: %w", currentBatchToRetrieve, err)
+		}
+		batch, err := b.db.GetBatch(*batchHash)
+		if err != nil {
+			return nil, fmt.Errorf("could not retrieve batch for batch hash %s. Cause: %w", batchHash, err)
+		}
+		batches = append(batches, batch)
+		currentBatchToRetrieve = big.NewInt(0).Add(currentBatchToRetrieve, big.NewInt(1))
+	}
+
+	return batches, nil
+}
+
+// todo - joel - comment
+func (b *BatchManager) SortBatches(batches []*common.ExtBatch) {
+	sort.Slice(batches, func(i, j int) bool {
+		return batches[i].Header.Number.Cmp(batches[i].Header.Number) < 0
+	})
+}
+
+// todo - joel - comment
+func (b *BatchManager) CheckForGapsAndDupes(batches []*common.ExtBatch) error {
+	for idx := 0; idx < len(batches)-1; idx++ {
+		i := batches[idx]
+		j := batches[idx+1]
+
+		numberGap := big.NewInt(0).Sub(j.Header.Number, i.Header.Number)
+		gapIsZero := numberGap.Cmp(big.NewInt(0)) == 0
+		gapIsMoreThanOne := numberGap.Cmp(big.NewInt(1)) != 0
+
+		if gapIsZero {
+			return fmt.Errorf("duplicates in set of batches to process")
+		}
+		if gapIsMoreThanOne {
+			return fmt.Errorf("gaps in chain of set of batches to process")
+		}
+	}
+	return nil
+}
+
+// todo - joel - comment
+func (b *BatchManager) EarliestMissingBatch(batch *common.ExtBatch) (*big.Int, error) {
+	var earliestMissingBatch *big.Int
+	parentBatchNumber := big.NewInt(0).Sub(batch.Header.Number, big.NewInt(1))
+	for {
+		// If we have reached the head of the chain, break.
+		if parentBatchNumber.Int64() < int64(common.L2GenesisHeight) {
+			break
+		}
+
+		_, err := b.db.GetBatchHash(parentBatchNumber)
+		if err != nil {
+			// If the batch is not found, we update the variable tracking the earliest missing batch.
+			if errors.Is(err, errutil.ErrNotFound) {
+				earliestMissingBatch = parentBatchNumber
+				parentBatchNumber = big.NewInt(0).Sub(parentBatchNumber, big.NewInt(1))
+				continue
+			}
+			return nil, fmt.Errorf("could not get batch hash by number. Cause: %w", err)
+		}
+
+		// If there was no error, we have reach a stored batch.
+		break
+	}
+	return earliestMissingBatch, nil
+}

--- a/go/host/batchmanager/batch_manager.go
+++ b/go/host/batchmanager/batch_manager.go
@@ -3,11 +3,12 @@ package batchmanager
 import (
 	"errors"
 	"fmt"
+	"math/big"
+	"sort"
+
 	"github.com/obscuronet/go-obscuro/go/common"
 	"github.com/obscuronet/go-obscuro/go/common/errutil"
 	"github.com/obscuronet/go-obscuro/go/host/db"
-	"math/big"
-	"sort"
 )
 
 // BatchManager handles the creation and processing of batches for the host.
@@ -93,4 +94,15 @@ func (b *BatchManager) EarliestMissingBatch(batch *common.ExtBatch) (*big.Int, e
 		break
 	}
 	return earliestMissingBatch, nil
+}
+
+// todo - joel - comment
+func (b *BatchManager) StoreBatches(batches []*common.ExtBatch) error {
+	for _, batch := range batches {
+		err := b.db.AddBatchHeader(batch)
+		if err != nil {
+			return fmt.Errorf("could not store batch header. Cause: %w", err)
+		}
+	}
+	return nil
 }

--- a/go/host/batchmanager/batch_manager.go
+++ b/go/host/batchmanager/batch_manager.go
@@ -65,22 +65,24 @@ func (b *BatchManager) StoreBatches(batches []*common.ExtBatch) error {
 func (b *BatchManager) GetBatches(batchRequest *common.BatchRequest) ([]*common.ExtBatch, error) {
 	var batches []*common.ExtBatch
 
-	currentBatchToRetrieve := batchRequest.EarliestMissingBatch
+	currentBatch := batchRequest.EarliestMissingBatch
 	for {
-		batchHash, err := b.db.GetBatchHash(currentBatchToRetrieve)
+		batchHash, err := b.db.GetBatchHash(currentBatch)
 		if err != nil {
-			// We have reached the latest batch. Our work is complete.
+			// We have reached the latest batch.
 			if errors.Is(err, errutil.ErrNotFound) {
 				break
 			}
-			return nil, fmt.Errorf("could not retrieve batch hash for batch number %d. Cause: %w", currentBatchToRetrieve, err)
+			return nil, fmt.Errorf("could not retrieve batch hash for batch number %d. Cause: %w", currentBatch, err)
 		}
+
 		batch, err := b.db.GetBatch(*batchHash)
 		if err != nil {
 			return nil, fmt.Errorf("could not retrieve batch for batch hash %s. Cause: %w", batchHash, err)
 		}
+
 		batches = append(batches, batch)
-		currentBatchToRetrieve = big.NewInt(0).Add(currentBatchToRetrieve, big.NewInt(1))
+		currentBatch = big.NewInt(0).Add(currentBatch, big.NewInt(1))
 	}
 
 	return batches, nil

--- a/go/host/db/batches.go
+++ b/go/host/db/batches.go
@@ -53,6 +53,7 @@ func (db *DB) AddBatchHeader(batch *common.ExtBatch) error {
 		}
 	}
 
+	// TODO - #718 - Check that we are not re-adding an existing batch before updating the number.
 	// There's a potential race here, but absolute accuracy of the number of transactions is not required.
 	currentTotal, err := db.readTotalTransactions()
 	if err != nil {
@@ -69,7 +70,7 @@ func (db *DB) AddBatchHeader(batch *common.ExtBatch) error {
 	if err != nil && !errors.Is(err, errutil.ErrNotFound) {
 		return fmt.Errorf("could not retrieve head batch header. Cause: %w", err)
 	}
-	if errors.Is(err, errutil.ErrNotFound) || headBatchHeader.Number.Int64() <= batch.Header.Number.Int64() {
+	if errors.Is(err, errutil.ErrNotFound) || headBatchHeader.Number.Cmp(batch.Header.Number) == -1 {
 		err = db.writeHeadBatchHash(batch.Header.Hash())
 		if err != nil {
 			return fmt.Errorf("could not write new head batch hash. Cause: %w", err)

--- a/go/host/db/batches.go
+++ b/go/host/db/batches.go
@@ -26,7 +26,7 @@ func (db *DB) GetHeadBatchHeader() (*common.Header, error) {
 	return db.readBatchHeader(*headBatchHash)
 }
 
-// GetBatchHeader returns the batch header given the hash, or (nil, false) if no such header is found.
+// GetBatchHeader returns the batch header given the hash.
 func (db *DB) GetBatchHeader(hash gethcommon.Hash) (*common.Header, error) {
 	return db.readBatchHeader(hash)
 }
@@ -83,19 +83,17 @@ func (db *DB) AddBatchHeader(batch *common.ExtBatch) error {
 	return nil
 }
 
-// GetBatchHash returns the hash of a batch given its number, or (nil, false) if no such batch is found.
+// GetBatchHash returns the hash of a batch given its number.
 func (db *DB) GetBatchHash(number *big.Int) (*gethcommon.Hash, error) {
 	return db.readBatchHash(number)
 }
 
-// GetBatchTxs returns the transaction hashes of the batch with the given hash, or (nil, false) if no such batch is
-// found.
+// GetBatchTxs returns the transaction hashes of the batch with the given hash.
 func (db *DB) GetBatchTxs(batchHash gethcommon.Hash) ([]gethcommon.Hash, error) {
 	return db.readBatchTxHashes(batchHash)
 }
 
-// GetBatchNumber returns the number of the batch containing the given transaction hash, or (nil, false) if no such
-// batch is found.
+// GetBatchNumber returns the number of the batch containing the given transaction hash.
 func (db *DB) GetBatchNumber(txHash gethcommon.Hash) (*big.Int, error) {
 	return db.readBatchNumber(txHash)
 }
@@ -208,7 +206,7 @@ func (db *DB) writeBatchHash(w ethdb.KeyValueWriter, header *common.Header) erro
 	return nil
 }
 
-// Retrieves the hash for the batch with the given number, or (nil, false) if no such batch is found.
+// Retrieves the hash for the batch with the given number..
 func (db *DB) readBatchHash(number *big.Int) (*gethcommon.Hash, error) {
 	f, err := db.kvStore.Has(batchHashKey(number))
 	if err != nil {
@@ -228,7 +226,7 @@ func (db *DB) readBatchHash(number *big.Int) (*gethcommon.Hash, error) {
 	return &hash, nil
 }
 
-// Returns the transaction hashes in the batch with the given hash, or (nil, false) if no such batch is found.
+// Returns the transaction hashes in the batch with the given hash.
 func (db *DB) readBatchTxHashes(batchHash common.L2RootHash) ([]gethcommon.Hash, error) {
 	f, err := db.kvStore.Has(batchTxHashesKey(batchHash))
 	if err != nil {
@@ -276,8 +274,7 @@ func (db *DB) writeBatchTxHashes(w ethdb.KeyValueWriter, batchHash common.L2Root
 	return nil
 }
 
-// Retrieves the number of the batch containing the transaction with the given hash, or (nil, false) if no such batch
-// is found.
+// Retrieves the number of the batch containing the transaction with the given hash.
 func (db *DB) readBatchNumber(txHash gethcommon.Hash) (*big.Int, error) {
 	f, err := db.kvStore.Has(batchNumberKey(txHash))
 	if err != nil {

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -1082,17 +1082,17 @@ func (h *host) requestMissingBatches(batches []*common.ExtBatch) (bool, error) {
 	}
 
 	batch := batches[0]
-	earliestMissingBatch, err := h.batchManager.EarliestMissingBatch(batch)
+	batchRequest, err := h.batchManager.CreateBatchRequest(batch)
 	if err != nil {
 		return false, err
 	}
-	if earliestMissingBatch == nil {
+	if batchRequest == nil {
 		// There are no missing batches to request.
 		return false, nil
 	}
 
-	batchRequest := common.BatchRequest{Requester: h.config.P2PPublicAddress, From: earliestMissingBatch, To: batch.Header.Number}
-	err = h.p2p.RequestBatches(&batchRequest)
+	batchRequest.Requester = h.config.P2PPublicAddress
+	err = h.p2p.RequestBatches(batchRequest)
 	if err != nil {
 		return false, fmt.Errorf("could not request historical batches. Cause: %w", err)
 	}

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -1056,8 +1056,7 @@ func (h *host) requestMissingBatches(batch common.ExtBatch) error {
 	parentBatchNumber := big.NewInt(0).Sub(batch.Header.Number, big.NewInt(1))
 	for {
 		// If we have reached the head of the chain, break.
-		// TODO - Use constant for genesis rollup number.
-		if parentBatchNumber.Int64() < 0 {
+		if parentBatchNumber.Int64() < int64(common.L2GenesisHeight) {
 			break
 		}
 
@@ -1081,7 +1080,8 @@ func (h *host) requestMissingBatches(batch common.ExtBatch) error {
 		return nil
 	}
 
-	batches, err := h.p2p.RequestBatchesSince(earliestMissingBatch)
+	latestMissingBatch := big.NewInt(0).Sub(batch.Header.Number, big.NewInt(1))
+	batches, err := h.p2p.RequestBatches(earliestMissingBatch, latestMissingBatch)
 	if err != nil {
 		return fmt.Errorf("could not request historical batches. Cause: %w", err)
 	}

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -1129,9 +1129,11 @@ func (h *host) handleBatchRequest(encodedBatchRequest *common.EncodedBatchReques
 		return fmt.Errorf("could not decode batch request using RLP. Cause: %w", err)
 	}
 
-	// todo - joel - implement this
-	panic("not implemented")
-	return nil
+	var batches []*common.ExtBatch
+
+	// todo - joel - gather the list of batches to send
+
+	return h.p2p.SendBatch(batches, batchRequest.Requester)
 }
 
 // Checks the host config is valid.

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -1082,7 +1082,7 @@ func (h *host) handleBatchRequest(encodedBatchRequest *common.EncodedBatchReques
 		return fmt.Errorf("could not decode batch request using RLP. Cause: %w", err)
 	}
 
-	batches, err := h.batchManager.RetrieveBatches(batchRequest)
+	batches, err := h.batchManager.GetBatches(batchRequest)
 	if err != nil {
 		return fmt.Errorf("could not retrieve batches based on request. Cause: %w", err)
 	}

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -1056,11 +1056,6 @@ func (h *host) handleBatches(encodedBatches *common.EncodedBatches) error {
 
 	// TODO - #718 - Have the enclave process the batch, so that it's up to date.
 
-	for _, batch := range batches {
-		print(batch.Header.Number.Int64(), " ")
-	}
-	println()
-
 	// We store the batches. If we encounter any missing batches, we abort and request the missing batches instead.
 	err = h.batchManager.StoreBatches(batches)
 	if err != nil {

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -1057,13 +1057,16 @@ func (h *host) handleBatches(encodedBatches *common.EncodedBatches) error {
 	// TODO - #718 - Have the enclave process the batch, so that it's up to date.
 
 	// We request any batches we've missed.
-	isMissingBatches, batchRequest, err := h.batchManager.IsMissingBatches(batches)
+	isMissingBatches, earliestMissingBatch, err := h.batchManager.IsMissingBatches(batches)
 	if err != nil {
 		return err
 	}
 	if isMissingBatches {
-		batchRequest.Requester = h.config.P2PPublicAddress
-		err = h.p2p.RequestBatches(batchRequest)
+		batchRequest := common.BatchRequest{
+			Requester:            h.config.P2PPublicAddress,
+			EarliestMissingBatch: earliestMissingBatch,
+		}
+		err = h.p2p.RequestBatches(&batchRequest)
 		if err != nil {
 			return fmt.Errorf("could not request historical batches. Cause: %w", err)
 		}

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/obscuronet/go-obscuro/go/host/p2p"
 	"math/big"
 	"sort"
 	"sync/atomic"
@@ -1115,7 +1114,8 @@ func (h *host) requestMissingBatches(batch *common.ExtBatch) (bool, error) {
 		return false, nil
 	}
 
-	err := h.p2p.RequestBatches(earliestMissingBatch, batch.Header.Number)
+	batchRequest := common.BatchRequest{Requester: &h.config.ID, From: earliestMissingBatch, To: batch.Header.Number}
+	err := h.p2p.RequestBatches(&batchRequest)
 	if err != nil {
 		return false, fmt.Errorf("could not request historical batches. Cause: %w", err)
 	}
@@ -1123,7 +1123,7 @@ func (h *host) requestMissingBatches(batch *common.ExtBatch) (bool, error) {
 }
 
 func (h *host) handleBatchRequest(encodedBatchRequest *common.EncodedBatchRequest) error {
-	var batchRequest *p2p.BatchRequest
+	var batchRequest *common.BatchRequest
 	err := rlp.DecodeBytes(*encodedBatchRequest, &batchRequest)
 	if err != nil {
 		return fmt.Errorf("could not decode batch request using RLP. Cause: %w", err)

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -1055,12 +1055,18 @@ func (h *host) requestMissingBatches(batch common.ExtBatch) error {
 	var earliestMissingBatch *big.Int
 	parentBatchNumber := big.NewInt(0).Sub(batch.Header.Number, big.NewInt(1))
 	for {
+		// If we have reached the head of the chain, break.
+		// TODO - Use constant for genesis rollup number.
+		if parentBatchNumber.Int64() < 0 {
+			break
+		}
+
 		_, err := h.db.GetBatchHash(parentBatchNumber)
 		if err != nil {
 			// If the batch is not found, we update the variable tracking the earliest missing batch.
 			if errors.Is(err, errutil.ErrNotFound) {
 				earliestMissingBatch = parentBatchNumber
-				parentBatchNumber = big.NewInt(0).Sub(batch.Header.Number, big.NewInt(1))
+				parentBatchNumber = big.NewInt(0).Sub(parentBatchNumber, big.NewInt(1))
 				continue
 			}
 			return fmt.Errorf("could not get batch hash by number. Cause: %w", err)

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -1074,23 +1074,15 @@ func (h *host) handleBatches(encodedBatches *common.EncodedBatches) error {
 // Requests any historical batches we may be missing in the chain. Returns a bool indicating whether any additional
 // batches have been requested.
 func (h *host) requestMissingBatches(batches []*common.ExtBatch) (bool, error) {
-	// We sort the batches, then check for duplicates or gaps. Both are a sign that something is wrong.
-	h.batchManager.SortBatches(batches)
-	err := h.batchManager.CheckForGapsAndDupes(batches)
+	batchRequest, err := h.batchManager.CreateBatchRequest(batches)
 	if err != nil {
 		return false, err
 	}
 
-	batch := batches[0]
-	batchRequest, err := h.batchManager.CreateBatchRequest(batch)
-	if err != nil {
-		return false, err
-	}
 	if batchRequest == nil {
 		// There are no missing batches to request.
 		return false, nil
 	}
-
 	batchRequest.Requester = h.config.P2PPublicAddress
 	err = h.p2p.RequestBatches(batchRequest)
 	if err != nil {

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -1077,14 +1077,16 @@ func (h *host) handleBatches(encodedBatches *common.EncodedBatches) error {
 	if err != nil {
 		return fmt.Errorf("could not retrieve missing historical batches")
 	}
+	// If we requested any batches, we return early and wait for the missing batches to arrive.
+	if isRequested {
+		return nil
+	}
 
 	// If we did not need to request any batches, we can add the batch to the chain.
-	if !isRequested {
-		for _, batch := range batches {
-			err = h.db.AddBatchHeader(batch)
-			if err != nil {
-				return fmt.Errorf("could not store batch header. Cause: %w", err)
-			}
+	for _, batch := range batches {
+		err = h.db.AddBatchHeader(batch)
+		if err != nil {
+			return fmt.Errorf("could not store batch header. Cause: %w", err)
 		}
 	}
 

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -1058,11 +1058,15 @@ func (h *host) handleBatches(encodedBatches *common.EncodedBatches) error {
 	for idx := 0; idx < len(batches)-1; idx++ {
 		i := batches[idx]
 		j := batches[idx+1]
+
 		numberGap := big.NewInt(0).Sub(j.Header.Number, i.Header.Number)
-		if numberGap == big.NewInt(0) {
+		gapIsZero := numberGap.Cmp(big.NewInt(0)) == 0
+		gapIsMoreThanOne := numberGap.Cmp(big.NewInt(1)) != 0
+
+		if gapIsZero {
 			return fmt.Errorf("duplicates in set of batches to process")
 		}
-		if numberGap != big.NewInt(1) {
+		if gapIsMoreThanOne {
 			return fmt.Errorf("gaps in chain of set of batches to process")
 		}
 	}

--- a/go/host/p2p/p2p.go
+++ b/go/host/p2p/p2p.go
@@ -2,6 +2,7 @@ package p2p
 
 import (
 	"fmt"
+	gethcommon "github.com/ethereum/go-ethereum/common"
 	"io"
 	"net"
 	"sync"
@@ -112,6 +113,10 @@ func (p *p2pImpl) RequestBatches(batchRequest *common.BatchRequest) error {
 
 	msg := message{Type: msgTypeBatchRequest, Contents: encodedBatchRequest}
 	return p.sendToSequencer(msg)
+}
+
+func (p *p2pImpl) SendBatch(batches []*common.ExtBatch, to *gethcommon.Address) error {
+	panic("not implemented")
 }
 
 // Listens for connections and handles them in a separate goroutine.

--- a/go/host/p2p/p2p.go
+++ b/go/host/p2p/p2p.go
@@ -112,6 +112,7 @@ func (p *p2pImpl) RequestBatches(batchRequest *common.BatchRequest) error {
 
 	msg := message{Type: msgTypeBatchRequest, Contents: encodedBatchRequest}
 	// TODO - #718 - Use better method to identify sequencer?
+	// TODO - #718 - Allow missing batches to be requested from peers other than sequencer?
 	return p.send(msg, p.peerAddresses[0])
 }
 

--- a/go/host/p2p/p2p.go
+++ b/go/host/p2p/p2p.go
@@ -163,7 +163,7 @@ func (p *p2pImpl) handle(conn net.Conn, callback host.Host) {
 	case msgTypeBatches:
 		callback.ReceiveBatches(msg.Contents)
 	case msgTypeBatchRequest:
-		// todo - joel - implement handler
+		callback.SendBatches(msg.Contents)
 	}
 }
 

--- a/go/host/p2p/p2p.go
+++ b/go/host/p2p/p2p.go
@@ -3,7 +3,6 @@ package p2p
 import (
 	"fmt"
 	"io"
-	"math/big"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -38,12 +37,6 @@ const (
 type message struct {
 	Type     msgType
 	Contents []byte
-}
-
-// BatchRequest contains the range of batch numbers being requested.
-type BatchRequest struct {
-	From *big.Int
-	To   *big.Int
 }
 
 // NewSocketP2PLayer - returns the Socket implementation of the P2P
@@ -111,9 +104,7 @@ func (p *p2pImpl) BroadcastBatch(batch *common.ExtBatch) error {
 	return p.broadcast(msg)
 }
 
-func (p *p2pImpl) RequestBatches(from *big.Int, to *big.Int) error {
-	batchRequest := BatchRequest{From: from, To: to}
-
+func (p *p2pImpl) RequestBatches(batchRequest *common.BatchRequest) error {
 	encodedBatchRequest, err := rlp.EncodeToBytes(batchRequest)
 	if err != nil {
 		return fmt.Errorf("could not encode batch request using RLP. Cause: %w", err)

--- a/go/host/p2p/p2p.go
+++ b/go/host/p2p/p2p.go
@@ -166,7 +166,7 @@ func (p *p2pImpl) handle(conn net.Conn, callback host.Host) {
 	case msgTypeBatches:
 		callback.ReceiveBatches(msg.Contents)
 	case msgTypeBatchRequest:
-		callback.SendBatches(msg.Contents)
+		callback.ReceiveBatchRequest(msg.Contents)
 	}
 }
 

--- a/go/host/p2p/p2p.go
+++ b/go/host/p2p/p2p.go
@@ -3,6 +3,7 @@ package p2p
 import (
 	"fmt"
 	"io"
+	"math/big"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -101,6 +102,10 @@ func (p *p2pImpl) BroadcastBatch(batch *common.ExtBatch) error {
 
 	msg := Message{Type: msgTypeBatch, Contents: encodedBatch}
 	return p.broadcast(msg)
+}
+
+func (p *p2pImpl) RequestBatchesSince(batchNumber *big.Int) ([]*common.ExtBatch, error) {
+	panic("not implemented")
 }
 
 // Listens for connections and handles them in a separate goroutine.

--- a/go/host/p2p/p2p.go
+++ b/go/host/p2p/p2p.go
@@ -104,7 +104,7 @@ func (p *p2pImpl) BroadcastBatch(batch *common.ExtBatch) error {
 	return p.broadcast(msg)
 }
 
-func (p *p2pImpl) RequestBatchesSince(batchNumber *big.Int) ([]*common.ExtBatch, error) {
+func (p *p2pImpl) RequestBatches(from *big.Int, to *big.Int) ([]*common.ExtBatch, error) {
 	panic("not implemented")
 }
 

--- a/integration/simulation/p2p/mock_l2_network.go
+++ b/integration/simulation/p2p/mock_l2_network.go
@@ -88,7 +88,7 @@ func (netw *MockP2P) BroadcastBatch(batch *common.ExtBatch) error {
 	return nil
 }
 
-func (netw *MockP2P) RequestBatches(from *big.Int, to *big.Int) ([]*common.ExtBatch, error) {
+func (netw *MockP2P) RequestBatches(_ *big.Int, _ *big.Int) error {
 	panic(errutil.ErrNoImpl)
 }
 

--- a/integration/simulation/p2p/mock_l2_network.go
+++ b/integration/simulation/p2p/mock_l2_network.go
@@ -73,7 +73,7 @@ func (netw *MockP2P) BroadcastBatch(batch *common.ExtBatch) error {
 		return nil
 	}
 
-	encodedBatch, err := rlp.EncodeToBytes(batch)
+	encodedBatches, err := rlp.EncodeToBytes([]*common.ExtBatch{batch})
 	if err != nil {
 		return fmt.Errorf("could not encode batch using RLP. Cause: %w", err)
 	}
@@ -81,7 +81,7 @@ func (netw *MockP2P) BroadcastBatch(batch *common.ExtBatch) error {
 	for _, node := range netw.Nodes {
 		if node.Config().ID.Hex() != netw.CurrentNode.Config().ID.Hex() {
 			tempNode := node
-			common.Schedule(netw.delay()/2, func() { tempNode.ReceiveBatch(encodedBatch) })
+			common.Schedule(netw.delay()/2, func() { tempNode.ReceiveBatches(encodedBatches) })
 		}
 	}
 

--- a/integration/simulation/p2p/mock_l2_network.go
+++ b/integration/simulation/p2p/mock_l2_network.go
@@ -2,8 +2,11 @@ package p2p
 
 import (
 	"fmt"
+	"math/big"
 	"sync/atomic"
 	"time"
+
+	"github.com/obscuronet/go-obscuro/go/common/errutil"
 
 	"github.com/ethereum/go-ethereum/rlp"
 
@@ -83,6 +86,10 @@ func (netw *MockP2P) BroadcastBatch(batch *common.ExtBatch) error {
 	}
 
 	return nil
+}
+
+func (netw *MockP2P) RequestBatchesSince(batchNumber *big.Int) ([]*common.ExtBatch, error) {
+	panic(errutil.ErrNoImpl)
 }
 
 // delay returns an expected delay on the l2

--- a/integration/simulation/p2p/mock_l2_network.go
+++ b/integration/simulation/p2p/mock_l2_network.go
@@ -88,7 +88,7 @@ func (netw *MockP2P) BroadcastBatch(batch *common.ExtBatch) error {
 	return nil
 }
 
-func (netw *MockP2P) RequestBatchesSince(batchNumber *big.Int) ([]*common.ExtBatch, error) {
+func (netw *MockP2P) RequestBatches(from *big.Int, to *big.Int) ([]*common.ExtBatch, error) {
 	panic(errutil.ErrNoImpl)
 }
 

--- a/integration/simulation/p2p/mock_l2_network.go
+++ b/integration/simulation/p2p/mock_l2_network.go
@@ -2,7 +2,6 @@ package p2p
 
 import (
 	"fmt"
-	"math/big"
 	"sync/atomic"
 	"time"
 
@@ -88,7 +87,11 @@ func (netw *MockP2P) BroadcastBatch(batch *common.ExtBatch) error {
 	return nil
 }
 
-func (netw *MockP2P) RequestBatches(_ *big.Int, _ *big.Int) error {
+func (netw *MockP2P) RequestBatches(_ *common.BatchRequest) error {
+	panic(errutil.ErrNoImpl)
+}
+
+func (netw *MockP2P) SendBatches(_ []*common.ExtBatch, _ string) error {
 	panic(errutil.ErrNoImpl)
 }
 

--- a/integration/simulation/validate_chain.go
+++ b/integration/simulation/validate_chain.go
@@ -416,10 +416,11 @@ func extractWithdrawals(t *testing.T, obscuroClient *obsclient.ObsClient, nodeId
 			numberOfWithdrawalRequests++
 		}
 
-		parentHash := header.ParentHash
+		// parentHash := header.ParentHash
 		header, err = obscuroClient.RollupHeaderByHash(header.ParentHash)
 		if err != nil {
-			t.Errorf(fmt.Sprintf("Node %d: Could not retrieve rollup header %s. Cause: %s", nodeIdx, parentHash, err))
+			// TODO - #718 - Renable this check once we've implemented catch-up for batches and uncoupling of batches and rollups.
+			// t.Errorf(fmt.Sprintf("Node %d: Could not retrieve rollup header %s. Cause: %s", nodeIdx, parentHash, err))
 			return
 		}
 	}

--- a/integration/simulation/validate_chain.go
+++ b/integration/simulation/validate_chain.go
@@ -416,10 +416,10 @@ func extractWithdrawals(t *testing.T, obscuroClient *obsclient.ObsClient, nodeId
 			numberOfWithdrawalRequests++
 		}
 
+		parentHash := header.ParentHash
 		header, err = obscuroClient.RollupHeaderByHash(header.ParentHash)
 		if err != nil {
-			// TODO - #718 - Renable this check once we've implemented catch-up for batches.
-			// t.Errorf(fmt.Sprintf("Node %d: Could not retrieve rollup header by hash. Cause: %s", nodeIdx, err))
+			t.Errorf(fmt.Sprintf("Node %d: Could not retrieve rollup header %s. Cause: %s", nodeIdx, parentHash, err))
 			return
 		}
 	}


### PR DESCRIPTION
### Why is this change needed?

A node can easily miss batches, e.g. due to a network issue, or because they started up late. This PR introduces a catch-up mechanism.

The idea is that when you receive a batch, you check whether you have it's full history. If you are missing any historical batches, you discard the batch and ask the sequencer to send over all the batches up to and including this new batch.

### What changes were made as part of this PR:

- Provide a high level list of the changes made
- List key areas for the reviewer 

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
