### PR TITLE
Reduce sleep time after unexpected block provider error

### DIFF
--- a/go/ethadapter/blockprovider.go
+++ b/go/ethadapter/blockprovider.go
@@ -80,7 +80,7 @@ func (e *EthBlockProvider) streamBlocks(ctx context.Context, fromHeight *big.Int
 			block, err := e.fetchNextCanonicalBlock(ctx, fromHeight, latestSent)
 			if err != nil {
 				e.logger.Error("unexpected error while preparing block to stream, will retry in 1 sec", log.ErrKey, err)
-				time.Sleep(time.Second)
+				time.Sleep(10 * time.Millisecond)
 				continue
 			}
 			e.logger.Trace("blockProvider streaming block", "height", block.Number(), "hash", block.Hash())

--- a/go/ethadapter/blockprovider.go
+++ b/go/ethadapter/blockprovider.go
@@ -80,6 +80,7 @@ func (e *EthBlockProvider) streamBlocks(ctx context.Context, fromHeight *big.Int
 			block, err := e.fetchNextCanonicalBlock(ctx, fromHeight, latestSent)
 			if err != nil {
 				e.logger.Error("unexpected error while preparing block to stream, will retry in 1 sec", log.ErrKey, err)
+				// todo: consider possible scenarios and what an appropriate wait time is here. Perhaps use a back-off strategy?
 				time.Sleep(10 * time.Millisecond)
 				continue
 			}

--- a/integration/simulation/network/inmemory.go
+++ b/integration/simulation/network/inmemory.go
@@ -94,7 +94,7 @@ func (n *basicNetworkOfInMemoryNodes) Create(params *params.SimParams, stats *st
 	for _, m := range n.ethNodes {
 		t := m
 		go t.Start()
-		time.Sleep(params.AvgBlockDuration / 20)
+		time.Sleep(params.AvgBlockDuration)
 	}
 
 	for _, m := range obscuroNodes {


### PR DESCRIPTION
### Why is this change needed?

When blockprovider hits an unexpected error it had a hardcoded 1 second sleep. For some reason it's hitting a bunch of these errors in the in-mem (which has a mock L1).

But 10 blocks go by in that 1 second in the in-mem sim, this is what's causing the inefficiency failures I think. This PR which reduces the hardcoded sleep seems to improve stability (we can look at the cause of the in-mem failures separately).

The unexpected error is rarely hit in normal usage so I don't think having a shorter sleep will have an impact. We should consider adding a back-off perhaps.

### What changes were made as part of this PR:

- Reduce hard-coded sleep after failure for in-mem sim stability
- Increase sleep at startup to allow mock L1 to produce first block before host starts (one source of unexpected errors)

### Definition of done

- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
- [ ] End-to-end tests run if required (see below)

### End-to-end tests

Running the end-to-end tests in the [obscuro-test repo](https://github.com/obscuronet/obscuro-test) is currently at the 
discretion of the developer prior to merging a PR. The intention is not to slow down development by having the longer 
running end-to-end tests as a PR gate run on each branch commit etc. To manually trigger a run pre-merge;

- Go to [run_local_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_local_tests.yml)
- Click the "Run workflow" button
- Use the main branch of obscuro-test 
- Enter the name of the PR branch for go-obscuro
- Run the workflow

The run takes approximately 20 minutes and any failure will be reported in the workflow output. Should the tests fail 
the docker container output for the local testnet and all test artifacts will be added to the run and can be downloaded
for debugging and analysis, with a retention period of 2 days. 

Note that every PR merge to main will also trigger a run of post-merge tests, so even if you do not manually trigger 
pre-merge, tests will be run post-merge. The intention being to catch any issues fast on main to allow for quick 
resolution. The post-merge test output can be seen at 
[run_merge_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_merge_tests.yml) and will show both 
the PR number and author in the list of runs. 


