### PR TITLE
Quote the owner in the json

### DIFF
--- a/.github/workflows/on-merged-pr.yml
+++ b/.github/workflows/on-merged-pr.yml
@@ -12,5 +12,5 @@ jobs:
     steps:
       - name: 'Trigger obscuro-test local testnet tun'
         run: |
-          curl -XPOST -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" -H "Accept:application/vnd.github" -H "Content-Type:application/json" https://api.github.com/repos/obscuronet/obscuro-test/dispatches --data '{ "event_type": "merged_pull_request", "client_payload": { "number": ${{ github.event.number }}, "owner": ${{ github.event.pull_request.user.login }} } }'
+          curl -XPOST -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" -H "Accept:application/vnd.github" -H "Content-Type:application/json" https://api.github.com/repos/obscuronet/obscuro-test/dispatches --data '{ "event_type": "merged_pull_request", "client_payload": { "number": ${{ github.event.number }}, "owner": "${{ github.event.pull_request.user.login }}" } }'
          


### PR DESCRIPTION
### Why is this change needed?

It looks like the POST has invalid format which I assume is that the string owner should have quotes. This adds quotes into the command. 

```
Run curl -XPOST -H "Authorization: ***" -H "Accept:application/vnd.github" -H "Content-Type:application/json" https://api.github.com/repos/obscuronet/obscuro-test/dispatches --data '{ "event_type": "merged_pull_request", "client_payload": { "number": 931, "owner": otherview } }'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100   2[4](https://github.com/obscuronet/go-obscuro/actions/runs/3619600243/jobs/6100836138#step:2:5)3  100   147  100    96    [5](https://github.com/obscuronet/go-obscuro/actions/runs/3619600243/jobs/6100836138#step:2:6)4[7](https://github.com/obscuronet/go-obscuro/actions/runs/3619600243/jobs/6100836138#step:2:8)    357 --:--:-- --:--:-- --:--:--   [9](https://github.com/obscuronet/go-obscuro/actions/runs/3619600243/jobs/6100836138#step:2:10)03
{
  "message": "Problems parsing JSON",
  "documentation_url": "https://docs.github.com/rest/reference/repos#create-a-repository-dispatch-event"
}
```