### PR TITLE
Has-Get pattern in the db fix

### DIFF
--- a/go/common/gethdb/geth_inmemdb.go
+++ b/go/common/gethdb/geth_inmemdb.go
@@ -1,0 +1,29 @@
+package gethdb
+
+import (
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/ethdb/memorydb"
+	"github.com/obscuronet/go-obscuro/go/common/errutil"
+)
+
+type InMemGethDB struct {
+	*memorydb.Database
+}
+
+func NewMemDB() ethdb.KeyValueStore {
+	return &InMemGethDB{memorydb.New()}
+}
+
+// Get retrieves the given key if it's present in the key-value store.
+// this method is adapted to ensure the correct error is always returned
+func (db *InMemGethDB) Get(key []byte) ([]byte, error) {
+	value, err := db.Database.Get(key)
+	if err != nil {
+		// memoryDB will return not found error instead of a custom error type
+		if err.Error() == "not found" {
+			return nil, errutil.ErrNotFound
+		}
+		return nil, err
+	}
+	return value, nil
+}

--- a/go/host/db/batches.go
+++ b/go/host/db/batches.go
@@ -136,14 +136,6 @@ func batchNumberKey(txHash gethcommon.Hash) []byte {
 
 // Retrieves the batch header corresponding to the hash.
 func (db *DB) readBatchHeader(hash gethcommon.Hash) (*common.Header, error) {
-	// TODO - #1208 - Analyse this weird Has/Get pattern, here and in other part of the `db` package.
-	f, err := db.kvStore.Has(batchHeaderKey(hash))
-	if err != nil {
-		return nil, err
-	}
-	if !f {
-		return nil, errutil.ErrNotFound
-	}
 	data, err := db.kvStore.Get(batchHeaderKey(hash))
 	if err != nil {
 		return nil, err
@@ -160,13 +152,6 @@ func (db *DB) readBatchHeader(hash gethcommon.Hash) (*common.Header, error) {
 
 // Retrieves the hash of the head batch.
 func (db *DB) readHeadBatchHash() (*gethcommon.Hash, error) {
-	f, err := db.kvStore.Has(headBatch)
-	if err != nil {
-		return nil, err
-	}
-	if !f {
-		return nil, errutil.ErrNotFound
-	}
 	value, err := db.kvStore.Get(headBatch)
 	if err != nil {
 		return nil, err
@@ -209,13 +194,6 @@ func (db *DB) writeBatchHash(w ethdb.KeyValueWriter, header *common.Header) erro
 
 // Retrieves the hash for the batch with the given number..
 func (db *DB) readBatchHash(number *big.Int) (*gethcommon.Hash, error) {
-	f, err := db.kvStore.Has(batchHashKey(number))
-	if err != nil {
-		return nil, err
-	}
-	if !f {
-		return nil, errutil.ErrNotFound
-	}
 	data, err := db.kvStore.Get(batchHashKey(number))
 	if err != nil {
 		return nil, err
@@ -229,14 +207,6 @@ func (db *DB) readBatchHash(number *big.Int) (*gethcommon.Hash, error) {
 
 // Returns the transaction hashes in the batch with the given hash.
 func (db *DB) readBatchTxHashes(batchHash common.L2RootHash) ([]gethcommon.Hash, error) {
-	f, err := db.kvStore.Has(batchTxHashesKey(batchHash))
-	if err != nil {
-		return nil, err
-	}
-	if !f {
-		return nil, errutil.ErrNotFound
-	}
-
 	data, err := db.kvStore.Get(batchTxHashesKey(batchHash))
 	if err != nil {
 		return nil, err
@@ -277,13 +247,6 @@ func (db *DB) writeBatchTxHashes(w ethdb.KeyValueWriter, batchHash common.L2Root
 
 // Retrieves the number of the batch containing the transaction with the given hash.
 func (db *DB) readBatchNumber(txHash gethcommon.Hash) (*big.Int, error) {
-	f, err := db.kvStore.Has(batchNumberKey(txHash))
-	if err != nil {
-		return nil, err
-	}
-	if !f {
-		return nil, errutil.ErrNotFound
-	}
 	data, err := db.kvStore.Get(batchNumberKey(txHash))
 	if err != nil {
 		return nil, err
@@ -294,17 +257,13 @@ func (db *DB) readBatchNumber(txHash gethcommon.Hash) (*big.Int, error) {
 	return big.NewInt(0).SetBytes(data), nil
 }
 
-// Retrieves the total number of rolled-up transactions.
+// Retrieves the total number of rolled-up transactions - returns 0 if no tx count is found
 func (db *DB) readTotalTransactions() (*big.Int, error) {
-	f, err := db.kvStore.Has(totalTransactionsKey)
-	if err != nil {
-		return nil, err
-	}
-	if !f {
-		return big.NewInt(0), nil
-	}
 	data, err := db.kvStore.Get(totalTransactionsKey)
 	if err != nil {
+		if errors.Is(err, errutil.ErrNotFound) {
+			return big.NewInt(0), nil
+		}
 		return nil, err
 	}
 	if len(data) == 0 {
@@ -338,13 +297,6 @@ func (db *DB) writeBatch(batch *common.ExtBatch) error {
 
 // Retrieves the batch corresponding to the hash.
 func (db *DB) readBatch(hash gethcommon.Hash) (*common.ExtBatch, error) {
-	f, err := db.kvStore.Has(batchKey(hash))
-	if err != nil {
-		return nil, err
-	}
-	if !f {
-		return nil, errutil.ErrNotFound
-	}
 	data, err := db.kvStore.Get(batchKey(hash))
 	if err != nil {
 		return nil, err

--- a/go/host/db/blocks.go
+++ b/go/host/db/blocks.go
@@ -55,13 +55,6 @@ func (db *DB) writeBlockHeader(header *types.Header) error {
 
 // Retrieves the block header corresponding to the hash.
 func (db *DB) readBlockHeader(r ethdb.KeyValueReader, hash gethcommon.Hash) (*types.Header, error) {
-	f, err := r.Has(blockHeaderKey(hash))
-	if err != nil {
-		return nil, err
-	}
-	if !f {
-		return nil, errutil.ErrNotFound
-	}
 	data, err := r.Get(blockHeaderKey(hash))
 	if err != nil {
 		return nil, err

--- a/go/host/db/hostdb.go
+++ b/go/host/db/hostdb.go
@@ -3,14 +3,12 @@ package db
 import (
 	"os"
 
-	gethlog "github.com/ethereum/go-ethereum/log"
-
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/ethdb/leveldb"
+	"github.com/obscuronet/go-obscuro/go/common/gethdb"
 	"github.com/obscuronet/go-obscuro/go/common/log"
 
-	"github.com/ethereum/go-ethereum/ethdb/leveldb"
-
-	"github.com/ethereum/go-ethereum/ethdb"
-	"github.com/ethereum/go-ethereum/ethdb/memorydb"
+	gethlog "github.com/ethereum/go-ethereum/log"
 )
 
 // Schema keys, in alphabetical order.
@@ -37,7 +35,7 @@ type DB struct {
 // NewInMemoryDB returns a new instance of the Node DB
 func NewInMemoryDB() *DB {
 	return &DB{
-		kvStore: memorydb.New(),
+		kvStore: gethdb.NewMemDB(),
 	}
 }
 

--- a/go/host/db/rollups.go
+++ b/go/host/db/rollups.go
@@ -87,13 +87,6 @@ func (db *DB) writeRollupHeader(w ethdb.KeyValueWriter, header *common.Header) e
 
 // Retrieves the rollup header corresponding to the hash, or (nil, false) if no such header is found.
 func (db *DB) readRollupHeader(hash gethcommon.Hash) (*common.Header, error) {
-	f, err := db.kvStore.Has(rollupHeaderKey(hash))
-	if err != nil {
-		return nil, err
-	}
-	if !f {
-		return nil, errutil.ErrNotFound
-	}
 	data, err := db.kvStore.Get(rollupHeaderKey(hash))
 	if err != nil {
 		return nil, err
@@ -110,13 +103,6 @@ func (db *DB) readRollupHeader(hash gethcommon.Hash) (*common.Header, error) {
 
 // Returns the head rollup's hash, or (nil, false) is no such hash is found.
 func (db *DB) readHeadRollupHash() (*gethcommon.Hash, error) {
-	f, err := db.kvStore.Has(headRollup)
-	if err != nil {
-		return nil, err
-	}
-	if !f {
-		return nil, errutil.ErrNotFound
-	}
 	value, err := db.kvStore.Get(headRollup)
 	if err != nil {
 		return nil, err
@@ -145,13 +131,6 @@ func (db *DB) writeRollupHash(w ethdb.KeyValueWriter, header *common.Header) err
 
 // Retrieves the hash for the rollup with the given number, or (nil, false) if no such rollup is found.
 func (db *DB) readRollupHash(number *big.Int) (*gethcommon.Hash, error) {
-	f, err := db.kvStore.Has(rollupHashKey(number))
-	if err != nil {
-		return nil, err
-	}
-	if !f {
-		return nil, errutil.ErrNotFound
-	}
 	data, err := db.kvStore.Get(rollupHashKey(number))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### Why is this change needed?

- https://github.com/obscuronet/obscuro-internal/issues/1208
- memorydb in geth returns a string error instead of a typed one. It messes with our db usage. This normalizes the error usage.

### What changes were made as part of this PR:

- Provide a high level list of the changes made
- List key areas for the reviewer 

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
