### PR TITLE
Hooks SequencerId flag

### DIFF
--- a/.github/workflows/manual-deploy-dev-testnet.yml
+++ b/.github/workflows/manual-deploy-dev-testnet.yml
@@ -220,6 +220,7 @@ jobs:
                --pocerc20addr=${{needs.build-l2.outputs.pocErc20Addr}} \
                --pkstring=${{ secrets[matrix.node_pk_str] }} \
                --dev_testnet=true \
+               --sequencerID=${{ GETHNETWORK_PREFUNDED_ADDR_0 }} \
                --p2p_public_address=dev-obscuronode-${{ matrix.host_id }}-testnet-${{ GITHUB.RUN_NUMBER }}.uksouth.cloudapp.azure.com:10000'
 
 

--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -172,6 +172,7 @@ jobs:
                --hocerc20addr=${{needs.build.outputs.hocErc20Addr}} \
                --pocerc20addr=${{needs.build.outputs.pocErc20Addr}} \
                --pkstring=${{ secrets[matrix.node_pk_str] }} \
+               --sequencerID=${{ GETHNETWORK_PREFUNDED_ADDR_0 }} \
                --p2p_public_address=obscuronode-${{ matrix.host_id }}-testnet-${{ GITHUB.RUN_NUMBER }}.uksouth.cloudapp.azure.com:10000'
 
 

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -619,10 +619,9 @@ func (rc *RollupChain) isInternallyValidBatch(batch *core.Batch) (types.Receipts
 	}
 
 	// Check that the signature is valid.
-	// todo: #1297 re-enable seq sig validation ASAP - once the testnet nodes all have access to the sequencer ID
-	//if err := rc.validateSequencerSig(batch.Hash(), &batch.Header.Agg, batch.Header.R, batch.Header.S); err != nil {
-	//	return nil, fmt.Errorf("verify batch r_%d: invalid signature. Cause: %s", common.ShortHash(*batch.Hash()), err.Error())
-	//}
+	if err := rc.validateSequencerSig(batch.Hash(), &batch.Header.Agg, batch.Header.R, batch.Header.S); err != nil {
+		return nil, fmt.Errorf("verify batch r_%d: invalid signature. Cause: %s", common.ShortHash(*batch.Hash()), err.Error())
+	}
 
 	// todo - check that the transactions hash to the header.txHash
 
@@ -721,7 +720,6 @@ func (rc *RollupChain) signBatch(batch *core.Batch) error {
 }
 
 // Checks that the header is signed validly by the sequencer.
