### PR TITLE
simplify blockprovider process control to use context

### DIFF
--- a/go/ethadapter/blockprovider.go
+++ b/go/ethadapter/blockprovider.go
@@ -32,7 +32,7 @@ type EthBlockProvider struct {
 	ethClient     EthClient
 	ctx           context.Context
 	logger        gethlog.Logger
-	cancelRunning context.CancelFunc // if this is not nil it kills the latest running goroutine
+	cancelRunning context.CancelFunc // if this is not nil it kills the currently running goroutine
 
 	// the state of the block provider
 	latestSent *types.Header // most recently sent block (reset to nil when a `StartStreaming...` method is called)
@@ -51,7 +51,7 @@ func (e *EthBlockProvider) StartStreamingFromHash(latestHash gethcommon.Hash) (<
 // StartStreamingFromHeight will (re)start streaming from the given height, closing out any existing stream channel and
 // returning the fresh channel - the next block will be the requested height
 func (e *EthBlockProvider) StartStreamingFromHeight(height *big.Int) (<-chan *types.Block, error) {
-	// make sure we stop any running stream
+	// make sure we stop the running stream if there is one
 	e.Stop()
 
 	// block heights start at 1
@@ -66,6 +66,7 @@ func (e *EthBlockProvider) StartStreamingFromHeight(height *big.Int) (<-chan *ty
 	return streamCh, nil
 }
 
+// Stop resets the state of the BlockProvider ready to start streaming again
 func (e *EthBlockProvider) Stop() {
 	if e.cancelRunning != nil {
 		e.cancelRunning()

--- a/go/ethadapter/blockprovider_test.go
+++ b/go/ethadapter/blockprovider_test.go
@@ -70,11 +70,9 @@ func setupBlockProvider(mockEthClient EthClient) (EthBlockProvider, context.Canc
 
 	logger := log.New(log.HostCmp, int(gethlog.LvlInfo), log.SysOut, log.NodeIDKey, "test")
 	blockProvider := EthBlockProvider{
-		ethClient:     mockEthClient,
-		ctx:           ctx,
-		runningStatus: new(int32),
-		streamCh:      make(chan *types.Block),
-		logger:        logger,
+		ethClient: mockEthClient,
+		ctx:       ctx,
+		logger:    logger,
 	}
 	return blockProvider, cancelCtx
 }


### PR DESCRIPTION
### Why is this change needed?

- Blockprovider manages a goroutine that is responsible for streaming out the blocks to its client
- When client requests a new stream the old stream dies and the process is restarted with a clean stream channel
- There were bugs with the goroutine controlling mechanism in block provider
- And it was confusing to understand

### What changes were made as part of this PR:

- Replace the atomic status changes to use a context-based approach to stopping the streaming goroutine

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
