### PR TITLE
Fix in-mem mock concurrency bug

### DIFF
--- a/integration/ethereummock/node.go
+++ b/integration/ethereummock/node.go
@@ -270,10 +270,12 @@ func (m *Node) setHead(b *types.Block) *types.Block {
 	}
 
 	// notify the client subscriptions
+	m.subMu.Lock()
 	for _, s := range m.subs {
 		sub := s
 		go sub.publish(b)
 	}
+	m.subMu.Unlock()
 	m.canonicalCh <- b
 
 	return b
@@ -286,10 +288,12 @@ func (m *Node) setFork(blocks []*types.Block) *types.Block {
 	}
 
 	// notify the client subs
+	m.subMu.Lock()
 	for _, s := range m.subs {
 		sub := s
 		go sub.publishAll(blocks)
 	}
+	m.subMu.Unlock()
 
 	m.canonicalCh <- head
 


### PR DESCRIPTION
### Why is this change needed?

- Joel noticed he'd occasionally hit concurrent map errors like:
```
fatal error: concurrent map iteration and map write

goroutine 45 [running]:
github.com/obscuronet/go-obscuro/integration/ethereummock.(*Node).setHead(0xc0002e4700, 0xc027a2ab40)
    /Users/joeldudley/Desktop/go-obscuro/integration/ethereummock/node.go:273 +0xa9
github.com/obscuronet/go-obscuro/integration/ethereummock.(*Node).processBlock(0xc0002e4700, 0xc027a2ab40, 0xc033aed710)
    /Users/joeldudley/Desktop/go-obscuro/integration/ethereummock/node.go:263 +0x26f
github.com/obscuronet/go-obscuro/integration/ethereummock.(*Node).Start(0xc0002e4700)
    /Users/joeldudley/Desktop/go-obscuro/integration/ethereummock/node.go:199 +0x25a
created by github.com/obscuronet/go-obscuro/integration/simulation/network.(*basicNetworkOfInMemoryNodes).Create
    /Users/joeldudley/Desktop/go-obscuro/integration/simulation/network/inmemory.go:96 +0x64a
```

### What changes were made as part of this PR:

- apply mutex lock when looping through subscriptions to notify them. Worth noting the actual notifying is done in a separate go routine so the lock won't be applied for long periods of time.
- Decided against read-write lock, feel more comfortable knowing that publish calls can't interleave (plus don't expect perf impact, plus mock test code)

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
