### PR TITLE
Tx Injector L1 Deposits are estimated

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -26,7 +26,7 @@ jobs:
         run: go build -v ./...
 
       - name: Test
-        run: go test --failfast -v ./...
+        run: go test --failfast -v ./... -count=1
         env:
           USE_GETH_BINARY: true
 

--- a/go/obsclient/authclient.go
+++ b/go/obsclient/authclient.go
@@ -139,3 +139,27 @@ func (ac *AuthObsClient) EstimateGas(ctx context.Context, msg *ethereum.CallMsg)
 	}
 	return hexutil.DecodeUint64(result)
 }
+
+func (ac *AuthObsClient) EstimateGasAndGasPrice(txData types.TxData) (types.TxData, error) {
+	unEstimatedTx := types.NewTx(txData)
+	gasPrice := gethcommon.Big1 // constant gas price atm
+
+	gasLimit, err := ac.EstimateGas(context.Background(), &ethereum.CallMsg{
+		From:  ac.Address(),
+		To:    unEstimatedTx.To(),
+		Value: unEstimatedTx.Value(),
+		Data:  unEstimatedTx.Data(),
+	})
+	if err != nil {
+		gasLimit = unEstimatedTx.Gas()
+	}
+
+	return &types.LegacyTx{
+		Nonce:    unEstimatedTx.Nonce(),
+		GasPrice: gasPrice,
+		Gas:      gasLimit,
+		To:       unEstimatedTx.To(),
+		Value:    unEstimatedTx.Value(),
+		Data:     unEstimatedTx.Data(),
+	}, nil
+}

--- a/integration/simulation/transaction_injector.go
+++ b/integration/simulation/transaction_injector.go
@@ -153,7 +153,7 @@ func (ti *TransactionInjector) Stop() {
 // issueRandomTransfers creates and issues a number of L2 transfer transactions proportional to the simulation time, such that they can be processed
 func (ti *TransactionInjector) issueRandomTransfers() {
 	var err error
-	
+
 	for txCounter := 0; ti.shouldKeepIssuing(txCounter); txCounter++ {
 		fromWallet := ti.rndObsWallet()
 		toWallet := ti.rndObsWallet()


### PR DESCRIPTION
### Why is this change needed?

- https://github.com/obscuronet/obscuro-internal/issues/1284

### What changes were made as part of this PR:

- Provide a high level list of the changes made

### Definition of done

- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
- [ ] End-to-end tests run if required (see below)

### End-to-end tests

Running the end-to-end tests in the [obscuro-test repo](https://github.com/obscuronet/obscuro-test) is currently at the 
discretion of the developer prior to merging a PR. The intention is not to slow down development by having the longer 
running end-to-end tests as a PR gate run on each branch commit etc. To manually trigger a run pre-merge;

- Go to [run_local_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_local_tests.yml)
- Click the "Run workflow" button
- Use the main branch of obscuro-test 
- Enter the name of the PR branch for go-obscuro
- Run the workflow

The run takes approximately 20 minutes and any failure will be reported in the workflow output. Should the tests fail 
the docker container output for the local testnet and all test artifacts will be added to the run and can be downloaded
for debugging and analysis, with a retention period of 2 days. 

Note that every PR merge to main will also trigger a run of post-merge tests, so even if you do not manually trigger 
pre-merge, tests will be run post-merge. The intention being to catch any issues fast on main to allow for quick 
resolution. The post-merge test output can be seen at 
[run_merge_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_merge_tests.yml) and will show both 
the PR number and author in the list of runs. 


