### PR TITLE
Reintroduce storage of rollups; store genesis rollup and rollups from blocks

### DIFF
--- a/go/enclave/db/interfaces.go
+++ b/go/enclave/db/interfaces.go
@@ -41,6 +41,11 @@ type BatchResolver interface {
 	StoreBatch(batch *core.Batch, receipts []*types.Receipt) error
 }
 
+type RollupResolver interface {
+	// StoreRollup stores a rollup.
+	StoreRollup(batch *core.Rollup) error
+}
+
 type HeadsAfterL1BlockStorage interface {
 	// FetchL2Head returns the hash of the head batch at a given L1 block.
 	FetchL2Head(blockHash common.L1RootHash) (*common.L2RootHash, error)
@@ -90,6 +95,7 @@ type CrossChainMessagesStorage interface {
 type Storage interface {
 	BlockResolver
 	BatchResolver
+	RollupResolver
 	SharedSecretStorage
 	HeadsAfterL1BlockStorage
 	TransactionStorage

--- a/go/enclave/db/interfaces.go
+++ b/go/enclave/db/interfaces.go
@@ -43,7 +43,7 @@ type BatchResolver interface {
 
 type RollupResolver interface {
 	// StoreRollup stores a rollup.
-	StoreRollup(batch *core.Rollup) error
+	StoreRollup(rollup *core.Rollup) error
 }
 
 type HeadsAfterL1BlockStorage interface {

--- a/go/enclave/db/rawdb/accessors_chain.go
+++ b/go/enclave/db/rawdb/accessors_chain.go
@@ -34,7 +34,7 @@ func ReadBatch(db ethdb.KeyValueReader, hash common.L2RootHash) (*core.Batch, er
 
 // ReadHeaderNumber returns the header number assigned to a hash.
 func ReadHeaderNumber(db ethdb.KeyValueReader, hash gethcommon.Hash) (*uint64, error) {
-	data, err := db.Get(batchHeaderNumberKey(hash))
+	data, err := db.Get(batchNumberKey(hash))
 	if err != nil {
 		return nil, errutil.ErrNotFound
 	}
@@ -46,19 +46,29 @@ func ReadHeaderNumber(db ethdb.KeyValueReader, hash gethcommon.Hash) (*uint64, e
 }
 
 func WriteBatch(db ethdb.KeyValueWriter, batch *core.Batch) error {
-	if err := writeHeader(db, batch.Header); err != nil {
+	if err := writeBatchHeader(db, batch.Header); err != nil {
 		return fmt.Errorf("could not write header. Cause: %w", err)
 	}
-	if err := writeBody(db, *batch.Hash(), batch.Transactions); err != nil {
+	if err := writeBatchBody(db, *batch.Hash(), batch.Transactions); err != nil {
+		return fmt.Errorf("could not write body. Cause: %w", err)
+	}
+	return nil
+}
+
+func WriteRollup(db ethdb.KeyValueWriter, rollup *core.Rollup) error {
+	if err := writeRollupHeader(db, rollup.Header); err != nil {
+		return fmt.Errorf("could not write header. Cause: %w", err)
+	}
+	if err := writeRollupBody(db, *rollup.Hash(), rollup.Transactions); err != nil {
 		return fmt.Errorf("could not write body. Cause: %w", err)
 	}
 	return nil
 }
 
 // Stores a batch header into the database and also stores the hash-to-number mapping.
-func writeHeader(db ethdb.KeyValueWriter, header *common.Header) error {
+func writeBatchHeader(db ethdb.KeyValueWriter, header *common.Header) error {
 	// Write the hash -> number mapping
-	err := writeHeaderNumber(db, header.Hash(), header.Number.Uint64())
+	err := writeBatchHeaderNumber(db, header.Hash(), header.Number.Uint64())
 	if err != nil {
 		return fmt.Errorf("could not write header number. Cause: %w", err)
 	}
@@ -76,9 +86,9 @@ func writeHeader(db ethdb.KeyValueWriter, header *common.Header) error {
 }
 
 // Stores the hash->number mapping.
-func writeHeaderNumber(db ethdb.KeyValueWriter, hash gethcommon.Hash, number uint64) error {
-	key := batchHeaderNumberKey(hash)
-	enc := encodeBatchNumber(number)
+func writeBatchHeaderNumber(db ethdb.KeyValueWriter, hash gethcommon.Hash, number uint64) error {
+	key := batchNumberKey(hash)
+	enc := encodeNumber(number)
 	if err := db.Put(key, enc); err != nil {
 		return fmt.Errorf("could not put header number in DB. Cause: %w", err)
 	}
@@ -107,12 +117,12 @@ func readHeaderRLP(db ethdb.KeyValueReader, hash gethcommon.Hash) (rlp.RawValue,
 	return data, nil
 }
 
-func writeBody(db ethdb.KeyValueWriter, hash gethcommon.Hash, body []*common.L2Tx) error {
+func writeBatchBody(db ethdb.KeyValueWriter, hash gethcommon.Hash, body []*common.L2Tx) error {
 	data, err := rlp.EncodeToBytes(body)
 	if err != nil {
 		return fmt.Errorf("could not encode L2 transactions. Cause: %w", err)
 	}
-	if err = writeBodyRLP(db, hash, data); err != nil {
+	if err = writeBatchBodyRLP(db, hash, data); err != nil {
 		return fmt.Errorf("could not write L2 transactions. Cause: %w", err)
 	}
 	return nil
@@ -120,7 +130,7 @@ func writeBody(db ethdb.KeyValueWriter, hash gethcommon.Hash, body []*common.L2T
 
 // ReadBody retrieves the batch body corresponding to the hash.
 func ReadBody(db ethdb.KeyValueReader, hash common.L2RootHash) ([]*common.L2Tx, error) {
-	data, err := readBodyRLP(db, hash)
+	data, err := readBatchBodyRLP(db, hash)
 	if err != nil {
 		return nil, fmt.Errorf("could not read body. Cause: %w", err)
 	}
@@ -132,7 +142,7 @@ func ReadBody(db ethdb.KeyValueReader, hash common.L2RootHash) ([]*common.L2Tx, 
 }
 
 // Stores an RLP encoded batch body into the database.
-func writeBodyRLP(db ethdb.KeyValueWriter, hash common.L2RootHash, rlp rlp.RawValue) error {
+func writeBatchBodyRLP(db ethdb.KeyValueWriter, hash common.L2RootHash, rlp rlp.RawValue) error {
 	if err := db.Put(batchBodyKey(hash), rlp); err != nil {
 		return fmt.Errorf("could not put batch body into DB. Cause: %w", err)
 	}
@@ -140,7 +150,7 @@ func writeBodyRLP(db ethdb.KeyValueWriter, hash common.L2RootHash, rlp rlp.RawVa
 }
 
 // Retrieves the batch body (transactions and uncles) in RLP encoding.
-func readBodyRLP(db ethdb.KeyValueReader, hash common.L2RootHash) (rlp.RawValue, error) {
+func readBatchBodyRLP(db ethdb.KeyValueReader, hash common.L2RootHash) (rlp.RawValue, error) {
 	data, err := db.Get(batchBodyKey(hash))
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve batch body from DB. Cause: %w", err)
@@ -217,6 +227,55 @@ func ReadCanonicalHash(db ethdb.Reader, number uint64) (*common.L2RootHash, erro
 func WriteCanonicalHash(db ethdb.KeyValueWriter, l2Head *core.Batch) error {
 	if err := db.Put(batchHeaderHashKey(l2Head.NumberU64()), l2Head.Hash().Bytes()); err != nil {
 		return fmt.Errorf("failed to store number to hash mapping. Cause: %w", err)
+	}
+	return nil
+}
+
+// Stores a rollup header into the database and also stores the hash-to-number mapping.
+func writeRollupHeader(db ethdb.KeyValueWriter, header *common.Header) error {
+	// Write the hash -> number mapping
+	err := writeRollupHeaderNumber(db, header.Hash(), header.Number.Uint64())
+	if err != nil {
+		return fmt.Errorf("could not write header number. Cause: %w", err)
+	}
+
+	// Write the encoded header
+	data, err := rlp.EncodeToBytes(header)
+	if err != nil {
+		return fmt.Errorf("could not encode batch header. Cause: %w", err)
+	}
+	key := rollupHeaderKey(header.Hash())
+	if err = db.Put(key, data); err != nil {
+		return fmt.Errorf("could not put header in DB. Cause: %w", err)
+	}
+	return nil
+}
+
+func writeRollupBody(db ethdb.KeyValueWriter, hash gethcommon.Hash, body []*common.L2Tx) error {
+	data, err := rlp.EncodeToBytes(body)
+	if err != nil {
+		return fmt.Errorf("could not encode L2 transactions. Cause: %w", err)
+	}
+	if err = writeRollupBodyRLP(db, hash, data); err != nil {
+		return fmt.Errorf("could not write L2 transactions. Cause: %w", err)
+	}
+	return nil
+}
+
+// Stores the hash->number mapping.
+func writeRollupHeaderNumber(db ethdb.KeyValueWriter, hash gethcommon.Hash, number uint64) error {
+	key := rollupNumberKey(hash)
+	enc := encodeNumber(number)
+	if err := db.Put(key, enc); err != nil {
+		return fmt.Errorf("could not put rollup header number in DB. Cause: %w", err)
+	}
+	return nil
+}
+
+// Stores an RLP encoded rollup body into the database.
+func writeRollupBodyRLP(db ethdb.KeyValueWriter, hash common.L2RootHash, rlp rlp.RawValue) error {
+	if err := db.Put(rollupBodyKey(hash), rlp); err != nil {
+		return fmt.Errorf("could not put rollup body into DB. Cause: %w", err)
 	}
 	return nil
 }

--- a/go/enclave/db/rawdb/accessors_chain.go
+++ b/go/enclave/db/rawdb/accessors_chain.go
@@ -32,8 +32,8 @@ func ReadBatch(db ethdb.KeyValueReader, hash common.L2RootHash) (*core.Batch, er
 	}, nil
 }
 
-// ReadHeaderNumber returns the header number assigned to a hash.
-func ReadHeaderNumber(db ethdb.KeyValueReader, hash gethcommon.Hash) (*uint64, error) {
+// ReadBatchNumber returns the number of a batch.
+func ReadBatchNumber(db ethdb.KeyValueReader, hash common.L2RootHash) (*uint64, error) {
 	data, err := db.Get(batchNumberKey(hash))
 	if err != nil {
 		return nil, errutil.ErrNotFound
@@ -212,8 +212,8 @@ func ReadBlockLogs(kv ethdb.KeyValueReader, blockHash gethcommon.Hash) ([]*types
 	return logs, nil
 }
 
-// ReadCanonicalHash retrieves the hash of the canonical batch at a given height.
-func ReadCanonicalHash(db ethdb.Reader, number uint64) (*common.L2RootHash, error) {
+// ReadCanonicalBatchHash retrieves the hash of the canonical batch at a given height.
+func ReadCanonicalBatchHash(db ethdb.Reader, number uint64) (*common.L2RootHash, error) {
 	// Get it by hash from leveldb
 	data, err := db.Get(batchHeaderHashKey(number))
 	if err != nil {

--- a/go/enclave/db/rawdb/accessors_indexes.go
+++ b/go/enclave/db/rawdb/accessors_indexes.go
@@ -1,7 +1,6 @@
 package rawdb
 
 import (
-	"bytes"
 	"fmt"
 	"math/big"
 
@@ -10,7 +9,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethdb"
-	"github.com/ethereum/go-ethereum/params"
 	"github.com/obscuronet/go-obscuro/go/enclave/core"
 )
 
@@ -40,19 +38,6 @@ func writeTxLookupEntry(db ethdb.KeyValueWriter, hash common.Hash, numberBytes [
 	return nil
 }
 
-// WriteTxLookupEntries is identical to WriteTxLookupEntry, but it works on
-// a list of hashes
-func WriteTxLookupEntries(db ethdb.KeyValueWriter, number uint64, hashes []common.Hash) error {
-	numberBytes := new(big.Int).SetUint64(number).Bytes()
-	for _, hash := range hashes {
-		err := writeTxLookupEntry(db, hash, numberBytes)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 // WriteTxLookupEntriesByBatch stores a positional metadata for every transaction from a batch, enabling hash based
 // transaction and receipt lookups.
 func WriteTxLookupEntriesByBatch(db ethdb.KeyValueWriter, batch *core.Batch) error {
@@ -61,25 +46,6 @@ func WriteTxLookupEntriesByBatch(db ethdb.KeyValueWriter, batch *core.Batch) err
 		if err != nil {
 			return err
 		}
-	}
-	return nil
-}
-
-// DeleteTxLookupEntries removes all transaction lookups for a given block.
-func DeleteTxLookupEntries(db ethdb.KeyValueWriter, hashes []common.Hash) error {
-	for _, hash := range hashes {
-		err := deleteTxLookupEntry(db, hash)
-		if err != nil {
-			return fmt.Errorf("could not delete transaction lookuo entry. Cause: %w", err)
-		}
-	}
-	return nil
-}
-
-// Removes all transaction data associated with a hash.
-func deleteTxLookupEntry(db ethdb.KeyValueWriter, hash common.Hash) error {
-	if err := db.Delete(txLookupKey(hash)); err != nil {
-		return fmt.Errorf("failed to delete transaction lookup entry. Cause: %w", err)
 	}
 	return nil
 }
@@ -107,70 +73,4 @@ func ReadTransaction(db ethdb.Reader, hash common.Hash) (*types.Transaction, com
 		}
 	}
 	return nil, common.Hash{}, 0, 0, fmt.Errorf("transaction not found")
-}
-
-// ReadReceipt retrieves a specific transaction receipt from the database, along with
-// its added positional metadata.
-func ReadReceipt(db ethdb.Reader, hash common.Hash, config *params.ChainConfig) (*types.Receipt, common.Hash, uint64, uint64, error) {
-	// Retrieve the context of the receipt based on the transaction hash
-	blockNumber, err := ReadTxLookupEntry(db, hash)
-	if err != nil {
-		return nil, common.Hash{}, 0, 0, fmt.Errorf("could not retrieve transaction lookup entry. Cause: %w", err)
-	}
-	blockHash, err := ReadCanonicalHash(db, *blockNumber)
-	if err != nil {
-		return nil, common.Hash{}, 0, 0, fmt.Errorf("could not retrieve canonical hash for block number. Cause: %w", err)
-	}
-
-	// Read all the receipts from the block and return the one with the matching hash
-	receipts, err := ReadReceipts(db, *blockHash, *blockNumber, config)
-	if err != nil {
-		return nil, common.Hash{}, 0, 0, fmt.Errorf("could not retrieve receipts for block number. Cause: %w", err)
-	}
-	for receiptIndex, receipt := range receipts {
-		if receipt.TxHash == hash {
-			return receipt, *blockHash, *blockNumber, uint64(receiptIndex), nil
-		}
-	}
-	return nil, common.Hash{}, 0, 0, fmt.Errorf("receipt not found. Cause: %w", err)
-}
-
-// ReadBloomBits retrieves the compressed bloom bit vector belonging to the given
-// section and bit index.
-func ReadBloomBits(db ethdb.KeyValueReader, bit uint, section uint64, head common.Hash) ([]byte, error) {
-	return db.Get(bloomBitsKey(bit, section, head))
-}
-
-// WriteBloomBits stores the compressed bloom bits vector belonging to the given
-// section and bit index.
-func WriteBloomBits(db ethdb.KeyValueWriter, bit uint, section uint64, head common.Hash, bits []byte) error {
-	if err := db.Put(bloomBitsKey(bit, section, head), bits); err != nil {
-		return fmt.Errorf("failed to store bloom bits. Cause: %w", err)
-	}
-	return nil
-}
-
-// DeleteBloombits removes all compressed bloom bits vector belonging to the
-// given section range and bit index.
-func DeleteBloombits(db ethdb.Database, bit uint, from uint64, to uint64) error {
-	start, end := bloomBitsKey(bit, from, common.Hash{}), bloomBitsKey(bit, to, common.Hash{})
-	it := db.NewIterator(nil, start)
-	defer it.Release()
-
-	for it.Next() {
-		if bytes.Compare(it.Key(), end) >= 0 {
-			break
-		}
-		if len(it.Key()) != len(bloomBitsPrefix)+2+8+32 {
-			continue
-		}
-		err := db.Delete(it.Key())
-		if err != nil {
-			return fmt.Errorf("failed to delete bloom bits. Cause: %w", err)
-		}
-	}
-	if it.Error() != nil {
-		return fmt.Errorf("failed to delete bloom bits. Cause: %w", it.Error())
-	}
-	return nil
 }

--- a/go/enclave/db/rawdb/accessors_indexes.go
+++ b/go/enclave/db/rawdb/accessors_indexes.go
@@ -58,7 +58,7 @@ func ReadTransaction(db ethdb.Reader, hash common.Hash) (*types.Transaction, com
 		return nil, common.Hash{}, 0, 0, fmt.Errorf("could not retrieve transaction lookup entry. Cause: %w", err)
 	}
 
-	blockHash, err := ReadCanonicalHash(db, *blockNumber)
+	blockHash, err := ReadCanonicalBatchHash(db, *blockNumber)
 	if err != nil {
 		return nil, common.Hash{}, 0, 0, fmt.Errorf("could not retrieve canonical hash for block number. Cause: %w", err)
 	}

--- a/go/enclave/db/rawdb/accessors_receipts.go
+++ b/go/enclave/db/rawdb/accessors_receipts.go
@@ -2,7 +2,6 @@ package rawdb
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 
 	common2 "github.com/obscuronet/go-obscuro/go/common"
@@ -13,18 +12,6 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
 )
-
-// HasReceipts verifies the existence of all the transaction receipts belonging to a batch.
-func HasReceipts(db ethdb.Reader, hash common.Hash) (bool, error) {
-	has, err := db.Has(batchReceiptsKey(hash))
-	if err != nil {
-		return false, err
-	}
-	if !has {
-		return false, nil
-	}
-	return true, nil
-}
 
 // ReadReceiptsRLP retrieves all the transaction receipts belonging to a batch in RLP encoding.
 func ReadReceiptsRLP(db ethdb.Reader, hash common.Hash) (rlp.RawValue, error) {
@@ -119,109 +106,4 @@ func ReadContractTransaction(db ethdb.Reader, address common.Address) (*common.H
 	}
 	hash := common.BytesToHash(value)
 	return &hash, nil
-}
-
-// DeleteReceipts removes all receipt data associated with a batch hash.
-func DeleteReceipts(db ethdb.KeyValueWriter, hash common.Hash) error {
-	if err := db.Delete(batchReceiptsKey(hash)); err != nil {
-		return fmt.Errorf("failed to delete block receipts. Cause: %w", err)
-	}
-	return nil
-}
-
-// storedReceiptRLP is the storage encoding of a receipt.
-// Re-definition in core/types/receipt.go.
-type storedReceiptRLP struct {
-	PostStateOrStatus []byte
-	CumulativeGasUsed uint64
-	Logs              []*types.LogForStorage
-}
-
-// ReceiptLogs is a barebone version of ReceiptForStorage which only keeps
-// the list of logs. When decoding a stored receipt into this object we
-// avoid creating the bloom filter.
-type receiptLogs struct {
-	Logs []*types.Log
-}
-
-// DecodeRLP implements rlp.Decoder.
-func (r *receiptLogs) DecodeRLP(s *rlp.Stream) error {
-	var stored storedReceiptRLP
-	if err := s.Decode(&stored); err != nil {
-		return err
-	}
-	r.Logs = make([]*types.Log, len(stored.Logs))
-	for i, log := range stored.Logs {
-		r.Logs[i] = (*types.Log)(log)
-	}
-	return nil
-}
-
-// DeriveLogFields fills the logs in receiptLogs with information such as block number, txhash, etc.
-func deriveLogFields(receipts []*receiptLogs, hash common.Hash, number uint64, txs types.Transactions) error {
-	logIndex := uint(0)
-	if len(txs) != len(receipts) {
-		return errors.New("transaction and receipt count mismatch")
-	}
-	for i := 0; i < len(receipts); i++ {
-		txHash := txs[i].Hash()
-		// The derived log fields can simply be set from the block and transaction
-		for j := 0; j < len(receipts[i].Logs); j++ {
-			receipts[i].Logs[j].BlockNumber = number
-			receipts[i].Logs[j].BlockHash = hash
-			receipts[i].Logs[j].TxHash = txHash
-			receipts[i].Logs[j].TxIndex = uint(i)
-			receipts[i].Logs[j].Index = logIndex
-			logIndex++
-		}
-	}
-	return nil
-}
-
-// ReadLogs retrieves the logs for all transactions in a block. The log fields
-// are populated with metadata. In case the receipts or the block body
-// are not found, a nil is returned.
-func ReadLogs(db ethdb.Reader, hash common.Hash, number uint64, config *params.ChainConfig) ([][]*types.Log, error) {
-	// Retrieve the flattened receipt slice
-	data, err := ReadReceiptsRLP(db, hash)
-	if err != nil {
-		return nil, fmt.Errorf("could not read RLP receipts.hash = %s. Cause: %w", hash, err)
-	}
-	receipts := []*receiptLogs{}
-	if err := rlp.DecodeBytes(data, &receipts); err != nil {
-		// Receipts might be in the legacy format, try decoding that.
-		// TODO: to be removed after users migrated
-		if logs, err := readLegacyLogs(db, hash, number, config); err == nil {
-			return logs, nil
-		}
-		return nil, fmt.Errorf("invalid receipt array RLP.hash = %s. Cause: %w", hash, err)
-	}
-
-	body, err := ReadBody(db, hash)
-	if err != nil {
-		return nil, fmt.Errorf("have receipt but could not retrieve body. Cause: %w", err)
-	}
-	if err = deriveLogFields(receipts, hash, number, body); err != nil {
-		return nil, fmt.Errorf("failed to derive block receipts fields. hash = %s; number = %d; cause: %w", hash, number, err)
-	}
-	logs := make([][]*types.Log, len(receipts))
-	for i, receipt := range receipts {
-		logs[i] = receipt.Logs
-	}
-	return logs, nil
-}
-
-// readLegacyLogs is a temporary workaround for when trying to read logs
-// from a block which has its receipt stored in the legacy format. It'll
-// be removed after users have migrated their freezer databases.
-func readLegacyLogs(db ethdb.Reader, hash common.Hash, number uint64, config *params.ChainConfig) ([][]*types.Log, error) {
-	receipts, err := ReadReceipts(db, hash, number, config)
-	if err != nil {
-		return nil, fmt.Errorf("could not read receipts. Cause: %w", err)
-	}
-	logs := make([][]*types.Log, len(receipts))
-	for i, receipt := range receipts {
-		logs[i] = receipt.Logs
-	}
-	return logs, nil
 }

--- a/go/enclave/db/rawdb/schema.go
+++ b/go/enclave/db/rawdb/schema.go
@@ -14,9 +14,12 @@ var (
 	syntheticTransactionsKeyPrefix = []byte("oSTX") // attestationKeyPrefix + address -> key
 
 	batchHeaderPrefix       = []byte("oh")  // batchHeaderPrefix + num (uint64 big endian) + hash -> header
-	headerHashSuffix        = []byte("on")  // batchHeaderPrefix + num (uint64 big endian) + headerHashSuffix -> hash
+	batchHashSuffix         = []byte("on")  // batchHeaderPrefix + num (uint64 big endian) + headerHashSuffix -> hash
 	batchBodyPrefix         = []byte("ob")  // batchBodyPrefix + num (uint64 big endian) + hash -> batch body
-	batchHeaderNumberPrefix = []byte("oH")  // batchHeaderNumberPrefix + hash -> num (uint64 big endian)
+	batchNumberPrefix       = []byte("oH")  // batchNumberPrefix + hash -> num (uint64 big endian)
+	rollupHeaderPrefix      = []byte("rh")  // rollupHeaderPrefix + num (uint64 big endian) + hash -> header
+	rollupBodyPrefix        = []byte("rb")  // rollupBodyPrefix + num (uint64 big endian) + hash -> batch body
+	rollupNumberPrefix      = []byte("rn")  // rollupNumberPrefix + hash -> num (uint64 big endian)
 	headsAfterL1BlockPrefix = []byte("och") // headsAfterL1BlockPrefix + hash -> num (uint64 big endian)
 	logsPrefix              = []byte("olg") // logsPrefix + hash -> block logs
 	batchReceiptsPrefix     = []byte("or")  // batchReceiptsPrefix + num (uint64 big endian) + hash -> batch receipts
@@ -24,8 +27,9 @@ var (
 	txLookupPrefix          = []byte("ol")  // txLookupPrefix + hash -> transaction/receipt lookup metadata
 )
 
-// encodeBatchNumber encodes a batch number as big endian uint64
-func encodeBatchNumber(number uint64) []byte {
+// todo - joel - should this be here?
+// encodeNumber encodes a number as big endian uint64
+func encodeNumber(number uint64) []byte {
 	enc := make([]byte, 8)
 	binary.BigEndian.PutUint64(enc, number)
 	return enc
@@ -42,8 +46,8 @@ func batchBodyKey(hash common.L2RootHash) []byte {
 }
 
 // For storing and fetching a batch number by batch hash.
-func batchHeaderNumberKey(hash common.L2RootHash) []byte {
-	return append(batchHeaderNumberPrefix, hash.Bytes()...)
+func batchNumberKey(hash common.L2RootHash) []byte {
+	return append(batchNumberPrefix, hash.Bytes()...)
 }
 
 // For storing and fetching the L2 head hash by L1 block hash.
@@ -53,7 +57,7 @@ func headsAfterL1BlockKey(hash common.L1RootHash) []byte {
 
 // For storing and fetching the canonical L2 head hash by height.
 func batchHeaderHashKey(number uint64) []byte {
-	return append(append(batchHeaderPrefix, encodeBatchNumber(number)...), headerHashSuffix...)
+	return append(append(batchHeaderPrefix, encodeNumber(number)...), batchHashSuffix...)
 }
 
 // For storing and fetching a batch's receipts by batch hash.
@@ -81,4 +85,19 @@ func attestationPkKey(aggregator gethcommon.Address) []byte {
 
 func crossChainMessagesKey(blockHash common.L1RootHash) []byte {
 	return append(syntheticTransactionsKeyPrefix, blockHash.Bytes()...)
+}
+
+// For storing and fetching a rollup header by batch hash.
+func rollupHeaderKey(hash common.L2RootHash) []byte {
+	return append(rollupHeaderPrefix, hash.Bytes()...)
+}
+
+// For storing and fetching a rollup body by batch hash.
+func rollupBodyKey(hash common.L2RootHash) []byte {
+	return append(rollupBodyPrefix, hash.Bytes()...)
+}
+
+// For storing and fetching a rollup number by batch hash.
+func rollupNumberKey(hash common.L2RootHash) []byte {
+	return append(rollupNumberPrefix, hash.Bytes()...)
 }

--- a/go/enclave/db/rawdb/schema.go
+++ b/go/enclave/db/rawdb/schema.go
@@ -3,7 +3,8 @@ package rawdb
 import (
 	"encoding/binary"
 
-	"github.com/ethereum/go-ethereum/common"
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/obscuronet/go-obscuro/go/common"
 )
 
 var (
@@ -21,7 +22,6 @@ var (
 	batchReceiptsPrefix     = []byte("or")  // batchReceiptsPrefix + num (uint64 big endian) + hash -> batch receipts
 	contractReceiptPrefix   = []byte("ocr") // contractReceiptPrefix + address -> tx hash
 	txLookupPrefix          = []byte("ol")  // txLookupPrefix + hash -> transaction/receipt lookup metadata
-	bloomBitsPrefix         = []byte("oB")  // bloomBitsPrefix + bit (uint16 big endian) + section (uint64 big endian) + hash -> bloom bits
 )
 
 // encodeBatchNumber encodes a batch number as big endian uint64
@@ -31,69 +31,54 @@ func encodeBatchNumber(number uint64) []byte {
 	return enc
 }
 
-// headerKey = batchHeaderPrefix + hash
-func headerKey(hash common.Hash) []byte {
+// For storing and fetching a batch header by batch hash.
+func batchHeaderKey(hash common.L2RootHash) []byte {
 	return append(batchHeaderPrefix, hash.Bytes()...)
 }
 
-// headerKeyPrefix = batchHeaderPrefix + num (uint64 big endian)
-func headerKeyPrefix(number uint64) []byte {
-	return append(batchHeaderPrefix, encodeBatchNumber(number)...)
-}
-
-// headerNumberKey = headerNumberPrefix + hash
-func headerNumberKey(hash common.Hash) []byte {
-	return append(batchHeaderNumberPrefix, hash.Bytes()...)
-}
-
-// batchBodyKey = batchBodyPrefix + hash
-func batchBodyKey(hash common.Hash) []byte {
+// For storing and fetching a batch body by batch hash.
+func batchBodyKey(hash common.L2RootHash) []byte {
 	return append(batchBodyPrefix, hash.Bytes()...)
 }
 
-// headsAfterL1BlockKey = headsAfterL1BlockPrefix + hash
-func headsAfterL1BlockKey(hash common.Hash) []byte {
+// For storing and fetching a batch number by batch hash.
+func batchHeaderNumberKey(hash common.L2RootHash) []byte {
+	return append(batchHeaderNumberPrefix, hash.Bytes()...)
+}
+
+// For storing and fetching the L2 head hash by L1 block hash.
+func headsAfterL1BlockKey(hash common.L1RootHash) []byte {
 	return append(headsAfterL1BlockPrefix, hash.Bytes()...)
 }
 
-// logsKey = logsPrefix + hash
-func logsKey(hash common.Hash) []byte {
-	return append(logsPrefix, hash.Bytes()...)
+// For storing and fetching the canonical L2 head hash by height.
+func batchHeaderHashKey(number uint64) []byte {
+	return append(append(batchHeaderPrefix, encodeBatchNumber(number)...), headerHashSuffix...)
 }
 
-// batchReceiptsKey = batchReceiptsPrefix + hash
-func batchReceiptsKey(hash common.Hash) []byte {
+// For storing and fetching a batch's receipts by batch hash.
+func batchReceiptsKey(hash common.L2RootHash) []byte {
 	return append(batchReceiptsPrefix, hash.Bytes()...)
 }
 
-func contractReceiptKey(contractAddress common.Address) []byte {
+// logsPrefix + hash
+func logsKey(hash common.L1RootHash) []byte {
+	return append(logsPrefix, hash.Bytes()...)
+}
+
+func contractReceiptKey(contractAddress gethcommon.Address) []byte {
 	return append(contractReceiptPrefix, contractAddress.Bytes()...)
 }
 
 // txLookupKey = txLookupPrefix + hash
-func txLookupKey(hash common.Hash) []byte {
+func txLookupKey(hash common.TxHash) []byte {
 	return append(txLookupPrefix, hash.Bytes()...)
 }
 
-// bloomBitsKey = bloomBitsPrefix + bit (uint16 big endian) + section (uint64 big endian) + hash
-func bloomBitsKey(bit uint, section uint64, hash common.Hash) []byte {
-	key := append(append(bloomBitsPrefix, make([]byte, 10)...), hash.Bytes()...)
-
-	binary.BigEndian.PutUint16(key[1:], uint16(bit))
-	binary.BigEndian.PutUint64(key[3:], section)
-
-	return key
-}
-
-// headerHashKey = headerPrefix + num (uint64 big endian) + headerHashSuffix
-func headerHashKey(number uint64) []byte {
-	return append(append(batchHeaderPrefix, encodeBatchNumber(number)...), headerHashSuffix...)
-}
-
-func attestationPkKey(aggregator common.Address) []byte {
+func attestationPkKey(aggregator gethcommon.Address) []byte {
 	return append(attestationKeyPrefix, aggregator.Bytes()...)
 }
 
-func crossChainMessagesKey(blockHash common.Hash) []byte {
+func crossChainMessagesKey(blockHash common.L1RootHash) []byte {
 	return append(syntheticTransactionsKeyPrefix, blockHash.Bytes()...)
 }

--- a/go/enclave/db/storage.go
+++ b/go/enclave/db/storage.go
@@ -311,3 +311,17 @@ func (s *storageImpl) StoreL1Messages(blockHash common.L1RootHash, messages comm
 func (s *storageImpl) GetL1Messages(blockHash common.L1RootHash) (common.CrossChainMessages, error) {
 	return obscurorawdb.GetL1Messages(s.db, blockHash, s.logger)
 }
+
+func (s *storageImpl) StoreRollup(rollup *core.Rollup) error {
+	// todo - joel
+	//batch := s.db.NewBatch()
+	//
+	//if err := obscurorawdb.WriteBatch(batch, rollup); err != nil {
+	//	return fmt.Errorf("could not write rollup. Cause: %w", err)
+	//}
+	//
+	//if err := batch.Write(); err != nil {
+	//	return fmt.Errorf("could not write batch to storage. Cause: %w", err)
+	//}
+	return nil
+}

--- a/go/enclave/db/storage.go
+++ b/go/enclave/db/storage.go
@@ -65,7 +65,7 @@ func (s *storageImpl) FetchBatch(hash common.L2RootHash) (*core.Batch, error) {
 }
 
 func (s *storageImpl) FetchBatchByHeight(height uint64) (*core.Batch, error) {
-	hash, err := obscurorawdb.ReadCanonicalHash(s.db, height)
+	hash, err := obscurorawdb.ReadCanonicalBatchHash(s.db, height)
 	if err != nil {
 		return nil, err
 	}
@@ -223,7 +223,7 @@ func (s *storageImpl) EmptyStateDB() (*state.StateDB, error) {
 
 // GetReceiptsByHash retrieves the receipts for all transactions in a given batch.
 func (s *storageImpl) GetReceiptsByHash(hash gethcommon.Hash) (types.Receipts, error) {
-	number, err := obscurorawdb.ReadHeaderNumber(s.db, hash)
+	number, err := obscurorawdb.ReadBatchNumber(s.db, hash)
 	if err != nil {
 		return nil, err
 	}

--- a/go/enclave/db/storage.go
+++ b/go/enclave/db/storage.go
@@ -313,15 +313,14 @@ func (s *storageImpl) GetL1Messages(blockHash common.L1RootHash) (common.CrossCh
 }
 
 func (s *storageImpl) StoreRollup(rollup *core.Rollup) error {
-	// todo - joel
-	//batch := s.db.NewBatch()
-	//
-	//if err := obscurorawdb.WriteBatch(batch, rollup); err != nil {
-	//	return fmt.Errorf("could not write rollup. Cause: %w", err)
-	//}
-	//
-	//if err := batch.Write(); err != nil {
-	//	return fmt.Errorf("could not write batch to storage. Cause: %w", err)
-	//}
+	batch := s.db.NewBatch()
+
+	if err := obscurorawdb.WriteRollup(batch, rollup); err != nil {
+		return fmt.Errorf("could not write rollup. Cause: %w", err)
+	}
+
+	if err := batch.Write(); err != nil {
+		return fmt.Errorf("could not write rollup to storage. Cause: %w", err)
+	}
 	return nil
 }


### PR DESCRIPTION
### Why is this change needed?

We switched all the rollup storage operations over to storing batches. But we still need to store rollups, to check which batches are finalised. We introduce a storage operation to do this here.

I also took this opportunity to delete a bunch of unused `accessors_x` code.

### What changes were made as part of this PR:

- Provide a high level list of the changes made
- List key areas for the reviewer 

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
