### PR TITLE
Added transaction description to log messages on failure.

### DIFF
--- a/go/common/types.go
+++ b/go/common/types.go
@@ -79,3 +79,8 @@ type (
 	EncryptedSharedEnclaveSecret []byte
 	EncodedAttestationReport     []byte
 )
+
+type DescribedTransactionData struct {
+	Data        types.TxData
+	Description string
+}

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -641,7 +641,8 @@ func (h *host) signAndBroadcastL1Tx(describedTx common.DescribedTransactionData,
 	if err != nil {
 		return fmt.Errorf("broadcasting L1 transaction failed after %d tries. Cause: %w", tries, err)
 	}
-	h.logger.Trace("L1 transaction sent successfully, watching for receipt.")
+	h.logger.Trace("L1 transaction sent successfully, watching for receipt.",
+		"tx", signedTx.Hash().Hex())
 
 	// asynchronously watch for a successful receipt
 	// todo: consider how to handle the various ways that L1 transactions could fail to improve node operator QoL
@@ -662,7 +663,10 @@ func (h *host) watchForReceipt(txHash common.TxHash, txDescription string) {
 	)
 	if err != nil {
 		h.logger.Error("receipt for L1 transaction never found despite 'successful' broadcast",
-			"err", err, "signer", h.ethWallet.Address().Hex(), "tx_description", txDescription,
+			"err", err,
+			"signer", h.ethWallet.Address().Hex(),
+			"tx", txHash.Hex(),
+			"tx_description", txDescription,
 		)
 		return
 	}
@@ -671,10 +675,14 @@ func (h *host) watchForReceipt(txHash common.TxHash, txDescription string) {
 		h.logger.Error("unsuccessful receipt found for published L1 transaction",
 			"status", receipt.Status,
 			"signer", h.ethWallet.Address().Hex(),
+			"tx", txHash.Hex(),
 			"tx_description", txDescription)
 		return
 	}
-	h.logger.Trace("Successful L1 transaction receipt found.", "blk", receipt.BlockNumber, "blkHash", receipt.BlockHash)
+	h.logger.Trace("Successful L1 transaction receipt found.",
+		"blk", receipt.BlockNumber,
+		"blkHash", receipt.BlockHash,
+		"tx", txHash.Hex())
 }
 
 // This method implements the procedure by which a node obtains the secret

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -251,7 +251,10 @@ func (h *host) broadcastSecret() error {
 		HostAddress:   h.config.P2PPublicAddress,
 	}
 	initialiseSecretTx := h.mgmtContractLib.CreateInitializeSecret(l1tx, h.ethWallet.GetNonceAndIncrement())
-	err = h.signAndBroadcastL1Tx(initialiseSecretTx, l1TxTriesSecret)
+	err = h.signAndBroadcastL1Tx(common.DescribedTransactionData{
+		Data:        initialiseSecretTx,
+		Description: "Initialize secret transaction.",
+	}, l1TxTriesSecret)
 	if err != nil {
 		return fmt.Errorf("failed to initialise enclave secret. Cause: %w", err)
 	}
@@ -572,7 +575,10 @@ func (h *host) publishRollup(producedRollup *common.ExtRollup) {
 		}})
 
 	rollupTx := h.mgmtContractLib.CreateRollup(tx, h.ethWallet.GetNonceAndIncrement())
-	err = h.signAndBroadcastL1Tx(rollupTx, l1TxTriesRollup)
+	err = h.signAndBroadcastL1Tx(common.DescribedTransactionData{
+		Data:        rollupTx,
+		Description: "Publish rollup transaction.",
+	}, l1TxTriesRollup)
 	if err != nil {
 		h.logger.Error("could not broadcast rollup", log.ErrKey, err)
 	}
@@ -617,9 +623,9 @@ func (h *host) initialiseProtocol(block *types.Block) error {
 }
 
 // `tries` is the number of times to attempt broadcasting the transaction.
