### PR TITLE
Testnet DNS now point to node1

### DIFF
--- a/.github/workflows/manual-deploy-dev-testnet.yml
+++ b/.github/workflows/manual-deploy-dev-testnet.yml
@@ -245,7 +245,7 @@ jobs:
           inlineScript: |
             az network nic ip-config address-pool add \
               --address-pool Dev-Backend-Pool-Obscuro-Testnet \
-              --ip-config-name ipconfigD-0-${{ GITHUB.RUN_NUMBER }} \
+              --ip-config-name ipconfigD-1-${{ GITHUB.RUN_NUMBER }} \
               --nic-name D-1-${{ GITHUB.RUN_NUMBER }}VMNic \
               --resource-group Testnet \
               --lb-name dev-testnet-loadbalancer

--- a/.github/workflows/manual-deploy-dev-testnet.yml
+++ b/.github/workflows/manual-deploy-dev-testnet.yml
@@ -246,7 +246,7 @@ jobs:
             az network nic ip-config address-pool add \
               --address-pool Dev-Backend-Pool-Obscuro-Testnet \
               --ip-config-name ipconfigD-0-${{ GITHUB.RUN_NUMBER }} \
-              --nic-name D-0-${{ GITHUB.RUN_NUMBER }}VMNic \
+              --nic-name D-1-${{ GITHUB.RUN_NUMBER }}VMNic \
               --resource-group Testnet \
               --lb-name dev-testnet-loadbalancer
 

--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -196,7 +196,7 @@ jobs:
           inlineScript: |
             az network nic ip-config address-pool add \
               --address-pool Backend-Pool-Obscuro-Testnet \
-              --ip-config-name ipconfigT-0-${{ GITHUB.RUN_NUMBER }} \
+              --ip-config-name ipconfigT-1-${{ GITHUB.RUN_NUMBER }} \
               --nic-name T-1-${{ GITHUB.RUN_NUMBER }}VMNic \
               --resource-group Testnet \
               --lb-name testnet-loadbalancer

--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -197,7 +197,7 @@ jobs:
             az network nic ip-config address-pool add \
               --address-pool Backend-Pool-Obscuro-Testnet \
               --ip-config-name ipconfigT-0-${{ GITHUB.RUN_NUMBER }} \
-              --nic-name T-0-${{ GITHUB.RUN_NUMBER }}VMNic \
+              --nic-name T-1-${{ GITHUB.RUN_NUMBER }}VMNic \
               --resource-group Testnet \
               --lb-name testnet-loadbalancer
 


### PR DESCRIPTION
### Why is this change needed?

- Puts back the change to point RPC traffic to node 1. 


