### PR TITLE
Fixes two bugs in batch catchup

### DIFF
--- a/go/common/retry/retry.go
+++ b/go/common/retry/retry.go
@@ -18,7 +18,7 @@ func Do(fn func() error, retryStrat Strategy) error {
 			return nil
 		}
 
-		var ffErr *failFastError
+		var ffErr *FailFastError
 		if errors.As(err, &ffErr) {
 			// if error has been wrapped as fail fast then we don't continue to retry
 			return ffErr.wrapped
@@ -35,21 +35,21 @@ func Do(fn func() error, retryStrat Strategy) error {
 	}
 }
 
-type failFastError struct {
+type FailFastError struct {
 	wrapped error
 }
 
-func (f *failFastError) Error() string {
+func (f *FailFastError) Error() string {
 	return f.wrapped.Error()
 }
 
 // Unwrap function means failFastError will still work with errors.Is and errors.As for the wrapped error
-func (f *failFastError) Unwrap() error {
+func (f *FailFastError) Unwrap() error {
 	return f.wrapped
 }
 
 // FailFast allows code to break out of the retry if they encounter a situation they would prefer to fail fast.
 // - `retry.Do` will not retry if the error is of type `failFastError`, instead it will immediately return the wrapped error.
-func FailFast(err error) *failFastError {
-	return &failFastError{wrapped: err}
+func FailFast(err error) *FailFastError {
+	return &FailFastError{wrapped: err}
 }

--- a/go/host/batchmanager/batch_manager.go
+++ b/go/host/batchmanager/batch_manager.go
@@ -66,7 +66,7 @@ func (b *BatchManager) GetBatches(batchRequest *common.BatchRequest) ([]*common.
 	if err != nil {
 		return nil, fmt.Errorf("could not determine latest canonical ancestor. Cause: %w", err)
 	}
-	batchesToSend := []*common.ExtBatch{firstBatch}
+	var batchesToSend []*common.ExtBatch
 
 	// We find the batch we want to send up to - either the head batch, or the max number of requested batches,
 	// whichever is lower.
@@ -101,6 +101,7 @@ func (b *BatchManager) GetBatches(batchRequest *common.BatchRequest) ([]*common.
 			return nil, fmt.Errorf("could not retrieve batch header. Cause: %w", err)
 		}
 	}
+	batchesToSend = append(batchesToSend, firstBatch)
 
 	// We reverse the batches so that the recipient can process them in order.
 	for i, j := 0, len(batchesToSend)-1; i < j; i, j = i+1, j-1 {

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -875,7 +875,7 @@ func (h *host) handleBatches(encodedBatchMsg *common.EncodedBatchMsg) error {
 
 	for _, batch := range batchMsg.Batches {
 		// The enclave retrieves the genesis from the L1 chain, so we do not need to submit it.
-		if batch.Header.Number == big.NewInt(int64(common.L2GenesisHeight)) {
+		if batch.Header.Number.Cmp(big.NewInt(int64(common.L2GenesisHeight))) == 0 {
 			if err = h.db.AddBatchHeader(batch); err != nil {
 				return fmt.Errorf("could not store genesis batch header. Cause: %w", err)
 			}
@@ -909,6 +909,7 @@ func (h *host) handleBatches(encodedBatchMsg *common.EncodedBatchMsg) error {
 				}
 				return nil
 			}
+			return nil
 		}
 
 		// We only store the batch locally if it stores successfully on the enclave.


### PR DESCRIPTION
### Why is this change needed?

- Provide a description and a link to the underlying ticket

### What changes were made as part of this PR:

- Provide a high level list of the changes made

### Definition of done

- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
- [ ] End-to-end tests run if required (see below)

### End-to-end tests

Running the end-to-end tests in the [obscuro-test repo](https://github.com/obscuronet/obscuro-test) is currently at the 
discretion of the developer prior to merging a PR. The intention is not to slow down development by having the longer 
running end-to-end tests as a PR gate run on each branch commit etc. To manually trigger a run pre-merge;

- Go to [run_local_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_local_tests.yml)
- Click the "Run workflow" button
- Use the main branch of obscuro-test 
- Enter the name of the PR branch for go-obscuro
- Run the workflow

The run takes approximately 20 minutes and any failure will be reported in the workflow output. Should the tests fail 
the docker container output for the local testnet and all test artifacts will be added to the run and can be downloaded
for debugging and analysis, with a retention period of 2 days. 

Note that every PR merge to main will also trigger a run of post-merge tests, so even if you do not manually trigger 
pre-merge, tests will be run post-merge. The intention being to catch any issues fast on main to allow for quick 
resolution. The post-merge test output can be seen at 
[run_merge_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_merge_tests.yml) and will show both 
the PR number and author in the list of runs. 


