### PR TITLE
Log error if no peers list yet to send batch request to

### DIFF
--- a/go/host/p2p/p2p.go
+++ b/go/host/p2p/p2p.go
@@ -1,6 +1,7 @@
 package p2p
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -105,6 +106,9 @@ func (p *p2pImpl) BroadcastBatch(batch *common.ExtBatch) error {
 }
 
 func (p *p2pImpl) RequestBatches(batchRequest *common.BatchRequest) error {
+	if len(p.peerAddresses) == 0 {
+		return errors.New("no peers available to request batches")
+	}
 	encodedBatchRequest, err := rlp.EncodeToBytes(batchRequest)
 	if err != nil {
 		return fmt.Errorf("could not encode batch request using RLP. Cause: %w", err)


### PR DESCRIPTION
### Why is this change needed?

-If batches are getting processed before peers list has been updated (or peers list becomes empty for any reason) we don't want to see panics like this:
```
panic: runtime error: index out of range [0] with length 0

goroutine 313 [running]:
github.com/obscuronet/go-obscuro/go/host/p2p.(*p2pImpl).RequestBatches(0xc00048c780, 0xc0010a64a0?)
    /Users/joeldudley/Desktop/go-obscuro/go/host/p2p/p2p.go:116 +0xb0
```

The nature of the batch catch-up (batchup, if you will) is that it will recover later on if and when peers are available.

The reason this becomes an issue after my PR is that we jump straight into the main loop and we want to be resilient for the inputs for whatever state the host is in.

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
