### PR TITLE
Check that rollups processed from L1 blocks are sequential

### DIFF
--- a/go/enclave/db/interfaces.go
+++ b/go/enclave/db/interfaces.go
@@ -47,12 +47,12 @@ type RollupResolver interface {
 }
 
 type HeadsAfterL1BlockStorage interface {
-	// FetchL2Head returns the hash of the head batch at a given L1 block.
-	FetchL2Head(blockHash common.L1RootHash) (*common.L2RootHash, error)
+	// FetchL2HeadBatch returns the hash of the head batch at a given L1 block.
+	FetchL2HeadBatch(blockHash common.L1RootHash) (*common.L2RootHash, error)
 	// UpdateL1Head updates the L1 head.
 	UpdateL1Head(l1Head common.L1RootHash) error
-	// UpdateL2Head updates the canonical L2 head for a given L1 block.
-	UpdateL2Head(l1Head common.L1RootHash, l2Head *core.Batch, receipts []*types.Receipt) error
+	// UpdateL2HeadBatch updates the canonical L2 head batch for a given L1 block.
+	UpdateL2HeadBatch(l1Head common.L1RootHash, l2Head *core.Batch, receipts []*types.Receipt) error
 	// CreateStateDB creates a database that can be used to execute transactions
 	CreateStateDB(hash common.L2RootHash) (*state.StateDB, error)
 	// EmptyStateDB creates the original empty StateDB

--- a/go/enclave/db/interfaces.go
+++ b/go/enclave/db/interfaces.go
@@ -47,16 +47,16 @@ type RollupResolver interface {
 }
 
 type HeadsAfterL1BlockStorage interface {
-	// FetchL2HeadBatch returns the hash of the head batch at a given L1 block.
-	FetchL2HeadBatch(blockHash common.L1RootHash) (*common.L2RootHash, error)
-	// FetchL2HeadRollup returns the hash of the head rollup at a given L1 block.
-	FetchL2HeadRollup(blockHash *common.L1RootHash) (*common.L2RootHash, error)
+	// FetchHeadBatchForBlock returns the hash of the head batch at a given L1 block.
+	FetchHeadBatchForBlock(blockHash common.L1RootHash) (*common.L2RootHash, error)
+	// FetchHeadRollupForBlock returns the hash of the head rollup at a given L1 block.
+	FetchHeadRollupForBlock(blockHash *common.L1RootHash) (*common.L2RootHash, error)
 	// UpdateL1Head updates the L1 head.
 	UpdateL1Head(l1Head common.L1RootHash) error
-	// UpdateL2HeadBatch updates the canonical L2 head batch for a given L1 block.
-	UpdateL2HeadBatch(l1Head common.L1RootHash, l2Head *core.Batch, receipts []*types.Receipt) error
-	// UpdateL2HeadRollup updates the canonical L2 head rollup for a given L1 block.
-	UpdateL2HeadRollup(l1Head *common.L1RootHash, l2Head *common.L2RootHash) error
+	// UpdateHeadBatch updates the canonical L2 head batch for a given L1 block.
+	UpdateHeadBatch(l1Head common.L1RootHash, l2Head *core.Batch, receipts []*types.Receipt) error
+	// UpdateHeadRollup updates the canonical L2 head rollup for a given L1 block.
+	UpdateHeadRollup(l1Head *common.L1RootHash, l2Head *common.L2RootHash) error
 	// CreateStateDB creates a database that can be used to execute transactions
 	CreateStateDB(hash common.L2RootHash) (*state.StateDB, error)
 	// EmptyStateDB creates the original empty StateDB

--- a/go/enclave/db/interfaces.go
+++ b/go/enclave/db/interfaces.go
@@ -50,7 +50,7 @@ type HeadsAfterL1BlockStorage interface {
 	// FetchHeadBatchForBlock returns the hash of the head batch at a given L1 block.
 	FetchHeadBatchForBlock(blockHash common.L1RootHash) (*core.Batch, error)
 	// FetchHeadRollupForBlock returns the hash of the head rollup at a given L1 block.
-	FetchHeadRollupForBlock(blockHash *common.L1RootHash) (*common.L2RootHash, error)
+	FetchHeadRollupForBlock(blockHash *common.L1RootHash) (*core.Rollup, error)
 	// UpdateL1Head updates the L1 head.
 	UpdateL1Head(l1Head common.L1RootHash) error
 	// UpdateHeadBatch updates the canonical L2 head batch for a given L1 block.

--- a/go/enclave/db/interfaces.go
+++ b/go/enclave/db/interfaces.go
@@ -48,7 +48,7 @@ type RollupResolver interface {
 
 type HeadsAfterL1BlockStorage interface {
 	// FetchHeadBatchForBlock returns the hash of the head batch at a given L1 block.
-	FetchHeadBatchForBlock(blockHash common.L1RootHash) (*common.L2RootHash, error)
+	FetchHeadBatchForBlock(blockHash common.L1RootHash) (*core.Batch, error)
 	// FetchHeadRollupForBlock returns the hash of the head rollup at a given L1 block.
 	FetchHeadRollupForBlock(blockHash *common.L1RootHash) (*common.L2RootHash, error)
 	// UpdateL1Head updates the L1 head.

--- a/go/enclave/db/interfaces.go
+++ b/go/enclave/db/interfaces.go
@@ -49,10 +49,14 @@ type RollupResolver interface {
 type HeadsAfterL1BlockStorage interface {
 	// FetchL2HeadBatch returns the hash of the head batch at a given L1 block.
 	FetchL2HeadBatch(blockHash common.L1RootHash) (*common.L2RootHash, error)
+	// FetchL2HeadRollup returns the hash of the head rollup at a given L1 block.
+	FetchL2HeadRollup(blockHash *common.L1RootHash) (*common.L2RootHash, error)
 	// UpdateL1Head updates the L1 head.
 	UpdateL1Head(l1Head common.L1RootHash) error
 	// UpdateL2HeadBatch updates the canonical L2 head batch for a given L1 block.
 	UpdateL2HeadBatch(l1Head common.L1RootHash, l2Head *core.Batch, receipts []*types.Receipt) error
+	// UpdateL2HeadRollup updates the canonical L2 head rollup for a given L1 block.
+	UpdateL2HeadRollup(l1Head *common.L1RootHash, l2Head *common.L2RootHash) error
 	// CreateStateDB creates a database that can be used to execute transactions
 	CreateStateDB(hash common.L2RootHash) (*state.StateDB, error)
 	// EmptyStateDB creates the original empty StateDB

--- a/go/enclave/db/rawdb/accessors_chain.go
+++ b/go/enclave/db/rawdb/accessors_chain.go
@@ -21,7 +21,7 @@ func ReadBatch(db ethdb.KeyValueReader, hash common.L2RootHash) (*core.Batch, er
 		return nil, fmt.Errorf("could not read header. Cause: %w", err)
 	}
 
-	body, err := ReadBody(db, hash)
+	body, err := readBody(db, hash)
 	if err != nil {
 		return nil, fmt.Errorf("could not read body. Cause: %w", err)
 	}
@@ -128,8 +128,8 @@ func writeBatchBody(db ethdb.KeyValueWriter, hash gethcommon.Hash, body []*commo
 	return nil
 }
 
-// ReadBody retrieves the batch body corresponding to the hash.
-func ReadBody(db ethdb.KeyValueReader, hash common.L2RootHash) ([]*common.L2Tx, error) {
+// Retrieves the batch body corresponding to the hash.
+func readBody(db ethdb.KeyValueReader, hash common.L2RootHash) ([]*common.L2Tx, error) {
 	data, err := readBatchBodyRLP(db, hash)
 	if err != nil {
 		return nil, fmt.Errorf("could not read body. Cause: %w", err)

--- a/go/enclave/db/rawdb/accessors_chain.go
+++ b/go/enclave/db/rawdb/accessors_chain.go
@@ -16,12 +16,12 @@ import (
 )
 
 func ReadBatch(db ethdb.KeyValueReader, hash common.L2RootHash) (*core.Batch, error) {
-	header, err := readHeader(db, hash)
+	header, err := readBatchHeader(db, hash)
 	if err != nil {
 		return nil, fmt.Errorf("could not read header. Cause: %w", err)
 	}
 
-	body, err := readBody(db, hash)
+	body, err := readBatchBody(db, hash)
 	if err != nil {
 		return nil, fmt.Errorf("could not read body. Cause: %w", err)
 	}
@@ -96,8 +96,8 @@ func writeBatchHeaderNumber(db ethdb.KeyValueWriter, hash gethcommon.Hash, numbe
 }
 
 // Retrieves the batch header corresponding to the hash.
-func readHeader(db ethdb.KeyValueReader, hash common.L2RootHash) (*common.Header, error) {
-	data, err := readHeaderRLP(db, hash)
+func readBatchHeader(db ethdb.KeyValueReader, hash common.L2RootHash) (*common.Header, error) {
+	data, err := readBatchHeaderRLP(db, hash)
 	if err != nil {
 		return nil, fmt.Errorf("could not read header. Cause: %w", err)
 	}
@@ -108,8 +108,8 @@ func readHeader(db ethdb.KeyValueReader, hash common.L2RootHash) (*common.Header
 	return header, nil
 }
 
-// Retrieves a block header in its raw RLP database encoding.
-func readHeaderRLP(db ethdb.KeyValueReader, hash gethcommon.Hash) (rlp.RawValue, error) {
+// Retrieves a batch header in its raw RLP database encoding.
+func readBatchHeaderRLP(db ethdb.KeyValueReader, hash gethcommon.Hash) (rlp.RawValue, error) {
 	data, err := db.Get(batchHeaderKey(hash))
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve block header. Cause: %w", err)
@@ -129,7 +129,7 @@ func writeBatchBody(db ethdb.KeyValueWriter, hash gethcommon.Hash, body []*commo
 }
 
 // Retrieves the batch body corresponding to the hash.
-func readBody(db ethdb.KeyValueReader, hash common.L2RootHash) ([]*common.L2Tx, error) {
+func readBatchBody(db ethdb.KeyValueReader, hash common.L2RootHash) ([]*common.L2Tx, error) {
 	data, err := readBatchBodyRLP(db, hash)
 	if err != nil {
 		return nil, fmt.Errorf("could not read body. Cause: %w", err)

--- a/go/enclave/db/rawdb/accessors_chain.go
+++ b/go/enclave/db/rawdb/accessors_chain.go
@@ -165,8 +165,24 @@ func WriteL2HeadBatch(db ethdb.KeyValueWriter, l1Head common.L1RootHash, l2Head 
 	return nil
 }
 
+func WriteL2HeadRollup(db ethdb.KeyValueWriter, l1Head *common.L1RootHash, l2Head *common.L2RootHash) error {
+	if err := db.Put(headRollupAfterL1BlockKey(l1Head), l2Head.Bytes()); err != nil {
+		return fmt.Errorf("could not put chain heads in DB. Cause: %w", err)
+	}
+	return nil
+}
+
 func ReadL2HeadBatch(kv ethdb.KeyValueReader, l1Head common.L1RootHash) (*common.L2RootHash, error) {
 	data, err := kv.Get(headBatchAfterL1BlockKey(l1Head))
+	if err != nil {
+		return nil, errutil.ErrNotFound
+	}
+	l2Head := gethcommon.BytesToHash(data)
+	return &l2Head, nil
+}
+
+func ReadL2HeadRollup(kv ethdb.KeyValueReader, l1Head *common.L1RootHash) (*common.L2RootHash, error) {
+	data, err := kv.Get(headRollupAfterL1BlockKey(l1Head))
 	if err != nil {
 		return nil, errutil.ErrNotFound
 	}

--- a/go/enclave/db/rawdb/accessors_chain.go
+++ b/go/enclave/db/rawdb/accessors_chain.go
@@ -158,15 +158,15 @@ func readBatchBodyRLP(db ethdb.KeyValueReader, hash common.L2RootHash) (rlp.RawV
 	return data, nil
 }
 
-func WriteL2Head(db ethdb.KeyValueWriter, l1Head common.L1RootHash, l2Head common.L2RootHash) error {
-	if err := db.Put(headsAfterL1BlockKey(l1Head), l2Head.Bytes()); err != nil {
+func WriteL2HeadBatch(db ethdb.KeyValueWriter, l1Head common.L1RootHash, l2Head common.L2RootHash) error {
+	if err := db.Put(headBatchAfterL1BlockKey(l1Head), l2Head.Bytes()); err != nil {
 		return fmt.Errorf("could not put chain heads in DB. Cause: %w", err)
 	}
 	return nil
 }
 
-func ReadL2Head(kv ethdb.KeyValueReader, l1Head common.L1RootHash) (*common.L2RootHash, error) {
-	data, err := kv.Get(headsAfterL1BlockKey(l1Head))
+func ReadL2HeadBatch(kv ethdb.KeyValueReader, l1Head common.L1RootHash) (*common.L2RootHash, error) {
+	data, err := kv.Get(headBatchAfterL1BlockKey(l1Head))
 	if err != nil {
 		return nil, errutil.ErrNotFound
 	}

--- a/go/enclave/db/rawdb/accessors_indexes.go
+++ b/go/enclave/db/rawdb/accessors_indexes.go
@@ -63,7 +63,7 @@ func ReadTransaction(db ethdb.Reader, hash common.Hash) (*types.Transaction, com
 		return nil, common.Hash{}, 0, 0, fmt.Errorf("could not retrieve canonical hash for block number. Cause: %w", err)
 	}
 
-	transactions, err := ReadBody(db, *blockHash)
+	transactions, err := readBody(db, *blockHash)
 	if err != nil {
 		return nil, common.Hash{}, 0, 0, fmt.Errorf("could not retrieve block body. Cause: %w", err)
 	}

--- a/go/enclave/db/rawdb/accessors_indexes.go
+++ b/go/enclave/db/rawdb/accessors_indexes.go
@@ -63,7 +63,7 @@ func ReadTransaction(db ethdb.Reader, hash common.Hash) (*types.Transaction, com
 		return nil, common.Hash{}, 0, 0, fmt.Errorf("could not retrieve canonical hash for block number. Cause: %w", err)
 	}
 
-	transactions, err := readBody(db, *blockHash)
+	transactions, err := readBatchBody(db, *blockHash)
 	if err != nil {
 		return nil, common.Hash{}, 0, 0, fmt.Errorf("could not retrieve block body. Cause: %w", err)
 	}

--- a/go/enclave/db/rawdb/accessors_receipts.go
+++ b/go/enclave/db/rawdb/accessors_receipts.go
@@ -56,7 +56,7 @@ func ReadReceipts(db ethdb.Reader, hash common.Hash, number uint64, config *para
 	if err != nil {
 		return nil, fmt.Errorf("could not read receipt. Cause: %w", err)
 	}
-	body, err := readBody(db, hash)
+	body, err := readBatchBody(db, hash)
 	if err != nil {
 		return nil, fmt.Errorf("missing body but have receipt. Cause: %w", err)
 	}

--- a/go/enclave/db/rawdb/accessors_receipts.go
+++ b/go/enclave/db/rawdb/accessors_receipts.go
@@ -56,7 +56,7 @@ func ReadReceipts(db ethdb.Reader, hash common.Hash, number uint64, config *para
 	if err != nil {
 		return nil, fmt.Errorf("could not read receipt. Cause: %w", err)
 	}
-	body, err := ReadBody(db, hash)
+	body, err := readBody(db, hash)
 	if err != nil {
 		return nil, fmt.Errorf("missing body but have receipt. Cause: %w", err)
 	}

--- a/go/enclave/db/rawdb/schema.go
+++ b/go/enclave/db/rawdb/schema.go
@@ -51,7 +51,7 @@ func batchNumberKey(hash common.L2RootHash) []byte {
 }
 
 // For storing and fetching the L2 head hash by L1 block hash.
-func headsAfterL1BlockKey(hash common.L1RootHash) []byte {
+func headBatchAfterL1BlockKey(hash common.L1RootHash) []byte {
 	return append(headsAfterL1BlockPrefix, hash.Bytes()...)
 }
 

--- a/go/enclave/db/rawdb/schema.go
+++ b/go/enclave/db/rawdb/schema.go
@@ -13,18 +13,19 @@ var (
 	attestationKeyPrefix           = []byte("oAK")  // attestationKeyPrefix + address -> key
 	syntheticTransactionsKeyPrefix = []byte("oSTX") // attestationKeyPrefix + address -> key
 
-	batchHeaderPrefix       = []byte("oh")  // batchHeaderPrefix + num (uint64 big endian) + hash -> header
-	batchHashSuffix         = []byte("on")  // batchHeaderPrefix + num (uint64 big endian) + headerHashSuffix -> hash
-	batchBodyPrefix         = []byte("ob")  // batchBodyPrefix + num (uint64 big endian) + hash -> batch body
-	batchNumberPrefix       = []byte("oH")  // batchNumberPrefix + hash -> num (uint64 big endian)
-	rollupHeaderPrefix      = []byte("rh")  // rollupHeaderPrefix + num (uint64 big endian) + hash -> header
-	rollupBodyPrefix        = []byte("rb")  // rollupBodyPrefix + num (uint64 big endian) + hash -> batch body
-	rollupNumberPrefix      = []byte("rn")  // rollupNumberPrefix + hash -> num (uint64 big endian)
-	headsAfterL1BlockPrefix = []byte("och") // headsAfterL1BlockPrefix + hash -> num (uint64 big endian)
-	logsPrefix              = []byte("olg") // logsPrefix + hash -> block logs
-	batchReceiptsPrefix     = []byte("or")  // batchReceiptsPrefix + num (uint64 big endian) + hash -> batch receipts
-	contractReceiptPrefix   = []byte("ocr") // contractReceiptPrefix + address -> tx hash
-	txLookupPrefix          = []byte("ol")  // txLookupPrefix + hash -> transaction/receipt lookup metadata
+	batchHeaderPrefix            = []byte("oh")  // batchHeaderPrefix + num (uint64 big endian) + hash -> header
+	batchHashSuffix              = []byte("on")  // batchHeaderPrefix + num (uint64 big endian) + headerHashSuffix -> hash
+	batchBodyPrefix              = []byte("ob")  // batchBodyPrefix + num (uint64 big endian) + hash -> batch body
+	batchNumberPrefix            = []byte("oH")  // batchNumberPrefix + hash -> num (uint64 big endian)
+	rollupHeaderPrefix           = []byte("rh")  // rollupHeaderPrefix + num (uint64 big endian) + hash -> header
+	rollupBodyPrefix             = []byte("rb")  // rollupBodyPrefix + num (uint64 big endian) + hash -> batch body
+	rollupNumberPrefix           = []byte("rn")  // rollupNumberPrefix + hash -> num (uint64 big endian)
+	headBatchAfterL1BlockPrefix  = []byte("hb")  // headBatchAfterL1BlockPrefix + hash -> num (uint64 big endian)
+	headRollupAfterL1BlockPrefix = []byte("hr")  // headRollupAfterL1BlockPrefix + hash -> num (uint64 big endian)
+	logsPrefix                   = []byte("olg") // logsPrefix + hash -> block logs
+	batchReceiptsPrefix          = []byte("or")  // batchReceiptsPrefix + num (uint64 big endian) + hash -> batch receipts
+	contractReceiptPrefix        = []byte("ocr") // contractReceiptPrefix + address -> tx hash
+	txLookupPrefix               = []byte("ol")  // txLookupPrefix + hash -> transaction/receipt lookup metadata
 )
 
 // todo - joel - should this be here?
@@ -50,12 +51,12 @@ func batchNumberKey(hash common.L2RootHash) []byte {
 	return append(batchNumberPrefix, hash.Bytes()...)
 }
 
-// For storing and fetching the L2 head hash by L1 block hash.
+// For storing and fetching the L2 head batch hash by L1 block hash.
 func headBatchAfterL1BlockKey(hash common.L1RootHash) []byte {
-	return append(headsAfterL1BlockPrefix, hash.Bytes()...)
+	return append(headBatchAfterL1BlockPrefix, hash.Bytes()...)
 }
 
-// For storing and fetching the canonical L2 head hash by height.
+// For storing and fetching the canonical L2 head batch hash by height.
 func batchHeaderHashKey(number uint64) []byte {
 	return append(append(batchHeaderPrefix, encodeNumber(number)...), batchHashSuffix...)
 }
@@ -63,6 +64,11 @@ func batchHeaderHashKey(number uint64) []byte {
 // For storing and fetching a batch's receipts by batch hash.
 func batchReceiptsKey(hash common.L2RootHash) []byte {
 	return append(batchReceiptsPrefix, hash.Bytes()...)
+}
+
+// For storing and fetching the L2 head rollup hash by L1 block hash.
+func headRollupAfterL1BlockKey(hash *common.L1RootHash) []byte {
+	return append(headRollupAfterL1BlockPrefix, hash.Bytes()...)
 }
 
 // logsPrefix + hash

--- a/go/enclave/db/storage.go
+++ b/go/enclave/db/storage.go
@@ -153,6 +153,10 @@ func (s *storageImpl) FetchL2HeadBatch(blockHash common.L1RootHash) (*common.L2R
 	return obscurorawdb.ReadL2HeadBatch(s.db, blockHash)
 }
 
+func (s *storageImpl) FetchL2HeadRollup(blockHash *common.L1RootHash) (*common.L2RootHash, error) {
+	return obscurorawdb.ReadL2HeadRollup(s.db, blockHash)
+}
+
 func (s *storageImpl) FetchLogs(blockHash common.L1RootHash) ([]*types.Log, error) {
 	logs, err := obscurorawdb.ReadBlockLogs(s.db, blockHash)
 	if err != nil {
@@ -183,6 +187,17 @@ func (s *storageImpl) UpdateL2HeadBatch(l1Head common.L1RootHash, l2Head *core.B
 		return fmt.Errorf("could not write block logs. Cause: %w", err)
 	}
 
+	if err := batch.Write(); err != nil {
+		return fmt.Errorf("could not save new head. Cause: %w", err)
+	}
+	return nil
+}
+
+func (s *storageImpl) UpdateL2HeadRollup(l1Head *common.L1RootHash, l2Head *common.L2RootHash) error {
+	batch := s.db.NewBatch()
+	if err := obscurorawdb.WriteL2HeadRollup(batch, l1Head, l2Head); err != nil {
+		return fmt.Errorf("could not write block state. Cause: %w", err)
+	}
 	if err := batch.Write(); err != nil {
 		return fmt.Errorf("could not save new head. Cause: %w", err)
 	}

--- a/go/enclave/db/storage.go
+++ b/go/enclave/db/storage.go
@@ -48,7 +48,7 @@ func (s *storageImpl) FetchHeadBatch() (*core.Batch, error) {
 	if (bytes.Equal(l1Head.Bytes(), gethcommon.Hash{}.Bytes())) {
 		return nil, fmt.Errorf("could not fetch L1 head hash")
 	}
-	l2Head, err := s.FetchL2HeadBatch(l1Head)
+	l2Head, err := s.FetchHeadBatchForBlock(l1Head)
 	if err != nil {
 		return nil, fmt.Errorf("could not fetch L2 head hash")
 	}
@@ -149,11 +149,11 @@ func (s *storageImpl) assertSecretAvailable() {
 	//}
 }
 
-func (s *storageImpl) FetchL2HeadBatch(blockHash common.L1RootHash) (*common.L2RootHash, error) {
+func (s *storageImpl) FetchHeadBatchForBlock(blockHash common.L1RootHash) (*common.L2RootHash, error) {
 	return obscurorawdb.ReadL2HeadBatch(s.db, blockHash)
 }
 
-func (s *storageImpl) FetchL2HeadRollup(blockHash *common.L1RootHash) (*common.L2RootHash, error) {
+func (s *storageImpl) FetchHeadRollupForBlock(blockHash *common.L1RootHash) (*common.L2RootHash, error) {
 	return obscurorawdb.ReadL2HeadRollup(s.db, blockHash)
 }
 
@@ -166,7 +166,7 @@ func (s *storageImpl) FetchLogs(blockHash common.L1RootHash) ([]*types.Log, erro
 	return logs, nil
 }
 
-func (s *storageImpl) UpdateL2HeadBatch(l1Head common.L1RootHash, l2Head *core.Batch, receipts []*types.Receipt) error {
+func (s *storageImpl) UpdateHeadBatch(l1Head common.L1RootHash, l2Head *core.Batch, receipts []*types.Receipt) error {
 	batch := s.db.NewBatch()
 
 	if err := obscurorawdb.WriteL2HeadBatch(batch, l1Head, *l2Head.Hash()); err != nil {
@@ -193,7 +193,7 @@ func (s *storageImpl) UpdateL2HeadBatch(l1Head common.L1RootHash, l2Head *core.B
 	return nil
 }
 
-func (s *storageImpl) UpdateL2HeadRollup(l1Head *common.L1RootHash, l2Head *common.L2RootHash) error {
+func (s *storageImpl) UpdateHeadRollup(l1Head *common.L1RootHash, l2Head *common.L2RootHash) error {
 	batch := s.db.NewBatch()
 	if err := obscurorawdb.WriteL2HeadRollup(batch, l1Head, l2Head); err != nil {
 		return fmt.Errorf("could not write block state. Cause: %w", err)

--- a/go/enclave/db/storage.go
+++ b/go/enclave/db/storage.go
@@ -48,7 +48,7 @@ func (s *storageImpl) FetchHeadBatch() (*core.Batch, error) {
 	if (bytes.Equal(l1Head.Bytes(), gethcommon.Hash{}.Bytes())) {
 		return nil, fmt.Errorf("could not fetch L1 head hash")
 	}
-	l2Head, err := s.FetchL2Head(l1Head)
+	l2Head, err := s.FetchL2HeadBatch(l1Head)
 	if err != nil {
 		return nil, fmt.Errorf("could not fetch L2 head hash")
 	}
@@ -149,8 +149,8 @@ func (s *storageImpl) assertSecretAvailable() {
 	//}
 }
 
-func (s *storageImpl) FetchL2Head(blockHash common.L1RootHash) (*common.L2RootHash, error) {
-	return obscurorawdb.ReadL2Head(s.db, blockHash)
+func (s *storageImpl) FetchL2HeadBatch(blockHash common.L1RootHash) (*common.L2RootHash, error) {
+	return obscurorawdb.ReadL2HeadBatch(s.db, blockHash)
 }
 
 func (s *storageImpl) FetchLogs(blockHash common.L1RootHash) ([]*types.Log, error) {
@@ -162,10 +162,10 @@ func (s *storageImpl) FetchLogs(blockHash common.L1RootHash) ([]*types.Log, erro
 	return logs, nil
 }
 
-func (s *storageImpl) UpdateL2Head(l1Head common.L1RootHash, l2Head *core.Batch, receipts []*types.Receipt) error {
+func (s *storageImpl) UpdateL2HeadBatch(l1Head common.L1RootHash, l2Head *core.Batch, receipts []*types.Receipt) error {
 	batch := s.db.NewBatch()
 
-	if err := obscurorawdb.WriteL2Head(batch, l1Head, *l2Head.Hash()); err != nil {
+	if err := obscurorawdb.WriteL2HeadBatch(batch, l1Head, *l2Head.Hash()); err != nil {
 		return fmt.Errorf("could not write block state. Cause: %w", err)
 	}
 

--- a/go/enclave/db/storage.go
+++ b/go/enclave/db/storage.go
@@ -148,13 +148,17 @@ func (s *storageImpl) assertSecretAvailable() {
 func (s *storageImpl) FetchHeadBatchForBlock(blockHash common.L1RootHash) (*core.Batch, error) {
 	l2HeadBatch, err := obscurorawdb.ReadL2HeadBatch(s.db, blockHash)
 	if err != nil {
-		return nil, fmt.Errorf("could not read head L2 batch for block. Cause: %w", err)
+		return nil, fmt.Errorf("could not read L2 head batch for block. Cause: %w", err)
 	}
 	return obscurorawdb.ReadBatch(s.db, *l2HeadBatch)
 }
 
-func (s *storageImpl) FetchHeadRollupForBlock(blockHash *common.L1RootHash) (*common.L2RootHash, error) {
-	return obscurorawdb.ReadL2HeadRollup(s.db, blockHash)
+func (s *storageImpl) FetchHeadRollupForBlock(blockHash *common.L1RootHash) (*core.Rollup, error) {
+	l2HeadBatch, err := obscurorawdb.ReadL2HeadRollup(s.db, blockHash)
+	if err != nil {
+		return nil, fmt.Errorf("could not read L2 head rollup for block. Cause: %w", err)
+	}
+	return obscurorawdb.ReadRollup(s.db, *l2HeadBatch)
 }
 
 func (s *storageImpl) FetchLogs(blockHash common.L1RootHash) ([]*types.Log, error) {

--- a/go/enclave/db/storage.go
+++ b/go/enclave/db/storage.go
@@ -48,11 +48,7 @@ func (s *storageImpl) FetchHeadBatch() (*core.Batch, error) {
 	if (bytes.Equal(l1Head.Bytes(), gethcommon.Hash{}.Bytes())) {
 		return nil, fmt.Errorf("could not fetch L1 head hash")
 	}
-	l2Head, err := s.FetchHeadBatchForBlock(l1Head)
-	if err != nil {
-		return nil, fmt.Errorf("could not fetch L2 head hash")
-	}
-	return s.FetchBatch(*l2Head)
+	return s.FetchHeadBatchForBlock(l1Head)
 }
 
 func (s *storageImpl) FetchBatch(hash common.L2RootHash) (*core.Batch, error) {
@@ -149,8 +145,12 @@ func (s *storageImpl) assertSecretAvailable() {
 	//}
 }
 
-func (s *storageImpl) FetchHeadBatchForBlock(blockHash common.L1RootHash) (*common.L2RootHash, error) {
-	return obscurorawdb.ReadL2HeadBatch(s.db, blockHash)
+func (s *storageImpl) FetchHeadBatchForBlock(blockHash common.L1RootHash) (*core.Batch, error) {
+	l2HeadBatch, err := obscurorawdb.ReadL2HeadBatch(s.db, blockHash)
+	if err != nil {
+		return nil, fmt.Errorf("could not read head L2 batch for block. Cause: %w", err)
+	}
+	return obscurorawdb.ReadBatch(s.db, *l2HeadBatch)
 }
 
 func (s *storageImpl) FetchHeadRollupForBlock(blockHash *common.L1RootHash) (*common.L2RootHash, error) {

--- a/go/enclave/enclave_test.go
+++ b/go/enclave/enclave_test.go
@@ -513,7 +513,7 @@ func createFakeGenesis(enclave common.Enclave, addresses []prefundedAddress) err
 	if err = enclave.(*enclaveImpl).storage.StoreBatch(genBatch, nil); err != nil {
 		return err
 	}
-	if err = enclave.(*enclaveImpl).storage.UpdateL2HeadBatch(blk.Hash(), genBatch, nil); err != nil {
+	if err = enclave.(*enclaveImpl).storage.UpdateHeadBatch(blk.Hash(), genBatch, nil); err != nil {
 		return err
 	}
 	return enclave.(*enclaveImpl).storage.UpdateL1Head(blk.Hash())
@@ -566,7 +566,7 @@ func injectNewBlockAndChangeBalance(enclave common.Enclave, funds []prefundedAdd
 	if err = enclave.(*enclaveImpl).storage.StoreBatch(batch, nil); err != nil {
 		return err
 	}
-	if err = enclave.(*enclaveImpl).storage.UpdateL2HeadBatch(blk.Hash(), batch, nil); err != nil {
+	if err = enclave.(*enclaveImpl).storage.UpdateHeadBatch(blk.Hash(), batch, nil); err != nil {
 		return err
 	}
 	return nil

--- a/go/enclave/enclave_test.go
+++ b/go/enclave/enclave_test.go
@@ -513,7 +513,7 @@ func createFakeGenesis(enclave common.Enclave, addresses []prefundedAddress) err
 	if err = enclave.(*enclaveImpl).storage.StoreBatch(genBatch, nil); err != nil {
 		return err
 	}
-	if err = enclave.(*enclaveImpl).storage.UpdateL2Head(blk.Hash(), genBatch, nil); err != nil {
+	if err = enclave.(*enclaveImpl).storage.UpdateL2HeadBatch(blk.Hash(), genBatch, nil); err != nil {
 		return err
 	}
 	return enclave.(*enclaveImpl).storage.UpdateL1Head(blk.Hash())
@@ -566,7 +566,7 @@ func injectNewBlockAndChangeBalance(enclave common.Enclave, funds []prefundedAdd
 	if err = enclave.(*enclaveImpl).storage.StoreBatch(batch, nil); err != nil {
 		return err
 	}
-	if err = enclave.(*enclaveImpl).storage.UpdateL2Head(blk.Hash(), batch, nil); err != nil {
+	if err = enclave.(*enclaveImpl).storage.UpdateL2HeadBatch(blk.Hash(), batch, nil); err != nil {
 		return err
 	}
 	return nil

--- a/go/enclave/events/subscription_manager.go
+++ b/go/enclave/events/subscription_manager.go
@@ -146,7 +146,7 @@ func (s *SubscriptionManager) GetFilteredLogs(account *gethcommon.Address, filte
 
 	// We proceed in this way instead of calling `FetchHeadRollup` because we want to ensure the chain has not advanced
 	// causing a head block/head rollup mismatch.
-	l2Head, err := s.storage.FetchL2HeadBatch(headBlock.Hash())
+	l2Head, err := s.storage.FetchHeadBatchForBlock(headBlock.Hash())
 	if err != nil {
 		return nil, fmt.Errorf("could not filter logs as block state for head block could not be retrieved. Cause: %w", err)
 	}

--- a/go/enclave/events/subscription_manager.go
+++ b/go/enclave/events/subscription_manager.go
@@ -150,7 +150,7 @@ func (s *SubscriptionManager) GetFilteredLogs(account *gethcommon.Address, filte
 	if err != nil {
 		return nil, fmt.Errorf("could not filter logs as block state for head block could not be retrieved. Cause: %w", err)
 	}
-	return s.FilterLogs(logs, *l2Head, account, filter)
+	return s.FilterLogs(logs, *l2Head.Hash(), account, filter)
 }
 
 // FilterLogs takes a list of logs and the hash of the rollup to use to create the state DB. It returns the logs

--- a/go/enclave/events/subscription_manager.go
+++ b/go/enclave/events/subscription_manager.go
@@ -146,7 +146,7 @@ func (s *SubscriptionManager) GetFilteredLogs(account *gethcommon.Address, filte
 
 	// We proceed in this way instead of calling `FetchHeadRollup` because we want to ensure the chain has not advanced
 	// causing a head block/head rollup mismatch.
-	l2Head, err := s.storage.FetchL2Head(headBlock.Hash())
+	l2Head, err := s.storage.FetchL2HeadBatch(headBlock.Hash())
 	if err != nil {
 		return nil, fmt.Errorf("could not filter logs as block state for head block could not be retrieved. Cause: %w", err)
 	}

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -925,12 +925,12 @@ func (rc *RollupChain) processRollups(rollups []*core.Rollup, block *common.L1Bl
 		if err = rc.storage.StoreRollup(rollup); err != nil {
 			return fmt.Errorf("could not store rollup. Cause: %w", err)
 		}
-		currentHeadRollup = rollup.Hash()
+		currentHeadRollup = rollup
 	}
 
 	// We update the current head rollup to the latest processed rollup.
 	l1Head := block.Hash()
-	if err = rc.storage.UpdateHeadRollup(&l1Head, currentHeadRollup); err != nil {
+	if err = rc.storage.UpdateHeadRollup(&l1Head, currentHeadRollup.Hash()); err != nil {
 		return fmt.Errorf("could not update L2 head rollup. Cause: %w", err)
 	}
 

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -634,13 +634,9 @@ func (rc *RollupChain) handlePostGenesisBlock(block *types.Block, rollupsInBlock
 
 	// TODO - #718 - Cannot assume that the most recent rollup is on the previous block anymore. May be on the same block.
 	// We retrieve the current L2 head.
-	l2HeadHash, err := rc.storage.FetchHeadBatchForBlock(block.ParentHash())
+	l2Head, err := rc.storage.FetchHeadBatchForBlock(block.ParentHash())
 	if err != nil {
-		return nil, nil, fmt.Errorf("could not retrieve current head batch hash. Cause: %w", err)
-	}
-	l2Head, err := rc.storage.FetchBatch(*l2HeadHash)
-	if err != nil {
-		return nil, nil, fmt.Errorf("could not fetch parent batch. Cause: %w", err)
+		return nil, nil, fmt.Errorf("could not retrieve current head batch. Cause: %w", err)
 	}
 	l2HeadTxReceipts, err := rc.storage.GetReceiptsByHash(*l2Head.Hash())
 	if err != nil {
@@ -785,11 +781,7 @@ func (rc *RollupChain) getBatch(height gethrpc.BlockNumber) (*core.Batch, error)
 
 // Creates a batch.
 func (rc *RollupChain) produceBatch(block *types.Block) (*core.Batch, error) {
-	headBatchHash, err := rc.storage.FetchHeadBatchForBlock(block.ParentHash())
-	if err != nil {
-		return nil, fmt.Errorf("could not retrieve head batch hash. Cause: %w", err)
-	}
-	headBatch, err := rc.storage.FetchBatch(*headBatchHash)
+	headBatch, err := rc.storage.FetchHeadBatchForBlock(block.ParentHash())
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve head batch. Cause: %w", err)
 	}

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -894,6 +894,21 @@ func (rc *RollupChain) isAccountContractAtBlock(accountAddr gethcommon.Address, 
 
 // Validates and stores the rollup in a given block.
 func (rc *RollupChain) processRollups(rollups []*core.Rollup, _ *gethcommon.Hash) error {
+	// We sort the rollups by number in ascending order, in order to process them in the correct order.
+	sort.Slice(rollups, func(i, j int) bool {
+		return rollups[i].Header.Number.Cmp(rollups[j].Header.Number) < 0
+	})
+
+	// We check if there are any duplicates.
+	for idx, rollup := range rollups {
+		if idx+1 >= len(rollups) {
+			break
+		}
+		if rollup.Header.Number.Cmp(rollups[idx+1].Header.Number) == 0 {
+			return fmt.Errorf("duplicates rollups found in block; two rollups with number %d", rollup.Header.Number)
+		}
+	}
+
 	if len(rollups) == 0 {
 		// TODO - #718 - Store previous rollup against new L1 head.
 		return nil

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -919,11 +919,10 @@ func (rc *RollupChain) processRollups(rollups []*core.Rollup, block *common.L1Bl
 			return fmt.Errorf("rollup signature was invalid. Cause: %w", err)
 		}
 
-		// We check that the rollup numbers are sequential.
-		rollupNumIncrement := big.NewInt(0).Sub(rollup.Number(), currentHeadRollup.Number())
-		if rollupNumIncrement.Cmp(big.NewInt(1)) != 0 {
-			return fmt.Errorf("rollup number jumped by %d, from %d to %d; expected increment by 1",
-				rollupNumIncrement, currentHeadRollup.Number(), rollup.Number())
+		// We check that the rollups are sequential.
+		if rollup.Header.ParentHash.Hex() != currentHeadRollup.Hash().Hex() {
+			return fmt.Errorf("found gap in rollup chain. Rollup %s's parent was %s instead of %s",
+				rollup.Header.Hash(), rollup.Header.ParentHash, currentHeadRollup.Header.Hash())
 		}
 
 		// TODO - #718 - Validate the rollups in the block against the stored batches.

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -181,7 +181,7 @@ func (rc *RollupChain) UpdateL2Chain(batch *core.Batch) (*common.Header, error) 
 	if err = rc.storage.StoreBatch(batch, batchTxReceipts); err != nil {
 		return nil, fmt.Errorf("failed to store batch. Cause: %w", err)
 	}
-	if err = rc.storage.UpdateL2HeadBatch(batch.Header.L1Proof, batch, batchTxReceipts); err != nil {
+	if err = rc.storage.UpdateHeadBatch(batch.Header.L1Proof, batch, batchTxReceipts); err != nil {
 		return nil, fmt.Errorf("could not store new L2 head. Cause: %w", err)
 	}
 
@@ -441,7 +441,7 @@ func (rc *RollupChain) handleGenesisBlock(block *types.Block, rollupsInBlock []*
 		return nil, fmt.Errorf("could not store genesis rollup. Cause: %w", err)
 	}
 	l1Head := block.Hash()
-	if err := rc.storage.UpdateL2HeadRollup(&l1Head, genesisRollup.Hash()); err != nil {
+	if err := rc.storage.UpdateHeadRollup(&l1Head, genesisRollup.Hash()); err != nil {
 		return nil, fmt.Errorf("could not update l2 head rollup. Cause: %w", err)
 	}
 
@@ -452,7 +452,7 @@ func (rc *RollupChain) handleGenesisBlock(block *types.Block, rollupsInBlock []*
 	if err := rc.storage.StoreBatch(genesisBatch, nil); err != nil {
 		return nil, fmt.Errorf("failed to store batch. Cause: %w", err)
 	}
-	if err := rc.storage.UpdateL2HeadBatch(l1Head, genesisBatch, nil); err != nil {
+	if err := rc.storage.UpdateHeadBatch(l1Head, genesisBatch, nil); err != nil {
 		return nil, fmt.Errorf("could not store new L2 head. Cause: %w", err)
 	}
 	if err := rc.storage.UpdateL1Head(l1Head); err != nil {
@@ -634,7 +634,7 @@ func (rc *RollupChain) handlePostGenesisBlock(block *types.Block, rollupsInBlock
 
 	// TODO - #718 - Cannot assume that the most recent rollup is on the previous block anymore. May be on the same block.
 	// We retrieve the current L2 head.
-	l2HeadHash, err := rc.storage.FetchL2HeadBatch(block.ParentHash())
+	l2HeadHash, err := rc.storage.FetchHeadBatchForBlock(block.ParentHash())
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not retrieve current head batch hash. Cause: %w", err)
 	}
@@ -664,7 +664,7 @@ func (rc *RollupChain) handlePostGenesisBlock(block *types.Block, rollupsInBlock
 	}
 
 	// We update the chain heads.
-	if err = rc.storage.UpdateL2HeadBatch(l1Head, l2Head, l2HeadTxReceipts); err != nil {
+	if err = rc.storage.UpdateHeadBatch(l1Head, l2Head, l2HeadTxReceipts); err != nil {
 		return nil, nil, fmt.Errorf("could not store new head. Cause: %w", err)
 	}
 	if err = rc.storage.UpdateL1Head(l1Head); err != nil {
@@ -785,7 +785,7 @@ func (rc *RollupChain) getBatch(height gethrpc.BlockNumber) (*core.Batch, error)
 
 // Creates a batch.
 func (rc *RollupChain) produceBatch(block *types.Block) (*core.Batch, error) {
-	headBatchHash, err := rc.storage.FetchL2HeadBatch(block.ParentHash())
+	headBatchHash, err := rc.storage.FetchHeadBatchForBlock(block.ParentHash())
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve head batch hash. Cause: %w", err)
 	}
@@ -915,7 +915,7 @@ func (rc *RollupChain) processRollups(rollups []*core.Rollup, block *common.L1Bl
 
 	// We retrieve the current head rollup.
 	l1ParentHash := block.ParentHash()
-	currentHeadRollup, err := rc.storage.FetchL2HeadRollup(&l1ParentHash)
+	currentHeadRollup, err := rc.storage.FetchHeadRollupForBlock(&l1ParentHash)
 	if err != nil {
 		return fmt.Errorf("could not fetch current L2 head rollup")
 	}
@@ -938,7 +938,7 @@ func (rc *RollupChain) processRollups(rollups []*core.Rollup, block *common.L1Bl
 
 	// We update the current head rollup to the latest processed rollup.
 	l1Head := block.Hash()
-	if err = rc.storage.UpdateL2HeadRollup(&l1Head, currentHeadRollup); err != nil {
+	if err = rc.storage.UpdateHeadRollup(&l1Head, currentHeadRollup); err != nil {
 		return fmt.Errorf("could not update L2 head rollup. Cause: %w", err)
 	}
 


### PR DESCRIPTION
### Why is this change needed?

- Provide a description and a link to the underlying ticket

### What changes were made as part of this PR:

- Provide a high level list of the changes made

### Definition of done

- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
- [ ] End-to-end tests run if required (see below)

### End-to-end tests

Running the end-to-end tests in the [obscuro-test repo](https://github.com/obscuronet/obscuro-test) is currently at the 
discretion of the developer prior to merging a PR. The intention is not to slow down development by having the longer 
running end-to-end tests as a PR gate run on each branch commit etc. To manually trigger a run pre-merge;

- Go to [run_local_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_local_tests.yml)
- Click the "Run workflow" button
- Use the main branch of obscuro-test 
- Enter the name of the PR branch for go-obscuro
- Run the workflow

The run takes approximately 20 minutes and any failure will be reported in the workflow output. Should the tests fail 
the docker container output for the local testnet and all test artifacts will be added to the run and can be downloaded
for debugging and analysis, with a retention period of 2 days. 

Note that every PR merge to main will also trigger a run of post-merge tests, so even if you do not manually trigger 
pre-merge, tests will be run post-merge. The intention being to catch any issues fast on main to allow for quick 
resolution. The post-merge test output can be seen at 
[run_merge_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_merge_tests.yml) and will show both 
the PR number and author in the list of runs. 


