### PR TITLE
Fix timing issue with sequencer secret

### DIFF
--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -874,9 +874,9 @@ func (rc *RollupChain) processRollups(block *common.L1Block) error {
 			return fmt.Errorf("rollup signature was invalid. Cause: %w", err)
 		}
 
-		// We check we receive the genesis batch first.
+		// We check we receive the genesis rollup first.
 		if currentHeadRollup == nil && rollup.Number().Cmp(big.NewInt(0)) != 0 {
-			return fmt.Errorf("received batch with number %d but no genesis batch is stored", rollup.Number())
+			return fmt.Errorf("received rollup with number %d but no genesis rollup is stored", rollup.Number())
 		}
 
 		// We check that the rollups are sequential.


### PR DESCRIPTION
### Why is this change needed?

- Validators require the initialise secret attestation from the sequencer to be able to validate rollups
- We see errors on simulations from genesis rollup getting processed before the attestation has arrived (and once the genesis rollup is missed, all rollup processing will fail for that node)

### What changes were made as part of this PR:

- Make some L1 transactions at initialisation block until successful receipt returned to guarantee they're published before entering main loop

### Testing

On `main` I see errors like this reliably in the full network sim logs:
```
ERROR[12-21|09:21:19.007] could not process rollups                cmp=test_log          node_id=0 cmp=enclave           err="rollup signature was invalid. Cause: could not retrieve attested key for aggregator 0x0000000000000000000000000000000000000000. Cause: could not retrieve attestation key for address 0x0000000000000000000000000000000000000000. Cause: not found"
```
but on the branch I no longer see rollup processing errors.

### Definition of done

- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
- [ ] End-to-end tests run if required (see below)

### End-to-end tests

Running the end-to-end tests in the [obscuro-test repo](https://github.com/obscuronet/obscuro-test) is currently at the 
discretion of the developer prior to merging a PR. The intention is not to slow down development by having the longer 
running end-to-end tests as a PR gate run on each branch commit etc. To manually trigger a run pre-merge;

- Go to [run_local_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_local_tests.yml)
- Click the "Run workflow" button
- Use the main branch of obscuro-test 
- Enter the name of the PR branch for go-obscuro
- Run the workflow

The run takes approximately 20 minutes and any failure will be reported in the workflow output. Should the tests fail 
the docker container output for the local testnet and all test artifacts will be added to the run and can be downloaded
for debugging and analysis, with a retention period of 2 days. 

Note that every PR merge to main will also trigger a run of post-merge tests, so even if you do not manually trigger 
pre-merge, tests will be run post-merge. The intention being to catch any issues fast on main to allow for quick 
resolution. The post-merge test output can be seen at 
[run_merge_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_merge_tests.yml) and will show both 
the PR number and author in the list of runs. 


