### PR TITLE
Fixes bug in batch catch-up code

### DIFF
--- a/go/common/batches.go
+++ b/go/common/batches.go
@@ -1,9 +1,5 @@
 package common
 
-import (
-	"math/big"
-)
-
 // ExtBatch is an encrypted form of batch used when passing the batch around outside of an enclave.
 // TODO - #718 - Expand this structure to contain the required fields.
 type ExtBatch struct {
@@ -14,8 +10,8 @@ type ExtBatch struct {
 
 // TODO - #718 - Cache hash calculation.
 
-// BatchRequest is used when requesting a range of batches from a peer.
+// BatchRequest is used when requesting a missing batch from a peer.
 type BatchRequest struct {
-	Requester            string
-	EarliestMissingBatch *big.Int
+	Requester    string
+	MissingBatch *L2RootHash
 }

--- a/go/common/host/host.go
+++ b/go/common/host/host.go
@@ -47,8 +47,8 @@ type P2P interface {
 	BroadcastTx(tx common.EncryptedTx) error
 	// BroadcastBatch sends the batch to every other node on the network.
 	BroadcastBatch(batch *common.ExtBatch) error
-	// RequestBatches requests batches from the sequencer.
-	RequestBatches(batchRequest *common.BatchRequest) error
+	// RequestBatch requests a batch from the sequencer.
+	RequestBatch(batchRequest *common.BatchRequest) error
 	// SendBatches sends batches to a specific node, in response to a batch request.
 	SendBatches(batches []*common.ExtBatch, to string) error
 }

--- a/go/common/host/host.go
+++ b/go/common/host/host.go
@@ -23,8 +23,8 @@ type Host interface {
 	SubmitAndBroadcastTx(encryptedParams common.EncryptedParamsSendRawTx) (common.EncryptedResponseSendRawTx, error)
 	// ReceiveTx processes a transaction received from a peer host.
 	ReceiveTx(tx common.EncryptedTx)
-	// ReceiveBatches receives a set of batches from a peer host.
-	ReceiveBatches(batches common.EncodedBatches)
+	// ReceiveBatch receives a batch from a peer host.
+	ReceiveBatch(batches common.EncodedBatch)
 	// ReceiveBatchRequest receives a batch request from a peer host. Used during catch-up.
 	ReceiveBatchRequest(batchRequest common.EncodedBatchRequest)
 	// Subscribe feeds logs matching the encrypted log subscription to the matchedLogs channel.
@@ -49,8 +49,8 @@ type P2P interface {
 	BroadcastBatch(batch *common.ExtBatch) error
 	// RequestBatch requests a batch from the sequencer.
 	RequestBatch(batchRequest *common.BatchRequest) error
-	// SendBatches sends batches to a specific node, in response to a batch request.
-	SendBatches(batches []*common.ExtBatch, to string) error
+	// SendBatch sends a batch to a specific node, in response to a batch request.
+	SendBatch(batch *common.ExtBatch, to string) error
 }
 
 // ReconnectingBlockProvider interface allows host to monitor and await L1 blocks.

--- a/go/common/types.go
+++ b/go/common/types.go
@@ -38,7 +38,7 @@ type (
 
 	Nonce               = uint64
 	EncodedRollup       []byte
-	EncodedBatches      []byte
+	EncodedBatch        []byte
 	EncodedBatchRequest []byte
 )
 

--- a/go/host/batchmanager/batch_manager.go
+++ b/go/host/batchmanager/batch_manager.go
@@ -3,6 +3,7 @@ package batchmanager
 import (
 	"errors"
 	"fmt"
+
 	"github.com/obscuronet/go-obscuro/go/common"
 	"github.com/obscuronet/go-obscuro/go/common/errutil"
 	"github.com/obscuronet/go-obscuro/go/host/db"
@@ -30,7 +31,7 @@ func (b BatchMissingError) Error() string {
 
 // StoreBatch stores the provided batch. If there is a batch missing in the chain, it returns a `BatchMissingError`.
 // There is no way to identify more than one missing batch in the chain - we cannot go by the batch numbers we have
-// stored, since these batches may have been stored as part of another chain.
+// stored, since these batches may have been stored as part of a discarded fork.
 func (b *BatchManager) StoreBatch(batch *common.ExtBatch) error {
 	_, err := b.db.GetBatch(batch.Header.ParentHash)
 

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -866,16 +866,16 @@ func (h *host) handleBatches(encodedBatches *common.EncodedBatches) error {
 	// We store the batches. If we encounter any missing batches, we abort and request the missing batches instead.
 	err = h.batchManager.StoreBatches(batches)
 	if err != nil {
-		batchesMissingError, ok := err.(*batchmanager.BatchesMissingError) //nolint:errorlint
+		batchMissingError, ok := err.(*batchmanager.BatchMissingError) //nolint:errorlint
 		if !ok {
 			return fmt.Errorf("could not store batches. Cause: %w", err)
 		}
 
 		batchRequest := common.BatchRequest{
-			Requester:            h.config.P2PPublicAddress,
-			EarliestMissingBatch: batchesMissingError.EarliestMissingBatch,
+			Requester:    h.config.P2PPublicAddress,
+			MissingBatch: batchMissingError.MissingBatch,
 		}
-		err = h.p2p.RequestBatches(&batchRequest)
+		err = h.p2p.RequestBatch(&batchRequest)
 		if err != nil {
 			return fmt.Errorf("could not request historical batches. Cause: %w", err)
 		}
@@ -899,12 +899,12 @@ func (h *host) handleBatchRequest(encodedBatchRequest *common.EncodedBatchReques
 		return fmt.Errorf("could not decode batch request using RLP. Cause: %w", err)
 	}
 
-	batches, err := h.batchManager.GetBatches(batchRequest)
+	batch, err := h.batchManager.GetBatch(batchRequest)
 	if err != nil {
 		return fmt.Errorf("could not retrieve batches based on request. Cause: %w", err)
 	}
 
-	return h.p2p.SendBatches(batches, batchRequest.Requester)
+	return h.p2p.SendBatches([]*common.ExtBatch{batch}, batchRequest.Requester)
 }
 
 // Checks the host config is valid.

--- a/go/host/p2p/p2p.go
+++ b/go/host/p2p/p2p.go
@@ -105,7 +105,7 @@ func (p *p2pImpl) BroadcastBatch(batch *common.ExtBatch) error {
 	return p.broadcast(msg)
 }
 
-func (p *p2pImpl) RequestBatches(batchRequest *common.BatchRequest) error {
+func (p *p2pImpl) RequestBatch(batchRequest *common.BatchRequest) error {
 	if len(p.peerAddresses) == 0 {
 		return errors.New("no peers available to request batches")
 	}
@@ -116,7 +116,7 @@ func (p *p2pImpl) RequestBatches(batchRequest *common.BatchRequest) error {
 
 	msg := message{Type: msgTypeBatchRequest, Contents: encodedBatchRequest}
 	// TODO - #718 - Use better method to identify sequencer?
-	// TODO - #718 - Allow missing batches to be requested from peers other than sequencer?
+	// TODO - #718 - Allow missing batch to be requested from peers other than sequencer?
 	return p.send(msg, p.peerAddresses[0])
 }
 

--- a/go/host/p2p/p2p.go
+++ b/go/host/p2p/p2p.go
@@ -30,7 +30,7 @@ type msgType uint8
 
 const (
 	msgTypeTx msgType = iota
-	msgTypeBatches
+	msgTypeBatch
 	msgTypeBatchRequest
 )
 
@@ -96,12 +96,12 @@ func (p *p2pImpl) BroadcastTx(tx common.EncryptedTx) error {
 }
 
 func (p *p2pImpl) BroadcastBatch(batch *common.ExtBatch) error {
-	encodedBatches, err := rlp.EncodeToBytes([]*common.ExtBatch{batch})
+	encodedBatch, err := rlp.EncodeToBytes(batch)
 	if err != nil {
 		return fmt.Errorf("could not encode batch using RLP. Cause: %w", err)
 	}
 
-	msg := message{Type: msgTypeBatches, Contents: encodedBatches}
+	msg := message{Type: msgTypeBatch, Contents: encodedBatch}
 	return p.broadcast(msg)
 }
 
@@ -120,13 +120,13 @@ func (p *p2pImpl) RequestBatch(batchRequest *common.BatchRequest) error {
 	return p.send(msg, p.peerAddresses[0])
 }
 
-func (p *p2pImpl) SendBatches(batches []*common.ExtBatch, to string) error {
-	encodedBatches, err := rlp.EncodeToBytes(batches)
+func (p *p2pImpl) SendBatch(batch *common.ExtBatch, to string) error {
+	encodedBatch, err := rlp.EncodeToBytes(batch)
 	if err != nil {
 		return fmt.Errorf("could not encode batches using RLP. Cause: %w", err)
 	}
 
-	msg := message{Type: msgTypeBatches, Contents: encodedBatches}
+	msg := message{Type: msgTypeBatch, Contents: encodedBatch}
 	return p.send(msg, to)
 }
 
@@ -167,8 +167,8 @@ func (p *p2pImpl) handle(conn net.Conn, callback host.Host) {
 	case msgTypeTx:
 		// The transaction is encrypted, so we cannot check that it's correctly formed.
 		callback.ReceiveTx(msg.Contents)
-	case msgTypeBatches:
-		callback.ReceiveBatches(msg.Contents)
+	case msgTypeBatch:
+		callback.ReceiveBatch(msg.Contents)
 	case msgTypeBatchRequest:
 		callback.ReceiveBatchRequest(msg.Contents)
 	}

--- a/integration/simulation/p2p/mock_l2_network.go
+++ b/integration/simulation/p2p/mock_l2_network.go
@@ -87,7 +87,7 @@ func (netw *MockP2P) BroadcastBatch(batch *common.ExtBatch) error {
 	return nil
 }
 
-func (netw *MockP2P) RequestBatches(_ *common.BatchRequest) error {
+func (netw *MockP2P) RequestBatch(_ *common.BatchRequest) error {
 	panic(errutil.ErrNoImpl)
 }
 

--- a/integration/simulation/p2p/mock_l2_network.go
+++ b/integration/simulation/p2p/mock_l2_network.go
@@ -72,7 +72,7 @@ func (netw *MockP2P) BroadcastBatch(batch *common.ExtBatch) error {
 		return nil
 	}
 
-	encodedBatches, err := rlp.EncodeToBytes([]*common.ExtBatch{batch})
+	encodedBatch, err := rlp.EncodeToBytes(batch)
 	if err != nil {
 		return fmt.Errorf("could not encode batch using RLP. Cause: %w", err)
 	}
@@ -80,7 +80,7 @@ func (netw *MockP2P) BroadcastBatch(batch *common.ExtBatch) error {
 	for _, node := range netw.Nodes {
 		if node.Config().ID.Hex() != netw.CurrentNode.Config().ID.Hex() {
 			tempNode := node
-			common.Schedule(netw.delay()/2, func() { tempNode.ReceiveBatches(encodedBatches) })
+			common.Schedule(netw.delay()/2, func() { tempNode.ReceiveBatch(encodedBatch) })
 		}
 	}
 
@@ -91,7 +91,7 @@ func (netw *MockP2P) RequestBatch(_ *common.BatchRequest) error {
 	panic(errutil.ErrNoImpl)
 }
 
-func (netw *MockP2P) SendBatches(_ []*common.ExtBatch, _ string) error {
+func (netw *MockP2P) SendBatch(_ *common.ExtBatch, _ string) error {
 	panic(errutil.ErrNoImpl)
 }
 


### PR DESCRIPTION
### Why is this change needed?

Previously, when catching up on missing batches, we'd check which rollup numbers we didn't have stored. This isn't correct, since we could have a rollup number stored, but from a discarded fork.

### What changes were made as part of this PR:

- Provide a high level list of the changes made
- List key areas for the reviewer 

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
