### PR TITLE
Separate DI constructor for container in testing

### DIFF
--- a/go/enclave/main/main.go
+++ b/go/enclave/main/main.go
@@ -14,6 +14,6 @@ func main() {
 		panic(fmt.Errorf("could not parse config. Cause: %w", err))
 	}
 
-	enclaveContainer := enclavecontainer.NewEnclaveContainer(config)
+	enclaveContainer := enclavecontainer.NewEnclaveContainerFromConfig(config)
 	container.Serve(enclaveContainer)
 }

--- a/go/host/container/host_container.go
+++ b/go/host/container/host_container.go
@@ -3,6 +3,8 @@ package container
 import (
 	"fmt"
 
+	"github.com/obscuronet/go-obscuro/go/common"
+
 	gethlog "github.com/ethereum/go-ethereum/log"
 	commonhost "github.com/obscuronet/go-obscuro/go/common/host"
 	"github.com/obscuronet/go-obscuro/go/common/log"
@@ -20,19 +22,30 @@ type HostContainer struct {
 	logger gethlog.Logger
 }
 
-// NewHostContainer wires up the components of the Host service and manages its lifecycle/monitors its status
-func NewHostContainer(parsedConfig *config.HostInputConfig) *HostContainer {
+func (h *HostContainer) Start() error {
+	fmt.Println("Starting Obscuro host...")
+	h.logger.Info("Starting Obscuro host...")
+	h.host.Start()
+	return nil
+}
+
+func (h *HostContainer) Stop() error {
+	h.host.Stop()
+	return nil
+}
+
+// NewHostContainerFromConfig uses config to create all HostContainer dependencies and inject them into a new HostContainer
+// (Note: it does not start the HostContainer process, `Start()` must be called on the container)
+func NewHostContainerFromConfig(parsedConfig *config.HostInputConfig) *HostContainer {
 	cfg := parsedConfig.ToHostConfig()
+
+	logger := log.New(log.HostCmp, cfg.LogLevel, cfg.LogPath, log.NodeIDKey, cfg.ID)
+	fmt.Printf("Building host container with config: %+v\n", cfg)
+	logger.Info(fmt.Sprintf("Building host container with config: %+v", cfg))
 
 	// set the Host ID as the Public Key Address
 	ethWallet := wallet.NewInMemoryWalletFromConfig(cfg.PrivateKeyString, cfg.L1ChainID, log.New(log.HostCmp, cfg.LogLevel, cfg.LogPath))
 	cfg.ID = ethWallet.Address()
-
-	logger := log.New(log.HostCmp, cfg.LogLevel, cfg.LogPath, log.NodeIDKey, cfg.ID)
-
-	fmt.Printf("Starting host with config: %+v\n", cfg)
-	logger.Info(fmt.Sprintf("Starting node with config: %+v", cfg))
-	mgmtContractLib := mgmtcontractlib.NewMgmtContractLib(&cfg.RollupContractAddress, logger)
 
 	fmt.Println("Connecting to L1 network...")
 	l1Client, err := ethadapter.NewEthClient(cfg.L1NodeHost, cfg.L1NodeWebsocketPort, cfg.L1RPCTimeout, cfg.ID, logger)
@@ -53,23 +66,24 @@ func NewHostContainer(parsedConfig *config.HostInputConfig) *HostContainer {
 	enclaveClient := enclaverpc.NewClient(cfg, logger)
 	p2pLogger := logger.New(log.CmpKey, log.P2PCmp)
 	aggP2P := p2p.NewSocketP2PLayer(cfg, p2pLogger)
-	h := host.NewHost(cfg, aggP2P, l1Client, enclaveClient, ethWallet, mgmtContractLib, logger)
 
-	// todo: initialise rpc server here and store it on the container, host shouldn't know about rpc server
+	return NewHostContainer(cfg, aggP2P, l1Client, enclaveClient, ethWallet, logger)
+}
+
+// NewHostContainer builds a host container with dependency injection rather than from config.
+// Useful for testing etc. (want to be able to pass in logger, and also have option to mock out dependencies)
+func NewHostContainer(
+	cfg *config.HostConfig, // provides various parameters that the host needs to function
+	p2p commonhost.P2P, // provides the inbound and outbound p2p communication layer
+	l1Client ethadapter.EthClient, // provides inbound and outbound L1 connectivity
+	enclaveClient common.Enclave, // provides RPC connection to this host's Enclave
+	hostWallet wallet.Wallet, // provides an L1 wallet for the host's transactions
+	logger gethlog.Logger, // provides logging with context
+) *HostContainer {
+	mgmtContractLib := mgmtcontractlib.NewMgmtContractLib(&cfg.RollupContractAddress, logger)
+	h := host.NewHost(cfg, p2p, l1Client, enclaveClient, hostWallet, mgmtContractLib, logger)
 	return &HostContainer{
 		host:   h,
 		logger: logger,
 	}
-}
-
-func (h *HostContainer) Start() error {
-	fmt.Println("Starting Obscuro host...")
-	h.logger.Info("Starting Obscuro host...")
-	h.host.Start()
-	return nil
-}
-
-func (h *HostContainer) Stop() error {
-	h.host.Stop()
-	return nil
 }

--- a/go/host/main/main.go
+++ b/go/host/main/main.go
@@ -14,6 +14,6 @@ func main() {
 		panic(fmt.Errorf("could not parse config. Cause: %w", err))
 	}
 
-	hostContainer := hostcontainer.NewHostContainer(parsedConfig)
+	hostContainer := hostcontainer.NewHostContainerFromConfig(parsedConfig)
 	container.Serve(hostContainer)
 }

--- a/integration/noderunner/noderunner_test.go
+++ b/integration/noderunner/noderunner_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/obscuronet/go-obscuro/integration/gethnetwork"
 )
 
-// TODO - Use the NewHostContainer/NewEnclaveContainer methods in the socket-based integration tests, and retire this smoketest.
+// TODO - Use the NewHostContainerFromConfig/NewEnclaveContainerFromConfig methods in the socket-based integration tests, and retire this smoketest.
 
 const (
 	testLogs             = "../.build/noderunner/"
@@ -85,13 +85,13 @@ func TestCanStartStandaloneObscuroHostAndEnclave(t *testing.T) {
 	defer network.StopNodes()
 
 	go func() {
-		err := enclavecontainer.NewEnclaveContainer(enclaveConfig).Start()
+		err := enclavecontainer.NewEnclaveContainerFromConfig(enclaveConfig).Start()
 		if err != nil {
 			panic(err)
 		}
 	}()
 	go func() {
-		err := hostcontainer.NewHostContainer(hostConfig).Start()
+		err := hostcontainer.NewHostContainerFromConfig(hostConfig).Start()
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
### Why is this change needed?

- For test use-cases we need to be able to start the containers with our own logger and potentially mocked out dependencies for the host
- Need this for the testing I'm doing on enclave/host restarts
- Note: this isn't super elegant but they're only used by tests

### What changes were made as part of this PR:

- Rename `NewXXXContainer` to `NewXXXContainerFromConfig` for the methods used by `main`s to initialise the servers
- Create a separate constructor that allows dependencies to be passed in (e.g. pass in the logger instead of constructing it based on config

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
