### PR TITLE
Clean up enclave storage

### DIFF
--- a/go/common/gethutil/gethutil.go
+++ b/go/common/gethutil/gethutil.go
@@ -20,25 +20,25 @@ func LCA(blockA *types.Block, blockB *types.Block, resolver db.BlockResolver) (*
 		return blockA, nil
 	}
 	if blockA.NumberU64() > blockB.NumberU64() {
-		p, err := resolver.ParentBlock(blockA)
+		p, err := resolver.FetchBlock(blockA.ParentHash())
 		if err != nil {
 			return nil, fmt.Errorf("could not retrieve parent block. Cause: %w", err)
 		}
 		return LCA(p, blockB, resolver)
 	}
 	if blockB.NumberU64() > blockA.NumberU64() {
-		p, err := resolver.ParentBlock(blockB)
+		p, err := resolver.FetchBlock(blockB.ParentHash())
 		if err != nil {
 			return nil, fmt.Errorf("could not retrieve parent block. Cause: %w", err)
 		}
 
 		return LCA(blockA, p, resolver)
 	}
-	parentBlockA, err := resolver.ParentBlock(blockA)
+	parentBlockA, err := resolver.FetchBlock(blockA.ParentHash())
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve parent block. Cause: %w", err)
 	}
-	parentBlockB, err := resolver.ParentBlock(blockB)
+	parentBlockB, err := resolver.FetchBlock(blockB.ParentHash())
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve parent block. Cause: %w", err)
 	}

