### PR TITLE
temporarily disable the validation of sequencer signatures

### DIFF
--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -615,10 +615,11 @@ func (rc *RollupChain) isValidBatch(batch *core.Batch, rootHash common.L2RootHas
 	}
 
 	// Check that the signature is valid.
-	if err := rc.validateSequencerSig(batch.Hash(), &batch.Header.Agg, batch.Header.R, batch.Header.S); err != nil {
-		rc.logger.Error(fmt.Sprintf("Verify batch r_%d: invalid signature. Cause: %s", common.ShortHash(*batch.Hash()), err.Error()))
-		return false
-	}
+	// todo: #1297 re-enable seq sig validation ASAP - once the testnet nodes all have access to the sequencer ID
+	//if err := rc.validateSequencerSig(batch.Hash(), &batch.Header.Agg, batch.Header.R, batch.Header.S); err != nil {
+	//	rc.logger.Error(fmt.Sprintf("Verify batch r_%d: invalid signature. Cause: %s", common.ShortHash(*batch.Hash()), err.Error()))
+	//	return false
+	//}
 
 	// todo - check that the transactions hash to the header.txHash
 
@@ -729,7 +730,8 @@ func (rc *RollupChain) signBatch(batch *core.Batch) error {
 }
 
 // Checks that the header is signed validly by the sequencer.
-func (rc *RollupChain) validateSequencerSig(headerHash *gethcommon.Hash, aggregator *gethcommon.Address, sigR *big.Int, sigS *big.Int) error {
+// todo: #1297 remove the nolint:unused here when validation usage is re-enabled
+func (rc *RollupChain) validateSequencerSig(headerHash *gethcommon.Hash, aggregator *gethcommon.Address, sigR *big.Int, sigS *big.Int) error { //nolint:unused
 	// Batches and rollups should only be produced by the sequencer.
 	// TODO - #718 - Sequencer identities should be retrieved from the L1 management contract.
 	if !bytes.Equal(aggregator.Bytes(), rc.sequencerID.Bytes()) {
@@ -915,9 +917,10 @@ func (rc *RollupChain) processRollups(rollups []*core.Rollup, block *common.L1Bl
 
 	// We check each rollup.
 	for _, rollup := range rollups {
-		if err := rc.validateSequencerSig(rollup.Hash(), &rollup.Header.Agg, rollup.Header.R, rollup.Header.S); err != nil {
-			return fmt.Errorf("rollup signature was invalid. Cause: %w", err)
-		}
+		// todo: #1297 re-enable seq sig validation ASAP - once the testnet nodes all have access to the sequencer ID
+		//if err := rc.validateSequencerSig(rollup.Hash(), &rollup.Header.Agg, rollup.Header.R, rollup.Header.S); err != nil {
+		//	return fmt.Errorf("rollup signature was invalid. Cause: %w", err)
+		//}
 
 		// We check that the rollups are sequential.
 		if rollup.Header.ParentHash.Hex() != currentHeadRollup.Hash().Hex() {


### PR DESCRIPTION
### Why is this change needed?

- E2E tests are broken because the validators don't have access to sequencer ID in network tests

### What changes were made as part of this PR:

- comment out validation usage with a todo that references this ticket: https://github.com/obscuronet/obscuro-internal/issues/1297 (and that ticket references how to find all the todos)
- I'll assign that ticket to myself and follow-up when the sequencer ID changes are in

### Definition of done

- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
- [ ] End-to-end tests run if required (see below)

### End-to-end tests

Running the end-to-end tests in the [obscuro-test repo](https://github.com/obscuronet/obscuro-test) is currently at the 
discretion of the developer prior to merging a PR. The intention is not to slow down development by having the longer 
running end-to-end tests as a PR gate run on each branch commit etc. To manually trigger a run pre-merge;

- Go to [run_local_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_local_tests.yml)
- Click the "Run workflow" button
- Use the main branch of obscuro-test 
- Enter the name of the PR branch for go-obscuro
- Run the workflow

The run takes approximately 20 minutes and any failure will be reported in the workflow output. Should the tests fail 
the docker container output for the local testnet and all test artifacts will be added to the run and can be downloaded
for debugging and analysis, with a retention period of 2 days. 

Note that every PR merge to main will also trigger a run of post-merge tests, so even if you do not manually trigger 
pre-merge, tests will be run post-merge. The intention being to catch any issues fast on main to allow for quick 
resolution. The post-merge test output can be seen at 
[run_merge_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_merge_tests.yml) and will show both 
the PR number and author in the list of runs. 


