### PR TITLE
Use a curl command to request OBX

### DIFF
--- a/docs/_docs/testnet/faucet.md
+++ b/docs/_docs/testnet/faucet.md
@@ -1,26 +1,21 @@
 ---
 ---
 # Using the Testnet Token Faucet
-Using the steps below you will request testnet OBX tokens from the faucet available on the Obscuro Discord server.
+Using the steps below you will request testnet OBX tokens from the faucet server.
 
 ## Prerequisites
 * Your wallet address.
-* Access to the [Obscuro Discord server](https://discord.gg/yQfmKeNzNd).
-* (Optional) [MetaMask](https://metamask.io/) wallet installed in your browser.
-* (Optional) A local copy of the [Obscuro MetaMask wallet extension](https://docs.obscu.ro/wallet-extension/wallet-extension/).
+* Access to a command shell with the curl cli installed.
 
 ## Requesting Testnet OBX Tokens
 1. Make a note of your wallet address or copy it to your clipboard.
-2. Open the [_faucet-requests_ channel](https://discord.gg/5qyj3qraaH) on Obscuro Discord.
-3. Request OBX using the `/faucet` command. The faucet will credit 100,000 OBX by default:
+2. Open a command shell and issue the below command, where `<address>` should be replaced with the value stored in your clipboard. The faucet server will credit 100,000 OBX by default.
 
-    ![faucet command](../../assets/images/faucet-cmd.png)
-4. Provide your wallet address and hit Enter. The faucet will acknowledge your request:
+```bash
+curl --location --request POST 'http://testnet-faucet.uksouth.azurecontainer.io/fund/obx' --header 'Content-Type: application/json' --data-raw '{ "address":"<your address>" }'
+```
 
-    ![faucet ack](../../assets/images/faucet-ack.png)
-5. After a short period of time the faucet will confirm the Testnet OBX tokens have been credited to your wallet:
-
-    ![faucet complete](../../assets/images/faucet-done.png)
+3. After a short period of time the curl command will return `{"status":"ok"}` confirming OBX tokens have been credited to your wallet.
 
 ## Viewing Your Wallet Balance
 To view the balance of your wallet you will need to establish a connection from your wallet to the Obscuro Testnet. An essential part of how Obscuro provides full privacy is the encryption of communication between an Obscuro application and Obscuro nodes on the network. As a result, you will need to use the wallet extension to allow your wallet to communication with the Obscuro Testnet.

--- a/docs/_docs/testnet/faucet.md
+++ b/docs/_docs/testnet/faucet.md
@@ -9,7 +9,7 @@ Using the steps below you will request testnet OBX tokens from the faucet server
 
 ## Requesting Testnet OBX Tokens
 1. Make a note of your wallet address or copy it to your clipboard.
-2. Open a command shell and issue the below command, where `<address>` should be replaced with the value stored in your clipboard. The faucet server will credit 100,000 OBX by default.
+2. Open a command shell and issue the below command, where `<address>` should be replaced with the value stored in your clipboard (e.g. `0x75Ad715443e1E2EBdaFA33ABB3B08443966019A6`). The faucet server will credit 100,000 OBX by default.
 
 ```bash
 curl --location --request POST 'http://testnet-faucet.uksouth.azurecontainer.io/fund/obx' --header 'Content-Type: application/json' --data-raw '{ "address":"<your address>" }'


### PR DESCRIPTION
### Why is this change needed?

- In the temp absence of the Discord faucet bot we need to provide information on users on how to obtain OBX - this can be achieved by issuing a curl command directly to the faucet server. 

### What changes were made as part of this PR:

- Section on using the testnet token faucet. 