### PR TITLE
Change sequencer ID var to read from GH secrets

### DIFF
--- a/.github/workflows/manual-deploy-dev-testnet.yml
+++ b/.github/workflows/manual-deploy-dev-testnet.yml
@@ -213,7 +213,7 @@ jobs:
                --is_genesis=${{ matrix.is_genesis }} \
                --node_type=${{ matrix.node_type }} \
                --sgx_enabled=true \
-               --host_id=${{ matrix.node_pk_addr }} \
+               --host_id=${{ secrets[matrix.node_pk_addr] }} \
                --l1host=${{ github.event.inputs.L1HOST }} \
                --mgmtcontractaddr=${{needs.build-l2.outputs.mgmtContractAddr}} \
                --hocerc20addr=${{needs.build-l2.outputs.hocErc20Addr}} \

--- a/.github/workflows/manual-deploy-dev-testnet.yml
+++ b/.github/workflows/manual-deploy-dev-testnet.yml
@@ -220,7 +220,7 @@ jobs:
                --pocerc20addr=${{needs.build-l2.outputs.pocErc20Addr}} \
                --pkstring=${{ secrets[matrix.node_pk_str] }} \
                --dev_testnet=true \
-               --sequencerID=${{ GETHNETWORK_PREFUNDED_ADDR_0 }} \
+               --sequencerID=${{ secrets.GETHNETWORK_PREFUNDED_ADDR_0 }} \
                --p2p_public_address=dev-obscuronode-${{ matrix.host_id }}-testnet-${{ GITHUB.RUN_NUMBER }}.uksouth.cloudapp.azure.com:10000'
 
 

--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -172,7 +172,7 @@ jobs:
                --hocerc20addr=${{needs.build.outputs.hocErc20Addr}} \
                --pocerc20addr=${{needs.build.outputs.pocErc20Addr}} \
                --pkstring=${{ secrets[matrix.node_pk_str] }} \
-               --sequencerID=${{ GETHNETWORK_PREFUNDED_ADDR_0 }} \
+               --sequencerID=${{ secrets.GETHNETWORK_PREFUNDED_ADDR_0 }} \
                --p2p_public_address=obscuronode-${{ matrix.host_id }}-testnet-${{ GITHUB.RUN_NUMBER }}.uksouth.cloudapp.azure.com:10000'
 
 

--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -166,7 +166,7 @@ jobs:
                --is_genesis=${{ matrix.is_genesis }} \
                --node_type=${{ matrix.node_type }} \
                --sgx_enabled=true \
-               --host_id=${{ matrix.node_pk_addr }} \
+               --host_id=${{ secrets[matrix.node_pk_addr] }} \
                --l1host=${{ github.event.inputs.L1HOST }} \
                --mgmtcontractaddr=${{needs.build.outputs.mgmtContractAddr}} \
                --hocerc20addr=${{needs.build.outputs.hocErc20Addr}} \

--- a/testnet/start-obscuro-node.sh
+++ b/testnet/start-obscuro-node.sh
@@ -97,7 +97,7 @@ do
             --p2p_public_address)       p2p_public_address=${value} ;;
             --debug_enclave)            debug_enclave=${value} ;;
             --dev_testnet)              dev_testnet=${value} ;;
-            --sequencerId)              sequencer_id=${value} ;;
+            --sequencerID)              sequencer_id=${value} ;;
 
             --help)                     help_and_exit ;;
             *)


### PR DESCRIPTION
### Why is this change needed?

- The testnets are failing to start because GH can't find the sequencer ID var

### What changes were made as part of this PR:

- Add `secrets.` prefix to the variable used for seq ID in GH actions testnet scripts

### Definition of done

- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
- [ ] End-to-end tests run if required (see below)

### End-to-end tests

Running the end-to-end tests in the [obscuro-test repo](https://github.com/obscuronet/obscuro-test) is currently at the 
discretion of the developer prior to merging a PR. The intention is not to slow down development by having the longer 
running end-to-end tests as a PR gate run on each branch commit etc. To manually trigger a run pre-merge;

- Go to [run_local_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_local_tests.yml)
- Click the "Run workflow" button
- Use the main branch of obscuro-test 
- Enter the name of the PR branch for go-obscuro
- Run the workflow

The run takes approximately 20 minutes and any failure will be reported in the workflow output. Should the tests fail 
the docker container output for the local testnet and all test artifacts will be added to the run and can be downloaded
for debugging and analysis, with a retention period of 2 days. 

Note that every PR merge to main will also trigger a run of post-merge tests, so even if you do not manually trigger 
pre-merge, tests will be run post-merge. The intention being to catch any issues fast on main to allow for quick 
resolution. The post-merge test output can be seen at 
[run_merge_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_merge_tests.yml) and will show both 
the PR number and author in the list of runs. 


