### PR TITLE
Fix blockprovider integration bugs (pre-genesis and returning to prev fork)

### DIFF
--- a/go/common/host/host.go
+++ b/go/common/host/host.go
@@ -38,18 +38,6 @@ type Host interface {
 	HealthCheck() (bool, error)
 }
 
-// MockHost extends Host with additional methods that are only used for integration testing.
-// todo - remove this interface
-type MockHost interface {
-	Host
-
-	// MockedNewHead receives the notification of new blocks.
-	// TODO - Remove this method.
-	MockedNewHead(b common.EncodedL1Block, p common.EncodedL1Block)
-	// MockedNewFork receives the notification of a new fork.
-	MockedNewFork(b []common.EncodedL1Block)
-}
-
 // P2P is the layer responsible for sending and receiving messages to Obscuro network peers.
 type P2P interface {
 	StartListening(callback Host)
@@ -80,8 +68,13 @@ type P2P interface {
 //     \-> 13b --> 14b --> 15b
 //     If block provider had just published 14a and then discovered the 'b' fork is canonical, it would next publish 13b, 14b, 15b.
 type ReconnectingBlockProvider interface {
-	StartStreamingFromHeight(height *big.Int) (<-chan *types.Block, error)
-	StartStreamingFromHash(latestHash gethcommon.Hash) (<-chan *types.Block, error)
-	Stop()
+	// StartStreamingFromHeight and StartStreamingFromHash return the streaming channel and a function to cancel/clean-up the stream with
+	StartStreamingFromHeight(height *big.Int) (*BlockStream, error)
+	StartStreamingFromHash(latestHash gethcommon.Hash) (*BlockStream, error)
 	IsLive(hash gethcommon.Hash) bool // returns true if hash is of the latest known L1 head block
+}
+
+type BlockStream struct {
+	Stream <-chan *types.Block // the channel which will receive the consecutive, canonical blocks
+	Stop   func()              // function to permanently stop the stream and clean up any associated processes/resources
 }

--- a/go/enclave/db/interfaces.go
+++ b/go/enclave/db/interfaces.go
@@ -16,8 +16,10 @@ import (
 type BlockResolver interface {
 	// FetchBlock returns the L1 Block with the given hash.
 	FetchBlock(blockHash common.L1RootHash) (*types.Block, error)
-	// StoreBlock persists the L1 Block
-	StoreBlock(block *types.Block)
+	// StoreL1HeadBlock stores L1 blocks (which should only be stored when they are the head of the chain that is known to the enclave)
+	StoreL1HeadBlock(block *types.Block) error
+	// SetL1Head sets the L1 canonical head to the given block (used if block has already been ingested but head has rewound/moved)
+	SetL1Head(block gethcommon.Hash) error
 	// ParentBlock returns the L1 Block's parent.
 	ParentBlock(block *types.Block) (*types.Block, error)
 	// IsAncestor returns true if maybeAncestor is an ancestor of the L1 Block, and false otherwise

--- a/go/enclave/events/subscription_manager.go
+++ b/go/enclave/events/subscription_manager.go
@@ -121,13 +121,12 @@ func (s *SubscriptionManager) GetFilteredLogs(account *gethcommon.Address, filte
 	for {
 		blockHashes = append(blockHashes, currentBlock.Hash())
 
-		if currentBlock.NumberU64() <= common.L1GenesisHeight {
-			break // We have reached the end of the chain.
-		}
-
 		parentHash := currentBlock.ParentHash()
 		currentBlock, err = s.storage.FetchBlock(parentHash)
 		if err != nil {
+			if errors.Is(err, errutil.ErrNotFound) {
+				break // we have reached the beginning of the known chain
+			}
 			return nil, fmt.Errorf("could not retrieve block %s to extract its logs. Cause: %w", parentHash, err)
 		}
 	}

--- a/go/ethadapter/blockprovider.go
+++ b/go/ethadapter/blockprovider.go
@@ -7,6 +7,8 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/obscuronet/go-obscuro/go/common/host"
+
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	gethlog "github.com/ethereum/go-ethereum/log"
@@ -22,25 +24,19 @@ var one = big.NewInt(1)
 func NewEthBlockProvider(ethClient EthClient, logger gethlog.Logger) *EthBlockProvider {
 	return &EthBlockProvider{
 		ethClient: ethClient,
-		ctx:       context.TODO(),
 		logger:    logger,
 	}
 }
 
 // EthBlockProvider streams blocks from the ethereum L1 client in the order expected by the enclave (consecutive, canonical blocks)
 type EthBlockProvider struct {
-	ethClient     EthClient
-	ctx           context.Context
-	logger        gethlog.Logger
-	cancelRunning context.CancelFunc // if this is not nil it kills the currently running goroutine
-
-	// the state of the block provider
-	latestSent *types.Header // most recently sent block (reset to nil when a `StartStreaming...` method is called)
+	ethClient EthClient
+	logger    gethlog.Logger
 }
 
 // StartStreamingFromHash will look up the hash block, find the appropriate height (LCA if there have been forks) and
 // then call StartStreamingFromHeight based on that
-func (e *EthBlockProvider) StartStreamingFromHash(latestHash gethcommon.Hash) (<-chan *types.Block, error) {
+func (e *EthBlockProvider) StartStreamingFromHash(latestHash gethcommon.Hash) (*host.BlockStream, error) {
 	ancestorBlk, err := e.latestCanonAncestor(latestHash)
 	if err != nil {
 		return nil, err
@@ -48,31 +44,18 @@ func (e *EthBlockProvider) StartStreamingFromHash(latestHash gethcommon.Hash) (<
 	return e.StartStreamingFromHeight(increment(ancestorBlk.Number()))
 }
 
-// StartStreamingFromHeight will (re)start streaming from the given height, closing out any existing stream channel and
-// returning the fresh channel - the next block will be the requested height
-func (e *EthBlockProvider) StartStreamingFromHeight(height *big.Int) (<-chan *types.Block, error) {
-	// make sure we stop the running stream if there is one
-	e.Stop()
-
+// StartStreamingFromHeight will start streaming from the given height
+// returning the fresh channel (the next block will be the requested height) and a cancel function to kill the stream
+func (e *EthBlockProvider) StartStreamingFromHeight(height *big.Int) (*host.BlockStream, error) {
 	// block heights start at 1
 	if height.Cmp(one) < 0 {
 		height = one
 	}
+	ctx, cancel := context.WithCancel(context.Background())
 	streamCh := make(chan *types.Block)
-	streamCtx, cancel := context.WithCancel(e.ctx)
-	e.cancelRunning = cancel
-	go e.streamBlocks(streamCtx, height, streamCh)
+	go e.streamBlocks(ctx, height, streamCh)
 
-	return streamCh, nil
-}
-
-// Stop resets the state of the BlockProvider ready to start streaming again
-func (e *EthBlockProvider) Stop() {
-	if e.cancelRunning != nil {
-		e.cancelRunning()
-		e.cancelRunning = nil
-		e.latestSent = nil
-	}
+	return &host.BlockStream{Stream: streamCh, Stop: cancel}, nil
 }
 
 func (e *EthBlockProvider) IsLive(h gethcommon.Hash) bool {
@@ -86,13 +69,15 @@ func (e *EthBlockProvider) IsLive(h gethcommon.Hash) bool {
 // - publishing a block, it blocks on the outbound channel until the block is consumed
 // - awaiting a live block, when consumer is completely up-to-date it waits for a live block to arrive
 func (e *EthBlockProvider) streamBlocks(ctx context.Context, fromHeight *big.Int, streamCh chan *types.Block) {
+	var latestSent *types.Header // most recently sent block (reset to nil when a `StartStreaming...` method is called)
+
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		default:
 			// this will block if we're up-to-date with live blocks
-			block, err := e.fetchNextCanonicalBlock(fromHeight)
+			block, err := e.fetchNextCanonicalBlock(ctx, fromHeight, latestSent)
 			if err != nil {
 				e.logger.Error("unexpected error while preparing block to stream, will retry in 1 sec", log.ErrKey, err)
 				time.Sleep(time.Second)
@@ -101,21 +86,21 @@ func (e *EthBlockProvider) streamBlocks(ctx context.Context, fromHeight *big.Int
 			e.logger.Trace("blockProvider streaming block", "height", block.Number(), "hash", block.Hash())
 			streamCh <- block // we block here until consumer takes it
 			// update stream state
-			e.latestSent = block.Header()
+			latestSent = block.Header()
 		}
 	}
 }
 
 // fetchNextCanonicalBlock finds the next block to send downstream to the consumer.
 // It looks at:
-//   - the latest block that was sent to the consumer (`e.latestSent`)
+//   - the latest block that was sent to the consumer (`latestSent`)
 //   - the current head of the L1 according to the Eth client (`l1Block`)
 //
 // If the consumer is up-to-date: this method will wait until a new block arrives from the L1
 // If the consumer is behind or there has been a fork: it returns the next canonical block that the consumer needs to see (no waiting)
-func (e *EthBlockProvider) fetchNextCanonicalBlock(fromHeight *big.Int) (*types.Block, error) {
+func (e *EthBlockProvider) fetchNextCanonicalBlock(ctx context.Context, fromHeight *big.Int, latestSent *types.Header) (*types.Block, error) {
 	// check for the initial case, when consumer has first requested a stream
-	if e.latestSent == nil {
+	if latestSent == nil {
 		// we try to return the canonical block at the height requested
 		blk, err := e.ethClient.BlockByNumber(fromHeight)
 		if err != nil {
@@ -131,17 +116,17 @@ func (e *EthBlockProvider) fetchNextCanonicalBlock(fromHeight *big.Int) (*types.
 	l1Head := l1Block.Header()
 
 	// check if the block provider is already up-to-date with the latest L1 block (if it is, then wait for a new block)
-	if l1Head.Hash() == e.latestSent.Hash() {
+	if l1Head.Hash() == latestSent.Hash() {
 		var err error
 		// block provider's current head is up-to-date, we will wait for the next L1 block to arrive
-		l1Head, err = e.awaitNewBlock()
+		l1Head, err = e.awaitNewBlock(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("no new block found from stream - %w", err)
 		}
 	}
 
 	// most common path should be: new head block that arrived is the next block, and needs to be sent
-	if l1Head.ParentHash == e.latestSent.Hash() {
+	if l1Head.ParentHash == latestSent.Hash() {
 		blk, err := e.ethClient.BlockByHash(l1Head.Hash())
 		if err != nil {
 			return nil, fmt.Errorf("could not fetch block with hash=%s - %w", l1Head.Hash(), err)
@@ -150,9 +135,9 @@ func (e *EthBlockProvider) fetchNextCanonicalBlock(fromHeight *big.Int) (*types.
 	}
 
 	// and if not then, we walk back up the tree from the current head, to find the most recent **canonical** block we sent
-	latestCanon, err := e.latestCanonAncestor(e.latestSent.Hash())
+	latestCanon, err := e.latestCanonAncestor(latestSent.Hash())
 	if err != nil {
-		return nil, fmt.Errorf("could not find ancestor on canonical chain for hash=%s - %w", e.latestSent.Hash(), err)
+		return nil, fmt.Errorf("could not find ancestor on canonical chain for hash=%s - %w", latestSent.Hash(), err)
 	}
 
 	// and send the canonical block at the height after that
@@ -181,7 +166,7 @@ func (e *EthBlockProvider) latestCanonAncestor(blkHash gethcommon.Hash) (*types.
 
 // awaitNewBlock will block, waiting for the next live L1 block from the L1 client.
 // It is used when the block provider is up-to-date and waiting for a new block to forward to its consumer.
-func (e *EthBlockProvider) awaitNewBlock() (*types.Header, error) {
+func (e *EthBlockProvider) awaitNewBlock(ctx context.Context) (*types.Header, error) {
 	liveStream, streamSub := e.ethClient.BlockListener()
 
 	for {
@@ -191,7 +176,7 @@ func (e *EthBlockProvider) awaitNewBlock() (*types.Header, error) {
 			streamSub.Unsubscribe()
 			return blkHead, nil
 
-		case <-e.ctx.Done():
+		case <-ctx.Done():
 			return nil, fmt.Errorf("context closed before block was received")
 
 		case err := <-streamSub.Err():

--- a/go/ethadapter/blockprovider_test.go
+++ b/go/ethadapter/blockprovider_test.go
@@ -19,18 +19,18 @@ import (
 
 func TestBlockProviderHappyPath_LiveStream(t *testing.T) {
 	mockEthClient := mockEthClient(3)
-	blockProvider, ctxCancel := setupBlockProvider(mockEthClient)
-	defer ctxCancel()
+	blockProvider := setupBlockProvider(mockEthClient)
 
 	blkStream, err := blockProvider.StartStreamingFromHeight(big.NewInt(3))
 	if err != nil {
 		t.Error(err)
 	}
+	defer blkStream.Stop()
 	blkCount := 0
 
 	for blkCount < 3 {
 		select {
-		case blk := <-blkStream:
+		case blk := <-blkStream.Stream:
 			if blk != nil {
 				blkCount++
 			}
@@ -43,18 +43,18 @@ func TestBlockProviderHappyPath_LiveStream(t *testing.T) {
 
 func TestBlockProviderHappyPath_HistoricThenStream(t *testing.T) {
 	mockEthClient := mockEthClient(3)
-	blockProvider, ctxCancel := setupBlockProvider(mockEthClient)
-	defer ctxCancel()
+	blockProvider := setupBlockProvider(mockEthClient)
 
 	blkStream, err := blockProvider.StartStreamingFromHeight(big.NewInt(1))
 	if err != nil {
 		t.Error(err)
 	}
+	defer blkStream.Stop()
 	blkCount := 0
 
 	for blkCount < 3 {
 		select {
-		case blk := <-blkStream:
+		case blk := <-blkStream.Stream:
 			if blk != nil {
 				blkCount++
 			}
@@ -65,16 +65,13 @@ func TestBlockProviderHappyPath_HistoricThenStream(t *testing.T) {
 	}
 }
 
-func setupBlockProvider(mockEthClient EthClient) (EthBlockProvider, context.CancelFunc) {
-	ctx, cancelCtx := context.WithCancel(context.Background())
-
+func setupBlockProvider(mockEthClient EthClient) EthBlockProvider {
 	logger := log.New(log.HostCmp, int(gethlog.LvlInfo), log.SysOut, log.NodeIDKey, "test")
 	blockProvider := EthBlockProvider{
 		ethClient: mockEthClient,
-		ctx:       ctx,
 		logger:    logger,
 	}
-	return blockProvider, cancelCtx
+	return blockProvider
 }
 
 func mockEthClient(liveStreamingStart int) EthClient {

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -8,6 +8,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/obscuronet/go-obscuro/go/host/batchmanager"
 
 	"github.com/ethereum/go-ethereum/rlp"
@@ -31,8 +32,6 @@ import (
 
 	"github.com/obscuronet/go-obscuro/go/common/log"
 
-	"github.com/ethereum/go-ethereum"
-	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/naoina/toml"
 	"github.com/obscuronet/go-obscuro/go/common"
@@ -62,27 +61,25 @@ const (
 
 // Implementation of host.Host.
 type host struct {
-	config      config.HostConfig
-	shortID     uint64
-	isSequencer bool
+	config          config.HostConfig
+	shortID         uint64
+	isSequencer     bool
+	genesisRequired bool
 
 	p2p           hostcommon.P2P       // For communication with other Obscuro nodes
 	ethClient     ethadapter.EthClient // For communication with the L1 node
 	enclaveClient common.Enclave       // For communication with the enclave
 	rpcServer     clientrpc.Server     // For communication with Obscuro client applications
 
-	blockProvider hostcommon.ReconnectingBlockProvider
-
 	// control the host lifecycle
 	exitHostCh            chan bool
 	stopHostInterrupt     *int32
 	bootstrappingComplete *int32 // Marks when the host is done bootstrapping
 
-	l1BlockRPCCh   chan l1BlockAndParent           // The channel that new blocks from the L1 node are sent to
-	forkRPCCh      chan []common.EncodedL1Block    // The channel that new forks from the L1 node are sent to
-	txP2PCh        chan common.EncryptedTx         // The channel that new transactions from peers are sent to
-	batchP2PCh     chan common.EncodedBatches      // The channel that new batches from peers are sent to
-	batchRequestCh chan common.EncodedBatchRequest // The channel that batch requests from peers are sent to
+	l1BlockProvider hostcommon.ReconnectingBlockProvider
+	txP2PCh         chan common.EncryptedTx         // The channel that new transactions from peers are sent to
+	batchP2PCh      chan common.EncodedBatches      // The channel that new batches from peers are sent to
+	batchRequestCh  chan common.EncodedBatchRequest // The channel that batch requests from peers are sent to
 
 	db *db.DB // Stores the host's publicly-available data
 
@@ -94,9 +91,16 @@ type host struct {
 	logger gethlog.Logger
 }
 
-func NewHost(config config.HostConfig, p2p hostcommon.P2P, ethClient ethadapter.EthClient, enclaveClient common.Enclave, ethWallet wallet.Wallet, mgmtContractLib mgmtcontractlib.MgmtContractLib, logger gethlog.Logger) hostcommon.MockHost {
+func NewHost(
+	config config.HostConfig,
+	p2p hostcommon.P2P,
+	ethClient ethadapter.EthClient,
+	enclaveClient common.Enclave,
+	ethWallet wallet.Wallet,
+	mgmtContractLib mgmtcontractlib.MgmtContractLib,
+	logger gethlog.Logger,
+) hostcommon.Host {
 	database := db.NewInMemoryDB() // todo - make this config driven
-
 	host := &host{
 		// config
 		config:      config,
@@ -107,7 +111,6 @@ func NewHost(config config.HostConfig, p2p hostcommon.P2P, ethClient ethadapter.
 		p2p:           p2p,
 		ethClient:     ethClient,
 		enclaveClient: enclaveClient,
-		blockProvider: ethadapter.NewEthBlockProvider(ethClient, logger),
 
 		// lifecycle channels
 		exitHostCh:            make(chan bool),
@@ -115,11 +118,10 @@ func NewHost(config config.HostConfig, p2p hostcommon.P2P, ethClient ethadapter.
 		bootstrappingComplete: new(int32),
 
 		// incoming data
-		l1BlockRPCCh:   make(chan l1BlockAndParent),
-		forkRPCCh:      make(chan []common.EncodedL1Block),
-		txP2PCh:        make(chan common.EncryptedTx),
-		batchP2PCh:     make(chan common.EncodedBatches),
-		batchRequestCh: make(chan common.EncodedBatchRequest),
+		l1BlockProvider: ethadapter.NewEthBlockProvider(ethClient, logger),
+		txP2PCh:         make(chan common.EncryptedTx),
+		batchP2PCh:      make(chan common.EncodedBatches),
+		batchRequestCh:  make(chan common.EncodedBatchRequest),
 
 		// Initialize the host DB
 		db: database,
@@ -214,23 +216,10 @@ func (h *host) Start() {
 		}
 	}
 
-	// attach the l1 monitor
-	go h.monitorBlocks()
-
-	// bootstrap the host
-	latestL1Block := h.bootstrapHost()
-
-	// start the enclave speculative work from last L1 block
-	err = h.enclaveClient.Start(latestL1Block)
-	if err != nil {
-		h.logger.Crit("Could not start the enclave.", log.ErrKey, err.Error())
-	}
-
 	if h.config.IsGenesis {
-		_, err = h.initialiseProtocol(&latestL1Block)
-		if err != nil {
-			h.logger.Crit("Could not bootstrap.", log.ErrKey, err.Error())
-		}
+		// the genesis node gets a flag set on it until it has published the genesis block
+		// todo: handle genesis separately as an initial step for the genesis node
+		h.genesisRequired = true
 	}
 	// start the obscuro RPC endpoints
 	if h.rpcServer != nil {
@@ -288,14 +277,6 @@ func (h *host) DB() *db.DB {
 
 func (h *host) EnclaveClient() common.Enclave {
 	return h.enclaveClient
-}
-
-func (h *host) MockedNewHead(b common.EncodedL1Block, p common.EncodedL1Block) {
-	h.l1BlockRPCCh <- l1BlockAndParent{b, p}
-}
-
-func (h *host) MockedNewFork(b []common.EncodedL1Block) {
-	h.forkRPCCh <- b
 }
 
 func (h *host) SubmitAndBroadcastTx(encryptedParams common.EncryptedParamsSendRawTx) (common.EncryptedResponseSendRawTx, error) {
@@ -361,9 +342,6 @@ func (h *host) Stop() {
 		// connection remains open, waiting for the RPC server to close.
 		go h.rpcServer.Stop()
 	}
-	if h.blockProvider != nil {
-		go h.blockProvider.Stop()
-	}
 
 	// Leave some time for all processing to finish before exiting the main loop.
 	time.Sleep(time.Second)
@@ -402,10 +380,15 @@ func (h *host) waitForEnclave() {
 }
 
 // starts the host main processing loop
-// todo: matt to fix this complexity `nolint` in next PR with block provider
-func (h *host) startProcessing() { //nolint:gocognit
-	// Only open the p2p connection when the host is fully initialised
+func (h *host) startProcessing() {
 	h.p2p.StartListening(h)
+
+	// The blockStream channel is a stream of consecutive, canonical blocks. BlockStream may be replaced with a new
+	// stream ch during the main loop if enclave gets out-of-sync, and we need to stream from an earlier block
+	blockStream, err := h.l1BlockProvider.StartStreamingFromHeight(big.NewInt(1))
+	if err != nil {
+		h.logger.Crit("unable to stream l1 blocks for enclave", log.ErrKey, err)
+	}
 
 	// use the roundInterrupt as a signaling mechanism for interrupting block processing
 	// stops processing the current round if a new block arrives
@@ -417,44 +400,23 @@ func (h *host) startProcessing() { //nolint:gocognit
 	// - Process new Transactions gossiped from L2 Peers
 	for {
 		select {
-		case blockAndParent := <-h.l1BlockRPCCh:
+		case b := <-blockStream.Stream:
 			roundInterrupt = triggerInterrupt(roundInterrupt)
-			err := h.processL1Block(blockAndParent.parent, false)
+			isLive := h.l1BlockProvider.IsLive(b.Hash()) // checks whether the block is the current head of the L1 (false if there is a newer block available)
+			err := h.processL1Block(b, isLive)
 			if err != nil {
-				var rejErr *common.BlockRejectError
-				if errors.As(err, &rejErr) {
-					// this is a common error (the parent has usually already been processed and is being sent just in case)
-					h.logger.Debug("Rejected parent block.", log.ErrKey, rejErr, "enclaveHead", rejErr.L1Head)
-				} else {
-					h.logger.Info("Could not process parent block. ", log.ErrKey, err)
-				}
-			}
-			err = h.processL1Block(blockAndParent.block, true)
-			if err != nil {
-				var rejErr *common.BlockRejectError
-				if errors.As(err, &rejErr) {
-					h.logger.Info("Rejected latest block.", log.ErrKey, rejErr, "enclaveHead", rejErr.L1Head)
-				} else {
-					h.logger.Warn("Could not process latest block.", log.ErrKey, err)
-				}
-			}
-
-		case f := <-h.forkRPCCh:
-			roundInterrupt = triggerInterrupt(roundInterrupt)
-			for i, blk := range f {
-				isLatest := i == (len(f) - 1)
-				err := h.processL1Block(blk, isLatest)
-				if err != nil && isLatest {
-					h.logger.Warn("Could not process latest fork block received via RPC.", log.ErrKey, err)
-				}
+				// handle the error, replace the blockStream if necessary (e.g. if stream needs resetting based on enclave's reported L1 head)
+				blockStream = h.handleProcessBlockErr(b, blockStream, err)
 			}
 
 		case tx := <-h.txP2PCh:
+			// todo: discard p2p messages if enclave won't be able to make use of them (e.g. we're way behind L1 head)
 			if _, err := h.enclaveClient.SubmitTx(tx); err != nil {
 				h.logger.Warn("Could not submit transaction. ", log.ErrKey, err)
 			}
 
 		case batches := <-h.batchP2PCh:
+			// todo: discard p2p messages if enclave won't be able to make use of them (e.g. we're way behind L1 head)
 			if err := h.handleBatches(&batches); err != nil {
 				h.logger.Error("Could not handle batches. ", log.ErrKey, err)
 			}
@@ -470,6 +432,29 @@ func (h *host) startProcessing() { //nolint:gocognit
 	}
 }
 
+func (h *host) handleProcessBlockErr(processedBlock *types.Block, stream *hostcommon.BlockStream, err error) *hostcommon.BlockStream {
+	var rejErr *common.BlockRejectError
+	if !errors.As(err, &rejErr) {
+		// received unexpected error (no useful information from the enclave)
+		// we log it out and ignore it until the enclave tells us more information
+		h.logger.Warn("Error processing block.", log.ErrKey, err)
+		return stream
+	}
+	h.logger.Info("Block rejected by enclave.", log.ErrKey, rejErr, "blk", processedBlock.Hash(), "blkHeight", processedBlock.Number())
+	if rejErr.L1Head == (gethcommon.Hash{}) {
+		h.logger.Warn("No L1 head information provided by enclave, continuing with existing stream")
+		return stream
+	}
+	h.logger.Info("Resetting block provider stream to enclave latest head.", "streamFrom", rejErr.L1Head)
+	replacementStream, err := h.l1BlockProvider.StartStreamingFromHash(rejErr.L1Head)
+	if err != nil {
+		h.logger.Warn("Could not reset block provider, continuing with previous stream", log.ErrKey, err)
+		return stream
+	}
+	stream.Stop() // cancel the previous stream and return the replacement
+	return replacementStream
+}
+
 // activates the given interrupt (atomically) and returns a new interrupt
 func triggerInterrupt(interrupt *int32) *int32 {
 	// Notify the previous round to stop work
@@ -478,30 +463,21 @@ func triggerInterrupt(interrupt *int32) *int32 {
 	return &i
 }
 
-type l1BlockAndParent struct {
-	block  common.EncodedL1Block
-	parent common.EncodedL1Block
-}
-
-func (h *host) processL1Block(block common.EncodedL1Block, isLatestBlock bool) error {
+func (h *host) processL1Block(block *types.Block, isLatestBlock bool) error {
 	// For the genesis block the parent is nil
 	if block == nil {
 		return nil
 	}
-	decodedBlock, err := block.DecodeBlock()
-	if err != nil {
-		return err
-	}
-	h.processL1BlockTransactions(decodedBlock)
+
+	h.processL1BlockTransactions(block)
 
 	// submit each block to the enclave for ingestion plus validation
 	// todo: isLatest should only be true when we're not behind
-	var result *common.BlockSubmissionResponse
-	result, err = h.enclaveClient.SubmitL1Block(*decodedBlock, isLatestBlock)
+	result, err := h.enclaveClient.SubmitL1Block(*block, isLatestBlock)
 	if err != nil {
-		return fmt.Errorf("did not ingest block b_%d. Cause: %w", common.ShortHash(decodedBlock.Hash()), err)
+		return fmt.Errorf("did not ingest block b_%d. Cause: %w", common.ShortHash(block.Hash()), err)
 	}
-	err = h.storeBlockProcessingResult(result, decodedBlock.Header())
+	err = h.storeBlockProcessingResult(result, block.Header())
 	if err != nil {
 		return fmt.Errorf("submitted block to enclave but could not store the block processing result. Cause: %w", err)
 	}
@@ -517,11 +493,22 @@ func (h *host) processL1Block(block common.EncodedL1Block, isLatestBlock bool) e
 	if !h.isSequencer || !isLatestBlock {
 		return nil
 	}
-	blockHash := decodedBlock.Hash()
+
+	if h.genesisRequired {
+		err := h.initialiseProtocol(block)
+		if err != nil {
+			h.logger.Crit("Could not initialise protocol.", log.ErrKey, err)
+		}
+		h.genesisRequired = false
+		return nil // nothing further to process since network had no genesis
+	}
+
+	blockHash := block.Hash()
 	rollup, err := h.enclaveClient.ProduceRollup(&blockHash)
 	if err != nil {
 		return fmt.Errorf("could not produce rollup. Cause: %w", err)
 	}
+
 	if rollup.Header != nil {
 		// TODO - #718 - Unlink rollup production from L1 cadence.
 		h.publishRollup(rollup)
@@ -602,11 +589,12 @@ func (h *host) storeBlockProcessingResult(result *common.BlockSubmissionResponse
 }
 
 // Called only by the first enclave to bootstrap the network
-func (h *host) initialiseProtocol(block *types.Block) (common.L2RootHash, error) {
-	// Create the genesis rollup.
+
+func (h *host) initialiseProtocol(block *types.Block) error {
+	// Create the genesis rollup
 	genesisRollup, err := h.enclaveClient.ProduceGenesis(block.Hash())
 	if err != nil {
-		return common.L2RootHash{}, fmt.Errorf("could not produce genesis. Cause: %w", err)
+		return fmt.Errorf("could not produce genesis. Cause: %w", err)
 	}
 	h.logger.Info(
 		fmt.Sprintf("Initialising network. Genesis rollup r_%d.",
@@ -619,7 +607,7 @@ func (h *host) initialiseProtocol(block *types.Block) (common.L2RootHash, error)
 	// Submit the rollup to the management contract.
 	encodedRollup, err := common.EncodeRollup(genesisRollup)
 	if err != nil {
-		return common.L2RootHash{}, fmt.Errorf("could not encode rollup. Cause: %w", err)
+		return fmt.Errorf("could not encode rollup. Cause: %w", err)
 	}
 	l1tx := &ethadapter.L1RollupTx{
 		Rollup: encodedRollup,
@@ -627,10 +615,10 @@ func (h *host) initialiseProtocol(block *types.Block) (common.L2RootHash, error)
 	rollupTx := h.mgmtContractLib.CreateRollup(l1tx, h.ethWallet.GetNonceAndIncrement())
 	err = h.signAndBroadcastL1Tx(rollupTx, l1TxTriesRollup)
 	if err != nil {
-		return common.L2RootHash{}, fmt.Errorf("could not initialise protocol. Cause: %w", err)
+		return fmt.Errorf("could not initialise protocol. Cause: %w", err)
 	}
 
-	return genesisRollup.Header.ParentHash, nil
+	return nil
 }
 
 // `tries` is the number of times to attempt broadcasting the transaction.
@@ -712,7 +700,6 @@ func (h *host) requestSecret() error {
 	if err != nil {
 		h.logger.Crit("could not receive the secret", log.ErrKey, err)
 	}
-	h.logger.Info("§§§ Secret received")
 	return nil
 }
 
@@ -805,203 +792,18 @@ func (h *host) processSharedSecretResponse(_ *ethadapter.L1RespondSecretTx) erro
 	return nil
 }
 
-// monitors the L1 client for new blocks and injects them into the aggregator
-func (h *host) monitorBlocks() {
-	var lastKnownBlkHash gethcommon.Hash
-	listener, subs := h.ethClient.BlockListener()
-	h.logger.Info("Start monitoring Ethereum blocks..")
-
-	// only process blocks if the host is running
-	for atomic.LoadInt32(h.stopHostInterrupt) == 0 {
-		select {
-		case err := <-subs.Err():
-			if errors.Is(err, ethadapter.ErrSubscriptionNotSupported) {
-				// there will never be a block from this monitor process, we can abandon it
-				return
-			}
-			h.logger.Error("L1 block monitoring error", log.ErrKey, err)
-			h.logger.Info("Restarting L1 block Monitoring...")
-			// it's fine to immediately restart the listener, any incoming blocks will be on hold in the queue
-			listener, subs = h.ethClient.BlockListener()
-
-			err = h.catchupMissedBlocks(lastKnownBlkHash)
-			if err != nil {
-				h.logger.Crit("could not catch up missed blocks.", log.ErrKey, err)
-			}
-
-		case blkHeader := <-listener:
-			// don't process blocks if the host is stopping
-			if atomic.LoadInt32(h.stopHostInterrupt) == 1 {
-				break
-			}
-
-			// ignore blocks if bootstrapping is happening
-			if atomic.LoadInt32(h.bootstrappingComplete) == 0 {
-				h.logger.Trace(fmt.Sprintf("Host in bootstrap - ignoring block %s", blkHeader.Hash()))
-				continue
-			}
-
-			block, err := h.ethClient.BlockByHash(blkHeader.Hash())
-			if err != nil {
-				h.logger.Crit(fmt.Sprintf("could not fetch block for hash %s.", blkHeader.Hash().String()), log.ErrKey, err)
-			}
-			blockParent, err := h.ethClient.BlockByHash(block.ParentHash())
-			if err != nil {
-				h.logger.Crit(fmt.Sprintf("could not fetch block's parent with hash %s.", block.ParentHash().String()), log.ErrKey, err)
-			}
-
-			h.logger.Info(fmt.Sprintf(
-				"Received a new block b_%d(%d)",
-				common.ShortHash(blkHeader.Hash()),
-				blkHeader.Number.Uint64(),
-			))
-
-			// issue the block to the ingestion channel
-			err = h.encodeAndIngest(block, blockParent)
-			if err != nil {
-				h.logger.Crit("Internal error", log.ErrKey, err)
-			}
-			lastKnownBlkHash = block.Hash()
-		}
-	}
-
-	h.logger.Info("Stopped monitoring for l1 blocks")
-	// make sure it cleanly unsubscribes
-	// todo this should be defered when the errors are upstreamed instead of panic'd
-	subs.Unsubscribe()
-}
-
-func (h *host) catchupMissedBlocks(lastKnownBlkHash gethcommon.Hash) error {
-	var lastBlkNumber *big.Int
-	var reingestBlocks []*types.Block
-
-	// get the blockchain tip block
-	blk, err := h.ethClient.BlockByNumber(lastBlkNumber)
-	if err != nil {
-		return fmt.Errorf("catching up on missed blocks, unable to fetch tip block - reason: %w", err)
-	}
-
-	if blk.Hash().Hex() == lastKnownBlkHash.Hex() {
-		// if no new blocks have been issued then nothing to catchup
-		return nil
-	}
-	reingestBlocks = append(reingestBlocks, blk)
-
-	// get all blocks from the blockchain tip to the last block ingested by the host
-	for blk.Hash().Hex() != lastKnownBlkHash.Hex() {
-		blockParent, err := h.ethClient.BlockByHash(blk.ParentHash())
-		if err != nil {
-			return fmt.Errorf("catching up on missed blocks, could not fetch block's parent with hash %s. Cause: %w", blk.ParentHash(), err)
-		}
-
-		reingestBlocks = append(reingestBlocks, blockParent)
-		blk = blockParent
-	}
-
-	// make sure to have the last ingested block available for ingestion (because we always ingest ( blk, blk_parent)
-	lastKnownBlk, err := h.ethClient.BlockByHash(lastKnownBlkHash)
-	if err != nil {
-		return fmt.Errorf("catching up on missed blocks, unable to feth last known block - reason: %w", err)
-	}
-	reingestBlocks = append(reingestBlocks, lastKnownBlk)
-
-	// issue the block to the ingestion channel in reverse, with the parent attached too
-	for i := len(reingestBlocks) - 2; i >= 0; i-- {
-		h.logger.Debug(fmt.Sprintf("Ingesting %s and %s blocks of %v", reingestBlocks[i].Hash(), reingestBlocks[i+1].Hash(), reingestBlocks))
-		err = h.encodeAndIngest(reingestBlocks[i], reingestBlocks[i+1])
-		if err != nil {
-			h.logger.Crit("Internal error", log.ErrKey, err)
-		}
-	}
-
-	return nil
-}
-
-func (h *host) encodeAndIngest(block *types.Block, blockParent *types.Block) error {
-	encodedBlock, err := common.EncodeBlock(block)
-	if err != nil {
-		return fmt.Errorf("could not encode block with hash %s. Cause: %w", block.Hash().String(), err)
-	}
-
-	encodedBlockParent, err := common.EncodeBlock(blockParent)
-	if err != nil {
-		return fmt.Errorf("could not encode block's parent with hash %s. Cause: %w", block.ParentHash().String(), err)
-	}
-
-	h.l1BlockRPCCh <- l1BlockAndParent{encodedBlock, encodedBlockParent}
-	return nil
-}
-
-func (h *host) bootstrapHost() types.Block {
-	var err error
-	var nextBlk *types.Block
-
-	// build up from the genesis block
-	// todo update to bootstrap from the last block in storage
-	// todo the genesis block should be the block where the contract was deployed
-	currentL1Block, err := h.ethClient.BlockByNumber(big.NewInt(0))
-	if err != nil {
-		h.logger.Crit("Internal error", log.ErrKey, err)
-	}
-
-	h.logger.Info(fmt.Sprintf("Started host bootstrap with block %d", currentL1Block.NumberU64()))
-
-	startTime, logTime := time.Now(), time.Now()
-	for {
-		cb := *currentL1Block
-		h.processL1BlockTransactions(&cb)
-		result, err := h.enclaveClient.SubmitL1Block(cb, false)
-		if err != nil {
-			var bsErr *common.BlockRejectError
-			isBSE := errors.As(err, &bsErr)
-			if !isBSE {
-				// unexpected error
-				h.logger.Crit("Internal error", log.ErrKey, err)
-			}
-			// todo: we need to use the latest hash info from the BlockRejectError to realign the block streaming for the enclave
-			h.logger.Info(fmt.Sprintf("Failed to ingest block b_%d. Cause: %s", common.ShortHash(cb.Header().Hash()), bsErr))
-		} else {
-			// submission was successful
-			err := h.storeBlockProcessingResult(result, cb.Header())
-			if err != nil {
-				h.logger.Crit("Could not store block processing result", log.ErrKey, err)
-			}
-		}
-
-		nextBlk, err = h.ethClient.BlockByNumber(big.NewInt(cb.Number().Int64() + 1))
-		if err != nil {
-			if errors.Is(err, ethereum.NotFound) {
-				break
-			}
-			h.logger.Crit("Internal error", log.ErrKey, err)
-		}
-		currentL1Block = nextBlk
-
-		if time.Since(logTime) > 30*time.Second {
-			h.logger.Info(fmt.Sprintf("Bootstrapping host at block... %d", cb.NumberU64()))
-			logTime = time.Now()
-		}
-	}
-	atomic.StoreInt32(h.bootstrappingComplete, 1)
-	h.logger.Info(fmt.Sprintf("Finished bootstrap process with block %d after %s",
-		currentL1Block.NumberU64(),
-		time.Since(startTime),
-	))
-	return *currentL1Block
-}
-
 func (h *host) awaitSecret(fromHeight *big.Int) error {
-	blkStream, err := h.blockProvider.StartStreamingFromHeight(fromHeight)
+	blkStream, err := h.l1BlockProvider.StartStreamingFromHeight(fromHeight)
 	if err != nil {
 		return err
 	}
+	defer blkStream.Stop()
 
 	for {
 		select {
-		case blk := <-blkStream:
+		case blk := <-blkStream.Stream:
 			h.logger.Trace("checking block for secret resp", "height", blk.Number())
 			if h.checkBlockForSecretResponse(blk) {
-				h.blockProvider.Stop()
 				return nil
 			}
 
@@ -1010,7 +812,6 @@ func (h *host) awaitSecret(fromHeight *big.Int) error {
 			h.logger.Warn(fmt.Sprintf(" Waiting for secret from the L1. No blocks received for over %s", blockStreamWarningTimeout))
 
 		case <-h.exitHostCh:
-			h.blockProvider.Stop()
 			return nil
 		}
 	}

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -509,7 +509,7 @@ func (h *host) processL1Block(block *types.Block, isLatestBlock bool) error {
 		return fmt.Errorf("could not produce rollup. Cause: %w", err)
 	}
 
-	if rollup.Header != nil {
+	if rollup != nil && rollup.Header != nil {
 		// TODO - #718 - Unlink rollup production from L1 cadence.
 		h.publishRollup(rollup)
 		// TODO - #718 - Unlink batch production from L1 cadence.

--- a/integration/ethereummock/mock_l1_network.go
+++ b/integration/ethereummock/mock_l1_network.go
@@ -50,7 +50,7 @@ func (n *MockEthNetwork) BroadcastBlock(b common.EncodedL1Block, p common.Encode
 			t := m
 			common.Schedule(n.delay(), func() { t.P2PReceiveBlock(b, p) })
 		} else {
-			m.logger.Info(printBlock(bl, *m))
+			m.logger.Info(printBlock(bl, m))
 		}
 	}
 
@@ -75,7 +75,7 @@ func (n *MockEthNetwork) delay() time.Duration {
 	return testcommon.RndBtwTime(n.avgLatency/10, 2*n.avgLatency)
 }
 
-func printBlock(b *types.Block, m Node) string {
+func printBlock(b *types.Block, m *Node) string {
 	// This is just for printing
 	var txs []string
 	for _, tx := range b.Transactions() {

--- a/integration/ethereummock/node.go
+++ b/integration/ethereummock/node.go
@@ -5,8 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/google/uuid"
 
 	"github.com/obscuronet/go-obscuro/go/common/errutil"
 
@@ -50,20 +53,16 @@ type StatsCollector interface {
 	L1Reorg(id gethcommon.Address)
 }
 
-type NotifyNewBlock interface {
-	MockedNewHead(b common.EncodedL1Block, p common.EncodedL1Block)
-	MockedNewFork(b []common.EncodedL1Block)
-}
-
 type Node struct {
 	l2ID     gethcommon.Address // the address of the Obscuro node this client is dedicated to
 	cfg      MiningConfig
-	clients  []NotifyNewBlock
 	Network  L1Network
 	mining   bool
 	stats    StatsCollector
 	Resolver db.BlockResolver
 	db       TxDB
+	subs     map[uuid.UUID]*mockSubscription // active subscription for mock blocks
+	subMu    sync.Mutex
 
 	// Channels
 	exitCh       chan bool // the Node stops
@@ -100,9 +99,18 @@ func (m *Node) Nonce(gethcommon.Address) (uint64, error) {
 	return 0, nil
 }
 
-// BlockListener is not used in the mock
+// BlockListener provides stream of latest mock head headers as they are created
 func (m *Node) BlockListener() (chan *types.Header, ethereum.Subscription) {
-	return make(chan *types.Header), &mockSubscription{}
+	id := uuid.New()
+	mockSub := &mockSubscription{
+		node:   m,
+		id:     id,
+		headCh: make(chan *types.Header),
+	}
+	m.subMu.Lock()
+	defer m.subMu.Unlock()
+	m.subs[id] = mockSub
+	return mockSub.headCh, mockSub
 }
 
 func (m *Node) BlockNumber() (uint64, error) {
@@ -261,26 +269,10 @@ func (m *Node) setHead(b *types.Block) *types.Block {
 		return b
 	}
 
-	// notify the clients
-	for _, c := range m.clients {
-		t := c
-		encodedBlock, err := common.EncodeBlock(b)
-		if err != nil {
-			panic(fmt.Errorf("could not encode block. Cause: %w", err))
-		}
-		if b.NumberU64() == common.L1GenesisHeight {
-			go t.MockedNewHead(encodedBlock, nil)
-		} else {
-			p, err := m.Resolver.ParentBlock(b)
-			if err != nil {
-				panic(fmt.Errorf("could not retrieve parent. Cause: %w", err))
-			}
-			encodedParentBlock, err := common.EncodeBlock(p)
-			if err != nil {
-				panic(fmt.Errorf("could not encode parent block. Cause: %w", err))
-			}
-			go t.MockedNewHead(encodedBlock, encodedParentBlock)
-		}
+	// notify the client subscriptions
+	for _, s := range m.subs {
+		sub := s
+		go sub.publish(b)
 	}
 	m.canonicalCh <- b
 
@@ -293,19 +285,12 @@ func (m *Node) setFork(blocks []*types.Block) *types.Block {
 		return head
 	}
 
-	fork := make([]common.EncodedL1Block, len(blocks))
-	for i, block := range blocks {
-		encodedBlock, err := common.EncodeBlock(block)
-		if err != nil {
-			panic(fmt.Errorf("could not encode block. Cause: %w", err))
-		}
-		fork[i] = encodedBlock
+	// notify the client subs
+	for _, s := range m.subs {
+		sub := s
+		go sub.publishAll(blocks)
 	}
 
-	// notify the clients
-	for _, c := range m.clients {
-		go c.MockedNewFork(fork)
-	}
 	m.canonicalCh <- head
 
 	return head
@@ -393,10 +378,6 @@ func (m *Node) Stop() {
 	m.exitCh <- true
 }
 
-func (m *Node) AddClient(client NotifyNewBlock) {
-	m.clients = append(m.clients, client)
-}
-
 func (m *Node) BlocksBetween(blockA *types.Block, blockB *types.Block) []*types.Block {
 	if bytes.Equal(blockA.Hash().Bytes(), blockB.Hash().Bytes()) {
 		return []*types.Block{blockA}
@@ -430,6 +411,12 @@ func (m *Node) EthClient() *ethclient_ethereum.Client {
 	return nil
 }
 
+func (m *Node) RemoveSubscription(id uuid.UUID) {
+	m.subMu.Lock()
+	defer m.subMu.Unlock()
+	delete(m.subs, id)
+}
+
 func NewMiner(
 	id gethcommon.Address,
 	cfg MiningConfig,
@@ -456,18 +443,32 @@ func NewMiner(
 		erc20ContractLib: NewERC20ContractLibMock(),
 		mgmtContractLib:  NewMgmtContractLibMock(),
 		logger:           log.New(log.EthereumL1Cmp, int(gethlog.LvlInfo), cfg.LogFile, log.NodeIDKey, id),
+		subs:             map[uuid.UUID]*mockSubscription{},
+		subMu:            sync.Mutex{},
 	}
 }
 
 // implements the ethereum.Subscription
-type mockSubscription struct{}
+type mockSubscription struct {
+	id     uuid.UUID
+	headCh chan *types.Header
+	node   *Node // we hold a reference to the node to unsubscribe ourselves - not ideal but this is just a mock
+}
 
 func (sub *mockSubscription) Err() <-chan error {
-	c := make(chan error, 2) // size 2, so that we don't block
-	// drop an error in to this channel to remind callers that this client does not stream.
-	c <- ethadapter.ErrSubscriptionNotSupported
-	return c
+	return make(chan error)
 }
 
 func (sub *mockSubscription) Unsubscribe() {
+	sub.node.RemoveSubscription(sub.id)
+}
+
+func (sub *mockSubscription) publish(b *types.Block) {
+	sub.headCh <- b.Header()
+}
+
+func (sub *mockSubscription) publishAll(blocks []*types.Block) {
+	for _, b := range blocks {
+		sub.publish(b)
+	}
 }

--- a/integration/ethereummock/node.go
+++ b/integration/ethereummock/node.go
@@ -186,7 +186,10 @@ func (m *Node) Start() {
 		go m.startMining()
 	}
 
-	m.Resolver.StoreBlock(common.GenesisBlock)
+	err := m.Resolver.StoreL1HeadBlock(common.GenesisBlock)
+	if err != nil {
+		m.logger.Crit("unable to store L1 block. Cause: %w", err)
+	}
 	head := m.setHead(common.GenesisBlock)
 
 	for {
@@ -228,8 +231,11 @@ func (m *Node) Start() {
 }
 
 func (m *Node) processBlock(b *types.Block, head *types.Block) *types.Block {
-	m.Resolver.StoreBlock(b)
-	_, err := m.Resolver.FetchBlock(b.Header().ParentHash)
+	err := m.Resolver.StoreL1HeadBlock(b)
+	if err != nil {
+		m.logger.Crit("unable to store new L1 head block. Cause: %w", b)
+	}
+	_, err = m.Resolver.FetchBlock(b.Header().ParentHash)
 	// only proceed if the parent is available
 	if err != nil {
 		if errors.Is(err, errutil.ErrNotFound) {

--- a/integration/simulation/network/inmemory.go
+++ b/integration/simulation/network/inmemory.go
@@ -37,7 +37,7 @@ func NewBasicNetworkOfInMemoryNodes() Network {
 func (n *basicNetworkOfInMemoryNodes) Create(params *params.SimParams, stats *stats.Stats) (*RPCHandles, error) {
 	l1Clients := make([]ethadapter.EthClient, params.NumberOfNodes)
 	n.ethNodes = make([]*ethereummock.Node, params.NumberOfNodes)
-	obscuroNodes := make([]host.MockHost, params.NumberOfNodes)
+	obscuroNodes := make([]host.Host, params.NumberOfNodes)
 	n.l2Clients = make([]rpc.Client, params.NumberOfNodes)
 	p2pLayers := make([]*p2p.MockP2P, params.NumberOfNodes)
 
@@ -69,9 +69,6 @@ func (n *basicNetworkOfInMemoryNodes) Create(params *params.SimParams, stats *st
 			p2pLayers[i],
 		)
 		obscuroClient := p2p.NewInMemObscuroClient(agg)
-
-		// and connect them to each other
-		miner.AddClient(agg)
 
 		n.ethNodes[i] = miner
 		obscuroNodes[i] = agg

--- a/integration/simulation/network/network_utils.go
+++ b/integration/simulation/network/network_utils.go
@@ -71,7 +71,7 @@ func createInMemObscuroNode(
 	ethClient ethadapter.EthClient,
 	wallets *params.SimWallets,
 	mockP2P *simp2p.MockP2P,
-) commonhost.MockHost {
+) commonhost.Host {
 	hostConfig := config.HostConfig{
 		ID:                  gethcommon.BigToAddress(big.NewInt(id)),
 		IsGenesis:           isGenesis,

--- a/integration/simulation/network/obscuro_node_utils.go
+++ b/integration/simulation/network/obscuro_node_utils.go
@@ -38,7 +38,7 @@ const (
 
 func startInMemoryObscuroNodes(params *params.SimParams, genesisJSON []byte, l1Clients []ethadapter.EthClient) []rpc.Client {
 	// Create the in memory obscuro nodes, each connect each to a geth node
-	obscuroNodes := make([]host.MockHost, params.NumberOfNodes)
+	obscuroNodes := make([]host.Host, params.NumberOfNodes)
 	p2pLayers := make([]*p2p.MockP2P, params.NumberOfNodes)
 	for i := 0; i < params.NumberOfNodes; i++ {
 		isGenesis := i == 0

--- a/integration/simulation/p2p/mock_l2_network.go
+++ b/integration/simulation/p2p/mock_l2_network.go
@@ -21,7 +21,7 @@ import (
 // Will be plugged into each node
 type MockP2P struct {
 	CurrentNode host.Host
-	Nodes       []host.MockHost
+	Nodes       []host.Host
 
 	avgLatency       time.Duration
 	avgBlockDuration time.Duration


### PR DESCRIPTION
The first commit of this PR was reviewed and merged yesterday. Then reverted because I noticed an increase in local test failures. Only the second commit is new here, it fixes the issues I was seeing.

### Why is this change needed?

the intermittent failures from that blockprovider PR yesterday turned out to be from a 'fun' bug when L1 returns to a fork it had previously abandoned.

When enclave finds a block it doesn't like it returns an error with its view of the current L1 head, then the host uses that information to start streaming from the correct place to continue.
```
   / a2 - a3 - a4
a1
   \ b2 
```
In this situation if the L1 was forking backwards and forward so that the enclave was fed: a1, a2, then b2, then back to a2, a3 it would get stuck.

Then this looping exchange takes place:

Enclave: a2 is a duplicate, I've seen it before. My current head is b2.
Host: ok your latest canonical ancestor is a1, I'll send you the block after that (a2) to get you back on track
Enclave: a2 is a duplicate, I've seen it before. My current head is b2.
{ and repeat forever}

My solution for now is that I will update the head pointer when we reject a duplicate. Will mention it in the logs so any side-effects of forks can be noticed as we keep improving this stuff.

### What changes were made as part of this PR:

- separate the L1 head storage from the L2 head storage:
  - set L1 head as soon as L1 block ingested
  - set L1 head when duplicate block submitted

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
