### PR TITLE
Remove genesis block references outside of in-mem mock code

### DIFF
--- a/go/enclave/bridge/bridge.go
+++ b/go/enclave/bridge/bridge.go
@@ -227,15 +227,11 @@ func (bridge *Bridge) ExtractDeposits(
 	blockResolver db.BlockResolver,
 	rollupState *state.StateDB,
 ) []*common.L2Tx {
-	from := common.GenesisBlock.Hash()
-	height := common.L1GenesisHeight
-	if fromBlock != nil {
-		from = fromBlock.Hash()
-		height = fromBlock.NumberU64()
-		if !blockResolver.IsAncestor(toBlock, fromBlock) {
-			bridge.logger.Crit("Deposits can't be processed because the rollups are not on the same Ethereum fork. This should not happen.")
-			return nil
-		}
+	from := fromBlock.Hash()
+	height := fromBlock.NumberU64()
+	if !blockResolver.IsAncestor(toBlock, fromBlock) {
+		bridge.logger.Crit("Deposits can't be processed because the rollups are not on the same Ethereum fork. This should not happen.")
+		return nil
 	}
 
 	allDeposits := make([]*common.L2Tx, 0)

--- a/go/enclave/core/rollup.go
+++ b/go/enclave/core/rollup.go
@@ -83,12 +83,8 @@ func EmptyRollup(agg gethcommon.Address, parent *common.Header, blkHash gethcomm
 	return &r, nil
 }
 
-// NewRollup - produces a new rollup. only used for genesis. todo - review
-func NewRollup(blkHash gethcommon.Hash, parent *Rollup, height uint64, a gethcommon.Address, txs []*common.L2Tx, withdrawals []common.Withdrawal, nonce common.Nonce, state common.StateRoot) *Rollup {
-	parentHash := common.GenesisHash
-	if parent != nil {
-		parentHash = parent.Hash()
-	}
+// NewRollup - produces a new rollup. only used for genesis and testing
+func NewRollup(blkHash gethcommon.Hash, parentHash gethcommon.Hash, height uint64, a gethcommon.Address, txs []*common.L2Tx, withdrawals []common.Withdrawal, state common.StateRoot) *Rollup {
 	h := common.Header{
 		Agg:         a,
 		ParentHash:  parentHash,

--- a/go/enclave/db/storage.go
+++ b/go/enclave/db/storage.go
@@ -181,7 +181,7 @@ func (s *storageImpl) IsBlockAncestor(block *types.Block, maybeAncestor common.L
 		return true
 	}
 
-	if bytes.Equal(maybeAncestor.Bytes(), common.GenesisBlock.Hash().Bytes()) {
+	if bytes.Equal(maybeAncestor.Bytes(), (common.L1RootHash{}).Bytes()) {
 		return true
 	}
 

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -133,12 +133,11 @@ func (rc *RollupChain) ProduceGenesisRollup(blkHash common.L1RootHash) (*core.Ro
 
 	rolGenesis := core.NewRollup(
 		blkHash,
-		nil,
+		common.L1RootHash{},
 		common.L2GenesisHeight,
 		gethcommon.HexToAddress("0x0"),
 		[]*common.L2Tx{},
 		[]common.Withdrawal{},
-		common.GenerateNonce(),
 		*preFundGenesisState,
 	)
 

--- a/go/ethadapter/geth_rpc_client.go
+++ b/go/ethadapter/geth_rpc_client.go
@@ -85,7 +85,7 @@ func (e *gethRPCClient) BlocksBetween(startingBlock *types.Block, lastBlock *typ
 }
 
 func (e *gethRPCClient) IsBlockAncestor(block *types.Block, maybeAncestor common.L1RootHash) bool {
-	if bytes.Equal(maybeAncestor.Bytes(), block.Hash().Bytes()) || bytes.Equal(maybeAncestor.Bytes(), common.GenesisBlock.Hash().Bytes()) {
+	if bytes.Equal(maybeAncestor.Bytes(), block.Hash().Bytes()) || bytes.Equal(maybeAncestor.Bytes(), (common.L1RootHash{}).Bytes()) {
 		return true
 	}
 

--- a/integration/ethereummock/db.go
+++ b/integration/ethereummock/db.go
@@ -96,7 +96,7 @@ func (n *blockResolverInMem) IsBlockAncestor(block *types.Block, maybeAncestor c
 		return true
 	}
 
-	if bytes.Equal(maybeAncestor.Bytes(), common.GenesisBlock.Hash().Bytes()) {
+	if bytes.Equal(maybeAncestor.Bytes(), MockGenesisBlock.Hash().Bytes()) {
 		return true
 	}
 

--- a/integration/ethereummock/mock_blocks.go
+++ b/integration/ethereummock/mock_blocks.go
@@ -1,4 +1,4 @@
-package common
+package ethereummock
 
 import (
 	"math/big"
@@ -8,15 +8,11 @@ import (
 	"github.com/ethereum/go-ethereum/trie"
 )
 
-var GenesisHash = common.HexToHash("0000000000000000000000000000000000000000000000000000000000000000")
+var MockGenesisBlock = NewBlock(nil, common.HexToAddress("0x0"), []*types.Transaction{})
 
-// GenesisBlock - this is a hack that has to be removed ASAP.
-var GenesisBlock = NewBlock(nil, common.HexToAddress("0x0"), []*types.Transaction{})
-
-// NewBlock - todo - remove this ASAP
 func NewBlock(parent *types.Block, nodeID common.Address, txs []*types.Transaction) *types.Block {
-	parentHash := GenesisHash
-	height := L1GenesisHeight
+	var parentHash common.Hash
+	var height uint64
 	if parent != nil {
 		parentHash = parent.Hash()
 		height = parent.NumberU64() + 1

--- a/integration/ethereummock/node.go
+++ b/integration/ethereummock/node.go
@@ -126,7 +126,7 @@ func (m *Node) BlockNumber() (uint64, error) {
 
 func (m *Node) BlockByNumber(n *big.Int) (*types.Block, error) {
 	if n.Int64() == 0 {
-		return common.GenesisBlock, nil
+		return MockGenesisBlock, nil
 	}
 	// TODO this should be a method in the resolver
 	blk, err := m.Resolver.FetchHeadBlock()
@@ -136,7 +136,7 @@ func (m *Node) BlockByNumber(n *big.Int) (*types.Block, error) {
 		}
 		return nil, fmt.Errorf("could not retrieve head block. Cause: %w", err)
 	}
-	for !bytes.Equal(blk.ParentHash().Bytes(), common.GenesisHash.Bytes()) {
+	for !bytes.Equal(blk.ParentHash().Bytes(), (common.L1RootHash{}).Bytes()) {
 		if blk.NumberU64() == n.Uint64() {
 			return blk, nil
 		}
@@ -186,8 +186,8 @@ func (m *Node) Start() {
 		go m.startMining()
 	}
 
-	m.Resolver.StoreBlock(common.GenesisBlock)
-	head := m.setHead(common.GenesisBlock)
+	m.Resolver.StoreBlock(MockGenesisBlock)
+	head := m.setHead(MockGenesisBlock)
 
 	for {
 		select {
@@ -350,7 +350,7 @@ func (m *Node) startMining() {
 					return
 				}
 
-				m.miningCh <- common.NewBlock(canonicalBlock, m.l2ID, toInclude)
+				m.miningCh <- NewBlock(canonicalBlock, m.l2ID, toInclude)
 			})
 		}
 	}

--- a/integration/simulation/output_stats.go
+++ b/integration/simulation/output_stats.go
@@ -57,7 +57,7 @@ func (o *OutputStats) countBlockChain() {
 	header := getHeadRollupHeader(obscuroClient)
 	var err error
 	for {
-		if header != nil && !bytes.Equal(header.Hash().Bytes(), common.GenesisHash.Bytes()) {
+		if header != nil && !bytes.Equal(header.Hash().Bytes(), (common.L1RootHash{}).Bytes()) {
 			break
 		}
 
@@ -70,7 +70,7 @@ func (o *OutputStats) countBlockChain() {
 	}
 
 	// iterate the L1 Blocks and get the rollups
-	for headBlock, _ := l1Node.FetchHeadBlock(); headBlock != nil && !bytes.Equal(headBlock.Hash().Bytes(), common.GenesisHash.Bytes()); headBlock, _ = l1Node.BlockByHash(headBlock.ParentHash()) {
+	for headBlock, _ := l1Node.FetchHeadBlock(); headBlock != nil && !bytes.Equal(headBlock.Hash().Bytes(), (common.L1RootHash{}).Bytes()); headBlock, _ = l1Node.BlockByHash(headBlock.ParentHash()) {
 		for _, tx := range headBlock.Transactions() {
 			t := o.simulation.Params.MgmtContractLib.DecodeTx(tx)
 			if t == nil {

--- a/integration/simulation/simulation.go
+++ b/integration/simulation/simulation.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/obscuronet/go-obscuro/integration/ethereummock"
+
 	"github.com/obscuronet/go-obscuro/go/common/errutil"
 
 	"github.com/ethereum/go-ethereum"
@@ -48,7 +50,7 @@ type Simulation struct {
 
 // Start executes the simulation given all the Params. Injects transactions.
 func (s *Simulation) Start() {
-	testlog.Logger().Info(fmt.Sprintf("Genesis block: b_%d.", common.ShortHash(common.GenesisBlock.Hash())))
+	testlog.Logger().Info(fmt.Sprintf("Genesis block: b_%d.", common.ShortHash(ethereummock.MockGenesisBlock.Hash())))
 	s.ctx = context.Background() // use injected context for graceful shutdowns
 
 	s.waitForObscuroGenesisOnL1()
@@ -98,7 +100,7 @@ func (s *Simulation) waitForObscuroGenesisOnL1() {
 			panic(fmt.Errorf("could not fetch head block. Cause: %w", err))
 		}
 		if err == nil {
-			for _, b := range client.BlocksBetween(common.GenesisBlock, head) {
+			for _, b := range client.BlocksBetween(ethereummock.MockGenesisBlock, head) {
 				for _, tx := range b.Transactions() {
 					t := s.Params.MgmtContractLib.DecodeTx(tx)
 					if t == nil {

--- a/integration/simulation/validate_chain.go
+++ b/integration/simulation/validate_chain.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/obscuronet/go-obscuro/integration/ethereummock"
+
 	"github.com/obscuronet/go-obscuro/integration/common/testlog"
 
 	"github.com/obscuronet/go-obscuro/go/obsclient"
@@ -127,7 +129,7 @@ func checkBlockchainOfEthereumNode(t *testing.T, node ethadapter.EthClient, minH
 		t.Errorf("Node %d: There were only %d blocks mined. Expected at least: %d.", nodeIdx, height, minHeight)
 	}
 
-	deposits, rollups, totalDeposited, blockCount := ExtractDataFromEthereumChain(common.GenesisBlock, head, node, s, nodeIdx)
+	deposits, rollups, totalDeposited, blockCount := ExtractDataFromEthereumChain(ethereummock.MockGenesisBlock, head, node, s, nodeIdx)
 	s.Stats.TotalL1Blocks = uint64(blockCount)
 
 	if len(findHashDups(deposits)) > 0 {


### PR DESCRIPTION
### Why is this change needed?

- we no longer go back to the genesis of the L1 - the enclave is happy with starting its view of the L1 chain from the location we begin feeding it (e.g. mgmt contract deployment block)

### What changes were made as part of this PR:

- remove genesis block references from everywhere outside of the in-mem mock code

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
