### PR TITLE
Revert "Use block provider as source of L1 blocks in host (#891)"

### DIFF
--- a/go/common/host/host.go
+++ b/go/common/host/host.go
@@ -36,6 +36,18 @@ type Host interface {
 	HealthCheck() (bool, error)
 }
 
+// MockHost extends Host with additional methods that are only used for integration testing.
+// todo - remove this interface
+type MockHost interface {
+	Host
+
+	// MockedNewHead receives the notification of new blocks.
+	// TODO - Remove this method.
+	MockedNewHead(b common.EncodedL1Block, p common.EncodedL1Block)
+	// MockedNewFork receives the notification of a new fork.
+	MockedNewFork(b []common.EncodedL1Block)
+}
+
 // P2P is the layer responsible for sending and receiving messages to Obscuro network peers.
 type P2P interface {
 	StartListening(callback Host)
@@ -60,13 +72,8 @@ type P2P interface {
 //     \-> 13b --> 14b --> 15b
 //     If block provider had just published 14a and then discovered the 'b' fork is canonical, it would next publish 13b, 14b, 15b.
 type ReconnectingBlockProvider interface {
-	// StartStreamingFromHeight and StartStreamingFromHash return the streaming channel and a function to cancel/clean-up the stream with
-	StartStreamingFromHeight(height *big.Int) (*BlockStream, error)
-	StartStreamingFromHash(latestHash gethcommon.Hash) (*BlockStream, error)
+	StartStreamingFromHeight(height *big.Int) (<-chan *types.Block, error)
+	StartStreamingFromHash(latestHash gethcommon.Hash) (<-chan *types.Block, error)
+	Stop()
 	IsLive(hash gethcommon.Hash) bool // returns true if hash is of the latest known L1 head block
-}
-
-type BlockStream struct {
-	Stream <-chan *types.Block // the channel which will receive the consecutive, canonical blocks
-	Stop   func()              // function to permanently stop the stream and clean up any associated processes/resources
 }

--- a/go/enclave/events/subscription_manager.go
+++ b/go/enclave/events/subscription_manager.go
@@ -121,12 +121,13 @@ func (s *SubscriptionManager) GetFilteredLogs(account *gethcommon.Address, filte
 	for {
 		blockHashes = append(blockHashes, currentBlock.Hash())
 
+		if currentBlock.NumberU64() <= common.L1GenesisHeight {
+			break // We have reached the end of the chain.
+		}
+
 		parentHash := currentBlock.ParentHash()
 		currentBlock, err = s.storage.FetchBlock(parentHash)
 		if err != nil {
-			if errors.Is(err, errutil.ErrNotFound) {
-				break // we have reached the beginning of the known chain
-			}
 			return nil, fmt.Errorf("could not retrieve block %s to extract its logs. Cause: %w", parentHash, err)
 		}
 	}

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -8,8 +8,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	gethcommon "github.com/ethereum/go-ethereum/common"
-
 	"github.com/ethereum/go-ethereum/rlp"
 
 	hostcommon "github.com/obscuronet/go-obscuro/go/common/host"
@@ -31,6 +29,8 @@ import (
 
 	"github.com/obscuronet/go-obscuro/go/common/log"
 
+	"github.com/ethereum/go-ethereum"
+	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/naoina/toml"
 	"github.com/obscuronet/go-obscuro/go/common"
@@ -60,24 +60,26 @@ const (
 
 // Implementation of host.Host.
 type host struct {
-	config          config.HostConfig
-	shortID         uint64
-	isSequencer     bool
-	genesisRequired bool
+	config      config.HostConfig
+	shortID     uint64
+	isSequencer bool
 
 	p2p           hostcommon.P2P       // For communication with other Obscuro nodes
 	ethClient     ethadapter.EthClient // For communication with the L1 node
 	enclaveClient common.Enclave       // For communication with the enclave
 	rpcServer     clientrpc.Server     // For communication with Obscuro client applications
 
+	blockProvider hostcommon.ReconnectingBlockProvider
+
 	// control the host lifecycle
 	exitHostCh            chan bool
 	stopHostInterrupt     *int32
 	bootstrappingComplete *int32 // Marks when the host is done bootstrapping
 
-	l1BlockProvider hostcommon.ReconnectingBlockProvider
-	txP2PCh         chan common.EncryptedTx  // The channel that new transactions from peers are sent to
-	batchP2PCh      chan common.EncodedBatch // The channel that new batches from peers are sent to
+	l1BlockRPCCh chan l1BlockAndParent        // The channel that new blocks from the L1 node are sent to
+	forkRPCCh    chan []common.EncodedL1Block // The channel that new forks from the L1 node are sent to
+	txP2PCh      chan common.EncryptedTx      // The channel that new transactions from peers are sent to
+	batchP2PCh   chan common.EncodedBatch     // The channel that new batches from peers are sent to
 
 	db *db.DB // Stores the host's publicly-available data
 
@@ -88,15 +90,7 @@ type host struct {
 	logger gethlog.Logger
 }
 
-func NewHost(
-	config config.HostConfig,
-	p2p hostcommon.P2P,
-	ethClient ethadapter.EthClient,
-	enclaveClient common.Enclave,
-	ethWallet wallet.Wallet,
-	mgmtContractLib mgmtcontractlib.MgmtContractLib,
-	logger gethlog.Logger,
-) hostcommon.Host {
+func NewHost(config config.HostConfig, p2p hostcommon.P2P, ethClient ethadapter.EthClient, enclaveClient common.Enclave, ethWallet wallet.Wallet, mgmtContractLib mgmtcontractlib.MgmtContractLib, logger gethlog.Logger) hostcommon.MockHost {
 	host := &host{
 		// config
 		config:      config,
@@ -107,6 +101,7 @@ func NewHost(
 		p2p:           p2p,
 		ethClient:     ethClient,
 		enclaveClient: enclaveClient,
+		blockProvider: ethadapter.NewEthBlockProvider(ethClient, logger),
 
 		// lifecycle channels
 		exitHostCh:            make(chan bool),
@@ -114,9 +109,10 @@ func NewHost(
 		bootstrappingComplete: new(int32),
 
 		// incoming data
-		l1BlockProvider: ethadapter.NewEthBlockProvider(ethClient, logger),
-		txP2PCh:         make(chan common.EncryptedTx),
-		batchP2PCh:      make(chan common.EncodedBatch),
+		l1BlockRPCCh: make(chan l1BlockAndParent),
+		forkRPCCh:    make(chan []common.EncodedL1Block),
+		txP2PCh:      make(chan common.EncryptedTx),
+		batchP2PCh:   make(chan common.EncodedBatch),
 
 		// Initialize the host DB
 		// nodeDB:       NewLevelDBBackedDB(), // todo - make this config driven
@@ -211,10 +207,23 @@ func (h *host) Start() {
 		}
 	}
 
+	// attach the l1 monitor
+	go h.monitorBlocks()
+
+	// bootstrap the host
+	latestL1Block := h.bootstrapHost()
+
+	// start the enclave speculative work from last L1 block
+	err = h.enclaveClient.Start(latestL1Block)
+	if err != nil {
+		h.logger.Crit("Could not start the enclave.", log.ErrKey, err.Error())
+	}
+
 	if h.config.IsGenesis {
-		// the genesis node gets a flag set on it until it has published the genesis block
-		// todo: handle genesis separately as an initial step for the genesis node
-		h.genesisRequired = true
+		_, err = h.initialiseProtocol(&latestL1Block)
+		if err != nil {
+			h.logger.Crit("Could not bootstrap.", log.ErrKey, err.Error())
+		}
 	}
 	// start the obscuro RPC endpoints
 	if h.rpcServer != nil {
@@ -272,6 +281,14 @@ func (h *host) DB() *db.DB {
 
 func (h *host) EnclaveClient() common.Enclave {
 	return h.enclaveClient
+}
+
+func (h *host) MockedNewHead(b common.EncodedL1Block, p common.EncodedL1Block) {
+	h.l1BlockRPCCh <- l1BlockAndParent{b, p}
+}
+
+func (h *host) MockedNewFork(b []common.EncodedL1Block) {
+	h.forkRPCCh <- b
 }
 
 func (h *host) SubmitAndBroadcastTx(encryptedParams common.EncryptedParamsSendRawTx) (common.EncryptedResponseSendRawTx, error) {
@@ -335,6 +352,9 @@ func (h *host) Stop() {
 		// connection remains open, waiting for the RPC server to close.
 		go h.rpcServer.Stop()
 	}
+	if h.blockProvider != nil {
+		go h.blockProvider.Stop()
+	}
 
 	// Leave some time for all processing to finish before exiting the main loop.
 	time.Sleep(time.Second)
@@ -373,15 +393,10 @@ func (h *host) waitForEnclave() {
 }
 
 // starts the host main processing loop
-func (h *host) startProcessing() {
+// todo: matt to fix this complexity `nolint` in next PR with block provider
+func (h *host) startProcessing() { //nolint:gocognit
+	// Only open the p2p connection when the host is fully initialised
 	h.p2p.StartListening(h)
-
-	// The blockStream channel is a stream of consecutive, canonical blocks. BlockStream may be replaced with a new
-	// stream ch during the main loop if enclave gets out-of-sync, and we need to stream from an earlier block
-	blockStream, err := h.l1BlockProvider.StartStreamingFromHeight(big.NewInt(1))
-	if err != nil {
-		h.logger.Crit("unable to stream l1 blocks for enclave", log.ErrKey, err)
-	}
 
 	// use the roundInterrupt as a signaling mechanism for interrupting block processing
 	// stops processing the current round if a new block arrives
@@ -393,23 +408,44 @@ func (h *host) startProcessing() {
 	// - Process new Transactions gossiped from L2 Peers
 	for {
 		select {
-		case b := <-blockStream.Stream:
+		case blockAndParent := <-h.l1BlockRPCCh:
 			roundInterrupt = triggerInterrupt(roundInterrupt)
-			isLive := h.l1BlockProvider.IsLive(b.Hash()) // checks whether the block is the current head of the L1 (false if there is a newer block available)
-			err := h.processL1Block(b, isLive)
+			err := h.processL1Block(blockAndParent.parent, false)
 			if err != nil {
-				// handle the error, replace the blockStream if necessary (e.g. if stream needs resetting based on enclave's reported L1 head)
-				blockStream = h.handleProcessBlockErr(b, blockStream, err)
+				var rejErr *common.BlockRejectError
+				if errors.As(err, &rejErr) {
+					// this is a common error (the parent has usually already been processed and is being sent just in case)
+					h.logger.Debug("Rejected parent block.", log.ErrKey, rejErr, "enclaveHead", rejErr.L1Head)
+				} else {
+					h.logger.Info("Could not process parent block. ", log.ErrKey, err)
+				}
+			}
+			err = h.processL1Block(blockAndParent.block, true)
+			if err != nil {
+				var rejErr *common.BlockRejectError
+				if errors.As(err, &rejErr) {
+					h.logger.Info("Rejected latest block.", log.ErrKey, rejErr, "enclaveHead", rejErr.L1Head)
+				} else {
+					h.logger.Warn("Could not process latest block.", log.ErrKey, err)
+				}
+			}
+
+		case f := <-h.forkRPCCh:
+			roundInterrupt = triggerInterrupt(roundInterrupt)
+			for i, blk := range f {
+				isLatest := i == (len(f) - 1)
+				err := h.processL1Block(blk, isLatest)
+				if err != nil && isLatest {
+					h.logger.Warn("Could not process latest fork block received via RPC.", log.ErrKey, err)
+				}
 			}
 
 		case tx := <-h.txP2PCh:
-			// todo: discard p2p messages if enclave won't be able to make use of them (e.g. we're way behind L1 head)
 			if _, err := h.enclaveClient.SubmitTx(tx); err != nil {
 				h.logger.Warn("Could not submit transaction. ", log.ErrKey, err)
 			}
 
 		case batch := <-h.batchP2PCh:
-			// todo: discard p2p messages if enclave won't be able to make use of them (e.g. we're way behind L1 head)
 			if err := h.handleBatch(&batch); err != nil {
 				h.logger.Error("Could not handle batch. ", log.ErrKey, err)
 			}
@@ -420,29 +456,6 @@ func (h *host) startProcessing() {
 	}
 }
 
-func (h *host) handleProcessBlockErr(processedBlock *types.Block, stream *hostcommon.BlockStream, err error) *hostcommon.BlockStream {
-	var rejErr *common.BlockRejectError
-	if !errors.As(err, &rejErr) {
-		// received unexpected error (no useful information from the enclave)
-		// we log it out and ignore it until the enclave tells us more information
-		h.logger.Warn("Error processing block.", log.ErrKey, err)
-		return stream
-	}
-	h.logger.Info("Block rejected by enclave.", log.ErrKey, rejErr, "blk", processedBlock.Hash(), "blkHeight", processedBlock.Number())
-	if rejErr.L1Head == (gethcommon.Hash{}) {
-		h.logger.Warn("No L1 head information provided by enclave, continuing with existing stream")
-		return stream
-	}
-	h.logger.Info("Resetting block provider stream to enclave latest head.", "streamFrom", rejErr.L1Head)
-	replacementStream, err := h.l1BlockProvider.StartStreamingFromHash(rejErr.L1Head)
-	if err != nil {
-		h.logger.Warn("Could not reset block provider, continuing with previous stream", log.ErrKey, err)
-		return stream
-	}
-	stream.Stop() // cancel the previous stream and return the replacement
-	return replacementStream
-}
-
 // activates the given interrupt (atomically) and returns a new interrupt
 func triggerInterrupt(interrupt *int32) *int32 {
 	// Notify the previous round to stop work
@@ -451,19 +464,30 @@ func triggerInterrupt(interrupt *int32) *int32 {
 	return &i
 }
 
-func (h *host) processL1Block(block *types.Block, isLatestBlock bool) error {
+type l1BlockAndParent struct {
+	block  common.EncodedL1Block
+	parent common.EncodedL1Block
+}
+
+func (h *host) processL1Block(block common.EncodedL1Block, isLatestBlock bool) error {
 	// For the genesis block the parent is nil
 	if block == nil {
 		return nil
 	}
 
-	h.processL1BlockTransactions(block)
+	var result *common.BlockSubmissionResponse
+
+	decodedBlock, err := block.DecodeBlock()
+	if err != nil {
+		return err
+	}
+	h.processL1BlockTransactions(decodedBlock)
 
 	// submit each block to the enclave for ingestion plus validation
 	// todo: isLatest should only be true when we're not behind
-	result, err := h.enclaveClient.SubmitL1Block(*block, isLatestBlock)
+	result, err = h.enclaveClient.SubmitL1Block(*decodedBlock, isLatestBlock)
 	if err != nil {
-		return fmt.Errorf("did not ingest block b_%d. Cause: %w", common.ShortHash(block.Hash()), err)
+		return fmt.Errorf("did not ingest block b_%d. Cause: %w", common.ShortHash(decodedBlock.Hash()), err)
 	}
 
 	err = h.storeBlockProcessingResult(result)
@@ -485,20 +509,11 @@ func (h *host) processL1Block(block *types.Block, isLatestBlock bool) error {
 		}
 	}
 
+	if result.ProducedRollup.Header == nil {
+		return nil
+	}
+
 	if isLatestBlock {
-		if h.genesisRequired {
-			err := h.initialiseProtocol(block)
-			if err != nil {
-				h.logger.Crit("Could not initialise protocol.", log.ErrKey, err)
-			}
-			h.genesisRequired = false
-			return nil // nothing further to process since network had no genesis
-		}
-
-		if result.ProducedRollup.Header == nil {
-			return nil
-		}
-
 		// TODO - #718 - Unlink rollup production from L1 cadence.
 		h.publishRollup(result.ProducedRollup)
 		// TODO - #718 - Unlink batch production from L1 cadence.
@@ -578,11 +593,11 @@ func (h *host) storeBlockProcessingResult(result *common.BlockSubmissionResponse
 }
 
 // Called only by the first enclave to bootstrap the network
-func (h *host) initialiseProtocol(block *types.Block) error {
-	// Create the genesis rollup
+func (h *host) initialiseProtocol(block *types.Block) (common.L2RootHash, error) {
+	// Create the genesis rollup.
 	genesisResponse, err := h.enclaveClient.ProduceGenesis(block.Hash())
 	if err != nil {
-		return fmt.Errorf("could not produce genesis. Cause: %w", err)
+		return common.L2RootHash{}, fmt.Errorf("could not produce genesis. Cause: %w", err)
 	}
 	h.logger.Info(
 		fmt.Sprintf("Initialising network. Genesis rollup r_%d.",
@@ -596,7 +611,7 @@ func (h *host) initialiseProtocol(block *types.Block) error {
 	// Submit the rollup to the management contract.
 	encodedRollup, err := common.EncodeRollup(producedRollup)
 	if err != nil {
-		return fmt.Errorf("could not encode rollup. Cause: %w", err)
+		return common.L2RootHash{}, fmt.Errorf("could not encode rollup. Cause: %w", err)
 	}
 	l1tx := &ethadapter.L1RollupTx{
 		Rollup: encodedRollup,
@@ -604,10 +619,10 @@ func (h *host) initialiseProtocol(block *types.Block) error {
 	rollupTx := h.mgmtContractLib.CreateRollup(l1tx, h.ethWallet.GetNonceAndIncrement())
 	err = h.signAndBroadcastL1Tx(rollupTx, l1TxTriesRollup)
 	if err != nil {
-		return fmt.Errorf("could not initialise protocol. Cause: %w", err)
+		return common.L2RootHash{}, fmt.Errorf("could not initialise protocol. Cause: %w", err)
 	}
 
-	return nil
+	return genesisResponse.ProducedRollup.Header.ParentHash, nil
 }
 
 // `tries` is the number of times to attempt broadcasting the transaction.
@@ -689,6 +704,7 @@ func (h *host) requestSecret() error {
 	if err != nil {
 		h.logger.Crit("could not receive the secret", log.ErrKey, err)
 	}
+	h.logger.Info("§§§ Secret received")
 	return nil
 }
 
@@ -779,18 +795,204 @@ func (h *host) processSharedSecretResponse(_ *ethadapter.L1RespondSecretTx) erro
 	return nil
 }
 
+// monitors the L1 client for new blocks and injects them into the aggregator
+func (h *host) monitorBlocks() {
+	var lastKnownBlkHash gethcommon.Hash
+	listener, subs := h.ethClient.BlockListener()
+	h.logger.Info("Start monitoring Ethereum blocks..")
+
+	// only process blocks if the host is running
+	for atomic.LoadInt32(h.stopHostInterrupt) == 0 {
+		select {
+		case err := <-subs.Err():
+			if errors.Is(err, ethadapter.ErrSubscriptionNotSupported) {
+				// there will never be a block from this monitor process, we can abandon it
+				return
+			}
+			h.logger.Error("L1 block monitoring error", log.ErrKey, err)
+			h.logger.Info("Restarting L1 block Monitoring...")
+			// it's fine to immediately restart the listener, any incoming blocks will be on hold in the queue
+			listener, subs = h.ethClient.BlockListener()
+
+			err = h.catchupMissedBlocks(lastKnownBlkHash)
+			if err != nil {
+				h.logger.Crit("could not catch up missed blocks.", log.ErrKey, err)
+			}
+
+		case blkHeader := <-listener:
+			// don't process blocks if the host is stopping
+			if atomic.LoadInt32(h.stopHostInterrupt) == 1 {
+				break
+			}
+
+			// ignore blocks if bootstrapping is happening
+			if atomic.LoadInt32(h.bootstrappingComplete) == 0 {
+				h.logger.Trace(fmt.Sprintf("Host in bootstrap - ignoring block %s", blkHeader.Hash()))
+				continue
+			}
+
+			block, err := h.ethClient.BlockByHash(blkHeader.Hash())
+			if err != nil {
+				h.logger.Crit(fmt.Sprintf("could not fetch block for hash %s.", blkHeader.Hash().String()), log.ErrKey, err)
+			}
+			blockParent, err := h.ethClient.BlockByHash(block.ParentHash())
+			if err != nil {
+				h.logger.Crit(fmt.Sprintf("could not fetch block's parent with hash %s.", block.ParentHash().String()), log.ErrKey, err)
+			}
+
+			h.logger.Info(fmt.Sprintf(
+				"Received a new block b_%d(%d)",
+				common.ShortHash(blkHeader.Hash()),
+				blkHeader.Number.Uint64(),
+			))
+
+			// issue the block to the ingestion channel
+			err = h.encodeAndIngest(block, blockParent)
+			if err != nil {
+				h.logger.Crit("Internal error", log.ErrKey, err)
+			}
+			lastKnownBlkHash = block.Hash()
+		}
+	}
+
+	h.logger.Info("Stopped monitoring for l1 blocks")
+	// make sure it cleanly unsubscribes
+	// todo this should be defered when the errors are upstreamed instead of panic'd
+	subs.Unsubscribe()
+}
+
+func (h *host) catchupMissedBlocks(lastKnownBlkHash gethcommon.Hash) error {
+	var lastBlkNumber *big.Int
+	var reingestBlocks []*types.Block
+
+	// get the blockchain tip block
+	blk, err := h.ethClient.BlockByNumber(lastBlkNumber)
+	if err != nil {
+		return fmt.Errorf("catching up on missed blocks, unable to fetch tip block - reason: %w", err)
+	}
+
+	if blk.Hash().Hex() == lastKnownBlkHash.Hex() {
+		// if no new blocks have been issued then nothing to catchup
+		return nil
+	}
+	reingestBlocks = append(reingestBlocks, blk)
+
+	// get all blocks from the blockchain tip to the last block ingested by the host
+	for blk.Hash().Hex() != lastKnownBlkHash.Hex() {
+		blockParent, err := h.ethClient.BlockByHash(blk.ParentHash())
+		if err != nil {
+			return fmt.Errorf("catching up on missed blocks, could not fetch block's parent with hash %s. Cause: %w", blk.ParentHash(), err)
+		}
+
+		reingestBlocks = append(reingestBlocks, blockParent)
+		blk = blockParent
+	}
+
+	// make sure to have the last ingested block available for ingestion (because we always ingest ( blk, blk_parent)
+	lastKnownBlk, err := h.ethClient.BlockByHash(lastKnownBlkHash)
+	if err != nil {
+		return fmt.Errorf("catching up on missed blocks, unable to feth last known block - reason: %w", err)
+	}
+	reingestBlocks = append(reingestBlocks, lastKnownBlk)
+
+	// issue the block to the ingestion channel in reverse, with the parent attached too
+	for i := len(reingestBlocks) - 2; i >= 0; i-- {
+		h.logger.Debug(fmt.Sprintf("Ingesting %s and %s blocks of %v", reingestBlocks[i].Hash(), reingestBlocks[i+1].Hash(), reingestBlocks))
+		err = h.encodeAndIngest(reingestBlocks[i], reingestBlocks[i+1])
+		if err != nil {
+			h.logger.Crit("Internal error", log.ErrKey, err)
+		}
+	}
+
+	return nil
+}
+
+func (h *host) encodeAndIngest(block *types.Block, blockParent *types.Block) error {
+	encodedBlock, err := common.EncodeBlock(block)
+	if err != nil {
+		return fmt.Errorf("could not encode block with hash %s. Cause: %w", block.Hash().String(), err)
+	}
+
+	encodedBlockParent, err := common.EncodeBlock(blockParent)
+	if err != nil {
+		return fmt.Errorf("could not encode block's parent with hash %s. Cause: %w", block.ParentHash().String(), err)
+	}
+
+	h.l1BlockRPCCh <- l1BlockAndParent{encodedBlock, encodedBlockParent}
+	return nil
+}
+
+func (h *host) bootstrapHost() types.Block {
+	var err error
+	var nextBlk *types.Block
+
+	// build up from the genesis block
+	// todo update to bootstrap from the last block in storage
+	// todo the genesis block should be the block where the contract was deployed
+	currentL1Block, err := h.ethClient.BlockByNumber(big.NewInt(0))
+	if err != nil {
+		h.logger.Crit("Internal error", log.ErrKey, err)
+	}
+
+	h.logger.Info(fmt.Sprintf("Started host bootstrap with block %d", currentL1Block.NumberU64()))
+
+	startTime, logTime := time.Now(), time.Now()
+	for {
+		cb := *currentL1Block
+		h.processL1BlockTransactions(&cb)
+		result, err := h.enclaveClient.SubmitL1Block(cb, false)
+		if err != nil {
+			var bsErr *common.BlockRejectError
+			isBSE := errors.As(err, &bsErr)
+			if !isBSE {
+				// unexpected error
+				h.logger.Crit("Internal error", log.ErrKey, err)
+			}
+			// todo: we need to use the latest hash info from the BlockRejectError to realign the block streaming for the enclave
+			h.logger.Info(fmt.Sprintf("Failed to ingest block b_%d. Cause: %s",
+				common.ShortHash(result.BlockHeader.Hash()), bsErr))
+		} else {
+			// submission was successful
+			err := h.storeBlockProcessingResult(result)
+			if err != nil {
+				h.logger.Crit("Could not store block processing result", log.ErrKey, err)
+			}
+		}
+
+		nextBlk, err = h.ethClient.BlockByNumber(big.NewInt(cb.Number().Int64() + 1))
+		if err != nil {
+			if errors.Is(err, ethereum.NotFound) {
+				break
+			}
+			h.logger.Crit("Internal error", log.ErrKey, err)
+		}
+		currentL1Block = nextBlk
+
+		if time.Since(logTime) > 30*time.Second {
+			h.logger.Info(fmt.Sprintf("Bootstrapping host at block... %d", cb.NumberU64()))
+			logTime = time.Now()
+		}
+	}
+	atomic.StoreInt32(h.bootstrappingComplete, 1)
+	h.logger.Info(fmt.Sprintf("Finished bootstrap process with block %d after %s",
+		currentL1Block.NumberU64(),
+		time.Since(startTime),
+	))
+	return *currentL1Block
+}
+
 func (h *host) awaitSecret(fromHeight *big.Int) error {
-	blkStream, err := h.l1BlockProvider.StartStreamingFromHeight(fromHeight)
+	blkStream, err := h.blockProvider.StartStreamingFromHeight(fromHeight)
 	if err != nil {
 		return err
 	}
-	defer blkStream.Stop()
 
 	for {
 		select {
-		case blk := <-blkStream.Stream:
+		case blk := <-blkStream:
 			h.logger.Trace("checking block for secret resp", "height", blk.Number())
 			if h.checkBlockForSecretResponse(blk) {
+				h.blockProvider.Stop()
 				return nil
 			}
 
@@ -799,6 +1001,7 @@ func (h *host) awaitSecret(fromHeight *big.Int) error {
 			h.logger.Warn(fmt.Sprintf(" Waiting for secret from the L1. No blocks received for over %s", blockStreamWarningTimeout))
 
 		case <-h.exitHostCh:
+			h.blockProvider.Stop()
 			return nil
 		}
 	}

--- a/integration/ethereummock/mock_l1_network.go
+++ b/integration/ethereummock/mock_l1_network.go
@@ -50,7 +50,7 @@ func (n *MockEthNetwork) BroadcastBlock(b common.EncodedL1Block, p common.Encode
 			t := m
 			common.Schedule(n.delay(), func() { t.P2PReceiveBlock(b, p) })
 		} else {
-			m.logger.Info(printBlock(bl, m))
+			m.logger.Info(printBlock(bl, *m))
 		}
 	}
 
@@ -75,7 +75,7 @@ func (n *MockEthNetwork) delay() time.Duration {
 	return testcommon.RndBtwTime(n.avgLatency/10, 2*n.avgLatency)
 }
 
-func printBlock(b *types.Block, m *Node) string {
+func printBlock(b *types.Block, m Node) string {
 	// This is just for printing
 	var txs []string
 	for _, tx := range b.Transactions() {

--- a/integration/ethereummock/node.go
+++ b/integration/ethereummock/node.go
@@ -5,11 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"sync"
 	"sync/atomic"
 	"time"
-
-	"github.com/google/uuid"
 
 	"github.com/obscuronet/go-obscuro/go/common/errutil"
 
@@ -53,16 +50,20 @@ type StatsCollector interface {
 	L1Reorg(id gethcommon.Address)
 }
 
+type NotifyNewBlock interface {
+	MockedNewHead(b common.EncodedL1Block, p common.EncodedL1Block)
+	MockedNewFork(b []common.EncodedL1Block)
+}
+
 type Node struct {
 	l2ID     gethcommon.Address // the address of the Obscuro node this client is dedicated to
 	cfg      MiningConfig
+	clients  []NotifyNewBlock
 	Network  L1Network
 	mining   bool
 	stats    StatsCollector
 	Resolver db.BlockResolver
 	db       TxDB
-	subs     map[uuid.UUID]*mockSubscription // active subscription for mock blocks
-	subMu    sync.Mutex
 
 	// Channels
 	exitCh       chan bool // the Node stops
@@ -99,18 +100,9 @@ func (m *Node) Nonce(gethcommon.Address) (uint64, error) {
 	return 0, nil
 }
 
-// BlockListener provides stream of latest mock head headers as they are created
+// BlockListener is not used in the mock
 func (m *Node) BlockListener() (chan *types.Header, ethereum.Subscription) {
-	id := uuid.New()
-	mockSub := &mockSubscription{
-		node:   m,
-		id:     id,
-		headCh: make(chan *types.Header),
-	}
-	m.subMu.Lock()
-	defer m.subMu.Unlock()
-	m.subs[id] = mockSub
-	return mockSub.headCh, mockSub
+	return make(chan *types.Header), &mockSubscription{}
 }
 
 func (m *Node) BlockNumber() (uint64, error) {
@@ -269,10 +261,26 @@ func (m *Node) setHead(b *types.Block) *types.Block {
 		return b
 	}
 
-	// notify the client subscriptions
-	for _, s := range m.subs {
-		sub := s
-		go sub.publish(b)
+	// notify the clients
+	for _, c := range m.clients {
+		t := c
+		encodedBlock, err := common.EncodeBlock(b)
+		if err != nil {
+			panic(fmt.Errorf("could not encode block. Cause: %w", err))
+		}
+		if b.NumberU64() == common.L1GenesisHeight {
+			go t.MockedNewHead(encodedBlock, nil)
+		} else {
+			p, err := m.Resolver.ParentBlock(b)
+			if err != nil {
+				panic(fmt.Errorf("could not retrieve parent. Cause: %w", err))
+			}
+			encodedParentBlock, err := common.EncodeBlock(p)
+			if err != nil {
+				panic(fmt.Errorf("could not encode parent block. Cause: %w", err))
+			}
+			go t.MockedNewHead(encodedBlock, encodedParentBlock)
+		}
 	}
 	m.canonicalCh <- b
 
@@ -285,12 +293,19 @@ func (m *Node) setFork(blocks []*types.Block) *types.Block {
 		return head
 	}
 
-	// notify the client subs
-	for _, s := range m.subs {
-		sub := s
-		go sub.publishAll(blocks)
+	fork := make([]common.EncodedL1Block, len(blocks))
+	for i, block := range blocks {
+		encodedBlock, err := common.EncodeBlock(block)
+		if err != nil {
+			panic(fmt.Errorf("could not encode block. Cause: %w", err))
+		}
+		fork[i] = encodedBlock
 	}
 
+	// notify the clients
+	for _, c := range m.clients {
+		go c.MockedNewFork(fork)
+	}
 	m.canonicalCh <- head
 
 	return head
@@ -378,6 +393,10 @@ func (m *Node) Stop() {
 	m.exitCh <- true
 }
 
+func (m *Node) AddClient(client NotifyNewBlock) {
+	m.clients = append(m.clients, client)
+}
+
 func (m *Node) BlocksBetween(blockA *types.Block, blockB *types.Block) []*types.Block {
 	if bytes.Equal(blockA.Hash().Bytes(), blockB.Hash().Bytes()) {
 		return []*types.Block{blockA}
@@ -411,12 +430,6 @@ func (m *Node) EthClient() *ethclient_ethereum.Client {
 	return nil
 }
 
-func (m *Node) RemoveSubscription(id uuid.UUID) {
-	m.subMu.Lock()
-	defer m.subMu.Unlock()
-	delete(m.subs, id)
-}
-
 func NewMiner(
 	id gethcommon.Address,
 	cfg MiningConfig,
@@ -443,32 +456,18 @@ func NewMiner(
 		erc20ContractLib: NewERC20ContractLibMock(),
 		mgmtContractLib:  NewMgmtContractLibMock(),
 		logger:           log.New(log.EthereumL1Cmp, int(gethlog.LvlInfo), cfg.LogFile, log.NodeIDKey, id),
-		subs:             map[uuid.UUID]*mockSubscription{},
-		subMu:            sync.Mutex{},
 	}
 }
 
 // implements the ethereum.Subscription
-type mockSubscription struct {
-	id     uuid.UUID
-	headCh chan *types.Header
-	node   *Node // we hold a reference to the node to unsubscribe ourselves - not ideal but this is just a mock
-}
+type mockSubscription struct{}
 
 func (sub *mockSubscription) Err() <-chan error {
-	return make(chan error)
+	c := make(chan error, 2) // size 2, so that we don't block
+	// drop an error in to this channel to remind callers that this client does not stream.
+	c <- ethadapter.ErrSubscriptionNotSupported
+	return c
 }
 
 func (sub *mockSubscription) Unsubscribe() {
-	sub.node.RemoveSubscription(sub.id)
-}
-
-func (sub *mockSubscription) publish(b *types.Block) {
-	sub.headCh <- b.Header()
-}
-
-func (sub *mockSubscription) publishAll(blocks []*types.Block) {
-	for _, b := range blocks {
-		sub.publish(b)
-	}
 }

--- a/integration/simulation/network/inmemory.go
+++ b/integration/simulation/network/inmemory.go
@@ -37,7 +37,7 @@ func NewBasicNetworkOfInMemoryNodes() Network {
 func (n *basicNetworkOfInMemoryNodes) Create(params *params.SimParams, stats *stats.Stats) (*RPCHandles, error) {
 	l1Clients := make([]ethadapter.EthClient, params.NumberOfNodes)
 	n.ethNodes = make([]*ethereummock.Node, params.NumberOfNodes)
-	obscuroNodes := make([]host.Host, params.NumberOfNodes)
+	obscuroNodes := make([]host.MockHost, params.NumberOfNodes)
 	n.l2Clients = make([]rpc.Client, params.NumberOfNodes)
 	p2pLayers := make([]*p2p.MockP2P, params.NumberOfNodes)
 
@@ -69,6 +69,9 @@ func (n *basicNetworkOfInMemoryNodes) Create(params *params.SimParams, stats *st
 			p2pLayers[i],
 		)
 		obscuroClient := p2p.NewInMemObscuroClient(agg)
+
+		// and connect them to each other
+		miner.AddClient(agg)
 
 		n.ethNodes[i] = miner
 		obscuroNodes[i] = agg

--- a/integration/simulation/network/network_utils.go
+++ b/integration/simulation/network/network_utils.go
@@ -71,7 +71,7 @@ func createInMemObscuroNode(
 	ethClient ethadapter.EthClient,
 	wallets *params.SimWallets,
 	mockP2P *simp2p.MockP2P,
-) commonhost.Host {
+) commonhost.MockHost {
 	hostConfig := config.HostConfig{
 		ID:                  gethcommon.BigToAddress(big.NewInt(id)),
 		IsGenesis:           isGenesis,

--- a/integration/simulation/network/obscuro_node_utils.go
+++ b/integration/simulation/network/obscuro_node_utils.go
@@ -38,7 +38,7 @@ const (
 
 func startInMemoryObscuroNodes(params *params.SimParams, genesisJSON []byte, l1Clients []ethadapter.EthClient) []rpc.Client {
 	// Create the in memory obscuro nodes, each connect each to a geth node
-	obscuroNodes := make([]host.Host, params.NumberOfNodes)
+	obscuroNodes := make([]host.MockHost, params.NumberOfNodes)
 	p2pLayers := make([]*p2p.MockP2P, params.NumberOfNodes)
 	for i := 0; i < params.NumberOfNodes; i++ {
 		isGenesis := i == 0

--- a/integration/simulation/p2p/mock_l2_network.go
+++ b/integration/simulation/p2p/mock_l2_network.go
@@ -19,7 +19,7 @@ import (
 // Will be plugged into each node
 type MockP2P struct {
 	CurrentNode host.Host
-	Nodes       []host.Host
+	Nodes       []host.MockHost
 
 	avgLatency       time.Duration
 	avgBlockDuration time.Duration


### PR DESCRIPTION
This reverts commit 2e59cdbd1ece8e624fcb2d45fd37e0da29d726f7.

### Why is this change needed?

- Seems to be causing test failures intermittently, don't want to slow the team down so will fix it and re-raise

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