-// todo: #1297 remove the nolint:unused here when validation usage is re-enabled
 func (rc *RollupChain) validateSequencerSig(headerHash *gethcommon.Hash, aggregator *gethcommon.Address, sigR *big.Int, sigS *big.Int) error { //nolint:unused
 	// Batches and rollups should only be produced by the sequencer.
 	// TODO - #718 - Sequencer identities should be retrieved from the L1 management contract.
@@ -907,10 +905,9 @@ func (rc *RollupChain) processRollups(rollups []*core.Rollup, block *common.L1Bl
 
 	// We check each rollup.
 	for _, rollup := range rollups {
-		// todo: #1297 re-enable seq sig validation ASAP - once the testnet nodes all have access to the sequencer ID
-		//if err := rc.validateSequencerSig(rollup.Hash(), &rollup.Header.Agg, rollup.Header.R, rollup.Header.S); err != nil {
-		//	return fmt.Errorf("rollup signature was invalid. Cause: %w", err)
-		//}
+		if err := rc.validateSequencerSig(rollup.Hash(), &rollup.Header.Agg, rollup.Header.R, rollup.Header.S); err != nil {
+			return fmt.Errorf("rollup signature was invalid. Cause: %w", err)
+		}
 
 		// We check that the rollups are sequential.
 		if rollup.Header.ParentHash.Hex() != currentHeadRollup.Hash().Hex() {

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -620,7 +620,7 @@ func (rc *RollupChain) isInternallyValidBatch(batch *core.Batch) (types.Receipts
 
 	// Check that the signature is valid.
 	if err := rc.validateSequencerSig(batch.Hash(), &batch.Header.Agg, batch.Header.R, batch.Header.S); err != nil {
-		return nil, fmt.Errorf("verify batch r_%d: invalid signature. Cause: %s", common.ShortHash(*batch.Hash()), err.Error())
+		return nil, fmt.Errorf("verify batch r_%d: invalid signature. Cause: %w", common.ShortHash(*batch.Hash()), err)
 	}
 
 	// todo - check that the transactions hash to the header.txHash
@@ -720,7 +720,7 @@ func (rc *RollupChain) signBatch(batch *core.Batch) error {
 }
 
 // Checks that the header is signed validly by the sequencer.
-func (rc *RollupChain) validateSequencerSig(headerHash *gethcommon.Hash, aggregator *gethcommon.Address, sigR *big.Int, sigS *big.Int) error { //nolint:unused
+func (rc *RollupChain) validateSequencerSig(headerHash *gethcommon.Hash, aggregator *gethcommon.Address, sigR *big.Int, sigS *big.Int) error {
 	// Batches and rollups should only be produced by the sequencer.
 	// TODO - #718 - Sequencer identities should be retrieved from the L1 management contract.
 	if !bytes.Equal(aggregator.Bytes(), rc.sequencerID.Bytes()) {

--- a/testnet/docker-compose.debug.yml
+++ b/testnet/docker-compose.debug.yml
@@ -53,6 +53,7 @@ services:
       PROFILERENABLED: some_bool
       P2PPUBLICADDRESS: some_string
       LOGLEVEL: some_int
+      SEQUENCERID: some_address
     image: testnetobscuronet.azurecr.io/obscuronet/enclave_debug:latest
     entrypoint: [
       "dlv",
@@ -74,5 +75,6 @@ services:
       "--profilerEnabled=$PROFILERENABLED",
       "--hostAddress=$P2PPUBLICADDRESS",
       "--logPath=sys_out",
-      "--logLevel=$LOGLEVEL"
+      "--logLevel=$LOGLEVEL",
+      "--sequencerID=$SEQUENCERID"
     ]

--- a/testnet/docker-compose.dev-testnet.yml
+++ b/testnet/docker-compose.dev-testnet.yml
@@ -58,6 +58,7 @@ services:
       PROFILERENABLED: some_bool
       P2PPUBLICADDRESS: some_string
       LOGLEVEL: some_int
+      SEQUENCERID: some_address
     image: testnetobscuronet.azurecr.io/obscuronet/dev_enclave:latest
     entrypoint: [
                  "ego", "run", "/home/obscuro/go-obscuro/go/enclave/main/main",
@@ -73,7 +74,8 @@ services:
                  "--profilerEnabled=$PROFILERENABLED",
                  "--hostAddress=$P2PPUBLICADDRESS",
                  "--logPath=sys_out",
-                 "--logLevel=$LOGLEVEL"
+                 "--logLevel=$LOGLEVEL",
+                 "--sequencerID=$SEQUENCERID"
     ]
 
   edgelessdb:

--- a/testnet/docker-compose.non-sgx.yml
+++ b/testnet/docker-compose.non-sgx.yml
@@ -53,6 +53,7 @@ services:
       PROFILERENABLED: some_bool
       P2PPUBLICADDRESS: some_string
       LOGLEVEL: some_int
+      SEQUENCERID: some_address
     image: testnetobscuronet.azurecr.io/obscuronet/enclave:latest
     entrypoint: [
                  "ego", "run", "/home/obscuro/go-obscuro/go/enclave/main/main",
@@ -67,5 +68,6 @@ services:
                  "--profilerEnabled=$PROFILERENABLED",
                  "--hostAddress=$P2PPUBLICADDRESS",
                  "--logPath=sys_out",
-                 "--logLevel=$LOGLEVEL"
+                 "--logLevel=$LOGLEVEL",
+                 "--sequencerID=$SEQUENCERID"
     ]

--- a/testnet/docker-compose.yml
+++ b/testnet/docker-compose.yml
@@ -58,6 +58,7 @@ services:
       PROFILERENABLED: some_bool
       P2PPUBLICADDRESS: some_string
       LOGLEVEL: some_int
+      SEQUENCERID: some_address
     image: testnetobscuronet.azurecr.io/obscuronet/enclave:latest
     entrypoint: [
                  "ego", "run", "/home/obscuro/go-obscuro/go/enclave/main/main",
@@ -73,7 +74,8 @@ services:
                  "--profilerEnabled=$PROFILERENABLED",
                  "--hostAddress=$P2PPUBLICADDRESS",
                  "--logPath=sys_out",
-                 "--logLevel=$LOGLEVEL"
+                 "--logLevel=$LOGLEVEL",
+                 "--sequencerID=$SEQUENCERID"
     ]
 
   edgelessdb:

--- a/testnet/start-obscuro-node.sh
+++ b/testnet/start-obscuro-node.sh
@@ -28,6 +28,8 @@ help_and_exit() {
     echo ""
     echo "  sgx_enabled        *Required* Set the execution to run with sgx enabled"
     echo ""
+    echo "  sequencerID        *Optional* Set the sequencer address. Defaults to 0x0654D8B60033144D567f25bF41baC1FB0D60F23B"
+    echo ""
     echo "  host_id            *Optional* Set the host ID used by the enclave. Defaults to 0x0654D8B60033144D567f25bF41baC1FB0D60F23B"
     echo ""
     echo "  l1port             *Optional* Set the l1 port. Defaults to 9000"
@@ -70,6 +72,7 @@ dev_testnet=false
 host_id=0x0654D8B60033144D567f25bF41baC1FB0D60F23B
 pk_string=8ead642ca80dadb0f346a66cd6aa13e08a8ac7b5c6f7578d4bac96f5db01ac99
 log_level=4
+sequencer_id=0x0654D8B60033144D567f25bF41baC1FB0D60F23B
 
 
 # Fetch options
@@ -94,6 +97,7 @@ do
             --p2p_public_address)       p2p_public_address=${value} ;;
             --debug_enclave)            debug_enclave=${value} ;;
             --dev_testnet)              dev_testnet=${value} ;;
+            --sequencerId)              sequencer_id=${value} ;;
 
             --help)                     help_and_exit ;;
             *)
@@ -119,6 +123,7 @@ echo "NODETYPE=${node_type}" >> "${testnet_path}/.env"
 echo "LOGLEVEL=${log_level}" >> "${testnet_path}/.env"
 echo "PROFILERENABLED=${profiler_enabled}" >> "${testnet_path}/.env"
 echo "P2PPUBLICADDRESS=${p2p_public_address}" >> "${testnet_path}/.env"
+echo "SEQUENCERID=${sequencer_id}" >> "${testnet_path}/.env"
 
 
 if ${debug_enclave} ;


### PR DESCRIPTION
### Why is this change needed?

- Provide a description and a link to the underlying ticket

### What changes were made as part of this PR:

- Provide a high level list of the changes made

### Definition of done

- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
- [ ] End-to-end tests run if required (see below)

### End-to-end tests

Running the end-to-end tests in the [obscuro-test repo](https://github.com/obscuronet/obscuro-test) is currently at the 
discretion of the developer prior to merging a PR. The intention is not to slow down development by having the longer 
running end-to-end tests as a PR gate run on each branch commit etc. To manually trigger a run pre-merge;

- Go to [run_local_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_local_tests.yml)
- Click the "Run workflow" button
- Use the main branch of obscuro-test 
- Enter the name of the PR branch for go-obscuro
- Run the workflow

The run takes approximately 20 minutes and any failure will be reported in the workflow output. Should the tests fail 
the docker container output for the local testnet and all test artifacts will be added to the run and can be downloaded
for debugging and analysis, with a retention period of 2 days. 

Note that every PR merge to main will also trigger a run of post-merge tests, so even if you do not manually trigger 
pre-merge, tests will be run post-merge. The intention being to catch any issues fast on main to allow for quick 
resolution. The post-merge test output can be seen at 
[run_merge_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_merge_tests.yml) and will show both 
the PR number and author in the list of runs. 