-func (h *host) signAndBroadcastL1Tx(tx types.TxData, tries uint64) error {
+func (h *host) signAndBroadcastL1Tx(describedTx common.DescribedTransactionData, tries uint64) error {
 	var err error
-	tx, err = h.ethClient.EstimateGasAndGasPrice(tx, h.ethWallet.Address())
+	tx, err := h.ethClient.EstimateGasAndGasPrice(describedTx.Data, h.ethWallet.Address())
 	if err != nil {
 		return fmt.Errorf("unable to estimate gas limit and gas price - %w", err)
 	}
@@ -639,12 +645,12 @@ func (h *host) signAndBroadcastL1Tx(tx types.TxData, tries uint64) error {
 
 	// asynchronously watch for a successful receipt
 	// todo: consider how to handle the various ways that L1 transactions could fail to improve node operator QoL
-	go h.watchForReceipt(signedTx.Hash())
+	go h.watchForReceipt(signedTx.Hash(), describedTx.Description)
 
 	return nil
 }
 
-func (h *host) watchForReceipt(txHash common.TxHash) {
+func (h *host) watchForReceipt(txHash common.TxHash, txDescription string) {
 	var receipt *types.Receipt
 	var err error
 	err = retry.Do(
@@ -656,7 +662,7 @@ func (h *host) watchForReceipt(txHash common.TxHash) {
 	)
 	if err != nil {
 		h.logger.Error("receipt for L1 transaction never found despite 'successful' broadcast",
-			"err", err, "signer", h.ethWallet.Address().Hex(),
+			"err", err, "signer", h.ethWallet.Address().Hex(), "tx_description", txDescription,
 		)
 		return
 	}
@@ -664,7 +670,8 @@ func (h *host) watchForReceipt(txHash common.TxHash) {
 	if err == nil && receipt.Status != types.ReceiptStatusSuccessful {
 		h.logger.Error("unsuccessful receipt found for published L1 transaction",
 			"status", receipt.Status,
-			"signer", h.ethWallet.Address().Hex())
+			"signer", h.ethWallet.Address().Hex(),
+			"tx_description", txDescription)
 	}
 	h.logger.Trace("Successful L1 transaction receipt found.", "blk", receipt.BlockNumber, "blkHash", receipt.BlockHash)
 }
@@ -692,7 +699,11 @@ func (h *host) requestSecret() error {
 		panic(fmt.Errorf("could not fetch head L1 block. Cause: %w", err))
 	}
 	requestSecretTx := h.mgmtContractLib.CreateRequestSecret(l1tx, h.ethWallet.GetNonceAndIncrement())
-	err = h.signAndBroadcastL1Tx(requestSecretTx, l1TxTriesSecret)
+	err = h.signAndBroadcastL1Tx(common.DescribedTransactionData{
+		Data:        requestSecretTx,
+		Description: "Request secret transsaction.",
+	}, l1TxTriesSecret)
+
 	if err != nil {
 		return err
 	}
@@ -738,7 +749,10 @@ func (h *host) publishSharedSecretResponses(scrtResponses []*common.ProducedSecr
 		// TODO review: l1tx.Sign(a.attestationPubKey) doesn't matter as the waitSecret will process a tx that was reverted
 		respondSecretTx := h.mgmtContractLib.CreateRespondSecret(l1tx, h.ethWallet.GetNonceAndIncrement(), false)
 		h.logger.Trace("Broadcasting secret response L1 tx.", "requester", scrtResponse.RequesterID)
-		err := h.signAndBroadcastL1Tx(respondSecretTx, l1TxTriesSecret)
+		err := h.signAndBroadcastL1Tx(common.DescribedTransactionData{
+			Data:        respondSecretTx,
+			Description: "Respond Secret Transaction.",
+		}, l1TxTriesSecret)
 		if err != nil {
 			return fmt.Errorf("could not broadcast secret response. Cause %w", err)
 		}

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -672,6 +672,7 @@ func (h *host) watchForReceipt(txHash common.TxHash, txDescription string) {
 			"status", receipt.Status,
 			"signer", h.ethWallet.Address().Hex(),
 			"tx_description", txDescription)
+		return
 	}
 	h.logger.Trace("Successful L1 transaction receipt found.", "blk", receipt.BlockNumber, "blkHash", receipt.BlockHash)
 }


### PR DESCRIPTION
### Why is this change needed?

- Provide a description and a link to the underlying ticket

### What changes were made as part of this PR:

- Provide a high level list of the changes made

### Definition of done

- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
- [ ] End-to-end tests run if required (see below)

### End-to-end tests

Running the end-to-end tests in the [obscuro-test repo](https://github.com/obscuronet/obscuro-test) is currently at the 
discretion of the developer prior to merging a PR. The intention is not to slow down development by having the longer 
running end-to-end tests as a PR gate run on each branch commit etc. To manually trigger a run pre-merge;

- Go to [run_local_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_local_tests.yml)
- Click the "Run workflow" button
- Use the main branch of obscuro-test 
- Enter the name of the PR branch for go-obscuro
- Run the workflow

The run takes approximately 20 minutes and any failure will be reported in the workflow output. Should the tests fail 
the docker container output for the local testnet and all test artifacts will be added to the run and can be downloaded
for debugging and analysis, with a retention period of 2 days. 

Note that every PR merge to main will also trigger a run of post-merge tests, so even if you do not manually trigger 
pre-merge, tests will be run post-merge. The intention being to catch any issues fast on main to allow for quick 
resolution. The post-merge test output can be seen at 
[run_merge_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_merge_tests.yml) and will show both 
the PR number and author in the list of runs. 


