### PR TITLE
Allow L1 start block to be configured to avoid all L1 history

### DIFF
--- a/go/config/host_config.go
+++ b/go/config/host_config.go
@@ -69,6 +69,8 @@ type HostConfig struct {
 	ObscuroChainID int64
 	// ProfilerEnabled starts a profiler instance
 	ProfilerEnabled bool
+	// L1StartHash is the hash of the L1 block we can start streaming from for all Obscuro state (e.g. management contract deployment block)
+	L1StartHash gethcommon.Hash
 }
 
 // DefaultHostConfig returns a HostConfig with default values.
@@ -99,5 +101,6 @@ func DefaultHostConfig() HostConfig {
 		L1ChainID:              1337,
 		ObscuroChainID:         777,
 		ProfilerEnabled:        false,
+		L1StartHash:            common.L1RootHash{}, // this hash will not be found, host will log a warning and then stream from L1 genesis
 	}
 }

--- a/go/ethadapter/blockprovider.go
+++ b/go/ethadapter/blockprovider.go
@@ -35,13 +35,13 @@ type EthBlockProvider struct {
 }
 
 // StartStreamingFromHash will look up the hash block, find the appropriate height (LCA if there have been forks) and
-// then call StartStreamingFromHeight based on that
+// then call StartStreamingFromHeight from there
 func (e *EthBlockProvider) StartStreamingFromHash(latestHash gethcommon.Hash) (*host.BlockStream, error) {
 	ancestorBlk, err := e.latestCanonAncestor(latestHash)
 	if err != nil {
 		return nil, err
 	}
-	return e.StartStreamingFromHeight(increment(ancestorBlk.Number()))
+	return e.StartStreamingFromHeight(ancestorBlk.Number())
 }
 
 // StartStreamingFromHeight will start streaming from the given height

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -388,7 +388,7 @@ func (h *host) startProcessing() {
 	blockStream, err := h.l1BlockProvider.StartStreamingFromHash(h.config.L1StartHash)
 	if err != nil {
 		// maybe start hash wasn't provided or couldn't be found, instead we stream from L1 genesis
-		// note: in production this could be expensive, hence the WARN log message
+		// note: in production this could be expensive, hence the WARN log message, todo: review whether we should fail here
 		h.logger.Warn("unable to stream from L1StartHash", log.ErrKey, err, "l1StartHash", h.config.L1StartHash)
 		blockStream, err = h.l1BlockProvider.StartStreamingFromHeight(big.NewInt(1))
 		if err != nil {

--- a/go/host/hostrunner/cli.go
+++ b/go/host/hostrunner/cli.go
@@ -43,6 +43,7 @@ type HostConfigToml struct {
 	L1ChainID              int64
 	ObscuroChainID         int64
 	ProfilerEnabled        bool
+	L1StartHash            string
 }
 
 // ParseConfig returns a config.HostConfig based on either the file identified by the `config` flag, or the flags with
@@ -165,5 +166,6 @@ func fileBasedConfig(configPath string) (config.HostConfig, error) {
 		L1ChainID:              tomlConfig.L1ChainID,
 		ObscuroChainID:         tomlConfig.ObscuroChainID,
 		ProfilerEnabled:        tomlConfig.ProfilerEnabled,
+		L1StartHash:            gethcommon.HexToHash(tomlConfig.L1StartHash),
 	}, nil
 }

--- a/go/host/hostrunner/cli.go
+++ b/go/host/hostrunner/cli.go
@@ -76,6 +76,7 @@ func ParseConfig() (config.HostConfig, error) {
 	privateKeyStr := flag.String(privateKeyName, cfg.PrivateKeyString, flagUsageMap[privateKeyName])
 	pkAddress := flag.String(pkAddressName, cfg.PKAddress, flagUsageMap[pkAddressName])
 	profilerEnabled := flag.Bool(profilerEnabledName, cfg.ProfilerEnabled, flagUsageMap[profilerEnabledName])
+	l1StartHash := flag.String(l1StartHashName, cfg.L1StartHash.Hex(), flagUsageMap[l1StartHashName])
 
 	flag.Parse()
 
@@ -114,6 +115,7 @@ func ParseConfig() (config.HostConfig, error) {
 	cfg.L1ChainID = *l1ChainID
 	cfg.ObscuroChainID = *obscuroChainID
 	cfg.ProfilerEnabled = *profilerEnabled
+	cfg.L1StartHash = gethcommon.HexToHash(*l1StartHash)
 
 	return cfg, nil
 }

--- a/go/host/hostrunner/cli_flags.go
+++ b/go/host/hostrunner/cli_flags.go
@@ -27,6 +27,7 @@ const (
 	l1ChainIDName                = "l1ChainID"
 	obscuroChainIDName           = "obscuroChainID"
 	profilerEnabledName          = "profilerEnabled"
+	l1StartHashName              = "l1Start"
 )
 
 // Returns a map of the flag usages.

--- a/integration/simulation/network/geth_network.go
+++ b/integration/simulation/network/geth_network.go
@@ -37,9 +37,9 @@ func (n *networkInMemGeth) Create(params *params.SimParams, stats *stats.Stats) 
 		int(params.AvgBlockDuration.Seconds()),
 	)
 
-	params.MgmtContractLib = mgmtcontractlib.NewMgmtContractLib(params.L1SetupData.MgmtContractAddress, testlog.Logger())
-	params.ERC20ContractLib = erc20contractlib.NewERC20ContractLib(params.L1SetupData.MgmtContractAddress,
-		params.L1SetupData.ObxErc20Address, params.L1SetupData.EthErc20Address)
+	params.MgmtContractLib = mgmtcontractlib.NewMgmtContractLib(&params.L1SetupData.MgmtContractAddress, testlog.Logger())
+	params.ERC20ContractLib = erc20contractlib.NewERC20ContractLib(&params.L1SetupData.MgmtContractAddress,
+		&params.L1SetupData.ObxErc20Address, &params.L1SetupData.EthErc20Address)
 
 	// Start the obscuro nodes and return the handles
 	n.l2Clients = startInMemoryObscuroNodes(params, n.gethNetwork.GenesisJSON, n.gethClients)

--- a/integration/simulation/network/geth_network.go
+++ b/integration/simulation/network/geth_network.go
@@ -30,15 +30,16 @@ func NewNetworkInMemoryGeth(wallets *params.SimWallets) Network {
 // Create inits and starts the nodes, wires them up, and populates the network objects
 func (n *networkInMemGeth) Create(params *params.SimParams, stats *stats.Stats) (*RPCHandles, error) {
 	// kickoff the network with the prefunded wallet addresses
-	params.MgmtContractAddr, params.ObxErc20Address, params.EthErc20Address, n.gethClients, n.gethNetwork = SetUpGethNetwork(
+	params.L1SetupData, n.gethClients, n.gethNetwork = SetUpGethNetwork(
 		n.wallets,
 		params.StartPort,
 		params.NumberOfNodes,
 		int(params.AvgBlockDuration.Seconds()),
 	)
 
-	params.MgmtContractLib = mgmtcontractlib.NewMgmtContractLib(params.MgmtContractAddr, testlog.Logger())
-	params.ERC20ContractLib = erc20contractlib.NewERC20ContractLib(params.MgmtContractAddr, params.ObxErc20Address, params.EthErc20Address)
+	params.MgmtContractLib = mgmtcontractlib.NewMgmtContractLib(params.L1SetupData.MgmtContractAddress, testlog.Logger())
+	params.ERC20ContractLib = erc20contractlib.NewERC20ContractLib(params.L1SetupData.MgmtContractAddress,
+		params.L1SetupData.ObxErc20Address, params.L1SetupData.EthErc20Address)
 
 	// Start the obscuro nodes and return the handles
 	n.l2Clients = startInMemoryObscuroNodes(params, n.gethNetwork.GenesisJSON, n.gethClients)

--- a/integration/simulation/network/geth_utils.go
+++ b/integration/simulation/network/geth_utils.go
@@ -60,14 +60,14 @@ func SetUpGethNetwork(wallets *params.SimWallets, StartPort int, nrNodes int, bl
 		panic(fmt.Sprintf("failed to deploy management contract. Cause: %s", err))
 	}
 
-	erc20ContractAddr := make([]*common.Address, 0)
+	erc20ContractAddr := make([]common.Address, 0)
 	for _, token := range wallets.Tokens {
 		erc20receipt, err := DeployContract(tmpEthClient, token.L1Owner, erc20contract.L1BytecodeWithDefaultSupply(string(token.Name)))
 		if err != nil {
 			panic(fmt.Sprintf("failed to deploy ERC20 contract. Cause: %s", err))
 		}
 		token.L1ContractAddress = &erc20receipt.ContractAddress
-		erc20ContractAddr = append(erc20ContractAddr, &erc20receipt.ContractAddress)
+		erc20ContractAddr = append(erc20ContractAddr, erc20receipt.ContractAddress)
 	}
 
 	ethClients := make([]ethadapter.EthClient, nrNodes)
@@ -76,8 +76,8 @@ func SetUpGethNetwork(wallets *params.SimWallets, StartPort int, nrNodes int, bl
 	}
 
 	l1Data := &params.L1SetupData{
-		ObscuroStartBlock:   &mgmtContractReceipt.BlockHash,
-		MgmtContractAddress: &mgmtContractReceipt.ContractAddress,
+		ObscuroStartBlock:   mgmtContractReceipt.BlockHash,
+		MgmtContractAddress: mgmtContractReceipt.ContractAddress,
 		ObxErc20Address:     erc20ContractAddr[0],
 		EthErc20Address:     erc20ContractAddr[1],
 	}

--- a/integration/simulation/network/geth_utils.go
+++ b/integration/simulation/network/geth_utils.go
@@ -29,7 +29,7 @@ const (
 	// TODO - Also prefund the L1 HOC and POC addresses used for the end-to-end tests when run locally.
 )
 
-func SetUpGethNetwork(wallets *params.SimWallets, StartPort int, nrNodes int, blockDurationSeconds int) (*common.Address, *common.Address, *common.Address, []ethadapter.EthClient, *gethnetwork.GethNetwork) {
+func SetUpGethNetwork(wallets *params.SimWallets, StartPort int, nrNodes int, blockDurationSeconds int) (*params.L1SetupData, []ethadapter.EthClient, *gethnetwork.GethNetwork) {
 	// make sure the geth network binaries exist
 	path, err := gethnetwork.EnsureBinariesExist(gethnetwork.LatestVersion)
 	if err != nil {
@@ -55,19 +55,19 @@ func SetUpGethNetwork(wallets *params.SimWallets, StartPort int, nrNodes int, bl
 	if err != nil {
 		panic(err)
 	}
-	mgmtContractAddr, err := DeployContract(tmpEthClient, wallets.MCOwnerWallet, bytecode)
+	mgmtContractReceipt, err := DeployContract(tmpEthClient, wallets.MCOwnerWallet, bytecode)
 	if err != nil {
 		panic(fmt.Sprintf("failed to deploy management contract. Cause: %s", err))
 	}
 
 	erc20ContractAddr := make([]*common.Address, 0)
 	for _, token := range wallets.Tokens {
-		address, err := DeployContract(tmpEthClient, token.L1Owner, erc20contract.L1BytecodeWithDefaultSupply(string(token.Name)))
+		erc20receipt, err := DeployContract(tmpEthClient, token.L1Owner, erc20contract.L1BytecodeWithDefaultSupply(string(token.Name)))
 		if err != nil {
 			panic(fmt.Sprintf("failed to deploy ERC20 contract. Cause: %s", err))
 		}
-		token.L1ContractAddress = address
-		erc20ContractAddr = append(erc20ContractAddr, address)
+		token.L1ContractAddress = &erc20receipt.ContractAddress
+		erc20ContractAddr = append(erc20ContractAddr, &erc20receipt.ContractAddress)
 	}
 
 	ethClients := make([]ethadapter.EthClient, nrNodes)
@@ -75,7 +75,14 @@ func SetUpGethNetwork(wallets *params.SimWallets, StartPort int, nrNodes int, bl
 		ethClients[i] = createEthClientConnection(int64(i), gethNetwork.WebSocketPorts[i])
 	}
 
-	return mgmtContractAddr, erc20ContractAddr[0], erc20ContractAddr[1], ethClients, gethNetwork
+	l1Data := &params.L1SetupData{
+		ObscuroStartBlock:   &mgmtContractReceipt.BlockHash,
+		MgmtContractAddress: &mgmtContractReceipt.ContractAddress,
+		ObxErc20Address:     erc20ContractAddr[0],
+		EthErc20Address:     erc20ContractAddr[1],
+	}
+
+	return l1Data, ethClients, gethNetwork
 }
 
 func StopGethNetwork(clients []ethadapter.EthClient, netw *gethnetwork.GethNetwork) {
@@ -91,8 +98,9 @@ func StopGethNetwork(clients []ethadapter.EthClient, netw *gethnetwork.GethNetwo
 	}
 }
 
-// DeployContract todo -this should live somewhere else
-func DeployContract(workerClient ethadapter.EthClient, w wallet.Wallet, contractBytes []byte) (*common.Address, error) {
+// DeployContract returns receipt of deployment
+// todo -this should live somewhere else
+func DeployContract(workerClient ethadapter.EthClient, w wallet.Wallet, contractBytes []byte) (*types.Receipt, error) {
 	deployContractTx := types.LegacyTx{
 		Nonce:    w.GetNonceAndIncrement(),
 		GasPrice: big.NewInt(2000000000),
@@ -119,7 +127,7 @@ func DeployContract(workerClient ethadapter.EthClient, w wallet.Wallet, contract
 				return nil, errors.New("unable to deploy contract")
 			}
 			testlog.Logger().Info(fmt.Sprintf("Contract successfully deployed to %s", receipt.ContractAddress))
-			return &receipt.ContractAddress, nil
+			return receipt, nil
 		}
 
 		testlog.Logger().Info(fmt.Sprintf("Contract deploy tx has not been mined into a block after %s...", time.Since(start)))

--- a/integration/simulation/network/inmemory.go
+++ b/integration/simulation/network/inmemory.go
@@ -54,20 +54,7 @@ func (n *basicNetworkOfInMemoryNodes) Create(params *params.SimParams, stats *st
 		miner := createMockEthNode(int64(i), params.NumberOfNodes, params.AvgBlockDuration, params.AvgNetworkLatency, stats)
 		p2pLayers[i] = p2p.NewMockP2P(params.AvgBlockDuration, params.AvgNetworkLatency)
 
-		agg := createInMemObscuroNode(
-			int64(i),
-			isGenesis,
-			GetNodeType(i),
-			params.MgmtContractLib,
-			params.ERC20ContractLib,
-			params.AvgGossipPeriod,
-			false,
-			nil,
-			params.Wallets.NodeWallets[i],
-			miner,
-			params.Wallets,
-			p2pLayers[i],
-		)
+		agg := createInMemObscuroNode(int64(i), isGenesis, GetNodeType(i), params.MgmtContractLib, params.ERC20ContractLib, params.AvgGossipPeriod, false, nil, params.Wallets.NodeWallets[i], miner, params.Wallets, p2pLayers[i], nil)
 		obscuroClient := p2p.NewInMemObscuroClient(agg)
 
 		n.ethNodes[i] = miner

--- a/integration/simulation/network/inmemory.go
+++ b/integration/simulation/network/inmemory.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"github.com/ethereum/go-ethereum/common"
 	"time"
 
 	"github.com/obscuronet/go-obscuro/go/obsclient"
@@ -54,7 +55,21 @@ func (n *basicNetworkOfInMemoryNodes) Create(params *params.SimParams, stats *st
 		miner := createMockEthNode(int64(i), params.NumberOfNodes, params.AvgBlockDuration, params.AvgNetworkLatency, stats)
 		p2pLayers[i] = p2p.NewMockP2P(params.AvgBlockDuration, params.AvgNetworkLatency)
 
-		agg := createInMemObscuroNode(int64(i), isGenesis, GetNodeType(i), params.MgmtContractLib, params.ERC20ContractLib, params.AvgGossipPeriod, false, nil, params.Wallets.NodeWallets[i], miner, params.Wallets, p2pLayers[i], nil)
+		agg := createInMemObscuroNode(
+			int64(i),
+			isGenesis,
+			GetNodeType(i),
+			params.MgmtContractLib,
+			params.ERC20ContractLib,
+			params.AvgGossipPeriod,
+			false,
+			nil,
+			params.Wallets.NodeWallets[i],
+			miner,
+			params.Wallets,
+			p2pLayers[i],
+			common.Hash{},
+		)
 		obscuroClient := p2p.NewInMemObscuroClient(agg)
 
 		n.ethNodes[i] = miner

--- a/integration/simulation/network/inmemory.go
+++ b/integration/simulation/network/inmemory.go
@@ -1,8 +1,9 @@
 package network
 
 import (
-	"github.com/ethereum/go-ethereum/common"
 	"time"
+
+	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/obscuronet/go-obscuro/go/obsclient"
 

--- a/integration/simulation/network/network_utils.go
+++ b/integration/simulation/network/network_utils.go
@@ -71,7 +71,7 @@ func createInMemObscuroNode(
 	ethClient ethadapter.EthClient,
 	wallets *params.SimWallets,
 	mockP2P *simp2p.MockP2P,
-	l1StartBlk *gethcommon.Hash,
+	l1StartBlk gethcommon.Hash,
 ) commonhost.Host {
 	hostConfig := config.HostConfig{
 		ID:                  gethcommon.BigToAddress(big.NewInt(id)),
@@ -80,7 +80,7 @@ func createInMemObscuroNode(
 		GossipRoundDuration: avgGossipPeriod,
 		HasClientRPCHTTP:    false,
 		P2PPublicAddress:    "dummy_address", // Required because the node sanity-checks that this field is not empty at start-up.
-		L1StartHash:         *l1StartBlk,
+		L1StartHash:         l1StartBlk,
 	}
 
 	enclaveConfig := config.EnclaveConfig{
@@ -118,7 +118,7 @@ func createSocketObscuroNode(
 	ethWallet wallet.Wallet,
 	mgmtContractLib mgmtcontractlib.MgmtContractLib,
 	ethClient ethadapter.EthClient,
-	l1StartBlk *gethcommon.Hash,
+	l1StartBlk gethcommon.Hash,
 ) commonhost.Host {
 	hostConfig := config.HostConfig{
 		ID:                     gethcommon.BigToAddress(big.NewInt(id)),
@@ -137,7 +137,7 @@ func createSocketObscuroNode(
 		P2PPublicAddress:       p2pAddr,
 		L1ChainID:              integration.EthereumChainID,
 		ObscuroChainID:         integration.ObscuroChainID,
-		L1StartHash:            *l1StartBlk,
+		L1StartHash:            l1StartBlk,
 	}
 
 	// create an enclave client

--- a/integration/simulation/network/network_utils.go
+++ b/integration/simulation/network/network_utils.go
@@ -71,6 +71,7 @@ func createInMemObscuroNode(
 	ethClient ethadapter.EthClient,
 	wallets *params.SimWallets,
 	mockP2P *simp2p.MockP2P,
+	l1StartBlk *gethcommon.Hash,
 ) commonhost.Host {
 	hostConfig := config.HostConfig{
 		ID:                  gethcommon.BigToAddress(big.NewInt(id)),
@@ -79,6 +80,7 @@ func createInMemObscuroNode(
 		GossipRoundDuration: avgGossipPeriod,
 		HasClientRPCHTTP:    false,
 		P2PPublicAddress:    "dummy_address", // Required because the node sanity-checks that this field is not empty at start-up.
+		L1StartHash:         *l1StartBlk,
 	}
 
 	enclaveConfig := config.EnclaveConfig{
@@ -116,6 +118,7 @@ func createSocketObscuroNode(
 	ethWallet wallet.Wallet,
 	mgmtContractLib mgmtcontractlib.MgmtContractLib,
 	ethClient ethadapter.EthClient,
+	l1StartBlk *gethcommon.Hash,
 ) commonhost.Host {
 	hostConfig := config.HostConfig{
 		ID:                     gethcommon.BigToAddress(big.NewInt(id)),
@@ -134,6 +137,7 @@ func createSocketObscuroNode(
 		P2PPublicAddress:       p2pAddr,
 		L1ChainID:              integration.EthereumChainID,
 		ObscuroChainID:         integration.ObscuroChainID,
+		L1StartHash:            *l1StartBlk,
 	}
 
 	// create an enclave client

--- a/integration/simulation/network/obscuro_node_utils.go
+++ b/integration/simulation/network/obscuro_node_utils.go
@@ -57,6 +57,7 @@ func startInMemoryObscuroNodes(params *params.SimParams, genesisJSON []byte, l1C
 			l1Clients[i],
 			params.Wallets,
 			p2pLayers[i],
+			params.L1SetupData.ObscuroStartBlock,
 		)
 	}
 	// make sure the aggregators can talk to each other
@@ -107,6 +108,7 @@ func startStandaloneObscuroNodes(params *params.SimParams, gethClients []ethadap
 			params.Wallets.NodeWallets[i],
 			params.MgmtContractLib,
 			gethClients[i],
+			params.L1SetupData.ObscuroStartBlock,
 		)
 
 		nodeRPCAddresses[i] = fmt.Sprintf("ws://%s:%d", Localhost, nodeRPCPortWS)

--- a/integration/simulation/network/socket.go
+++ b/integration/simulation/network/socket.go
@@ -47,9 +47,9 @@ func (n *networkOfSocketNodes) Create(simParams *params.SimParams, stats *stats.
 		int(simParams.AvgBlockDuration.Seconds()),
 	)
 
-	simParams.MgmtContractLib = mgmtcontractlib.NewMgmtContractLib(simParams.L1SetupData.MgmtContractAddress, testlog.Logger())
-	simParams.ERC20ContractLib = erc20contractlib.NewERC20ContractLib(simParams.L1SetupData.MgmtContractAddress,
-		simParams.L1SetupData.ObxErc20Address, simParams.L1SetupData.EthErc20Address)
+	simParams.MgmtContractLib = mgmtcontractlib.NewMgmtContractLib(&simParams.L1SetupData.MgmtContractAddress, testlog.Logger())
+	simParams.ERC20ContractLib = erc20contractlib.NewERC20ContractLib(&simParams.L1SetupData.MgmtContractAddress,
+		&simParams.L1SetupData.ObxErc20Address, &simParams.L1SetupData.EthErc20Address)
 
 	// Start the enclaves
 	startRemoteEnclaveServers(simParams)

--- a/integration/simulation/network/socket.go
+++ b/integration/simulation/network/socket.go
@@ -38,35 +38,36 @@ func NewNetworkOfSocketNodes(wallets *params.SimWallets) Network {
 	}
 }
 
-func (n *networkOfSocketNodes) Create(params *params.SimParams, stats *stats.Stats) (*RPCHandles, error) {
+func (n *networkOfSocketNodes) Create(simParams *params.SimParams, stats *stats.Stats) (*RPCHandles, error) {
 	// kickoff the network with the prefunded wallet addresses
-	params.MgmtContractAddr, params.ObxErc20Address, params.EthErc20Address, n.gethClients, n.gethNetwork = SetUpGethNetwork(
+	simParams.L1SetupData, n.gethClients, n.gethNetwork = SetUpGethNetwork(
 		n.wallets,
-		params.StartPort,
-		params.NumberOfNodes,
-		int(params.AvgBlockDuration.Seconds()),
+		simParams.StartPort,
+		simParams.NumberOfNodes,
+		int(simParams.AvgBlockDuration.Seconds()),
 	)
 
-	params.MgmtContractLib = mgmtcontractlib.NewMgmtContractLib(params.MgmtContractAddr, testlog.Logger())
-	params.ERC20ContractLib = erc20contractlib.NewERC20ContractLib(params.MgmtContractAddr, params.ObxErc20Address, params.EthErc20Address)
+	simParams.MgmtContractLib = mgmtcontractlib.NewMgmtContractLib(simParams.L1SetupData.MgmtContractAddress, testlog.Logger())
+	simParams.ERC20ContractLib = erc20contractlib.NewERC20ContractLib(simParams.L1SetupData.MgmtContractAddress,
+		simParams.L1SetupData.ObxErc20Address, simParams.L1SetupData.EthErc20Address)
 
 	// Start the enclaves
-	startRemoteEnclaveServers(params)
+	startRemoteEnclaveServers(simParams)
 
-	n.enclaveAddresses = make([]string, params.NumberOfNodes)
-	for i := 0; i < params.NumberOfNodes; i++ {
-		n.enclaveAddresses[i] = fmt.Sprintf("%s:%d", Localhost, params.StartPort+DefaultEnclaveOffset+i)
+	n.enclaveAddresses = make([]string, simParams.NumberOfNodes)
+	for i := 0; i < simParams.NumberOfNodes; i++ {
+		n.enclaveAddresses[i] = fmt.Sprintf("%s:%d", Localhost, simParams.StartPort+DefaultEnclaveOffset+i)
 	}
 
-	l2Clients, hostRPCAddresses := startStandaloneObscuroNodes(params, n.gethClients, n.enclaveAddresses)
+	l2Clients, hostRPCAddresses := startStandaloneObscuroNodes(simParams, n.gethClients, n.enclaveAddresses)
 	n.l2Clients = l2Clients
 	n.hostRPCAddresses = hostRPCAddresses
 
-	obscuroClients := make([]*obsclient.ObsClient, params.NumberOfNodes)
+	obscuroClients := make([]*obsclient.ObsClient, simParams.NumberOfNodes)
 	for idx, l2Client := range n.l2Clients {
 		obscuroClients[idx] = obsclient.NewObsClient(l2Client)
 	}
-	walletClients := createAuthClientsPerWallet(n.l2Clients, params.Wallets)
+	walletClients := createAuthClientsPerWallet(n.l2Clients, simParams.Wallets)
 
 	return &RPCHandles{
 		EthClients:     n.gethClients,

--- a/integration/simulation/params/params.go
+++ b/integration/simulation/params/params.go
@@ -3,10 +3,10 @@ package params
 import (
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
+
 	"github.com/obscuronet/go-obscuro/go/ethadapter/erc20contractlib"
 	"github.com/obscuronet/go-obscuro/go/ethadapter/mgmtcontractlib"
-
-	"github.com/ethereum/go-ethereum/common"
 )
 
 // SimParams are the parameters for setting up the simulation.
@@ -32,17 +32,22 @@ type SimParams struct {
 	// ERC20ContractLib allows parsing ERC20Contract txs to and from the eth txs
 	ERC20ContractLib erc20contractlib.ERC20ContractLib
 
-	// MgmtContractAddr defines the management contract address
-	MgmtContractAddr *common.Address
-
-	// ObxErc20Address - the address of the "OBX" ERC20
-	ObxErc20Address *common.Address
-	// EthErc20Address - the address of the "ETH" ERC20
-	EthErc20Address *common.Address
+	L1SetupData *L1SetupData
 
 	// Contains all the wallets required by the simulation
 	Wallets *SimWallets
 
 	StartPort int  // The port from which to start allocating ports. Must be unique across all simulations.
 	IsInMem   bool // Denotes that the sim does not have a full RPC layer.
+}
+
+type L1SetupData struct {
+	// ObscuroStartBlock is the L1 block hash where the Obscuro network activity begins (e.g. mgmt contract deployment)
+	ObscuroStartBlock *common.Hash
+	// MgmtContractAddr defines the management contract address
+	MgmtContractAddress *common.Address
+	// ObxErc20Address - the address of the "OBX" ERC20
+	ObxErc20Address *common.Address
+	// EthErc20Address - the address of the "ETH" ERC20
+	EthErc20Address *common.Address
 }

--- a/integration/simulation/params/params.go
+++ b/integration/simulation/params/params.go
@@ -43,11 +43,11 @@ type SimParams struct {
 
 type L1SetupData struct {
 	// ObscuroStartBlock is the L1 block hash where the Obscuro network activity begins (e.g. mgmt contract deployment)
-	ObscuroStartBlock *common.Hash
+	ObscuroStartBlock common.Hash
 	// MgmtContractAddr defines the management contract address
-	MgmtContractAddress *common.Address
+	MgmtContractAddress common.Address
 	// ObxErc20Address - the address of the "OBX" ERC20
-	ObxErc20Address *common.Address
+	ObxErc20Address common.Address
 	// EthErc20Address - the address of the "ETH" ERC20
-	EthErc20Address *common.Address
+	EthErc20Address common.Address
 }

--- a/integration/simulation/simulation.go
+++ b/integration/simulation/simulation.go
@@ -196,7 +196,7 @@ func (s *Simulation) prefundL1Accounts() {
 		addr := w.Address()
 		txData := &ethadapter.L1DepositTx{
 			Amount:        initialBalance,
-			To:            s.Params.L1SetupData.MgmtContractAddress,
+			To:            &s.Params.L1SetupData.MgmtContractAddress,
 			TokenContract: s.Params.Wallets.Tokens[bridge.HOC].L1ContractAddress,
 			Sender:        &addr,
 		}

--- a/integration/simulation/simulation.go
+++ b/integration/simulation/simulation.go
@@ -196,7 +196,7 @@ func (s *Simulation) prefundL1Accounts() {
 		addr := w.Address()
 		txData := &ethadapter.L1DepositTx{
 			Amount:        initialBalance,
-			To:            s.Params.MgmtContractAddr,
+			To:            s.Params.L1SetupData.MgmtContractAddress,
 			TokenContract: s.Params.Wallets.Tokens[bridge.HOC].L1ContractAddress,
 			Sender:        &addr,
 		}

--- a/integration/simulation/simulation_in_mem_test.go
+++ b/integration/simulation/simulation_in_mem_test.go
@@ -35,6 +35,7 @@ func TestInMemoryMonteCarloSimulation(t *testing.T) {
 		Wallets:                   wallets,
 		StartPort:                 integration.StartPortSimulationInMem,
 		IsInMem:                   true,
+		L1SetupData:               &params.L1SetupData{}, //
 	}
 
 	simParams.AvgNetworkLatency = simParams.AvgBlockDuration / 15

--- a/integration/simulation/simulation_tester.go
+++ b/integration/simulation/simulation_tester.go
@@ -47,7 +47,7 @@ func testSimulation(t *testing.T, netw network.Network, params *params.SimParams
 		stats,
 		networkClients,
 		params.Wallets,
-		params.MgmtContractAddr,
+		params.L1SetupData.MgmtContractAddress,
 		params.MgmtContractLib,
 		params.ERC20ContractLib,
 		0,

--- a/integration/simulation/simulation_tester.go
+++ b/integration/simulation/simulation_tester.go
@@ -47,7 +47,7 @@ func testSimulation(t *testing.T, netw network.Network, params *params.SimParams
 		stats,
 		networkClients,
 		params.Wallets,
-		params.L1SetupData.MgmtContractAddress,
+		&params.L1SetupData.MgmtContractAddress,
 		params.MgmtContractLib,
 		params.ERC20ContractLib,
 		0,

--- a/integration/smartcontract/smartcontracts_test.go
+++ b/integration/smartcontract/smartcontracts_test.go
@@ -94,14 +94,15 @@ func TestManagementContract(t *testing.T) {
 				panic(err)
 			}
 			// deploy the same contract to a new address
-			contractAddr, err := network.DeployContract(client, w, bytecode)
+			receipt, err := network.DeployContract(client, w, bytecode)
 			if err != nil {
 				t.Error(err)
 			}
 
 			// run the test using the new contract, but same wallet
 			test(t,
-				newDebugMgmtContractLib(*contractAddr, client.EthClient(), mgmtcontractlib.NewMgmtContractLib(contractAddr, testlog.Logger())),
+				newDebugMgmtContractLib(receipt.ContractAddress, client.EthClient(),
+					mgmtcontractlib.NewMgmtContractLib(&receipt.ContractAddress, testlog.Logger())),
 				w,
 				client,
 			)

--- a/tools/networkmanager/deploy_contract.go
+++ b/tools/networkmanager/deploy_contract.go
@@ -48,12 +48,11 @@ func DeployContract(config Config, logger gethlog.Logger) {
 	}
 	l1Wallet.SetNonce(nonce)
 
-	var contractAddress *common.Address
-	contractAddress, err = network.DeployContract(l1Client, l1Wallet, contractBytes)
+	receipt, err := network.DeployContract(l1Client, l1Wallet, contractBytes)
 	if err != nil {
 		panic(err)
 	}
 
-	println(contractAddress.Hex())
+	println(receipt.ContractAddress.Hex())
 	os.Exit(0)
 }


### PR DESCRIPTION
### Why is this change needed?

- To deploy Obscuro to a long-running L1 we want to be able to specify where in that network the nodes need to start tracking from
- No need to start tracking before mgmt contract deployed

### What changes were made as part of this PR:

- add host config param for L1StartHash
- use that param to start the block provider streaming in the main loop
- fallback to streaming from start of the L1 if that fails/if no hash provided (this change won't break testnets that are missing the arg)
- combined the start hash with the contract addresses in a L1SetupData struct, don't feel strongly about the name :)

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
