### PR TITLE
Send transactions to sequencer, instead of broadcasting them

### DIFF
--- a/go/common/host/host.go
+++ b/go/common/host/host.go
@@ -43,8 +43,8 @@ type P2P interface {
 	StartListening(callback Host)
 	StopListening() error
 	UpdatePeerList([]string)
-	// BroadcastTx sends the encrypted transaction to every other node on the network.
-	BroadcastTx(tx common.EncryptedTx) error
+	// SendTx sends the encrypted transaction to the sequencer.
+	SendTx(tx common.EncryptedTx) error
 	// BroadcastBatch sends the batch to every other node on the network.
 	BroadcastBatch(batchMsg *BatchMsg) error
 	// RequestBatches requests batches from the sequencer.

--- a/go/common/host/host.go
+++ b/go/common/host/host.go
@@ -43,12 +43,12 @@ type P2P interface {
 	StartListening(callback Host)
 	StopListening() error
 	UpdatePeerList([]string)
-	// SendTx sends the encrypted transaction to the sequencer.
-	SendTx(tx common.EncryptedTx) error
+	// SendTxToSequencer sends the encrypted transaction to the sequencer.
+	SendTxToSequencer(tx common.EncryptedTx) error
 	// BroadcastBatch sends the batch to every other node on the network.
 	BroadcastBatch(batchMsg *BatchMsg) error
-	// RequestBatches requests batches from the sequencer.
-	RequestBatches(batchRequest *common.BatchRequest) error
+	// RequestBatchesFromSequencer requests batches from the sequencer.
+	RequestBatchesFromSequencer(batchRequest *common.BatchRequest) error
 	// SendBatches sends batches to a specific node, in response to a batch request.
 	SendBatches(batchMsg *BatchMsg, to string) error
 }

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -293,7 +293,7 @@ func (h *host) SubmitAndBroadcastTx(encryptedParams common.EncryptedParamsSendRa
 	}
 
 	if h.config.NodeType != common.Sequencer {
-		err = h.p2p.SendTx(encryptedTx)
+		err = h.p2p.SendTxToSequencer(encryptedTx)
 		if err != nil {
 			return nil, fmt.Errorf("could not broadcast transaction to sequencer. Cause: %w", err)
 		}
@@ -916,7 +916,7 @@ func (h *host) handleBatches(encodedBatchMsg *common.EncodedBatchMsg) error {
 			// We only request the missing batches if the batches did not themselves arrive as part of catch-up, to
 			// avoid excessive P2P pressure.
 			if !batchMsg.IsCatchUp {
-				if err = h.p2p.RequestBatches(batchRequest); err != nil {
+				if err = h.p2p.RequestBatchesFromSequencer(batchRequest); err != nil {
 					return fmt.Errorf("could not request historical batches. Cause: %w", err)
 				}
 				return nil

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -284,14 +284,19 @@ func (h *host) EnclaveClient() common.Enclave {
 
 func (h *host) SubmitAndBroadcastTx(encryptedParams common.EncryptedParamsSendRawTx) (common.EncryptedResponseSendRawTx, error) {
 	encryptedTx := common.EncryptedTx(encryptedParams)
+
+	// TODO - #718 - We only need to submit to the enclave as the sequencer. But we still need to return the encrypted
+	//  transaction hash, so some round-trip to the enclave is required.
 	encryptedResponse, err := h.enclaveClient.SubmitTx(encryptedTx)
 	if err != nil {
 		return nil, fmt.Errorf("could not submit transaction. Cause: %w", err)
 	}
 
-	err = h.p2p.BroadcastTx(encryptedTx)
-	if err != nil {
-		return nil, fmt.Errorf("could not broadcast transaction. Cause: %w", err)
+	if h.config.NodeType != common.Sequencer {
+		err = h.p2p.SendTx(encryptedTx)
+		if err != nil {
+			return nil, fmt.Errorf("could not broadcast transaction to sequencer. Cause: %w", err)
+		}
 	}
 
 	return encryptedResponse, nil

--- a/go/host/p2p/p2p.go
+++ b/go/host/p2p/p2p.go
@@ -90,7 +90,7 @@ func (p *p2pImpl) UpdatePeerList(newPeers []string) {
 	p.peerAddresses = newPeers
 }
 
-func (p *p2pImpl) SendTx(tx common.EncryptedTx) error {
+func (p *p2pImpl) SendTxToSequencer(tx common.EncryptedTx) error {
 	msg := message{Type: msgTypeTx, Contents: tx}
 	return p.send(msg, p.getSequencer())
 }
@@ -105,7 +105,7 @@ func (p *p2pImpl) BroadcastBatch(batchMsg *host.BatchMsg) error {
 	return p.broadcast(msg)
 }
 
-func (p *p2pImpl) RequestBatches(batchRequest *common.BatchRequest) error {
+func (p *p2pImpl) RequestBatchesFromSequencer(batchRequest *common.BatchRequest) error {
 	if len(p.peerAddresses) == 0 {
 		return errors.New("no peers available to request batches")
 	}

--- a/go/host/p2p/p2p.go
+++ b/go/host/p2p/p2p.go
@@ -90,9 +90,9 @@ func (p *p2pImpl) UpdatePeerList(newPeers []string) {
 	p.peerAddresses = newPeers
 }
 
-func (p *p2pImpl) BroadcastTx(tx common.EncryptedTx) error {
+func (p *p2pImpl) SendTx(tx common.EncryptedTx) error {
 	msg := message{Type: msgTypeTx, Contents: tx}
-	return p.broadcast(msg)
+	return p.send(msg, p.getSequencer())
 }
 
 func (p *p2pImpl) BroadcastBatch(batchMsg *host.BatchMsg) error {
@@ -115,9 +115,8 @@ func (p *p2pImpl) RequestBatches(batchRequest *common.BatchRequest) error {
 	}
 
 	msg := message{Type: msgTypeBatchRequest, Contents: encodedBatchRequest}
-	// TODO - #718 - Use better method to identify sequencer?
 	// TODO - #718 - Allow missing batches to be requested from peers other than sequencer?
-	return p.send(msg, p.peerAddresses[0])
+	return p.send(msg, p.getSequencer())
 }
 
 func (p *p2pImpl) SendBatches(batchMsg *host.BatchMsg, to string) error {
@@ -191,7 +190,7 @@ func (p *p2pImpl) broadcast(msg message) error {
 	return nil
 }
 
-// Sends a message to the sequencer.
+// Sends a message to the provided address.
 func (p *p2pImpl) send(msg message, to string) error {
 	msgEncoded, err := rlp.EncodeToBytes(msg)
 	if err != nil {
@@ -201,7 +200,7 @@ func (p *p2pImpl) send(msg message, to string) error {
 	return nil
 }
 
-// sendBytes Sends the bytes over P2P to the given address.
+// Sends the bytes to the provided address.
 func (p *p2pImpl) sendBytes(wg *sync.WaitGroup, address string, tx []byte) {
 	if wg != nil {
 		defer wg.Done()
@@ -220,4 +219,10 @@ func (p *p2pImpl) sendBytes(wg *sync.WaitGroup, address string, tx []byte) {
 	if err != nil {
 		p.logger.Warn(fmt.Sprintf("could not send message to peer on address %s", address), log.ErrKey, err)
 	}
+}
+
+// Retrieves the sequencer's address.
+// TODO - #718 - Use better method to identify the sequencer?
+func (p *p2pImpl) getSequencer() string {
+	return p.peerAddresses[0]
 }

--- a/integration/simulation/p2p/mock_l2_network.go
+++ b/integration/simulation/p2p/mock_l2_network.go
@@ -50,7 +50,7 @@ func (netw *MockP2P) UpdatePeerList([]string) {
 	// Do nothing.
 }
 
-func (netw *MockP2P) SendTx(tx common.EncryptedTx) error {
+func (netw *MockP2P) SendTxToSequencer(tx common.EncryptedTx) error {
 	if atomic.LoadInt32(netw.listenerInterrupt) == 1 {
 		return nil
 	}
@@ -78,7 +78,7 @@ func (netw *MockP2P) BroadcastBatch(batchMsg *host.BatchMsg) error {
 	return nil
 }
 
-func (netw *MockP2P) RequestBatches(batchRequest *common.BatchRequest) error {
+func (netw *MockP2P) RequestBatchesFromSequencer(batchRequest *common.BatchRequest) error {
 	if atomic.LoadInt32(netw.listenerInterrupt) == 1 {
 		return nil
 	}

--- a/integration/simulation/p2p/mock_l2_network.go
+++ b/integration/simulation/p2p/mock_l2_network.go
@@ -50,18 +50,11 @@ func (netw *MockP2P) UpdatePeerList([]string) {
 	// Do nothing.
 }
 
-func (netw *MockP2P) BroadcastTx(tx common.EncryptedTx) error {
+func (netw *MockP2P) SendTx(tx common.EncryptedTx) error {
 	if atomic.LoadInt32(netw.listenerInterrupt) == 1 {
 		return nil
 	}
-
-	for _, node := range netw.Nodes {
-		if node.Config().ID.Hex() != netw.CurrentNode.Config().ID.Hex() {
-			tempNode := node
-			common.Schedule(netw.delay()/2, func() { tempNode.ReceiveTx(tx) })
-		}
-	}
-
+	common.Schedule(netw.delay()/2, func() { netw.Nodes[0].ReceiveTx(tx) })
 	return nil
 }
 


### PR DESCRIPTION
### Why is this change needed?

- Provide a description and a link to the underlying ticket

### What changes were made as part of this PR:

- Provide a high level list of the changes made

### Definition of done

- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
- [ ] End-to-end tests run if required (see below)

### End-to-end tests

Running the end-to-end tests in the [obscuro-test repo](https://github.com/obscuronet/obscuro-test) is currently at the 
discretion of the developer prior to merging a PR. The intention is not to slow down development by having the longer 
running end-to-end tests as a PR gate run on each branch commit etc. To manually trigger a run pre-merge;

- Go to [run_local_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_local_tests.yml)
- Click the "Run workflow" button
- Use the main branch of obscuro-test 
- Enter the name of the PR branch for go-obscuro
- Run the workflow

The run takes approximately 20 minutes and any failure will be reported in the workflow output. Should the tests fail 
the docker container output for the local testnet and all test artifacts will be added to the run and can be downloaded
for debugging and analysis, with a retention period of 2 days. 

Note that every PR merge to main will also trigger a run of post-merge tests, so even if you do not manually trigger 
pre-merge, tests will be run post-merge. The intention being to catch any issues fast on main to allow for quick 
resolution. The post-merge test output can be seen at 
[run_merge_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_merge_tests.yml) and will show both 
the PR number and author in the list of runs. 


