### PR TITLE
Genesis rollup `Agg` field should be the sequencer that produces it

### DIFF
--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -421,7 +421,7 @@ func (rc *RollupChain) produceGenesisBatch(blkHash common.L1RootHash) (*core.Bat
 
 	genesisBatch := &core.Batch{
 		Header: &common.BatchHeader{
-			Agg:         gethcommon.HexToAddress("0x0"),
+			Agg:         rc.hostID,
 			ParentHash:  common.L2RootHash{},
 			L1Proof:     blkHash,
 			Root:        *preFundGenesisState,


### PR DESCRIPTION
### Why is this change needed?

- Validation was failing for the genesis rollup (and then every subsequent rollup because the genesis was missing)
- The cause was that the rollup didn't include the address of the producing node (the sequencer address), instead a 0x0 address was set.

### What changes were made as part of this PR:

- Fix the genesis rollup agg field

### Testing

Before the change I see `could not process rollups` appear repeatedly in the logs from the full network sim test, after the change that message does not appear.

### Definition of done

- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
- [ ] End-to-end tests run if required (see below)

### End-to-end tests

Running the end-to-end tests in the [obscuro-test repo](https://github.com/obscuronet/obscuro-test) is currently at the 
discretion of the developer prior to merging a PR. The intention is not to slow down development by having the longer 
running end-to-end tests as a PR gate run on each branch commit etc. To manually trigger a run pre-merge;

- Go to [run_local_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_local_tests.yml)
- Click the "Run workflow" button
- Use the main branch of obscuro-test 
- Enter the name of the PR branch for go-obscuro
- Run the workflow

The run takes approximately 20 minutes and any failure will be reported in the workflow output. Should the tests fail 
the docker container output for the local testnet and all test artifacts will be added to the run and can be downloaded
for debugging and analysis, with a retention period of 2 days. 

Note that every PR merge to main will also trigger a run of post-merge tests, so even if you do not manually trigger 
pre-merge, tests will be run post-merge. The intention being to catch any issues fast on main to allow for quick 
resolution. The post-merge test output can be seen at 
[run_merge_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_merge_tests.yml) and will show both 
the PR number and author in the list of runs. 


