### PR TITLE
Add fast-fail mechanism to break out of retry

### DIFF
--- a/go/common/retry/retry.go
+++ b/go/common/retry/retry.go
@@ -1,6 +1,7 @@
 package retry
 
 import (
+	"errors"
 	"fmt"
 	"time"
 )
@@ -17,6 +18,12 @@ func Do(fn func() error, retryStrat Strategy) error {
 			return nil
 		}
 
+		var ffErr *failFastError
+		if errors.As(err, &ffErr) {
+			// if error has been wrapped as fail fast then we don't continue to retry
+			return ffErr.wrapped
+		}
+
 		// calling NextRetryInterval() marks the end of an attempt for the retry strategy, so we call it before checking Done()
 		nextInterval := retryStrat.NextRetryInterval()
 
@@ -26,4 +33,18 @@ func Do(fn func() error, retryStrat Strategy) error {
 
 		time.Sleep(nextInterval)
 	}
+}
+
+type failFastError struct {
+	wrapped error
+}
+
+func (f *failFastError) Error() string {
+	return f.wrapped.Error()
+}
+
+// FailFast allows code to break out of the retry if they encounter a situation they would prefer to fail fast.
+// - `retry.Do` will not retry if the error is of type `failFastError`, instead it will immediately return the wrapped error.
+func FailFast(err error) *failFastError {
+	return &failFastError{wrapped: err}
 }

--- a/go/common/retry/retry.go
+++ b/go/common/retry/retry.go
@@ -43,6 +43,11 @@ func (f *failFastError) Error() string {
 	return f.wrapped.Error()
 }
 
+// Unwrap function means failFastError will still work with errors.Is and errors.As for the wrapped error
+func (f *failFastError) Unwrap() error {
+	return f.wrapped
+}
+
 // FailFast allows code to break out of the retry if they encounter a situation they would prefer to fail fast.
 // - `retry.Do` will not retry if the error is of type `failFastError`, instead it will immediately return the wrapped error.
 func FailFast(err error) *failFastError {

--- a/go/common/retry/retry_test.go
+++ b/go/common/retry/retry_test.go
@@ -41,6 +41,22 @@ func TestDoWithTimeoutStrategy_UnsuccessfulAfterTimeout(t *testing.T) {
 	assert.Greater(t, count, 5, "expected function to be called at least 5 times before timing out")
 }
 
+func TestDoWithFailFast_ReturnImmediately(t *testing.T) {
+	// similar to unsuccessful test except our function returns a FailFast error and we expect no retries
+	var count int
+	testFunc := func() error {
+		count = count + 1
+		fmt.Printf("c: %d\n", count)
+		return FailFast(fmt.Errorf("attempt number %d", count))
+	}
+	err := Do(testFunc, NewTimeoutStrategy(600*time.Millisecond, 100*time.Millisecond))
+	if err == nil {
+		assert.Fail(t, "expected failure from timeout but no err received")
+	}
+
+	assert.Equal(t, count, 1, "expected function to only be called once before breaking out of retry")
+}
+
 func TestDoublingBackoffStrategy_DoublingIntervalsAndRespectMaxRetries(t *testing.T) {
 	var count int
 	prevAttempt := time.Now()


### PR DESCRIPTION
### Why is this change needed?

- A couple of situations have come up where it would be useful to be able to exit from a retry mechanism
- One is implemented in this PR, when awaiting receipt we want to retry for "not found" but bail out for other errors (to avoid sitting there for a minute if we can't connect to the RPC node)

### What changes were made as part of this PR:

- add `retry.FailFast` function that wraps an error to break out of the retry loop
- change AwaitReceipt to use it

### Definition of done

- [x] Unit tests added to cover new or changed functionality 
- [x] Docs pages updated to cover new or changed functionality
- [x] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
- [x] End-to-end tests run if required (see below)

### End-to-end tests

Running the end-to-end tests in the [obscuro-test repo](https://github.com/obscuronet/obscuro-test) is currently at the 
discretion of the developer prior to merging a PR. The intention is not to slow down development by having the longer 
running end-to-end tests as a PR gate run on each branch commit etc. To manually trigger a run pre-merge;

- Go to [run_local_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_local_tests.yml)
- Click the "Run workflow" button
- Use the main branch of obscuro-test 
- Enter the name of the PR branch for go-obscuro
- Run the workflow

The run takes approximately 20 minutes and any failure will be reported in the workflow output. Should the tests fail 
the docker container output for the local testnet and all test artifacts will be added to the run and can be downloaded
for debugging and analysis, with a retention period of 2 days. 

Note that every PR merge to main will also trigger a run of post-merge tests, so even if you do not manually trigger 
pre-merge, tests will be run post-merge. The intention being to catch any issues fast on main to allow for quick 
resolution. The post-merge test output can be seen at 
[run_merge_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_merge_tests.yml) and will show both 
the PR number and author in the list of runs. 


