### PR TITLE
Add Is() support to blockRejectErr for standard errors

### DIFF
--- a/go/common/enclave.go
+++ b/go/common/enclave.go
@@ -3,6 +3,7 @@ package common
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -144,4 +145,10 @@ func (r BlockRejectError) Error() string {
 
 func (r BlockRejectError) Unwrap() error {
 	return r.Wrapped
+}
+
+// Is implementation supports the errors.Is() behaviour. The error being sent over the wire means we lose the typing
+// on the `Wrapped` error, but comparing the string helps in our use cases of standard exported errors above
+func (r BlockRejectError) Is(err error) bool {
+	return strings.Contains(r.Error(), err.Error()) || errors.Is(err, r.Wrapped)
 }


### PR DESCRIPTION
### Why is this change needed?

- There is a bug in the L1 catch-up mechanism, we get stuck in a loop where the enclave is complaining of a block it's already seen and the host sends it the same one again
- This piece of code in `host.go` was supposed to prevent that bug by continuing to stream when it complains of duplicate block:
![Screenshot 2022-12-16 at 18 00 23](https://user-images.githubusercontent.com/98158711/208160474-3cebef07-38e0-406b-ac99-68da2024179a.png)

This piece of code didn't work because the `errors.Is()` was misreporting the error as *not* being an ErrBlockAlreadyProcessed. Because it lost its type when it was sent over the wire on RPC response

So we extend the blockRejErr.As() implementation to check for matching strings (which works for our standard errors).

### What changes were made as part of this PR:

- Have err.As() check string message as well as err type for the block reject error.

I have checked and this fixed the issue. After restarting the enclave and one case of the dup error it started processing blocks successfully.

### Definition of done

- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
- [ ] End-to-end tests run if required (see below)

### End-to-end tests

Running the end-to-end tests in the [obscuro-test repo](https://github.com/obscuronet/obscuro-test) is currently at the 
discretion of the developer prior to merging a PR. The intention is not to slow down development by having the longer 
running end-to-end tests as a PR gate run on each branch commit etc. To manually trigger a run pre-merge;

- Go to [run_local_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_local_tests.yml)
- Click the "Run workflow" button
- Use the main branch of obscuro-test 
- Enter the name of the PR branch for go-obscuro
- Run the workflow

The run takes approximately 20 minutes and any failure will be reported in the workflow output. Should the tests fail 
the docker container output for the local testnet and all test artifacts will be added to the run and can be downloaded
for debugging and analysis, with a retention period of 2 days. 

Note that every PR merge to main will also trigger a run of post-merge tests, so even if you do not manually trigger 
pre-merge, tests will be run post-merge. The intention being to catch any issues fast on main to allow for quick 
resolution. The post-merge test output can be seen at 
[run_merge_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_merge_tests.yml) and will show both 
the PR number and author in the list of runs. 