--- a/go/common/types.go
+++ b/go/common/types.go
@@ -21,6 +21,7 @@ type (
 
 	// Local Obscuro aliases
 	L2RootHash     = common.Hash
+	L2TxHash       = common.Hash
 	L2Tx           = types.Transaction
 	L2Transactions = types.Transactions
 	L2Address      = common.Address

--- a/go/enclave/bridge/bridge.go
+++ b/go/enclave/bridge/bridge.go
@@ -260,7 +260,7 @@ func (bridge *Bridge) ExtractDeposits(
 			bridge.logger.Crit("block height is less than genesis height")
 			return nil
 		}
-		p, err := blockResolver.ParentBlock(b)
+		p, err := blockResolver.FetchBlock(b.ParentHash())
 		if err != nil {
 			if errors.Is(err, errutil.ErrNotFound) {
 				bridge.logger.Crit("deposits can't be processed because the rollups are not on the same Ethereum fork")

--- a/go/enclave/crosschain/message_bus_manager.go
+++ b/go/enclave/crosschain/message_bus_manager.go
@@ -149,7 +149,7 @@ func (m *MessageBusManager) RetrieveInboundMessages(fromBlock *common.L1Block, t
 		if b.NumberU64() < height {
 			m.logger.Crit("block height is less than genesis height")
 		}
-		p, err := m.storage.ParentBlock(b)
+		p, err := m.storage.FetchBlock(b.ParentHash())
 		if err != nil {
 			m.logger.Crit("Synthetic transactions can't be processed because the rollups are not on the same Ethereum fork")
 		}

--- a/go/enclave/db/interfaces.go
+++ b/go/enclave/db/interfaces.go
@@ -18,8 +18,6 @@ type BlockResolver interface {
 	FetchBlock(blockHash common.L1RootHash) (*types.Block, error)
 	// StoreBlock persists the L1 Block
 	StoreBlock(block *types.Block)
-	// ParentBlock returns the L1 Block's parent.
-	ParentBlock(block *types.Block) (*types.Block, error)
 	// IsAncestor returns true if maybeAncestor is an ancestor of the L1 Block, and false otherwise
 	IsAncestor(block *types.Block, maybeAncestor *types.Block) bool
 	// IsBlockAncestor returns true if maybeAncestor is an ancestor of the L1 Block, and false otherwise
@@ -35,9 +33,9 @@ type BlockResolver interface {
 type RollupResolver interface {
 	// FetchRollup returns the rollup with the given hash.
 	FetchRollup(hash common.L2RootHash) (*core.Rollup, error)
-	// FetchRollupByHeight returns the rollup with the given height.
+	// FetchRollupByHeight returns the rollup on the canonical chain with the given height.
 	FetchRollupByHeight(height uint64) (*core.Rollup, error)
-	// FetchHeadRollup returns the current head rollup
+	// FetchHeadRollup returns the current head rollup of the canonical chain.
 	FetchHeadRollup() (*core.Rollup, error)
 	// StoreRollup stores a rollup.
 	StoreRollup(rollup *core.Rollup, receipts []*types.Receipt) error

--- a/go/enclave/db/interfaces.go
+++ b/go/enclave/db/interfaces.go
@@ -37,12 +37,10 @@ type RollupResolver interface {
 	FetchRollup(hash common.L2RootHash) (*core.Rollup, error)
 	// FetchRollupByHeight returns the rollup with the given height.
 	FetchRollupByHeight(height uint64) (*core.Rollup, error)
-	// ParentRollup returns the rollup's parent rollup.
-	ParentRollup(rollup *core.Rollup) (*core.Rollup, error)
-	// StoreRollup stores a rollup.
-	StoreRollup(rollup *core.Rollup, receipts []*types.Receipt) error
 	// FetchHeadRollup returns the current head rollup
 	FetchHeadRollup() (*core.Rollup, error)
+	// StoreRollup stores a rollup.
+	StoreRollup(rollup *core.Rollup, receipts []*types.Receipt) error
 	// Proof - returns the block used as proof for the rollup
 	Proof(rollup *core.Rollup) (*types.Block, error)
 }

--- a/go/enclave/db/interfaces.go
+++ b/go/enclave/db/interfaces.go
@@ -39,8 +39,6 @@ type RollupResolver interface {
 	FetchRollupByHeight(height uint64) (*core.Rollup, error)
 	// ParentRollup returns the rollup's parent rollup.
 	ParentRollup(rollup *core.Rollup) (*core.Rollup, error)
-	// StoreGenesisRollupHash stores the hash of the genesis rollup.
-	StoreGenesisRollupHash(rollupHash common.L2RootHash) error
 	// StoreRollup stores a rollup.
 	StoreRollup(rollup *core.Rollup, receipts []*types.Receipt) error
 	// FetchHeadRollup returns the current head rollup

--- a/go/enclave/db/interfaces.go
+++ b/go/enclave/db/interfaces.go
@@ -28,8 +28,8 @@ type BlockResolver interface {
 	IsBlockAncestor(block *types.Block, maybeAncestor common.L1RootHash) bool
 	// FetchHeadBlock - returns the head of the current chain.
 	FetchHeadBlock() (*types.Block, error)
-	// Proof - returns the block used as proof for the rollup
-	Proof(rollup *core.Rollup) (*types.Block, error)
+	// FetchLogs returns the block's logs.
+	FetchLogs(blockHash common.L1RootHash) ([]*types.Log, error)
 }
 
 type RollupResolver interface {
@@ -47,19 +47,19 @@ type RollupResolver interface {
 	FetchGenesisRollup() (*core.Rollup, error)
 	// FetchHeadRollup returns the current head rollup
 	FetchHeadRollup() (*core.Rollup, error)
+	// Proof - returns the block used as proof for the rollup
+	Proof(rollup *core.Rollup) (*types.Block, error)
 }
 
 type HeadsAfterL1BlockStorage interface {
-	// FetchHeadRollupForL1Block returns the hash of the head rollup at a given L1 block.
-	FetchHeadRollupForL1Block(blockHash common.L1RootHash) (*common.L2RootHash, error)
-	// FetchLogs returns the block's logs.
-	FetchLogs(blockHash common.L1RootHash) ([]*types.Log, error)
 	// FetchL2Head returns the current L2 chain head.
 	FetchL2Head() (*common.L2RootHash, error)
-	// UpdateL2HeadForL1Block updates the mapping from an L1 block to its corresponding L2 head.
-	UpdateL2HeadForL1Block(l1Head common.L1RootHash, l2Head *core.Rollup, receipts []*types.Receipt) error
+	// FetchL2HeadForL1Block returns the hash of the head rollup at a given L1 block.
+	FetchL2HeadForL1Block(blockHash common.L1RootHash) (*common.L2RootHash, error)
 	// UpdateL1Head updates the L1 head.
 	UpdateL1Head(l1Head common.L1RootHash) error
+	// UpdateL2Head updates the canonical L2 head for a given L1 block.
+	UpdateL2Head(l1Head common.L1RootHash, l2Head *core.Rollup, receipts []*types.Receipt) error
 	// CreateStateDB creates a database that can be used to execute transactions
 	CreateStateDB(hash common.L2RootHash) (*state.StateDB, error)
 	// EmptyStateDB creates the original empty StateDB
@@ -94,8 +94,8 @@ type AttestationStorage interface {
 }
 
 type CrossChainMessagesStorage interface {
-	StoreL1Messages(blockHash gethcommon.Hash, messages common.CrossChainMessages) error
-	GetL1Messages(blockHash gethcommon.Hash) (common.CrossChainMessages, error)
+	StoreL1Messages(blockHash common.L1RootHash, messages common.CrossChainMessages) error
+	GetL1Messages(blockHash common.L1RootHash) (common.CrossChainMessages, error)
 }
 
 // Storage is the enclave's interface for interacting with the enclave's datastore

--- a/go/enclave/db/interfaces.go
+++ b/go/enclave/db/interfaces.go
@@ -43,8 +43,6 @@ type RollupResolver interface {
 	StoreGenesisRollupHash(rollupHash common.L2RootHash) error
 	// StoreRollup stores a rollup.
 	StoreRollup(rollup *core.Rollup, receipts []*types.Receipt) error
-	// FetchGenesisRollup returns the rollup genesis.
-	FetchGenesisRollup() (*core.Rollup, error)
 	// FetchHeadRollup returns the current head rollup
 	FetchHeadRollup() (*core.Rollup, error)
 	// Proof - returns the block used as proof for the rollup

--- a/go/enclave/db/interfaces.go
+++ b/go/enclave/db/interfaces.go
@@ -52,10 +52,8 @@ type RollupResolver interface {
 }
 
 type HeadsAfterL1BlockStorage interface {
-	// FetchL2Head returns the current L2 chain head.
-	FetchL2Head() (*common.L2RootHash, error)
-	// FetchL2HeadForL1Block returns the hash of the head rollup at a given L1 block.
-	FetchL2HeadForL1Block(blockHash common.L1RootHash) (*common.L2RootHash, error)
+	// FetchL2Head returns the hash of the head rollup at a given L1 block.
+	FetchL2Head(blockHash common.L1RootHash) (*common.L2RootHash, error)
 	// UpdateL1Head updates the L1 head.
 	UpdateL1Head(l1Head common.L1RootHash) error
 	// UpdateL2Head updates the canonical L2 head for a given L1 block.

--- a/go/enclave/db/interfaces.go
+++ b/go/enclave/db/interfaces.go
@@ -16,6 +16,10 @@ import (
 type BlockResolver interface {
 	// FetchBlock returns the L1 Block with the given hash.
 	FetchBlock(blockHash common.L1RootHash) (*types.Block, error)
+	// FetchHeadBlock - returns the head of the current chain.
+	FetchHeadBlock() (*types.Block, error)
+	// FetchLogs returns the block's logs.
+	FetchLogs(blockHash common.L1RootHash) ([]*types.Log, error)
 	// StoreBlock persists the L1 Block
 	StoreBlock(block *types.Block)
 	// IsAncestor returns true if maybeAncestor is an ancestor of the L1 Block, and false otherwise
@@ -24,10 +28,6 @@ type BlockResolver interface {
 	// Takes into consideration that the Block to verify might be on a branch we haven't received yet
 	// Todo - this is super confusing, analyze the usage
 	IsBlockAncestor(block *types.Block, maybeAncestor common.L1RootHash) bool
-	// FetchHeadBlock - returns the head of the current chain.
-	FetchHeadBlock() (*types.Block, error)
-	// FetchLogs returns the block's logs.
-	FetchLogs(blockHash common.L1RootHash) ([]*types.Log, error)
 }
 
 type RollupResolver interface {
@@ -39,8 +39,6 @@ type RollupResolver interface {
 	FetchHeadRollup() (*core.Rollup, error)
 	// StoreRollup stores a rollup.
 	StoreRollup(rollup *core.Rollup, receipts []*types.Receipt) error
-	// Proof - returns the block used as proof for the rollup
-	Proof(rollup *core.Rollup) (*types.Block, error)
 }
 
 type HeadsAfterL1BlockStorage interface {

--- a/go/enclave/db/interfaces.go
+++ b/go/enclave/db/interfaces.go
@@ -73,13 +73,13 @@ type SharedSecretStorage interface {
 
 type TransactionStorage interface {
 	// GetTransaction - returns the positional metadata of the tx by hash
-	GetTransaction(txHash gethcommon.Hash) (*types.Transaction, gethcommon.Hash, uint64, uint64, error)
+	GetTransaction(txHash common.L2TxHash) (*types.Transaction, gethcommon.Hash, uint64, uint64, error)
 	// GetTransactionReceipt - returns the receipt of a tx by tx hash
-	GetTransactionReceipt(txHash gethcommon.Hash) (*types.Receipt, error)
+	GetTransactionReceipt(txHash common.L2TxHash) (*types.Receipt, error)
 	// GetReceiptsByHash retrieves the receipts for all transactions in a given rollup.
-	GetReceiptsByHash(hash gethcommon.Hash) (types.Receipts, error)
+	GetReceiptsByHash(hash common.L2RootHash) (types.Receipts, error)
 	// GetSender returns the sender of the tx by hash
-	GetSender(txHash gethcommon.Hash) (gethcommon.Address, error)
+	GetSender(txHash common.L2TxHash) (gethcommon.Address, error)
 	// GetContractCreationTx returns the hash of the tx that created a contract
 	GetContractCreationTx(address gethcommon.Address) (*gethcommon.Hash, error)
 }

--- a/go/enclave/db/rawdb/accessors_chain.go
+++ b/go/enclave/db/rawdb/accessors_chain.go
@@ -239,7 +239,7 @@ func ReadCanonicalHash(db ethdb.Reader, number uint64) (*gethcommon.Hash, error)
 	// Get it by hash from leveldb
 	data, err := db.Get(headerHashKey(number))
 	if err != nil {
-		return nil, err
+		return nil, errutil.ErrNotFound
 	}
 	hash := gethcommon.BytesToHash(data)
 	return &hash, nil

--- a/go/enclave/db/rawdb/accessors_metadata.go
+++ b/go/enclave/db/rawdb/accessors_metadata.go
@@ -3,7 +3,6 @@ package rawdb
 import (
 	"fmt"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/obscuronet/go-obscuro/go/common/errutil"
@@ -31,31 +30,6 @@ func WriteSharedSecret(db ethdb.KeyValueWriter, ss crypto.SharedEnclaveSecret) e
 	}
 	if err = db.Put(sharedSecret, enc); err != nil {
 		return fmt.Errorf("could not shared secret in DB. Cause: %w", err)
-	}
-	return nil
-}
-
-func ReadGenesisHash(db ethdb.KeyValueReader) (*common.Hash, error) {
-	var hash common.Hash
-
-	enc, err := db.Get(genesisRollupHash)
-	if err != nil {
-		return nil, errutil.ErrNotFound
-	}
-	if err := rlp.DecodeBytes(enc, &hash); err != nil {
-		return nil, fmt.Errorf("could not decode genesis rollup. Cause: %w", err)
-	}
-
-	return &hash, nil
-}
-
-func WriteGenesisHash(db ethdb.KeyValueWriter, hash common.Hash) error {
-	enc, err := rlp.EncodeToBytes(hash)
-	if err != nil {
-		return fmt.Errorf("could not encode genesis hash. Cause: %w", err)
-	}
-	if err = db.Put(genesisRollupHash, enc); err != nil {
-		return fmt.Errorf("could not genesis hash in DB. Cause: %w", err)
 	}
 	return nil
 }

--- a/go/enclave/db/rawdb/schema.go
+++ b/go/enclave/db/rawdb/schema.go
@@ -12,7 +12,6 @@ var (
 	attestationKeyPrefix           = []byte("oAK")  // attestationKeyPrefix + address -> key
 	syntheticTransactionsKeyPrefix = []byte("oSTX") // attestationKeyPrefix + address -> key
 
-	genesisRollupHash        = []byte("GenesisRollupHash")
 	rollupHeaderPrefix       = []byte("oh")  // rollupHeaderPrefix + num (uint64 big endian) + hash -> header
 	headerHashSuffix         = []byte("on")  // rollupHeaderPrefix + num (uint64 big endian) + headerHashSuffix -> hash
 	rollupBodyPrefix         = []byte("ob")  // rollupBodyPrefix + num (uint64 big endian) + hash -> rollup body

--- a/go/enclave/db/storage.go
+++ b/go/enclave/db/storage.go
@@ -194,7 +194,7 @@ func (s *storageImpl) Proof(r *core.Rollup) (*types.Block, error) {
 	return block, nil
 }
 
-func (s *storageImpl) FetchHeadRollupForL1Block(blockHash common.L1RootHash) (*common.L2RootHash, error) {
+func (s *storageImpl) FetchL2HeadForL1Block(blockHash common.L1RootHash) (*common.L2RootHash, error) {
 	return obscurorawdb.ReadL2Head(s.db, blockHash)
 }
 
@@ -207,7 +207,7 @@ func (s *storageImpl) FetchLogs(blockHash common.L1RootHash) ([]*types.Log, erro
 	return logs, nil
 }
 
-func (s *storageImpl) UpdateL2HeadForL1Block(l1Head common.L1RootHash, l2Head *core.Rollup, receipts []*types.Receipt) error {
+func (s *storageImpl) UpdateL2Head(l1Head common.L1RootHash, l2Head *core.Rollup, receipts []*types.Receipt) error {
 	batch := s.db.NewBatch()
 
 	if err := obscurorawdb.WriteL2Head(batch, l1Head, *l2Head.Hash()); err != nil {
@@ -363,10 +363,10 @@ func (s *storageImpl) StoreRollup(rollup *core.Rollup, receipts []*types.Receipt
 	return nil
 }
 
-func (s *storageImpl) StoreL1Messages(blockHash gethcommon.Hash, messages common.CrossChainMessages) error {
+func (s *storageImpl) StoreL1Messages(blockHash common.L1RootHash, messages common.CrossChainMessages) error {
 	return obscurorawdb.StoreL1Messages(s.db, blockHash, messages, s.logger)
 }
 
-func (s *storageImpl) GetL1Messages(blockHash gethcommon.Hash) (common.CrossChainMessages, error) {
+func (s *storageImpl) GetL1Messages(blockHash common.L1RootHash) (common.CrossChainMessages, error) {
 	return obscurorawdb.GetL1Messages(s.db, blockHash, s.logger)
 }

--- a/go/enclave/db/storage.go
+++ b/go/enclave/db/storage.go
@@ -107,11 +107,6 @@ func (s *storageImpl) FetchSecret() (*crypto.SharedEnclaveSecret, error) {
 	return obscurorawdb.ReadSharedSecret(s.db)
 }
 
-func (s *storageImpl) ParentRollup(r *core.Rollup) (*core.Rollup, error) {
-	s.assertSecretAvailable()
-	return s.FetchRollup(r.Header.ParentHash)
-}
-
 func (s *storageImpl) ParentBlock(b *types.Block) (*types.Block, error) {
 	s.assertSecretAvailable()
 	return s.FetchBlock(b.Header().ParentHash)

--- a/go/enclave/db/storage.go
+++ b/go/enclave/db/storage.go
@@ -149,14 +149,6 @@ func (s *storageImpl) assertSecretAvailable() {
 	//}
 }
 
-func (s *storageImpl) Proof(r *core.Rollup) (*types.Block, error) {
-	block, err := s.FetchBlock(r.Header.L1Proof)
-	if err != nil {
-		return nil, err
-	}
-	return block, nil
-}
-
 func (s *storageImpl) FetchL2Head(blockHash common.L1RootHash) (*common.L2RootHash, error) {
 	return obscurorawdb.ReadL2Head(s.db, blockHash)
 }

--- a/go/enclave/db/storage.go
+++ b/go/enclave/db/storage.go
@@ -54,18 +54,6 @@ func (s *storageImpl) StoreGenesisRollupHash(rollupHash common.L2RootHash) error
 	return nil
 }
 
-func (s *storageImpl) FetchGenesisRollup() (*core.Rollup, error) {
-	hash, err := obscurorawdb.ReadGenesisHash(s.db)
-	if err != nil {
-		return nil, fmt.Errorf("could not retrieve genesis rollup. Cause: %w", err)
-	}
-	rollup, err := s.FetchRollup(*hash)
-	if err != nil {
-		return nil, err
-	}
-	return rollup, nil
-}
-
 func (s *storageImpl) FetchHeadRollup() (*core.Rollup, error) {
 	l1Head := rawdb.ReadHeadHeaderHash(s.db)
 	if (bytes.Equal(l1Head.Bytes(), gethcommon.Hash{}.Bytes())) {
@@ -88,14 +76,6 @@ func (s *storageImpl) FetchRollup(hash common.L2RootHash) (*core.Rollup, error) 
 }
 
 func (s *storageImpl) FetchRollupByHeight(height uint64) (*core.Rollup, error) {
-	if height == 0 {
-		genesisRollup, err := s.FetchGenesisRollup()
-		if err != nil {
-			return nil, fmt.Errorf("could not fetch genesis rollup. Cause: %w", err)
-		}
-		return genesisRollup, nil
-	}
-
 	hash, err := obscurorawdb.ReadCanonicalHash(s.db, height)
 	if err != nil {
 		return nil, err

--- a/go/enclave/db/storage.go
+++ b/go/enclave/db/storage.go
@@ -43,17 +43,6 @@ func NewStorage(backingDB ethdb.Database, chainConfig *params.ChainConfig, logge
 	}
 }
 
-func (s *storageImpl) StoreGenesisRollupHash(rollupHash common.L2RootHash) error {
-	batch := s.db.NewBatch()
-	if err := obscurorawdb.WriteGenesisHash(s.db, rollupHash); err != nil {
-		return fmt.Errorf("could not write genesis rollup hash. Cause: %w", err)
-	}
-	if err := batch.Write(); err != nil {
-		return fmt.Errorf("could not write genesis rollup hash to storage. Cause: %w", err)
-	}
-	return nil
-}
-
 func (s *storageImpl) FetchHeadRollup() (*core.Rollup, error) {
 	l1Head := rawdb.ReadHeadHeaderHash(s.db)
 	if (bytes.Equal(l1Head.Bytes(), gethcommon.Hash{}.Bytes())) {

--- a/go/enclave/db/storage.go
+++ b/go/enclave/db/storage.go
@@ -107,11 +107,6 @@ func (s *storageImpl) FetchSecret() (*crypto.SharedEnclaveSecret, error) {
 	return obscurorawdb.ReadSharedSecret(s.db)
 }
 
-func (s *storageImpl) ParentBlock(b *types.Block) (*types.Block, error) {
-	s.assertSecretAvailable()
-	return s.FetchBlock(b.Header().ParentHash)
-}
-
 func (s *storageImpl) IsAncestor(block *types.Block, maybeAncestor *types.Block) bool {
 	s.assertSecretAvailable()
 	if bytes.Equal(maybeAncestor.Hash().Bytes(), block.Hash().Bytes()) {
@@ -122,7 +117,7 @@ func (s *storageImpl) IsAncestor(block *types.Block, maybeAncestor *types.Block)
 		return false
 	}
 
-	p, err := s.ParentBlock(block)
+	p, err := s.FetchBlock(block.ParentHash())
 	if err != nil {
 		return false
 	}

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -413,11 +413,11 @@ func (e *enclaveImpl) GetTransactionCount(encryptedParams common.EncryptedParams
 	if err != nil {
 		return nil, err
 	}
-	l2Head, err := e.storage.FetchL2Head()
+	l2Head, err := e.storage.FetchHeadRollup()
 	if err == nil {
 		// todo: we should return an error when head state is not available, but for current test situations with race
 		// 		conditions we allow it to return zero while head state is uninitialized
-		s, err := e.storage.CreateStateDB(*l2Head)
+		s, err := e.storage.CreateStateDB(*l2Head.Hash())
 		if err != nil {
 			return nil, fmt.Errorf("could not create stateDB. Cause: %w", err)
 		}

--- a/go/enclave/enclave_test.go
+++ b/go/enclave/enclave_test.go
@@ -513,9 +513,6 @@ func createFakeGenesis(enclave common.Enclave, addresses []prefundedAddress) err
 	if err = enclave.(*enclaveImpl).storage.StoreRollup(genRollup, nil); err != nil {
 		return err
 	}
-	if err = enclave.(*enclaveImpl).storage.StoreGenesisRollupHash(*genRollup.Hash()); err != nil {
-		return err
-	}
 	if err = enclave.(*enclaveImpl).storage.UpdateL2Head(blk.Hash(), genRollup, nil); err != nil {
 		return err
 	}

--- a/go/enclave/enclave_test.go
+++ b/go/enclave/enclave_test.go
@@ -516,7 +516,7 @@ func createFakeGenesis(enclave common.Enclave, addresses []prefundedAddress) err
 	if err = enclave.(*enclaveImpl).storage.StoreGenesisRollupHash(*genRollup.Hash()); err != nil {
 		return err
 	}
-	if err = enclave.(*enclaveImpl).storage.UpdateL2HeadForL1Block(blk.Hash(), genRollup, nil); err != nil {
+	if err = enclave.(*enclaveImpl).storage.UpdateL2Head(blk.Hash(), genRollup, nil); err != nil {
 		return err
 	}
 	return enclave.(*enclaveImpl).storage.UpdateL1Head(blk.Hash())
@@ -544,11 +544,11 @@ func injectNewBlockAndChangeBalance(enclave common.Enclave, funds []prefundedAdd
 	}
 
 	// make sure the state is updated otherwise balances will not be available
-	l2Head, err := enclave.(*enclaveImpl).storage.FetchL2Head()
+	l2Head, err := enclave.(*enclaveImpl).storage.FetchHeadRollup()
 	if err != nil {
 		return err
 	}
-	stateDB, err := enclave.(*enclaveImpl).storage.CreateStateDB(*l2Head)
+	stateDB, err := enclave.(*enclaveImpl).storage.CreateStateDB(*l2Head.Hash())
 	if err != nil {
 		return err
 	}
@@ -569,7 +569,7 @@ func injectNewBlockAndChangeBalance(enclave common.Enclave, funds []prefundedAdd
 	if err = enclave.(*enclaveImpl).storage.StoreRollup(rollup, nil); err != nil {
 		return err
 	}
-	if err = enclave.(*enclaveImpl).storage.UpdateL2HeadForL1Block(blk.Hash(), rollup, nil); err != nil {
+	if err = enclave.(*enclaveImpl).storage.UpdateL2Head(blk.Hash(), rollup, nil); err != nil {
 		return err
 	}
 	return nil

--- a/go/enclave/events/subscription_manager.go
+++ b/go/enclave/events/subscription_manager.go
@@ -146,7 +146,7 @@ func (s *SubscriptionManager) GetFilteredLogs(account *gethcommon.Address, filte
 
 	// We proceed in this way instead of calling `FetchHeadRollup` because we want to ensure the chain has not advanced
 	// causing a head block/head rollup mismatch.
-	l2Head, err := s.storage.FetchHeadRollupForL1Block(headBlock.Hash())
+	l2Head, err := s.storage.FetchL2HeadForL1Block(headBlock.Hash())
 	if err != nil {
 		return nil, fmt.Errorf("could not filter logs as block state for head block could not be retrieved. Cause: %w", err)
 	}

--- a/go/enclave/events/subscription_manager.go
+++ b/go/enclave/events/subscription_manager.go
@@ -146,7 +146,7 @@ func (s *SubscriptionManager) GetFilteredLogs(account *gethcommon.Address, filte
 
 	// We proceed in this way instead of calling `FetchHeadRollup` because we want to ensure the chain has not advanced
 	// causing a head block/head rollup mismatch.
-	l2Head, err := s.storage.FetchL2HeadForL1Block(headBlock.Hash())
+	l2Head, err := s.storage.FetchL2Head(headBlock.Hash())
 	if err != nil {
 		return nil, fmt.Errorf("could not filter logs as block state for head block could not be retrieved. Cause: %w", err)
 	}

--- a/go/enclave/mempool/manager.go
+++ b/go/enclave/mempool/manager.go
@@ -100,7 +100,7 @@ func txsXRollupsAgo(initialRollup *core.Rollup, resolver db.RollupResolver) (map
 			return map[gethcommon.Hash]gethcommon.Hash{}, nil
 		}
 
-		currentRollup, err = resolver.ParentRollup(currentRollup)
+		currentRollup, err = resolver.FetchRollup(currentRollup.Header.ParentHash)
 		if err != nil {
 			if errors.Is(err, errutil.ErrNotFound) {
 				return nil, fmt.Errorf("found a gap in the rollup chain")
@@ -150,7 +150,7 @@ func allIncludedTransactions(rollup *core.Rollup, s db.RollupResolver, stopAtHei
 	}
 
 	// If the rollup has a parent (i.e. it is not the genesis block), we recurse.
-	parentRollup, err := s.ParentRollup(rollup)
+	parentRollup, err := s.FetchRollup(rollup.Header.ParentHash)
 	if err != nil && !errors.Is(err, errutil.ErrNotFound) {
 		return nil, err
 	}

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -619,7 +619,7 @@ func (rc *RollupChain) validateRollup(rollup *core.Rollup, rootHash common.L2Roo
 func (rc *RollupChain) handlePostGenesisBlock(block *types.Block) (*common.L2RootHash, *core.Rollup, error) {
 	// TODO - #718 - Cannot assume that the most recent rollup is on the previous block anymore. May be on the same block.
 	// We retrieve the current L2 head.
-	l2HeadHash, err := rc.storage.FetchL2HeadForL1Block(block.ParentHash())
+	l2HeadHash, err := rc.storage.FetchL2Head(block.ParentHash())
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not retrieve current head rollup hash. Cause: %w", err)
 	}
@@ -738,14 +738,11 @@ func (rc *RollupChain) getRollup(height gethrpc.BlockNumber) (*core.Rollup, erro
 		// TODO - Depends on the current pending rollup; leaving it for a different iteration as it will need more thought.
 		return nil, fmt.Errorf("requested balance for pending block. This is not handled currently")
 	case gethrpc.LatestBlockNumber:
-		l2Head, err := rc.storage.FetchL2Head()
-		if err != nil {
-			return nil, fmt.Errorf("could not retrieve head state. Cause: %w", err)
-		}
-		rollup, err = rc.storage.FetchRollup(*l2Head)
+		headRollup, err := rc.storage.FetchHeadRollup()
 		if err != nil {
 			return nil, fmt.Errorf("rollup with requested height %d was not found. Cause: %w", height, err)
 		}
+		rollup = headRollup
 	default:
 		maybeRollup, err := rc.storage.FetchRollupByHeight(uint64(height))
 		if err != nil {
@@ -758,7 +755,7 @@ func (rc *RollupChain) getRollup(height gethrpc.BlockNumber) (*core.Rollup, erro
 
 // Creates a rollup.
 func (rc *RollupChain) produceRollup(block *types.Block) (*core.Rollup, error) {
-	headRollupHash, err := rc.storage.FetchL2HeadForL1Block(block.ParentHash())
+	headRollupHash, err := rc.storage.FetchL2Head(block.ParentHash())
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve head rollup hash. Cause: %w", err)
 	}

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -189,7 +189,7 @@ func (rc *RollupChain) UpdateL2Chain(batch *common.ExtBatch) (*common.Header, er
 	if err = rc.storage.StoreRollup(rollup, rollupTxReceipts); err != nil {
 		return nil, fmt.Errorf("failed to store rollup. Cause: %w", err)
 	}
-	if err = rc.storage.UpdateL2HeadForL1Block(batch.Header.L1Proof, rollup, rollupTxReceipts); err != nil {
+	if err = rc.storage.UpdateL2Head(batch.Header.L1Proof, rollup, rollupTxReceipts); err != nil {
 		return nil, fmt.Errorf("could not store new L2 head. Cause: %w", err)
 	}
 
@@ -451,7 +451,7 @@ func (rc *RollupChain) handleGenesisBlock(block *types.Block, rollupsInBlock []*
 	if err := rc.storage.StoreGenesisRollupHash(*genesisRollup.Hash()); err != nil {
 		return nil, fmt.Errorf("could not store genesis rollup. Cause: %w", err)
 	}
-	if err := rc.storage.UpdateL2HeadForL1Block(block.Hash(), genesisRollup, nil); err != nil {
+	if err := rc.storage.UpdateL2Head(block.Hash(), genesisRollup, nil); err != nil {
 		return nil, fmt.Errorf("could not store new chain heads. Cause: %w", err)
 	}
 	if err := rc.storage.UpdateL1Head(block.Hash()); err != nil {
@@ -619,7 +619,7 @@ func (rc *RollupChain) validateRollup(rollup *core.Rollup, rootHash common.L2Roo
 func (rc *RollupChain) handlePostGenesisBlock(block *types.Block) (*common.L2RootHash, *core.Rollup, error) {
 	// TODO - #718 - Cannot assume that the most recent rollup is on the previous block anymore. May be on the same block.
 	// We retrieve the current L2 head.
-	l2HeadHash, err := rc.storage.FetchHeadRollupForL1Block(block.ParentHash())
+	l2HeadHash, err := rc.storage.FetchL2HeadForL1Block(block.ParentHash())
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not retrieve current head rollup hash. Cause: %w", err)
 	}
@@ -651,7 +651,7 @@ func (rc *RollupChain) handlePostGenesisBlock(block *types.Block) (*common.L2Roo
 	}
 
 	// We update the chain heads.
-	if err = rc.storage.UpdateL2HeadForL1Block(block.Hash(), l2Head, l2HeadTxReceipts); err != nil {
+	if err = rc.storage.UpdateL2Head(block.Hash(), l2Head, l2HeadTxReceipts); err != nil {
 		return nil, nil, fmt.Errorf("could not store new head. Cause: %w", err)
 	}
 	if err = rc.storage.UpdateL1Head(block.Hash()); err != nil {
@@ -758,7 +758,7 @@ func (rc *RollupChain) getRollup(height gethrpc.BlockNumber) (*core.Rollup, erro
 
 // Creates a rollup.
 func (rc *RollupChain) produceRollup(block *types.Block) (*core.Rollup, error) {
-	headRollupHash, err := rc.storage.FetchHeadRollupForL1Block(block.ParentHash())
+	headRollupHash, err := rc.storage.FetchL2HeadForL1Block(block.ParentHash())
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve head rollup hash. Cause: %w", err)
 	}

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -486,7 +486,7 @@ func (rc *RollupChain) processState(rollup *core.Rollup, txs []*common.L2Tx, sta
 
 	// always process deposits last, either on top of the rollup produced speculatively or the newly created rollup
 	// process deposits from the fromBlock of the parent to the current block (which is the fromBlock of the new rollup)
-	parent, err := rc.storage.ParentRollup(rollup)
+	parent, err := rc.storage.FetchRollup(rollup.Header.ParentHash)
 	if err != nil {
 		rc.logger.Crit("Sanity check. Rollup has no parent.", log.ErrKey, err)
 	}

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -491,11 +491,11 @@ func (rc *RollupChain) processState(rollup *core.Rollup, txs []*common.L2Tx, sta
 		rc.logger.Crit("Sanity check. Rollup has no parent.", log.ErrKey, err)
 	}
 
-	parentProof, err := rc.storage.Proof(parent)
+	parentProof, err := rc.storage.FetchBlock(parent.Header.L1Proof)
 	if err != nil {
 		rc.logger.Crit(fmt.Sprintf("Could not retrieve a proof for rollup %s", rollup.Hash()), log.ErrKey, err)
 	}
-	rollupProof, err := rc.storage.Proof(rollup)
+	rollupProof, err := rc.storage.FetchBlock(rollup.Header.L1Proof)
 	if err != nil {
 		rc.logger.Crit(fmt.Sprintf("Could not retrieve a proof for rollup %s", rollup.Hash()), log.ErrKey, err)
 	}
@@ -799,7 +799,7 @@ func (rc *RollupChain) produceRollup(block *types.Block) (*core.Rollup, error) {
 
 	rc.logger.Trace(fmt.Sprintf("Added %d cross chain messages to rollup. Equivalent withdrawals in header - %d", len(r.Header.CrossChainMessages), len(r.Header.Withdrawals)), log.CmpKey, log.CrossChainCmp)
 
-	crossChainBind, err := rc.storage.Proof(r)
+	crossChainBind, err := rc.storage.FetchBlock(r.Header.L1Proof)
 	if err != nil {
 		rc.logger.Crit("Failed to extract rollup proof that should exist!")
 	}

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -448,9 +448,6 @@ func (rc *RollupChain) handleGenesisBlock(block *types.Block, rollupsInBlock []*
 	if err := rc.storage.StoreRollup(genesisRollup, nil); err != nil {
 		return nil, fmt.Errorf("failed to store rollup. Cause: %w", err)
 	}
-	if err := rc.storage.StoreGenesisRollupHash(*genesisRollup.Hash()); err != nil {
-		return nil, fmt.Errorf("could not store genesis rollup. Cause: %w", err)
-	}
 	if err := rc.storage.UpdateL2Head(block.Hash(), genesisRollup, nil); err != nil {
 		return nil, fmt.Errorf("could not store new chain heads. Cause: %w", err)
 	}

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -419,7 +419,7 @@ func (rc *RollupChain) updateL1AndL2Heads(block *types.Block) (*common.L2RootHas
 
 // Determines if this is a pre-genesis L2 block, the genesis L2 block, or a post-genesis L2 block.
 func (rc *RollupChain) getBlockStage(rollupsInBlock []*core.Rollup) (BlockStage, error) {
-	_, err := rc.storage.FetchGenesisRollup()
+	_, err := rc.storage.FetchRollupByHeight(0)
 	if err != nil {
 		if !errors.Is(err, errutil.ErrNotFound) {
 			return -1, fmt.Errorf("could not retrieve genesis rollup. Cause: %w", err)
@@ -729,7 +729,7 @@ func (rc *RollupChain) getRollup(height gethrpc.BlockNumber) (*core.Rollup, erro
 	var rollup *core.Rollup
 	switch height {
 	case gethrpc.EarliestBlockNumber:
-		genesisRollup, err := rc.storage.FetchGenesisRollup()
+		genesisRollup, err := rc.storage.FetchRollupByHeight(0)
 		if err != nil {
 			return nil, fmt.Errorf("could not retrieve genesis rollup. Cause: %w", err)
 		}

--- a/integration/ethereummock/db.go
+++ b/integration/ethereummock/db.go
@@ -167,7 +167,7 @@ func (m *Node) removeCommittedTransactions(
 			break
 		}
 
-		p, err := resolver.ParentBlock(b)
+		p, err := resolver.FetchBlock(b.ParentHash())
 		if err != nil {
 			m.logger.Crit("Could not retrieve parent block.", log.ErrKey, err)
 		}

--- a/integration/ethereummock/db.go
+++ b/integration/ethereummock/db.go
@@ -116,6 +116,10 @@ func (n *blockResolverInMem) IsBlockAncestor(block *types.Block, maybeAncestor c
 	return n.IsBlockAncestor(p, maybeAncestor)
 }
 
+func (n *blockResolverInMem) FetchLogs(common.L1RootHash) ([]*types.Log, error) {
+	return nil, errutil.ErrNoImpl
+}
+
 // The cache of included transactions
 type txDBInMem struct {
 	transactionsPerBlockCache map[common.L1RootHash]map[common.TxHash]*types.Transaction

--- a/integration/ethereummock/mock_l1_network.go
+++ b/integration/ethereummock/mock_l1_network.go
@@ -104,7 +104,7 @@ func printBlock(b *types.Block, m *Node) string {
 			txs = append(txs, fmt.Sprintf("deposit(%d=%d)", to, l1Tx.Amount))
 		}
 	}
-	p, err := m.Resolver.ParentBlock(b)
+	p, err := m.Resolver.FetchBlock(b.ParentHash())
 	if err != nil {
 		testlog.Logger().Crit("Should not happen. Could not retrieve parent", log.ErrKey, err)
 	}

--- a/integration/ethereummock/node.go
+++ b/integration/ethereummock/node.go
@@ -209,7 +209,7 @@ func (m *Node) Start() {
 		case mb := <-m.miningCh: // Received from the local mining
 			head = m.processBlock(mb, head)
 			if bytes.Equal(head.Hash().Bytes(), mb.Hash().Bytes()) { // Ignore the locally produced block if someone else found one already
-				p, err := m.Resolver.ParentBlock(mb)
+				p, err := m.Resolver.FetchBlock(mb.ParentHash())
 				if err != nil {
 					panic(fmt.Errorf("could not retrieve parent. Cause: %w", err))
 				}
@@ -398,7 +398,7 @@ func (m *Node) BlocksBetween(blockA *types.Block, blockB *types.Block) []*types.
 		if bytes.Equal(tempBlock.Hash().Bytes(), blockA.Hash().Bytes()) {
 			break
 		}
-		tempBlock, err = m.Resolver.ParentBlock(tempBlock)
+		tempBlock, err = m.Resolver.FetchBlock(tempBlock.ParentHash())
 		if err != nil {
 			panic(fmt.Errorf("could not retrieve parent block. Cause: %w", err))
 		}

--- a/integration/ethereummock/utils.go
+++ b/integration/ethereummock/utils.go
@@ -25,7 +25,7 @@ func allIncludedTransactions(b *types.Block, r db.BlockResolver, db TxDB) map[co
 		return makeMap(b.Transactions())
 	}
 	newMap := make(map[common.TxHash]*types.Transaction)
-	p, err := r.ParentBlock(b)
+	p, err := r.FetchBlock(b.ParentHash())
 	if err != nil {
 		panic(fmt.Errorf("should not happen. Could not retrieve parent. Cause: %w", err))
 	}


### PR DESCRIPTION
### Why is this change needed?

The enclave storage had too many methods. Some of these were confusing (e.g. the various "get L2 head" methods), some weren't required (e.g. special treatment of the genesis block), and some were pointless utilities (e.g. `ParentRollup(rollup)`, when you can just call `FetchRollup(rollup.Head.ParentHash`). By shrinking the API, it becomes simpler to reason about what the enclave's storage layer is doing.

### What changes were made as part of this PR:

- Provide a high level list of the changes made
- List key areas for the reviewer 

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
