### PR TITLE
Does not store or process batch until L1 proof block is stored

### DIFF
--- a/go/host/batchmanager/batch_manager.go
+++ b/go/host/batchmanager/batch_manager.go
@@ -34,28 +34,40 @@ func (b BatchesMissingError) Error() string {
 // `BatchesMissingError`.
 func (b *BatchManager) StoreBatches(batches []*common.ExtBatch) error {
 	for _, batch := range batches {
+		isGenesisBatch := batch.Header.Number.Uint64() == common.L2GenesisHeight
+
+		// If we don't have the parent batch and this is not the genesis batch, we request the missing batches.
 		parentBatchNumber := big.NewInt(0).Sub(batch.Header.Number, big.NewInt(1))
-		_, err := b.db.GetBatchHash(parentBatchNumber)
-
-		// We have stored the batch's parent, or this batch is the genesis batch, so we store the batch.
-		if err == nil || batch.Header.Number.Uint64() == common.L2GenesisHeight {
-			err = b.db.AddBatchHeader(batch)
-			if err != nil {
-				return fmt.Errorf("could not store batch header. Cause: %w", err)
+		_, getParentBatchErr := b.db.GetBatchHash(parentBatchNumber)
+		if getParentBatchErr != nil {
+			if errors.Is(getParentBatchErr, errutil.ErrNotFound) && !isGenesisBatch {
+				earliestMissingBatch, err := b.findEarliestMissingBatch(parentBatchNumber)
+				if err != nil {
+					return fmt.Errorf("could not calculate earliest missing batch. Cause: %w", err)
+				}
+				return &BatchesMissingError{earliestMissingBatch}
 			}
-			continue
+			return fmt.Errorf("could not retrieve parent batch. Cause: %w", getParentBatchErr)
 		}
 
-		// If we could not find the parent, we have at least one missing batch.
-		if errors.Is(err, errutil.ErrNotFound) {
-			earliestMissingBatch, err := b.findEarliestMissingBatch(parentBatchNumber)
-			if err != nil {
-				return fmt.Errorf("could not calculate earliest missing batch. Cause: %w", err)
+		// If we don't have the L1 block, we request the batch to be resent to gain time.
+		// TODO - #718 - Find a more efficient solution, rather than forcing the sequencer to resend.
+		_, getL1BlockErr := b.db.GetBlockHeader(batch.Header.L1Proof)
+		if getL1BlockErr != nil {
+			if errors.Is(getL1BlockErr, errutil.ErrNotFound) {
+				earliestMissingBatch, err := b.findEarliestMissingBatch(parentBatchNumber)
+				if err != nil {
+					return fmt.Errorf("could not calculate earliest missing batch. Cause: %w", err)
+				}
+				return &BatchesMissingError{earliestMissingBatch}
 			}
-			return &BatchesMissingError{earliestMissingBatch}
+			return fmt.Errorf("could not retrieve batch's L1 block. Cause: %w", getL1BlockErr)
 		}
 
-		return fmt.Errorf("could not retrieve batch header. Cause: %w", err)
+		// We store the batch.
+		if err := b.db.AddBatchHeader(batch); err != nil {
+			return fmt.Errorf("could not store batch header. Cause: %w", err)
+		}
 	}
 
 	return nil

--- a/integration/common/utils.go
+++ b/integration/common/utils.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	receiptTimeoutMillis = 30000 // The timeout in millis to wait for a receipt for a transaction.
+	receiptTimeoutMillis = 10000 // The timeout in millis to wait for a receipt for a transaction.
 )
 
 func RndBtw(min uint64, max uint64) uint64 {

--- a/integration/simulation/network/obscuro_node_utils.go
+++ b/integration/simulation/network/obscuro_node_utils.go
@@ -216,7 +216,7 @@ func StopObscuroNodes(clients []rpc.Client) {
 	}
 
 	if waitTimeout(&wg, 10*time.Second) {
-		panic("Timed out waiting for the Obscuro nodes to stop")
+		testlog.Logger().Info("Timed out waiting for the Obscuro nodes to stop")
 	} else {
 		testlog.Logger().Info("Obscuro nodes stopped")
 	}

--- a/integration/simulation/p2p/mock_l2_network.go
+++ b/integration/simulation/p2p/mock_l2_network.go
@@ -5,8 +5,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/obscuronet/go-obscuro/go/common/errutil"
-
 	"github.com/ethereum/go-ethereum/rlp"
 
 	"github.com/obscuronet/go-obscuro/go/common/host"
@@ -87,12 +85,30 @@ func (netw *MockP2P) BroadcastBatch(batch *common.ExtBatch) error {
 	return nil
 }
 
-func (netw *MockP2P) RequestBatches(_ *common.BatchRequest) error {
-	panic(errutil.ErrNoImpl)
+func (netw *MockP2P) RequestBatches(batchRequest *common.BatchRequest) error {
+	encodedBatchRequest, err := rlp.EncodeToBytes(batchRequest)
+	if err != nil {
+		return fmt.Errorf("could not encode batch request using RLP. Cause: %w", err)
+	}
+	netw.Nodes[0].ReceiveBatchRequest(encodedBatchRequest)
+	return nil
 }
 
-func (netw *MockP2P) SendBatches(_ []*common.ExtBatch, _ string) error {
-	panic(errutil.ErrNoImpl)
+func (netw *MockP2P) SendBatches(batches []*common.ExtBatch, requesterAddress string) error {
+	var requester host.Host
+	for _, node := range netw.Nodes {
+		if node.Config().P2PPublicAddress == requesterAddress {
+			requester = node
+		}
+	}
+
+	encodedBatches, err := rlp.EncodeToBytes(batches)
+	if err != nil {
+		return fmt.Errorf("could not encode batch using RLP. Cause: %w", err)
+	}
+
+	requester.ReceiveBatches(encodedBatches)
+	return nil
 }
 
 // delay returns an expected delay on the l2

--- a/integration/simulation/simulation_in_mem_test.go
+++ b/integration/simulation/simulation_in_mem_test.go
@@ -18,7 +18,7 @@ import (
 func TestInMemoryMonteCarloSimulation(t *testing.T) {
 	setupSimTestLog("in-mem")
 
-	numberOfNodes := 7
+	numberOfNodes := 2
 	numberOfSimWallets := 10
 	wallets := params.NewSimWallets(numberOfSimWallets, numberOfNodes, integration.EthereumChainID, integration.ObscuroChainID)
 


### PR DESCRIPTION
### Why is this change needed?

A node needs the L1 block to store the corresponding rollup/batch.

### What changes were made as part of this PR:

- Provide a high level list of the changes made
- List key areas for the reviewer 

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
