### PR TITLE
Create two separate header structs for batch and rollup

### DIFF
--- a/go/common/batches.go
+++ b/go/common/batches.go
@@ -9,7 +9,7 @@ import (
 // ExtBatch is an encrypted form of batch used when passing the batch around outside of an enclave.
 // TODO - #718 - Expand this structure to contain the required fields.
 type ExtBatch struct {
-	Header          *Header
+	Header          *BatchHeader
 	TxHashes        []TxHash // The hashes of the transactions included in the batch.
 	EncryptedTxBlob EncryptedTransactions
 	hash            atomic.Value
@@ -28,7 +28,7 @@ func (b *ExtBatch) Hash() L2RootHash {
 
 func (b *ExtBatch) ToExtRollup() *ExtRollup {
 	return &ExtRollup{
-		Header:          b.Header,
+		Header:          b.Header.ToRollupHeader(),
 		TxHashes:        b.TxHashes,
 		EncryptedTxBlob: b.EncryptedTxBlob,
 	}

--- a/go/common/headers.go
+++ b/go/common/headers.go
@@ -13,6 +13,11 @@ import (
 	"golang.org/x/crypto/sha3"
 )
 
+// Used to hash headers.
+var hasherPool = sync.Pool{
+	New: func() interface{} { return sha3.NewLegacyKeccak256() },
+}
+
 // BatchHeader is a public / plaintext struct that holds common properties of batches.
 // Making changes to this struct will require GRPC + GRPC Converters regen
 type BatchHeader struct {
@@ -36,7 +41,7 @@ type BatchHeader struct {
 
 	// The custom Obscuro fields.
 	Agg     common.Address // TODO - Can this be removed and replaced with the `Coinbase` field?
-	L1Proof L1RootHash     // the L1 block used by the enclave to generate the current rollup
+	L1Proof L1RootHash     // the L1 block used by the enclave to generate the current batch
 	R, S    *big.Int       // signature values
 	// TODO: mark as deprecated Withdrawals are now contained within cross chain messages.
 	Withdrawals        []Withdrawal
@@ -175,11 +180,6 @@ func (r *RollupHeader) ToBatchHeader() *BatchHeader {
 		LatestInboudCrossChainHash:    r.LatestInboudCrossChainHash,
 		LatestInboundCrossChainHeight: r.LatestInboundCrossChainHeight,
 	}
-}
-
-// Used to hash headers.
-var hasherPool = sync.Pool{
-	New: func() interface{} { return sha3.NewLegacyKeccak256() },
 }
 
 // Encodes value, hashes the encoded bytes and returns the hash.

--- a/go/common/rollups.go
+++ b/go/common/rollups.go
@@ -6,7 +6,7 @@ import (
 
 // ExtRollup is an encrypted form of rollup used when passing the rollup around outside of an enclave.
 type ExtRollup struct {
-	Header          *Header
+	Header          *RollupHeader
 	TxHashes        []TxHash // The hashes of the transactions included in the rollup
 	EncryptedTxBlob EncryptedTransactions
 	hash            atomic.Value
@@ -25,7 +25,7 @@ func (r *ExtRollup) Hash() L2RootHash {
 
 func (r *ExtRollup) ToExtBatch() *ExtBatch {
 	return &ExtBatch{
-		Header:          r.Header,
+		Header:          r.Header.ToBatchHeader(),
 		TxHashes:        r.TxHashes,
 		EncryptedTxBlob: r.EncryptedTxBlob,
 	}

--- a/go/common/rpc/converters.go
+++ b/go/common/rpc/converters.go
@@ -161,7 +161,7 @@ func ToExtBatchMsg(batch *common.ExtBatch) generated.ExtBatchMsg {
 	return generated.ExtBatchMsg{Header: ToBatchHeaderMsg(batch.Header), TxHashes: txHashBytes, Txs: batch.EncryptedTxBlob}
 }
 
-func ToRollupHeaderMsg(header *common.Header) *generated.RollupHeaderMsg { //nolint:dupl
+func ToRollupHeaderMsg(header *common.RollupHeader) *generated.RollupHeaderMsg { //nolint:dupl
 	if header == nil {
 		return nil
 	}
@@ -213,7 +213,7 @@ func ToRollupHeaderMsg(header *common.Header) *generated.RollupHeaderMsg { //nol
 	return &headerMsg
 }
 
-func ToBatchHeaderMsg(header *common.Header) *generated.BatchHeaderMsg { //nolint:dupl
+func ToBatchHeaderMsg(header *common.BatchHeader) *generated.BatchHeaderMsg { //nolint:dupl
 	if header == nil {
 		return nil
 	}
@@ -305,7 +305,7 @@ func FromExtBatchMsg(msg *generated.ExtBatchMsg) *common.ExtBatch {
 	}
 }
 
-func FromRollupHeaderMsg(header *generated.RollupHeaderMsg) *common.Header { //nolint:dupl
+func FromRollupHeaderMsg(header *generated.RollupHeaderMsg) *common.RollupHeader { //nolint:dupl
 	if header == nil {
 		return nil
 	}
@@ -320,7 +320,7 @@ func FromRollupHeaderMsg(header *generated.RollupHeaderMsg) *common.Header { //n
 
 	r := &big.Int{}
 	s := &big.Int{}
-	return &common.Header{
+	return &common.RollupHeader{
 		ParentHash:                    gethcommon.BytesToHash(header.ParentHash),
 		Agg:                           gethcommon.BytesToAddress(header.Node),
 		Nonce:                         types.EncodeNonce(big.NewInt(0).SetBytes(header.Nonce).Uint64()),
@@ -348,7 +348,7 @@ func FromRollupHeaderMsg(header *generated.RollupHeaderMsg) *common.Header { //n
 	}
 }
 
-func FromBatchHeaderMsg(header *generated.BatchHeaderMsg) *common.Header { //nolint:dupl
+func FromBatchHeaderMsg(header *generated.BatchHeaderMsg) *common.BatchHeader { //nolint:dupl
 	if header == nil {
 		return nil
 	}
@@ -363,7 +363,7 @@ func FromBatchHeaderMsg(header *generated.BatchHeaderMsg) *common.Header { //nol
 
 	r := &big.Int{}
 	s := &big.Int{}
-	return &common.Header{
+	return &common.BatchHeader{
 		ParentHash:                    gethcommon.BytesToHash(header.ParentHash),
 		Agg:                           gethcommon.BytesToAddress(header.Node),
 		Nonce:                         types.EncodeNonce(big.NewInt(0).SetBytes(header.Nonce).Uint64()),

--- a/go/enclave/core/batch.go
+++ b/go/enclave/core/batch.go
@@ -14,7 +14,7 @@ import (
 // Batch Data structure only for the internal use of the enclave since transactions are in clear
 // Making changes to this struct will require GRPC + GRPC Converters regen
 type Batch struct {
-	Header *common.Header
+	Header *common.BatchHeader
 
 	hash atomic.Value
 	// size   atomic.Value
@@ -59,12 +59,12 @@ func ToBatch(extBatch *common.ExtBatch, transactionBlobCrypto crypto.Transaction
 	}
 }
 
-func EmptyBatch(agg gethcommon.Address, parent *common.Header, blkHash gethcommon.Hash, nonce common.Nonce) (*Batch, error) {
+func EmptyBatch(agg gethcommon.Address, parent *common.BatchHeader, blkHash gethcommon.Hash) (*Batch, error) {
 	rand, err := crypto.GeneratePublicRandomness()
 	if err != nil {
 		return nil, err
 	}
-	h := common.Header{
+	h := common.BatchHeader{
 		Agg:        agg,
 		ParentHash: parent.Hash(),
 		L1Proof:    blkHash,

--- a/go/enclave/core/rollup.go
+++ b/go/enclave/core/rollup.go
@@ -13,7 +13,7 @@ import (
 // Rollup Data structure only for the internal use of the enclave since transactions are in clear
 // Making changes to this struct will require GRPC + GRPC Converters regen
 type Rollup struct {
-	Header *common.Header
+	Header *common.RollupHeader
 
 	hash atomic.Value
 	// size   atomic.Value
@@ -60,7 +60,7 @@ func ToRollup(encryptedRollup *common.ExtRollup, transactionBlobCrypto crypto.Tr
 
 func (r *Rollup) ToBatch() *Batch {
 	return &Batch{
-		Header:       r.Header,
+		Header:       r.Header.ToBatchHeader(),
 		Transactions: r.Transactions,
 	}
 }

--- a/go/enclave/db/rawdb/accessors_chain.go
+++ b/go/enclave/db/rawdb/accessors_chain.go
@@ -83,7 +83,7 @@ func WriteRollup(db ethdb.KeyValueWriter, rollup *core.Rollup) error {
 }
 
 // Stores a batch header into the database and also stores the hash-to-number mapping.
-func writeBatchHeader(db ethdb.KeyValueWriter, header *common.Header) error {
+func writeBatchHeader(db ethdb.KeyValueWriter, header *common.BatchHeader) error {
 	// Write the hash -> number mapping
 	err := writeBatchHeaderNumber(db, header.Hash(), header.Number.Uint64())
 	if err != nil {
@@ -113,12 +113,12 @@ func writeBatchHeaderNumber(db ethdb.KeyValueWriter, hash gethcommon.Hash, numbe
 }
 
 // Retrieves the batch header corresponding to the hash.
-func readBatchHeader(db ethdb.KeyValueReader, hash common.L2RootHash) (*common.Header, error) {
+func readBatchHeader(db ethdb.KeyValueReader, hash common.L2RootHash) (*common.BatchHeader, error) {
 	data, err := readBatchHeaderRLP(db, hash)
 	if err != nil {
 		return nil, fmt.Errorf("could not read header. Cause: %w", err)
 	}
-	header := new(common.Header)
+	header := new(common.BatchHeader)
 	if err := rlp.Decode(bytes.NewReader(data), header); err != nil {
 		return nil, fmt.Errorf("could not decode batch header. Cause: %w", err)
 	}
@@ -265,7 +265,7 @@ func WriteCanonicalHash(db ethdb.KeyValueWriter, l2Head *core.Batch) error {
 }
 
 // Stores a rollup header into the database and also stores the hash-to-number mapping.
-func writeRollupHeader(db ethdb.KeyValueWriter, header *common.Header) error {
+func writeRollupHeader(db ethdb.KeyValueWriter, header *common.RollupHeader) error {
 	// Write the hash -> number mapping
 	err := writeRollupHeaderNumber(db, header.Hash(), header.Number.Uint64())
 	if err != nil {
@@ -314,12 +314,12 @@ func writeRollupBodyRLP(db ethdb.KeyValueWriter, hash common.L2RootHash, rlp rlp
 }
 
 // Retrieves the rollup header corresponding to the hash.
-func readRollupHeader(db ethdb.KeyValueReader, hash common.L2RootHash) (*common.Header, error) {
+func readRollupHeader(db ethdb.KeyValueReader, hash common.L2RootHash) (*common.RollupHeader, error) {
 	data, err := readRollupHeaderRLP(db, hash)
 	if err != nil {
 		return nil, fmt.Errorf("could not read header. Cause: %w", err)
 	}
-	header := new(common.Header)
+	header := new(common.RollupHeader)
 	if err := rlp.Decode(bytes.NewReader(data), header); err != nil {
 		return nil, fmt.Errorf("could not decode rollup header. Cause: %w", err)
 	}

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -1051,7 +1051,7 @@ func extractGetLogsParams(paramBytes []byte) (*filters.FilterCriteria, *gethcomm
 }
 
 // Removes transactions from the mempool that are considered immune to re-orgs (i.e. over X batches deep).
-func (e *enclaveImpl) removeOldMempoolTxs(batchHeader *common.Header) error {
+func (e *enclaveImpl) removeOldMempoolTxs(batchHeader *common.BatchHeader) error {
 	if batchHeader == nil {
 		return nil
 	}

--- a/go/enclave/enclave_test.go
+++ b/go/enclave/enclave_test.go
@@ -606,7 +606,7 @@ type prefundedAddress struct {
 }
 
 func dummyRollup(blkHash gethcommon.Hash, height uint64, state *state.StateDB) *core.Rollup {
-	h := common.Header{
+	h := common.RollupHeader{
 		Agg:         gethcommon.HexToAddress("0x0"),
 		ParentHash:  common.L1RootHash{},
 		L1Proof:     blkHash,

--- a/go/enclave/evm/chain_context.go
+++ b/go/enclave/evm/chain_context.go
@@ -23,7 +23,7 @@ func (occ *ObscuroChainContext) Engine() consensus.Engine {
 }
 
 func (occ *ObscuroChainContext) GetHeader(hash common.Hash, height uint64) *types.Header {
-	rol, err := occ.storage.FetchBatch(hash)
+	batch, err := occ.storage.FetchBatch(hash)
 	if err != nil {
 		if errors.Is(err, errutil.ErrNotFound) {
 			return nil
@@ -31,7 +31,7 @@ func (occ *ObscuroChainContext) GetHeader(hash common.Hash, height uint64) *type
 		occ.logger.Crit("Could not retrieve rollup", log.ErrKey, err)
 	}
 
-	h, err := convertToEthHeader(rol.Header, secret(occ.storage))
+	h, err := convertToEthHeader(batch.Header, secret(occ.storage))
 	if err != nil {
 		occ.logger.Crit("Could not convert to eth header", log.ErrKey, err)
 		return nil

--- a/go/enclave/evm/evm_facade.go
+++ b/go/enclave/evm/evm_facade.go
@@ -25,7 +25,7 @@ import (
 // ExecuteTransactions
 // header - the header of the rollup where this transaction will be included
 // fromTxIndex - for the receipts and events, the evm needs to know for each transaction the order in which it was executed in the block.
-func ExecuteTransactions(txs []*common.L2Tx, s *state.StateDB, header *common.Header, storage db.Storage, chainConfig *params.ChainConfig, fromTxIndex int, logger gethlog.Logger) map[common.TxHash]interface{} {
+func ExecuteTransactions(txs []*common.L2Tx, s *state.StateDB, header *common.BatchHeader, storage db.Storage, chainConfig *params.ChainConfig, fromTxIndex int, logger gethlog.Logger) map[common.TxHash]interface{} {
 	chain, vmCfg, gp := initParams(storage, true, logger)
 	zero := uint64(0)
 	usedGas := &zero
@@ -89,7 +89,7 @@ func logReceipt(r *types.Receipt, logger gethlog.Logger) {
 func ExecuteOffChainCall(
 	msg *types.Message,
 	s *state.StateDB,
-	header *common.Header,
+	header *common.BatchHeader,
 	storage db.Storage,
 	chainConfig *params.ChainConfig,
 	logger gethlog.Logger,

--- a/go/enclave/evm/utils.go
+++ b/go/enclave/evm/utils.go
@@ -13,7 +13,7 @@ import (
 // Perform the conversion between an Obscuro header and an Ethereum header that the EVM understands
 // in the first stage we just encode the obscuro header in the Extra field
 // todo - find a better way
-func convertToEthHeader(h *common.Header, secret []byte) (*types.Header, error) {
+func convertToEthHeader(h *common.BatchHeader, secret []byte) (*types.Header, error) {
 	obscuroHeader, err := rlp.EncodeToBytes(h)
 	if err != nil {
 		return nil, err

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -695,6 +695,7 @@ func (rc *RollupChain) checkBatch(batch *core.Batch) ([]*types.Receipt, error) {
 
 	// calculate the state to compare with what is in the batch
 	rootHash, successfulTxs, txReceipts, depositReceipts := rc.processState(batch, batch.Transactions, stateDB)
+	// TODO - Do we filter out failed transaction receipts from batches? Don't validators need to know them?
 	if len(successfulTxs) != len(batch.Transactions) {
 		return nil, fmt.Errorf("all transactions that are included in a batch must be executed")
 	}

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -109,7 +109,7 @@ func (rc *RollupChain) ProduceGenesisRollup(blkHash common.L1RootHash) (*core.Ro
 		return nil, err
 	}
 
-	h := common.Header{
+	h := common.RollupHeader{
 		Agg:         gethcommon.HexToAddress("0x0"),
 		ParentHash:  common.L2RootHash{},
 		L1Proof:     blkHash,
@@ -165,7 +165,7 @@ func (rc *RollupChain) ProcessL1Block(block types.Block, receipts types.Receipts
 }
 
 // UpdateL2Chain updates the L2 chain based on the received batch.
-func (rc *RollupChain) UpdateL2Chain(batch *core.Batch) (*common.Header, error) {
+func (rc *RollupChain) UpdateL2Chain(batch *core.Batch) (*common.BatchHeader, error) {
 	rc.blockProcessingMutex.Lock()
 	defer rc.blockProcessingMutex.Unlock()
 
@@ -267,7 +267,7 @@ func (rc *RollupChain) ExecuteOffChainTransactionAtBlock(apiArgs *gethapi.Transa
 		return nil, err
 	}
 
-	r, err := rc.getBatch(*blockNumber)
+	batch, err := rc.getBatch(*blockNumber)
 	if err != nil {
 		return nil, fmt.Errorf("unable to fetch head state batch. Cause: %w", err)
 	}
@@ -277,11 +277,11 @@ func (rc *RollupChain) ExecuteOffChainTransactionAtBlock(apiArgs *gethapi.Transa
 			callMsg.To(),
 			callMsg.From(),
 			hexutils.BytesToHex(callMsg.Data()),
-			common.ShortHash(*r.Hash()),
-			r.Header.Root.Hex()),
+			common.ShortHash(*batch.Hash()),
+			batch.Header.Root.Hex()),
 	)
 
-	result, err := evm.ExecuteOffChainCall(&callMsg, blockState, r.Header, rc.storage, rc.chainConfig, rc.logger)
+	result, err := evm.ExecuteOffChainCall(&callMsg, blockState, batch.Header, rc.storage, rc.chainConfig, rc.logger)
 	if err != nil {
 		// also return the result as the result can be evaluated on some errors like ErrIntrinsicGas
 		return result, err
@@ -791,8 +791,7 @@ func (rc *RollupChain) produceBatch(block *types.Block) (*core.Batch, error) {
 	var newBatchState *state.StateDB
 
 	// Create a new batch based on the fromBlock of inclusion of the previous, including all new transactions
-	nonce := common.GenerateNonce()
-	batch, err := core.EmptyBatch(rc.hostID, headBatch.Header, block.Hash(), nonce)
+	batch, err := core.EmptyBatch(rc.hostID, headBatch.Header, block.Hash())
 	if err != nil {
 		return nil, fmt.Errorf("could not create batch. Cause: %w", err)
 	}

--- a/go/host/db/batches.go
+++ b/go/host/db/batches.go
@@ -18,7 +18,7 @@ import (
 // DB methods relating to batches.
 
 // GetHeadBatchHeader returns the header of the node's current head batch.
-func (db *DB) GetHeadBatchHeader() (*common.Header, error) {
+func (db *DB) GetHeadBatchHeader() (*common.BatchHeader, error) {
 	headBatchHash, err := db.readHeadBatchHash()
 	if err != nil {
 		return nil, err
@@ -27,7 +27,7 @@ func (db *DB) GetHeadBatchHeader() (*common.Header, error) {
 }
 
 // GetBatchHeader returns the batch header given the hash.
-func (db *DB) GetBatchHeader(hash gethcommon.Hash) (*common.Header, error) {
+func (db *DB) GetBatchHeader(hash gethcommon.Hash) (*common.BatchHeader, error) {
 	return db.readBatchHeader(hash)
 }
 
@@ -144,7 +144,7 @@ func batchNumberKey(txHash gethcommon.Hash) []byte {
 }
 
 // Retrieves the batch header corresponding to the hash.
-func (db *DB) readBatchHeader(hash gethcommon.Hash) (*common.Header, error) {
+func (db *DB) readBatchHeader(hash gethcommon.Hash) (*common.BatchHeader, error) {
 	data, err := db.kvStore.Get(batchHeaderKey(hash))
 	if err != nil {
 		return nil, err
@@ -152,7 +152,7 @@ func (db *DB) readBatchHeader(hash gethcommon.Hash) (*common.Header, error) {
 	if len(data) == 0 {
 		return nil, errutil.ErrNotFound
 	}
-	header := new(common.Header)
+	header := new(common.BatchHeader)
 	if err := rlp.Decode(bytes.NewReader(data), header); err != nil {
 		return nil, err
 	}
@@ -170,7 +170,7 @@ func (db *DB) readHeadBatchHash() (*gethcommon.Hash, error) {
 }
 
 // Stores a batch header into the database.
-func (db *DB) writeBatchHeader(header *common.Header) error {
+func (db *DB) writeBatchHeader(header *common.BatchHeader) error {
 	// Write the encoded header
 	data, err := rlp.EncodeToBytes(header)
 	if err != nil {
@@ -193,7 +193,7 @@ func (db *DB) writeHeadBatchHash(val gethcommon.Hash) error {
 }
 
 // Stores a batch's hash in the database, keyed by the batch's number.
-func (db *DB) writeBatchHash(w ethdb.KeyValueWriter, header *common.Header) error {
+func (db *DB) writeBatchHash(w ethdb.KeyValueWriter, header *common.BatchHeader) error {
 	key := batchHashKey(header.Number)
 	if err := w.Put(key, header.Hash().Bytes()); err != nil {
 		return err
@@ -233,7 +233,7 @@ func (db *DB) readBatchTxHashes(batchHash common.L2RootHash) ([]gethcommon.Hash,
 }
 
 // Stores a batch's number in the database, keyed by the hash of a transaction in that rollup.
-func (db *DB) writeBatchNumber(w ethdb.KeyValueWriter, header *common.Header, txHash gethcommon.Hash) error {
+func (db *DB) writeBatchNumber(w ethdb.KeyValueWriter, header *common.BatchHeader, txHash gethcommon.Hash) error {
 	key := batchNumberKey(txHash)
 	if err := w.Put(key, header.Number.Bytes()); err != nil {
 		return err

--- a/go/host/db/batches_test.go
+++ b/go/host/db/batches_test.go
@@ -14,8 +14,8 @@ import (
 
 func TestCanStoreAndRetrieveBatchHeader(t *testing.T) {
 	db := NewInMemoryDB()
-	header := common.Header{
-		Number: big.NewInt(rollupNumber),
+	header := common.BatchHeader{
+		Number: big.NewInt(batchNumber),
 	}
 	batch := common.ExtBatch{
 		Header: &header,
@@ -47,8 +47,8 @@ func TestUnknownBatchHeaderReturnsNotFound(t *testing.T) {
 
 func TestHigherNumberBatchBecomesBatchHeader(t *testing.T) { //nolint:dupl
 	db := NewInMemoryDB()
-	headerOne := common.Header{
-		Number: big.NewInt(rollupNumber),
+	headerOne := common.BatchHeader{
+		Number: big.NewInt(batchNumber),
 	}
 	batchOne := common.ExtBatch{
 		Header: &headerOne,
@@ -59,7 +59,7 @@ func TestHigherNumberBatchBecomesBatchHeader(t *testing.T) { //nolint:dupl
 		t.Errorf("could not store batch header. Cause: %s", err)
 	}
 
-	headerTwo := common.Header{
+	headerTwo := common.BatchHeader{
 		// We give the second header a higher number, making it the head.
 		Number: big.NewInt(0).Add(headerOne.Number, big.NewInt(1)),
 	}
@@ -83,8 +83,8 @@ func TestHigherNumberBatchBecomesBatchHeader(t *testing.T) { //nolint:dupl
 
 func TestLowerNumberBatchDoesNotBecomeBatchHeader(t *testing.T) { //nolint:dupl
 	db := NewInMemoryDB()
-	headerOne := common.Header{
-		Number: big.NewInt(rollupNumber),
+	headerOne := common.BatchHeader{
+		Number: big.NewInt(batchNumber),
 	}
 	batchOne := common.ExtBatch{
 		Header: &headerOne,
@@ -95,7 +95,7 @@ func TestLowerNumberBatchDoesNotBecomeBatchHeader(t *testing.T) { //nolint:dupl
 		t.Errorf("could not store batch header. Cause: %s", err)
 	}
 
-	headerTwo := common.Header{
+	headerTwo := common.BatchHeader{
 		// We give the second header a higher number, making it the head.
 		Number: big.NewInt(0).Sub(headerOne.Number, big.NewInt(1)),
 	}
@@ -128,8 +128,8 @@ func TestHeadBatchHeaderIsNotSetInitially(t *testing.T) {
 
 func TestCanRetrieveBatchHashByNumber(t *testing.T) {
 	db := NewInMemoryDB()
-	header := common.Header{
-		Number: big.NewInt(rollupNumber),
+	header := common.BatchHeader{
+		Number: big.NewInt(batchNumber),
 	}
 	batch := common.ExtBatch{
 		Header: &header,
@@ -161,8 +161,8 @@ func TestUnknownBatchNumberReturnsNotFound(t *testing.T) {
 
 func TestCanRetrieveBatchNumberByTxHash(t *testing.T) {
 	db := NewInMemoryDB()
-	header := common.Header{
-		Number: big.NewInt(rollupNumber),
+	header := common.BatchHeader{
+		Number: big.NewInt(batchNumber),
 	}
 	txHash := gethcommon.BytesToHash([]byte("magicString"))
 	batch := common.ExtBatch{
@@ -195,8 +195,8 @@ func TestUnknownBatchTxHashReturnsNotFound(t *testing.T) {
 
 func TestCanRetrieveBatchTransactions(t *testing.T) {
 	db := NewInMemoryDB()
-	header := common.Header{
-		Number: big.NewInt(rollupNumber),
+	header := common.BatchHeader{
+		Number: big.NewInt(batchNumber),
 	}
 	txHashes := []gethcommon.Hash{gethcommon.BytesToHash([]byte("magicStringOne")), gethcommon.BytesToHash([]byte("magicStringTwo"))}
 	batch := common.ExtBatch{
@@ -234,8 +234,8 @@ func TestTransactionsForUnknownBatchReturnsNotFound(t *testing.T) {
 
 func TestCanRetrieveTotalNumberOfTransactions(t *testing.T) {
 	db := NewInMemoryDB()
-	headerOne := common.Header{
-		Number: big.NewInt(rollupNumber),
+	headerOne := common.BatchHeader{
+		Number: big.NewInt(batchNumber),
 	}
 	txHashesOne := []gethcommon.Hash{gethcommon.BytesToHash([]byte("magicStringOne")), gethcommon.BytesToHash([]byte("magicStringTwo"))}
 	batchOne := common.ExtBatch{
@@ -248,8 +248,8 @@ func TestCanRetrieveTotalNumberOfTransactions(t *testing.T) {
 		t.Errorf("could not store batch header. Cause: %s", err)
 	}
 
-	headerTwo := common.Header{
-		Number: big.NewInt(rollupNumber + 1),
+	headerTwo := common.BatchHeader{
+		Number: big.NewInt(batchNumber + 1),
 	}
 	txHashesTwo := []gethcommon.Hash{gethcommon.BytesToHash([]byte("magicStringThree")), gethcommon.BytesToHash([]byte("magicStringFour"))}
 	batchTwo := common.ExtBatch{

--- a/go/host/db/blocks_test.go
+++ b/go/host/db/blocks_test.go
@@ -11,12 +11,12 @@ import (
 )
 
 // An arbitrary number to put in the header, to check that the header is retrieved correctly from the DB.
-const rollupNumber = 777
+const batchNumber = 777
 
 func TestCanStoreAndRetrieveBlockHeader(t *testing.T) {
 	db := NewInMemoryDB()
 	header := types.Header{
-		Number: big.NewInt(rollupNumber),
+		Number: big.NewInt(batchNumber),
 	}
 	err := db.AddBlockHeader(&header)
 	if err != nil {

--- a/go/host/rpc/clientapi/client_api_eth.go
+++ b/go/host/rpc/clientapi/client_api_eth.go
@@ -185,7 +185,7 @@ func (api *EthereumAPI) FeeHistory(context.Context, rpc.DecimalOrHex, rpc.BlockN
 
 // Converts a batch header to a key/value map.
 // TODO - Include all the fields of the rollup header that do not exist in the Geth block headers as well (not just withdrawals).
-func headerToMap(header *common.Header) map[string]interface{} {
+func headerToMap(header *common.BatchHeader) map[string]interface{} {
 	return map[string]interface{}{
 		// The fields present in Geth's `types/Header` struct.
 		"parentHash":       header.ParentHash,

--- a/go/obsclient/obsclient.go
+++ b/go/obsclient/obsclient.go
@@ -55,23 +55,23 @@ func (oc *ObsClient) RollupNumber() (uint64, error) {
 }
 
 // RollupHeaderByNumber returns the header of the rollup with the given number
-func (oc *ObsClient) RollupHeaderByNumber(number *big.Int) (*common.Header, error) {
-	var rollupHeader *common.Header
-	err := oc.rpcClient.Call(&rollupHeader, rpc.GetRollupByNumber, toBlockNumArg(number), false)
-	if err == nil && rollupHeader == nil {
+func (oc *ObsClient) RollupHeaderByNumber(number *big.Int) (*common.BatchHeader, error) {
+	var batchHeader *common.BatchHeader
+	err := oc.rpcClient.Call(&batchHeader, rpc.GetRollupByNumber, toBlockNumArg(number), false)
+	if err == nil && batchHeader == nil {
 		err = ethereum.NotFound
 	}
-	return rollupHeader, err
+	return batchHeader, err
 }
 
 // RollupHeaderByHash returns the block header with the given hash.
-func (oc *ObsClient) RollupHeaderByHash(hash gethcommon.Hash) (*common.Header, error) {
-	var rollupHeader *common.Header
-	err := oc.rpcClient.Call(&rollupHeader, rpc.GetRollupByHash, hash, false)
-	if err == nil && rollupHeader == nil {
+func (oc *ObsClient) RollupHeaderByHash(hash gethcommon.Hash) (*common.BatchHeader, error) {
+	var batchHeader *common.BatchHeader
+	err := oc.rpcClient.Call(&batchHeader, rpc.GetRollupByHash, hash, false)
+	if err == nil && batchHeader == nil {
 		err = ethereum.NotFound
 	}
-	return rollupHeader, err
+	return batchHeader, err
 }
 
 // Health returns the health of the node.

--- a/integration/datagenerator/batch.go
+++ b/integration/datagenerator/batch.go
@@ -13,7 +13,7 @@ import (
 // when submitting cross chain messages.
 func RandomBatch(block *types.Block) common.ExtBatch {
 	extBatch := common.ExtBatch{
-		Header: &common.Header{
+		Header: &common.BatchHeader{
 			ParentHash:  randomHash(),
 			Agg:         RandomAddress(),
 			L1Proof:     randomHash(),

--- a/integration/datagenerator/rollup.go
+++ b/integration/datagenerator/rollup.go
@@ -13,7 +13,7 @@ import (
 // when submitting cross chain messages.
 func RandomRollup(block *types.Block) common.ExtRollup {
 	extRollup := common.ExtRollup{
-		Header: &common.Header{
+		Header: &common.RollupHeader{
 			ParentHash:  randomHash(),
 			Agg:         RandomAddress(),
 			L1Proof:     randomHash(),

--- a/integration/simulation/p2p/in_mem_obscuro_client.go
+++ b/integration/simulation/p2p/in_mem_obscuro_client.go
@@ -236,13 +236,13 @@ func (c *inMemObscuroClient) getRollupByNumber(result interface{}, args []interf
 	if err != nil {
 		return fmt.Errorf("could not marshal %s response to JSON. Cause: %w", rpc.GetRollupByNumber, err)
 	}
-	var header common.Header
+	var header common.BatchHeader
 	err = json.Unmarshal(headerJSON, &header)
 	if err != nil {
 		return fmt.Errorf("could not marshal %s response to rollup header. Cause: %w", rpc.GetRollupByNumber, err)
 	}
 
-	*result.(**common.Header) = &header
+	*result.(**common.BatchHeader) = &header
 	return nil
 }
 
@@ -261,13 +261,13 @@ func (c *inMemObscuroClient) getRollupByHash(result interface{}, args []interfac
 	if err != nil {
 		return fmt.Errorf("could not marshal %s response to JSON. Cause: %w", rpc.GetRollupByHash, err)
 	}
-	var header common.Header
+	var header common.BatchHeader
 	err = json.Unmarshal(headerJSON, &header)
 	if err != nil {
 		return fmt.Errorf("could not marshal %s response to rollup header. Cause: %w", rpc.GetRollupByHash, err)
 	}
 
-	*result.(**common.Header) = &header
+	*result.(**common.BatchHeader) = &header
 	return nil
 }
 

--- a/integration/simulation/utils.go
+++ b/integration/simulation/utils.go
@@ -46,7 +46,7 @@ func minMax(arr []uint64) (min uint64, max uint64) {
 }
 
 // Uses the client to retrieve the current rollup head.
-func getHeadRollupHeader(client *obsclient.ObsClient, nodeIdx int) *common.Header {
+func getHeadRollupHeader(client *obsclient.ObsClient, nodeIdx int) *common.BatchHeader {
 	headRollupHeight, err := client.RollupNumber()
 	if err != nil {
 		panic(fmt.Errorf("simulation failed due to failed attempt to retrieve head rollup height. Cause: %w", err))

--- a/integration/simulation/validate_chain.go
+++ b/integration/simulation/validate_chain.go
@@ -413,7 +413,7 @@ func checkBlockchainOfObscuroNode(t *testing.T, rpcHandles *network.RPCHandles, 
 	}
 }
 
-func getLoggedWithdrawals(minObscuroHeight uint64, obscuroClient *obsclient.ObsClient, currentHeader *common.Header) *big.Int {
+func getLoggedWithdrawals(minObscuroHeight uint64, obscuroClient *obsclient.ObsClient, currentHeader *common.BatchHeader) *big.Int {
 	totalAmountLogged := big.NewInt(0)
 	for i := minObscuroHeight; i < currentHeader.Number.Uint64(); i++ {
 		header, err := obscuroClient.RollupHeaderByNumber(big.NewInt(int64(i)))

--- a/tools/obscuroscan/obscuroscan_test.go
+++ b/tools/obscuroscan/obscuroscan_test.go
@@ -43,8 +43,8 @@ func TestThrowsIfEncryptedRollupIsInvalid(t *testing.T) {
 
 // Generates an encrypted transaction blob in Base64 encoding.
 func generateEncryptedTxBlob(txs []*common.L2Tx) []byte {
-	rollup := core.Rollup{Header: &common.Header{}, Transactions: txs}
-	txBlob := rollup.ToExtRollup(crypto.NewTransactionBlobCryptoImpl(nil)).EncryptedTxBlob
+	rollup := core.Batch{Header: &common.BatchHeader{}, Transactions: txs}
+	txBlob := rollup.ToExtBatch(crypto.NewTransactionBlobCryptoImpl(nil)).EncryptedTxBlob
 	return []byte(base64.StdEncoding.EncodeToString(txBlob))
 }
 


### PR DESCRIPTION
### Why is this change needed?

- Provide a description and a link to the underlying ticket

### What changes were made as part of this PR:

- Provide a high level list of the changes made

### Definition of done

- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
- [ ] End-to-end tests run if required (see below)

### End-to-end tests

Running the end-to-end tests in the [obscuro-test repo](https://github.com/obscuronet/obscuro-test) is currently at the 
discretion of the developer prior to merging a PR. The intention is not to slow down development by having the longer 
running end-to-end tests as a PR gate run on each branch commit etc. To manually trigger a run pre-merge;

- Go to [run_local_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_local_tests.yml)
- Click the "Run workflow" button
- Use the main branch of obscuro-test 
- Enter the name of the PR branch for go-obscuro
- Run the workflow

The run takes approximately 20 minutes and any failure will be reported in the workflow output. Should the tests fail 
the docker container output for the local testnet and all test artifacts will be added to the run and can be downloaded
for debugging and analysis, with a retention period of 2 days. 

Note that every PR merge to main will also trigger a run of post-merge tests, so even if you do not manually trigger 
pre-merge, tests will be run post-merge. The intention being to catch any issues fast on main to allow for quick 
resolution. The post-merge test output can be seen at 
[run_merge_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_merge_tests.yml) and will show both 
the PR number and author in the list of runs. 


