### PR TITLE
Use block provider as source of L1 blocks in host

### DIFF
--- a/go/common/host/host.go
+++ b/go/common/host/host.go
@@ -36,18 +36,6 @@ type Host interface {
 	HealthCheck() (bool, error)
 }
 
-// MockHost extends Host with additional methods that are only used for integration testing.
-// todo - remove this interface
-type MockHost interface {
-	Host
-
-	// MockedNewHead receives the notification of new blocks.
-	// TODO - Remove this method.
-	MockedNewHead(b common.EncodedL1Block, p common.EncodedL1Block)
-	// MockedNewFork receives the notification of a new fork.
-	MockedNewFork(b []common.EncodedL1Block)
-}
-
 // P2P is the layer responsible for sending and receiving messages to Obscuro network peers.
 type P2P interface {
 	StartListening(callback Host)

--- a/go/common/host/host.go
+++ b/go/common/host/host.go
@@ -60,8 +60,8 @@ type P2P interface {
 //     \-> 13b --> 14b --> 15b
 //     If block provider had just published 14a and then discovered the 'b' fork is canonical, it would next publish 13b, 14b, 15b.
 type ReconnectingBlockProvider interface {
-	StartStreamingFromHeight(height *big.Int) (<-chan *types.Block, error)
-	StartStreamingFromHash(latestHash gethcommon.Hash) (<-chan *types.Block, error)
-	Stop()
+	// StartStreamingFromHeight and StartStreamingFromHash return the streaming channel and a function to cancel/clean-up the stream with
+	StartStreamingFromHeight(height *big.Int) (<-chan *types.Block, func(), error)
+	StartStreamingFromHash(latestHash gethcommon.Hash) (<-chan *types.Block, func(), error)
 	IsLive(hash gethcommon.Hash) bool // returns true if hash is of the latest known L1 head block
 }

--- a/go/common/host/host.go
+++ b/go/common/host/host.go
@@ -61,7 +61,12 @@ type P2P interface {
 //     If block provider had just published 14a and then discovered the 'b' fork is canonical, it would next publish 13b, 14b, 15b.
 type ReconnectingBlockProvider interface {
 	// StartStreamingFromHeight and StartStreamingFromHash return the streaming channel and a function to cancel/clean-up the stream with
-	StartStreamingFromHeight(height *big.Int) (<-chan *types.Block, func(), error)
-	StartStreamingFromHash(latestHash gethcommon.Hash) (<-chan *types.Block, func(), error)
+	StartStreamingFromHeight(height *big.Int) (*BlockStream, error)
+	StartStreamingFromHash(latestHash gethcommon.Hash) (*BlockStream, error)
 	IsLive(hash gethcommon.Hash) bool // returns true if hash is of the latest known L1 head block
+}
+
+type BlockStream struct {
+	Stream <-chan *types.Block // the channel which will receive the consecutive, canonical blocks
+	Stop   func()              // function to permanently stop the stream and clean up any associated processes/resources
 }

--- a/go/enclave/events/subscription_manager.go
+++ b/go/enclave/events/subscription_manager.go
@@ -121,13 +121,12 @@ func (s *SubscriptionManager) GetFilteredLogs(account *gethcommon.Address, filte
 	for {
 		blockHashes = append(blockHashes, currentBlock.Hash())
 
-		if currentBlock.NumberU64() <= common.L1GenesisHeight {
-			break // We have reached the end of the chain.
-		}
-
 		parentHash := currentBlock.ParentHash()
 		currentBlock, err = s.storage.FetchBlock(parentHash)
 		if err != nil {
+			if errors.Is(err, errutil.ErrNotFound) {
+				break // we have reached the beginning of the known chain
+			}
 			return nil, fmt.Errorf("could not retrieve block %s to extract its logs. Cause: %w", parentHash, err)
 		}
 	}

--- a/go/ethadapter/blockprovider.go
+++ b/go/ethadapter/blockprovider.go
@@ -19,60 +19,41 @@ const (
 
 var one = big.NewInt(1)
 
-func NewEthBlockProvider(ctx context.Context, ethClient EthClient, logger gethlog.Logger) *EthBlockProvider {
+func NewEthBlockProvider(ethClient EthClient, logger gethlog.Logger) *EthBlockProvider {
 	return &EthBlockProvider{
 		ethClient: ethClient,
-		ctx:       ctx,
 		logger:    logger,
 	}
 }
 
 // EthBlockProvider streams blocks from the ethereum L1 client in the order expected by the enclave (consecutive, canonical blocks)
 type EthBlockProvider struct {
-	ethClient     EthClient
-	ctx           context.Context
-	logger        gethlog.Logger
-	cancelRunning context.CancelFunc // if this is not nil it kills the currently running goroutine
-
-	// the state of the block provider
-	latestSent *types.Header // most recently sent block (reset to nil when a `StartStreaming...` method is called)
+	ethClient EthClient
+	logger    gethlog.Logger
 }
 
 // StartStreamingFromHash will look up the hash block, find the appropriate height (LCA if there have been forks) and
 // then call StartStreamingFromHeight based on that
-func (e *EthBlockProvider) StartStreamingFromHash(latestHash gethcommon.Hash) (<-chan *types.Block, error) {
+func (e *EthBlockProvider) StartStreamingFromHash(latestHash gethcommon.Hash) (<-chan *types.Block, func(), error) {
 	ancestorBlk, err := e.latestCanonAncestor(latestHash)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	return e.StartStreamingFromHeight(increment(ancestorBlk.Number()))
 }
 
-// StartStreamingFromHeight will (re)start streaming from the given height, closing out any existing stream channel and
-// returning the fresh channel - the next block will be the requested height
-func (e *EthBlockProvider) StartStreamingFromHeight(height *big.Int) (<-chan *types.Block, error) {
-	// make sure we stop the running stream if there is one
-	e.Stop()
-
+// StartStreamingFromHeight will start streaming from the given height
+// returning the fresh channel (the next block will be the requested height) and a cancel function to kill the stream
+func (e *EthBlockProvider) StartStreamingFromHeight(height *big.Int) (<-chan *types.Block, func(), error) {
 	// block heights start at 1
 	if height.Cmp(one) < 0 {
 		height = one
 	}
+	ctx, cancel := context.WithCancel(context.Background())
 	streamCh := make(chan *types.Block)
-	streamCtx, cancel := context.WithCancel(e.ctx)
-	e.cancelRunning = cancel
-	go e.streamBlocks(streamCtx, height, streamCh)
+	go e.streamBlocks(ctx, height, streamCh)
 
-	return streamCh, nil
-}
-
-// Stop resets the state of the BlockProvider ready to start streaming again
-func (e *EthBlockProvider) Stop() {
-	if e.cancelRunning != nil {
-		e.cancelRunning()
-		e.cancelRunning = nil
-		e.latestSent = nil
-	}
+	return streamCh, cancel, nil
 }
 
 func (e *EthBlockProvider) IsLive(h gethcommon.Hash) bool {
@@ -86,13 +67,15 @@ func (e *EthBlockProvider) IsLive(h gethcommon.Hash) bool {
 // - publishing a block, it blocks on the outbound channel until the block is consumed
 // - awaiting a live block, when consumer is completely up-to-date it waits for a live block to arrive
 func (e *EthBlockProvider) streamBlocks(ctx context.Context, fromHeight *big.Int, streamCh chan *types.Block) {
+	var latestSent *types.Header // most recently sent block (reset to nil when a `StartStreaming...` method is called)
+
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		default:
 			// this will block if we're up-to-date with live blocks
-			block, err := e.fetchNextCanonicalBlock(fromHeight)
+			block, err := e.fetchNextCanonicalBlock(ctx, fromHeight, latestSent)
 			if err != nil {
 				e.logger.Error("unexpected error while preparing block to stream, will retry in 1 sec", log.ErrKey, err)
 				time.Sleep(time.Second)
@@ -101,21 +84,21 @@ func (e *EthBlockProvider) streamBlocks(ctx context.Context, fromHeight *big.Int
 			e.logger.Trace("blockProvider streaming block", "height", block.Number(), "hash", block.Hash())
 			streamCh <- block // we block here until consumer takes it
 			// update stream state
-			e.latestSent = block.Header()
+			latestSent = block.Header()
 		}
 	}
 }
 
 // fetchNextCanonicalBlock finds the next block to send downstream to the consumer.
 // It looks at:
-//   - the latest block that was sent to the consumer (`e.latestSent`)
+//   - the latest block that was sent to the consumer (`latestSent`)
 //   - the current head of the L1 according to the Eth client (`l1Block`)
 //
 // If the consumer is up-to-date: this method will wait until a new block arrives from the L1
 // If the consumer is behind or there has been a fork: it returns the next canonical block that the consumer needs to see (no waiting)
-func (e *EthBlockProvider) fetchNextCanonicalBlock(fromHeight *big.Int) (*types.Block, error) {
+func (e *EthBlockProvider) fetchNextCanonicalBlock(ctx context.Context, fromHeight *big.Int, latestSent *types.Header) (*types.Block, error) {
 	// check for the initial case, when consumer has first requested a stream
-	if e.latestSent == nil {
+	if latestSent == nil {
 		// we try to return the canonical block at the height requested
 		blk, err := e.ethClient.BlockByNumber(fromHeight)
 		if err != nil {
@@ -131,17 +114,17 @@ func (e *EthBlockProvider) fetchNextCanonicalBlock(fromHeight *big.Int) (*types.
 	l1Head := l1Block.Header()
 
 	// check if the block provider is already up-to-date with the latest L1 block (if it is, then wait for a new block)
-	if l1Head.Hash() == e.latestSent.Hash() {
+	if l1Head.Hash() == latestSent.Hash() {
 		var err error
 		// block provider's current head is up-to-date, we will wait for the next L1 block to arrive
-		l1Head, err = e.awaitNewBlock()
+		l1Head, err = e.awaitNewBlock(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("no new block found from stream - %w", err)
 		}
 	}
 
 	// most common path should be: new head block that arrived is the next block, and needs to be sent
-	if l1Head.ParentHash == e.latestSent.Hash() {
+	if l1Head.ParentHash == latestSent.Hash() {
 		blk, err := e.ethClient.BlockByHash(l1Head.Hash())
 		if err != nil {
 			return nil, fmt.Errorf("could not fetch block with hash=%s - %w", l1Head.Hash(), err)
@@ -150,9 +133,9 @@ func (e *EthBlockProvider) fetchNextCanonicalBlock(fromHeight *big.Int) (*types.
 	}
 
 	// and if not then, we walk back up the tree from the current head, to find the most recent **canonical** block we sent
-	latestCanon, err := e.latestCanonAncestor(e.latestSent.Hash())
+	latestCanon, err := e.latestCanonAncestor(latestSent.Hash())
 	if err != nil {
-		return nil, fmt.Errorf("could not find ancestor on canonical chain for hash=%s - %w", e.latestSent.Hash(), err)
+		return nil, fmt.Errorf("could not find ancestor on canonical chain for hash=%s - %w", latestSent.Hash(), err)
 	}
 
 	// and send the canonical block at the height after that
@@ -181,7 +164,7 @@ func (e *EthBlockProvider) latestCanonAncestor(blkHash gethcommon.Hash) (*types.
 
 // awaitNewBlock will block, waiting for the next live L1 block from the L1 client.
 // It is used when the block provider is up-to-date and waiting for a new block to forward to its consumer.
-func (e *EthBlockProvider) awaitNewBlock() (*types.Header, error) {
+func (e *EthBlockProvider) awaitNewBlock(ctx context.Context) (*types.Header, error) {
 	liveStream, streamSub := e.ethClient.BlockListener()
 
 	for {
@@ -191,7 +174,7 @@ func (e *EthBlockProvider) awaitNewBlock() (*types.Header, error) {
 			streamSub.Unsubscribe()
 			return blkHead, nil
 
-		case <-e.ctx.Done():
+		case <-ctx.Done():
 			return nil, fmt.Errorf("context closed before block was received")
 
 		case err := <-streamSub.Err():

--- a/go/ethadapter/blockprovider.go
+++ b/go/ethadapter/blockprovider.go
@@ -19,10 +19,10 @@ const (
 
 var one = big.NewInt(1)
 
-func NewEthBlockProvider(ethClient EthClient, logger gethlog.Logger) *EthBlockProvider {
+func NewEthBlockProvider(ctx context.Context, ethClient EthClient, logger gethlog.Logger) *EthBlockProvider {
 	return &EthBlockProvider{
 		ethClient: ethClient,
-		ctx:       context.TODO(),
+		ctx:       ctx,
 		logger:    logger,
 	}
 }

--- a/go/ethadapter/blockprovider_test.go
+++ b/go/ethadapter/blockprovider_test.go
@@ -19,18 +19,18 @@ import (
 
 func TestBlockProviderHappyPath_LiveStream(t *testing.T) {
 	mockEthClient := mockEthClient(3)
-	blockProvider, ctxCancel := setupBlockProvider(mockEthClient)
-	defer ctxCancel()
+	blockProvider := setupBlockProvider(mockEthClient)
 
 	blkStream, err := blockProvider.StartStreamingFromHeight(big.NewInt(3))
 	if err != nil {
 		t.Error(err)
 	}
+	defer blkStream.Stop()
 	blkCount := 0
 
 	for blkCount < 3 {
 		select {
-		case blk := <-blkStream:
+		case blk := <-blkStream.Stream:
 			if blk != nil {
 				blkCount++
 			}
@@ -43,18 +43,18 @@ func TestBlockProviderHappyPath_LiveStream(t *testing.T) {
 
 func TestBlockProviderHappyPath_HistoricThenStream(t *testing.T) {
 	mockEthClient := mockEthClient(3)
-	blockProvider, ctxCancel := setupBlockProvider(mockEthClient)
-	defer ctxCancel()
+	blockProvider := setupBlockProvider(mockEthClient)
 
 	blkStream, err := blockProvider.StartStreamingFromHeight(big.NewInt(1))
 	if err != nil {
 		t.Error(err)
 	}
+	defer blkStream.Stop()
 	blkCount := 0
 
 	for blkCount < 3 {
 		select {
-		case blk := <-blkStream:
+		case blk := <-blkStream.Stream:
 			if blk != nil {
 				blkCount++
 			}
@@ -65,16 +65,13 @@ func TestBlockProviderHappyPath_HistoricThenStream(t *testing.T) {
 	}
 }
 
-func setupBlockProvider(mockEthClient EthClient) (EthBlockProvider, context.CancelFunc) {
-	ctx, cancelCtx := context.WithCancel(context.Background())
-
+func setupBlockProvider(mockEthClient EthClient) EthBlockProvider {
 	logger := log.New(log.HostCmp, int(gethlog.LvlInfo), log.SysOut, log.NodeIDKey, "test")
 	blockProvider := EthBlockProvider{
 		ethClient: mockEthClient,
-		ctx:       ctx,
 		logger:    logger,
 	}
-	return blockProvider, cancelCtx
+	return blockProvider
 }
 
 func mockEthClient(liveStreamingStart int) EthClient {

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -399,7 +399,7 @@ func (h *host) startProcessing() {
 		select {
 		case b := <-blockStream:
 			roundInterrupt = triggerInterrupt(roundInterrupt)
-			err := h.processL1Block(b, true) // h.l1BlockProvider.IsLive(b.Hash()))
+			err := h.processL1Block(b, h.l1BlockProvider.IsLive(b.Hash()))
 			// handle the error, replace the blockStream if necessary (e.g. if stream needs resetting based on enclave's reported L1 head)
 			blockStream = h.handleProcessBlockErr(b, blockStream, err)
 

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -399,7 +399,8 @@ func (h *host) startProcessing() {
 		select {
 		case b := <-blockStream:
 			roundInterrupt = triggerInterrupt(roundInterrupt)
-			err := h.processL1Block(b, h.l1BlockProvider.IsLive(b.Hash()))
+			// todo: fix this to use `h.l1BlockProvider.IsLive(b.Hash())` instead of hardcoded true (triggers timing issues in in-mem sim)
+			err := h.processL1Block(b, true)
 			// handle the error, replace the blockStream if necessary (e.g. if stream needs resetting based on enclave's reported L1 head)
 			blockStream = h.handleProcessBlockErr(b, blockStream, err)
 

--- a/integration/common/testlog/testlog.go
+++ b/integration/common/testlog/testlog.go
@@ -44,7 +44,7 @@ func Setup(cfg *Cfg) *os.File {
 	}
 	logFile = f.Name()
 	// hardcode geth log level to error only
-	gethlog.Root().SetHandler(gethlog.LvlFilterHandler(gethlog.LvlInfo, gethlog.StreamHandler(f, gethlog.TerminalFormat(false))))
+	gethlog.Root().SetHandler(gethlog.LvlFilterHandler(gethlog.LvlTrace, gethlog.StreamHandler(f, gethlog.TerminalFormat(false))))
 	testlog = gethlog.Root().New(log.CmpKey, log.TestLogCmp)
 	return f
 }

--- a/integration/common/testlog/testlog.go
+++ b/integration/common/testlog/testlog.go
@@ -44,7 +44,7 @@ func Setup(cfg *Cfg) *os.File {
 	}
 	logFile = f.Name()
 	// hardcode geth log level to error only
-	gethlog.Root().SetHandler(gethlog.LvlFilterHandler(gethlog.LvlTrace, gethlog.StreamHandler(f, gethlog.TerminalFormat(false))))
+	gethlog.Root().SetHandler(gethlog.LvlFilterHandler(gethlog.LvlInfo, gethlog.StreamHandler(f, gethlog.TerminalFormat(false))))
 	testlog = gethlog.Root().New(log.CmpKey, log.TestLogCmp)
 	return f
 }

--- a/integration/ethereummock/mock_l1_network.go
+++ b/integration/ethereummock/mock_l1_network.go
@@ -50,7 +50,7 @@ func (n *MockEthNetwork) BroadcastBlock(b common.EncodedL1Block, p common.Encode
 			t := m
 			common.Schedule(n.delay(), func() { t.P2PReceiveBlock(b, p) })
 		} else {
-			m.logger.Info(printBlock(bl, *m))
+			m.logger.Info(printBlock(bl, m))
 		}
 	}
 
@@ -75,7 +75,7 @@ func (n *MockEthNetwork) delay() time.Duration {
 	return testcommon.RndBtwTime(n.avgLatency/10, 2*n.avgLatency)
 }
 
-func printBlock(b *types.Block, m Node) string {
+func printBlock(b *types.Block, m *Node) string {
 	// This is just for printing
 	var txs []string
 	for _, tx := range b.Transactions() {

--- a/integration/ethereummock/node.go
+++ b/integration/ethereummock/node.go
@@ -8,6 +8,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/obscuronet/go-obscuro/go/common/errutil"
 
 	"github.com/obscuronet/go-obscuro/go/common/gethutil"
@@ -50,20 +52,15 @@ type StatsCollector interface {
 	L1Reorg(id gethcommon.Address)
 }
 
-type NotifyNewBlock interface {
-	MockedNewHead(b common.EncodedL1Block, p common.EncodedL1Block)
-	MockedNewFork(b []common.EncodedL1Block)
-}
-
 type Node struct {
 	l2ID     gethcommon.Address // the address of the Obscuro node this client is dedicated to
 	cfg      MiningConfig
-	clients  []NotifyNewBlock
 	Network  L1Network
 	mining   bool
 	stats    StatsCollector
 	Resolver db.BlockResolver
 	db       TxDB
+	subs     map[uuid.UUID]*mockSubscription // active subscription for mock blocks
 
 	// Channels
 	exitCh       chan bool // the Node stops
@@ -100,9 +97,16 @@ func (m *Node) Nonce(gethcommon.Address) (uint64, error) {
 	return 0, nil
 }
 
-// BlockListener is not used in the mock
+// BlockListener provides stream of latest mock head headers as they are created
 func (m *Node) BlockListener() (chan *types.Header, ethereum.Subscription) {
-	return make(chan *types.Header), &mockSubscription{}
+	id := uuid.New()
+	mockSub := &mockSubscription{
+		node:   m,
+		id:     id,
+		headCh: make(chan *types.Header),
+	}
+	m.subs[id] = mockSub
+	return mockSub.headCh, mockSub
 }
 
 func (m *Node) BlockNumber() (uint64, error) {
@@ -261,26 +265,10 @@ func (m *Node) setHead(b *types.Block) *types.Block {
 		return b
 	}
 
-	// notify the clients
-	for _, c := range m.clients {
-		t := c
-		encodedBlock, err := common.EncodeBlock(b)
-		if err != nil {
-			panic(fmt.Errorf("could not encode block. Cause: %w", err))
-		}
-		if b.NumberU64() == common.L1GenesisHeight {
-			go t.MockedNewHead(encodedBlock, nil)
-		} else {
-			p, err := m.Resolver.ParentBlock(b)
-			if err != nil {
-				panic(fmt.Errorf("could not retrieve parent. Cause: %w", err))
-			}
-			encodedParentBlock, err := common.EncodeBlock(p)
-			if err != nil {
-				panic(fmt.Errorf("could not encode parent block. Cause: %w", err))
-			}
-			go t.MockedNewHead(encodedBlock, encodedParentBlock)
-		}
+	// notify the client subscriptions
+	for _, s := range m.subs {
+		sub := s
+		go sub.publish(b)
 	}
 	m.canonicalCh <- b
 
@@ -293,19 +281,12 @@ func (m *Node) setFork(blocks []*types.Block) *types.Block {
 		return head
 	}
 
-	fork := make([]common.EncodedL1Block, len(blocks))
-	for i, block := range blocks {
-		encodedBlock, err := common.EncodeBlock(block)
-		if err != nil {
-			panic(fmt.Errorf("could not encode block. Cause: %w", err))
-		}
-		fork[i] = encodedBlock
+	// notify the client subs
+	for _, s := range m.subs {
+		sub := s
+		go sub.publishAll(blocks)
 	}
 
-	// notify the clients
-	for _, c := range m.clients {
-		go c.MockedNewFork(fork)
-	}
 	m.canonicalCh <- head
 
 	return head
@@ -393,10 +374,6 @@ func (m *Node) Stop() {
 	m.exitCh <- true
 }
 
-func (m *Node) AddClient(client NotifyNewBlock) {
-	m.clients = append(m.clients, client)
-}
-
 func (m *Node) BlocksBetween(blockA *types.Block, blockB *types.Block) []*types.Block {
 	if bytes.Equal(blockA.Hash().Bytes(), blockB.Hash().Bytes()) {
 		return []*types.Block{blockA}
@@ -430,6 +407,10 @@ func (m *Node) EthClient() *ethclient_ethereum.Client {
 	return nil
 }
 
+func (m *Node) RemoveSubscription(id uuid.UUID) {
+	delete(m.subs, id)
+}
+
 func NewMiner(
 	id gethcommon.Address,
 	cfg MiningConfig,
@@ -456,18 +437,31 @@ func NewMiner(
 		erc20ContractLib: NewERC20ContractLibMock(),
 		mgmtContractLib:  NewMgmtContractLibMock(),
 		logger:           log.New(log.EthereumL1Cmp, int(gethlog.LvlInfo), cfg.LogFile, log.NodeIDKey, id),
+		subs:             map[uuid.UUID]*mockSubscription{},
 	}
 }
 
 // implements the ethereum.Subscription
-type mockSubscription struct{}
+type mockSubscription struct {
+	id     uuid.UUID
+	headCh chan *types.Header
+	node   *Node // we hold a reference to the node to unsubscribe ourselves - not ideal but this is just a mock
+}
 
 func (sub *mockSubscription) Err() <-chan error {
-	c := make(chan error, 2) // size 2, so that we don't block
-	// drop an error in to this channel to remind callers that this client does not stream.
-	c <- ethadapter.ErrSubscriptionNotSupported
-	return c
+	return make(chan error)
 }
 
 func (sub *mockSubscription) Unsubscribe() {
+	sub.node.RemoveSubscription(sub.id)
+}
+
+func (sub *mockSubscription) publish(b *types.Block) {
+	sub.headCh <- b.Header()
+}
+
+func (sub *mockSubscription) publishAll(blocks []*types.Block) {
+	for _, b := range blocks {
+		sub.publish(b)
+	}
 }

--- a/integration/simulation/network/inmemory.go
+++ b/integration/simulation/network/inmemory.go
@@ -37,7 +37,7 @@ func NewBasicNetworkOfInMemoryNodes() Network {
 func (n *basicNetworkOfInMemoryNodes) Create(params *params.SimParams, stats *stats.Stats) (*RPCHandles, error) {
 	l1Clients := make([]ethadapter.EthClient, params.NumberOfNodes)
 	n.ethNodes = make([]*ethereummock.Node, params.NumberOfNodes)
-	obscuroNodes := make([]host.MockHost, params.NumberOfNodes)
+	obscuroNodes := make([]host.Host, params.NumberOfNodes)
 	n.l2Clients = make([]rpc.Client, params.NumberOfNodes)
 	p2pLayers := make([]*p2p.MockP2P, params.NumberOfNodes)
 
@@ -69,9 +69,6 @@ func (n *basicNetworkOfInMemoryNodes) Create(params *params.SimParams, stats *st
 			p2pLayers[i],
 		)
 		obscuroClient := p2p.NewInMemObscuroClient(agg)
-
-		// and connect them to each other
-		miner.AddClient(agg)
 
 		n.ethNodes[i] = miner
 		obscuroNodes[i] = agg

--- a/integration/simulation/network/network_utils.go
+++ b/integration/simulation/network/network_utils.go
@@ -71,7 +71,7 @@ func createInMemObscuroNode(
 	ethClient ethadapter.EthClient,
 	wallets *params.SimWallets,
 	mockP2P *simp2p.MockP2P,
-) commonhost.MockHost {
+) commonhost.Host {
 	hostConfig := config.HostConfig{
 		ID:                  gethcommon.BigToAddress(big.NewInt(id)),
 		IsGenesis:           isGenesis,

--- a/integration/simulation/network/obscuro_node_utils.go
+++ b/integration/simulation/network/obscuro_node_utils.go
@@ -38,7 +38,7 @@ const (
 
 func startInMemoryObscuroNodes(params *params.SimParams, genesisJSON []byte, l1Clients []ethadapter.EthClient) []rpc.Client {
 	// Create the in memory obscuro nodes, each connect each to a geth node
-	obscuroNodes := make([]host.MockHost, params.NumberOfNodes)
+	obscuroNodes := make([]host.Host, params.NumberOfNodes)
 	p2pLayers := make([]*p2p.MockP2P, params.NumberOfNodes)
 	for i := 0; i < params.NumberOfNodes; i++ {
 		isGenesis := i == 0

--- a/integration/simulation/p2p/mock_l2_network.go
+++ b/integration/simulation/p2p/mock_l2_network.go
@@ -19,7 +19,7 @@ import (
 // Will be plugged into each node
 type MockP2P struct {
 	CurrentNode host.Host
-	Nodes       []host.MockHost
+	Nodes       []host.Host
 
 	avgLatency       time.Duration
 	avgBlockDuration time.Duration


### PR DESCRIPTION
### Why is this change needed?

BlockProvider interface allows caller to stream canonical L1 blocks consecutively without having to worry about:
  * whether it is live streaming or catching-up
  * recovering from disconnects
  * getting missed blocks after a fork

The motivation for switching to it is:
- BlockProvider interface allows caller to stream from a certain block hash or height. It will allow us to start streaming from the mgmt contract deployment block instead of L1 genesis once we have configured that.
- `host.go` has too many responsibilities, this separation will reduce the code complexity in there

### What changes were made as part of this PR:

- Update the host main loop to pull blocks from block provider
- Get rid of the `bootstrap` code. The main loop works in catch-up/bootstrap situations as well as in the live streaming happy mode
- Get rid of the parent-child double feeding mechanism that was used to fix issues with accidentally missing a block when feeding the enclave
- Implement BlockListener() streaming method on the in-mem sim's mock eth client so that block provider can work smoothly
- Get rid of the `MockHost` interface and methods, the sim no longer needs to inject blocks directly to the host, they go through the block provider

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
