### PR TITLE
Fixed broken link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ The missing link to achieving fully private transactions while allowing end-user
 wallets (like MetaMask). This is a very thin component that is responsible for encrypting and decrypting traffic 
 between the Obscuro node and its clients.
 
-See the [docs](https://docs.obscu.ro/wallet-extension/wallet-extension.html) for more information.
+See the [docs](https://docs.obscu.ro/wallet-extension/wallet-extension/) for more information.
 
 
 ## Repository Structure

--- a/tools/walletextension/README.md
+++ b/tools/walletextension/README.md
@@ -1,6 +1,6 @@
 # 👛 The Obscuro wallet extension
 
-See the documentation [here](https://docs.obscu.ro/wallet-extension/wallet-extension.html).
+See the documentation [here](https://docs.obscu.ro/wallet-extension/wallet-extension/).
 
 ## Developer notes
 


### PR DESCRIPTION
### Why is this change needed?

Old link leads to 404. https://docs.obscu.ro/wallet-extension/wallet-extension/ seems to work.