### PR TITLE
Proper handling of genesis batch on the host side

### DIFF
--- a/go/host/batchmanager/batch_manager.go
+++ b/go/host/batchmanager/batch_manager.go
@@ -32,8 +32,8 @@ func NewBatchManager(db *db.DB, p2pPublicAddress string) *BatchManager {
 // IsParentStored indicates whether the batch has already been stored. If not, it returns the batch request to send to
 // the sequencer.
 func (b *BatchManager) IsParentStored(batch *common.ExtBatch) (bool, *common.BatchRequest, error) {
-	// If this is the genesis block, we don't need to request the parent.
-	if batch.Header.Number.Uint64() == common.L2GenesisHeight {
+	// If this is the genesis batch or its child, we don't need to request the parent.
+	if batch.Header.Number.Uint64() <= common.L2GenesisHeight+1 {
 		return true, nil, nil
 	}
 


### PR DESCRIPTION
### Why is this change needed?

Previously, the genesis batch was submitted to the enclave by the validators, which didn't make sense (since the genesis is retrieved from the L1 blocks). But the genesis batch still needs to be distributed, since some API calls rely on retrieving all batches, including the genesis batch, from the host.

### What changes were made as part of this PR:

- Provide a high level list of the changes made
- List key areas for the reviewer 

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
