### PR TITLE
Produce block submission response outside of RollupChain; some cleanup

### DIFF
--- a/go/enclave/core/rollup.go
+++ b/go/enclave/core/rollup.go
@@ -24,7 +24,7 @@ type Rollup struct {
 
 // Hash returns the keccak256 hash of b's header.
 // The hash is computed on the first call and cached thereafter.
-func (r *Rollup) Hash() common.L2RootHash {
+func (r *Rollup) Hash() *common.L2RootHash {
 	// Temporarily disabling the caching of the hash because it's causing bugs.
 	// Transforming a Rollup to an ExtRollup and then back to a Rollup will generate a different hash if caching is enabled.
 	// Todo - re-enable
@@ -33,7 +33,7 @@ func (r *Rollup) Hash() common.L2RootHash {
 	//}
 	v := r.Header.Hash()
 	r.hash.Store(v)
-	return v
+	return &v
 }
 
 func (r *Rollup) NumberU64() uint64 { return r.Header.Number.Uint64() }

--- a/go/enclave/db/rawdb/accessors_chain.go
+++ b/go/enclave/db/rawdb/accessors_chain.go
@@ -54,7 +54,7 @@ func WriteRollup(db ethdb.KeyValueWriter, rollup *core.Rollup) error {
 	if err := writeHeader(db, rollup.Header); err != nil {
 		return fmt.Errorf("could not write header. Cause: %w", err)
 	}
-	if err := writeBody(db, rollup.Hash(), rollup.Header.Number.Uint64(), rollup.Transactions); err != nil {
+	if err := writeBody(db, *rollup.Hash(), rollup.Header.Number.Uint64(), rollup.Transactions); err != nil {
 		return fmt.Errorf("could not write body. Cause: %w", err)
 	}
 	return nil

--- a/go/enclave/db/storage.go
+++ b/go/enclave/db/storage.go
@@ -46,7 +46,7 @@ func NewStorage(backingDB ethdb.Database, chainConfig *params.ChainConfig, logge
 func (s *storageImpl) StoreGenesisRollup(rol *core.Rollup) error {
 	batch := s.db.NewBatch()
 
-	err := obscurorawdb.WriteGenesisHash(s.db, rol.Hash())
+	err := obscurorawdb.WriteGenesisHash(s.db, *rol.Hash())
 	if err != nil {
 		return fmt.Errorf("could not write genesis hash. Cause: %w", err)
 	}
@@ -228,7 +228,7 @@ func (s *storageImpl) StoreNewHeads(l1Head common.L1RootHash, rollup *core.Rollu
 		}
 	}
 
-	if err := obscurorawdb.WriteL2Head(batch, l1Head, rollup.Hash()); err != nil {
+	if err := obscurorawdb.WriteL2Head(batch, l1Head, *rollup.Hash()); err != nil {
 		return fmt.Errorf("could not write block state. Cause: %w", err)
 	}
 
@@ -348,13 +348,13 @@ func (s *storageImpl) storeNewRollup(batch ethdb.Batch, rollup *core.Rollup, rec
 	if err := obscurorawdb.WriteRollup(batch, rollup); err != nil {
 		return fmt.Errorf("could not write rollup. Cause: %w", err)
 	}
-	if err := obscurorawdb.WriteCanonicalHash(batch, rollup.Hash(), rollup.NumberU64()); err != nil {
+	if err := obscurorawdb.WriteCanonicalHash(batch, *rollup.Hash(), rollup.NumberU64()); err != nil {
 		return fmt.Errorf("could not write canonical hash. Cause: %w", err)
 	}
 	if err := obscurorawdb.WriteTxLookupEntriesByBlock(batch, rollup); err != nil {
 		return fmt.Errorf("could not write transaction lookup entries by block. Cause: %w", err)
 	}
-	if err := obscurorawdb.WriteReceipts(batch, rollup.Hash(), rollup.NumberU64(), receipts); err != nil {
+	if err := obscurorawdb.WriteReceipts(batch, *rollup.Hash(), rollup.NumberU64(), receipts); err != nil {
 		return fmt.Errorf("could not write transaction receipts. Cause: %w", err)
 	}
 	if err := obscurorawdb.WriteContractCreationTx(batch, receipts); err != nil {

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -6,8 +6,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/obscuronet/go-obscuro/go/enclave/core"
 	"math/big"
+
+	"github.com/obscuronet/go-obscuro/go/enclave/core"
 
 	"github.com/obscuronet/go-obscuro/go/common/errutil"
 
@@ -266,9 +267,8 @@ func (e *enclaveImpl) SubmitL1Block(block types.Block, receipts types.Receipts, 
 	}
 	e.logger.Trace("SubmitL1Block successful", "blk", block.Number(), "blkHash", block.Hash())
 
+	// We prepare the block submission response.
 	blockSubmissionResponse := e.produceBlockSubmissionResponse(&block, newL2Head, producedRollup)
-
-	// We add any secret responses.
 	blockSubmissionResponse.ProducedSecretResponses = e.processNetworkSecretMsgs(block)
 
 	// We remove any transactions considered immune to re-orgs from the mempool.

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -259,7 +259,7 @@ func (e *enclaveImpl) ProduceGenesis(blkHash gethcommon.Hash) (*common.ExtRollup
 // SubmitL1Block is used to update the enclave with an additional L1 block.
 func (e *enclaveImpl) SubmitL1Block(block types.Block, receipts types.Receipts, isLatest bool) (*common.BlockSubmissionResponse, error) {
 	// We update the enclave state based on the L1 block.
-	blockSubmissionResponse, ingestedRollupHeader, err := e.chain.ProcessL1Block(block, receipts, isLatest)
+	blockSubmissionResponse, err := e.chain.ProcessL1Block(block, receipts, isLatest)
 	if err != nil {
 		e.logger.Trace("SubmitL1Block failed", "blk", block.Number(), "blkHash", block.Hash(), "err", err)
 		return nil, fmt.Errorf("could not submit L1 block. Cause: %w", err)
@@ -270,9 +270,11 @@ func (e *enclaveImpl) SubmitL1Block(block types.Block, receipts types.Receipts, 
 	blockSubmissionResponse.ProducedSecretResponses = e.processNetworkSecretMsgs(block)
 
 	// We remove any transactions considered immune to re-orgs from the mempool.
-	err = e.removeOldMempoolTxs(ingestedRollupHeader)
-	if err != nil {
-		e.logger.Crit("Could not remove transactions from mempool.", log.ErrKey, err)
+	if blockSubmissionResponse.ProducedRollup != nil {
+		err = e.removeOldMempoolTxs(blockSubmissionResponse.ProducedRollup.Header)
+		if err != nil {
+			e.logger.Crit("Could not remove transactions from mempool.", log.ErrKey, err)
+		}
 	}
 
 	return blockSubmissionResponse, nil

--- a/go/enclave/enclave_test.go
+++ b/go/enclave/enclave_test.go
@@ -513,7 +513,7 @@ func createFakeGenesis(enclave common.Enclave, addresses []prefundedAddress) err
 	if err = enclave.(*enclaveImpl).storage.StoreRollup(genRollup, nil); err != nil {
 		return err
 	}
-	if err = enclave.(*enclaveImpl).storage.StoreGenesisRollupHash(genRollup.Hash()); err != nil {
+	if err = enclave.(*enclaveImpl).storage.StoreGenesisRollupHash(*genRollup.Hash()); err != nil {
 		return err
 	}
 	if err = enclave.(*enclaveImpl).storage.UpdateL2HeadForL1Block(blk.Hash(), genRollup, nil); err != nil {

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -158,7 +158,7 @@ func (rc *RollupChain) ProcessL1Block(block types.Block, receipts types.Receipts
 	}
 
 	// We update the L1 and L2 chain heads.
-	newL2Head, producedRollup, err := rc.updateHeads(&block)
+	newL2Head, producedRollup, err := rc.updateL1AndL2Heads(&block)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -423,7 +423,7 @@ func (rc *RollupChain) produceNewRollupAndUpdateL2Head(block *types.Block) (*cor
 }
 
 // Updates the heads of the L1 and L2 chains.
-func (rc *RollupChain) updateHeads(block *types.Block) (*common.L2RootHash, *core.Rollup, error) {
+func (rc *RollupChain) updateL1AndL2Heads(block *types.Block) (*common.L2RootHash, *core.Rollup, error) {
 	// We extract the rollups from the block.
 	rollupsInBlock := rc.bridge.ExtractRollups(block, rc.storage)
 

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -162,8 +162,6 @@ func (rc *RollupChain) ProcessL1Block(block types.Block, receipts types.Receipts
 	if err != nil {
 		return nil, nil, rc.rejectBlockErr(err)
 	}
-
-	// TODO - #718 - We should produce the block submission response in `enclave.go`, not here.
 	return newL2Head, producedRollup, nil
 }
 


### PR DESCRIPTION
### Why is this change needed?

RollupChain should only be responsible for managing the L1 and L2 state, and not producing the block submission response for clients.

### What changes were made as part of this PR:

- Provide a high level list of the changes made
- List key areas for the reviewer 

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
