### PR TITLE
Updates PCCS URL for edgelessdb + ego

### DIFF
--- a/dockerfiles/enclave.Dockerfile
+++ b/dockerfiles/enclave.Dockerfile
@@ -3,14 +3,13 @@ FROM ghcr.io/edgelesssys/ego-dev:latest
 # on the container:
 #   /home/obscuro/data       contains working files for the enclave
 #   /home/obscuro/go-obscuro contains the src
-RUN mkdir /home/obscuro
-RUN mkdir /home/obscuro/data
+RUN mkdir -p /home/obscuro/data
 COPY . /home/obscuro/go-obscuro
 
 # build binary
 WORKDIR /home/obscuro/go-obscuro/go/enclave/main
 RUN ego-go build && ego sign main
 
+# simulation mode is ACTIVE by default
 ENV OE_SIMULATION=1
 EXPOSE 11000
-ENTRYPOINT ["ego", "run", "/home/obscuro/go-obscuro/go/enclave/main/main"]

--- a/dockerfiles/enclave.debug.Dockerfile
+++ b/dockerfiles/enclave.debug.Dockerfile
@@ -9,8 +9,7 @@ FROM golang:1.17-alpine
 # Note: ego uses a virtual file system mount to map data directory to /data inside the enclave,
 #   for this non-ego build I'm using /data as the data dir to preserve /data folder in paths inside enclave
 RUN mkdir /data
-RUN mkdir /home/obscuro
-RUN mkdir /home/obscuro/go-obscuro
+RUN mkdir -p /home/obscuro/go-obscuro
 
 # build the enclave from the current branch
 COPY . /home/obscuro/go-obscuro
@@ -23,4 +22,3 @@ RUN go get -d -v ./...
 RUN go install -v ./...
 RUN go install github.com/go-delve/delve/cmd/dlv@latest
 EXPOSE 11000
-ENTRYPOINT ["main"]

--- a/dockerfiles/host.Dockerfile
+++ b/dockerfiles/host.Dockerfile
@@ -24,4 +24,3 @@ RUN go build
 
 # expose the http and the ws ports to the host
 EXPOSE 8025 9000
-ENTRYPOINT ["/home/go-obscuro/go/host/main/main"]

--- a/dockerfiles/plain_go_enclave_local.Dockerfile
+++ b/dockerfiles/plain_go_enclave_local.Dockerfile
@@ -7,8 +7,7 @@ FROM golang:1.17-alpine
 # Note: ego uses a virtual file system mount to map data directory to /data inside the enclave,
 #   for this non-ego build I'm using /data as the data dir to preserve /data folder in paths inside enclave
 RUN mkdir /data
-RUN mkdir /home/obscuro
-RUN mkdir /home/obscuro/go-obscuro
+RUN mkdir -p /home/obscuro/go-obscuro
 
 # build the enclave from the current branch
 COPY . /home/obscuro/go-obscuro
@@ -20,4 +19,3 @@ RUN go get -d -v ./...
 # Install the package
 RUN go install -v ./...
 EXPOSE 11000
-ENTRYPOINT ["main"]

--- a/docs/_docs/testnet/starting-a-node.md
+++ b/docs/_docs/testnet/starting-a-node.md
@@ -50,3 +50,32 @@ chmod +x start-obscuro-node.sh \
   --pocerc20addr="0xB46213b1755545261Ce32e8b46B300fB01663889" \
   --pkstring="PrivateKeyString" \
   --p2p_public_address="HOST:10000"
+```
+
+## - (Alternatively) Steps required to run a node on Alibaba SGX
+Setup an Alibaba node to provide SGX to docker .
+
+Instance Type g7t - Linux Distro : Alibaba Linux 3
+
+### Install docker
+```
+sudo yum install -y yum-utils \
+    && sudo yum-config-manager \
+    --add-repo https://download.docker.com/linux/centos/docker-ce.repo \
+    && sudo yum install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin \
+    && sudo systemctl start docker
+```
+
+### Install sgx
+```
+yum install -y yum-utils && \
+yum-config-manager --add-repo \
+https://enclave-cn-hongkong.oss-cn-hongkong-internal.aliyuncs.com/repo/alinux/enclave-expr.repo \
+&& yum install -y libsgx-ae-le libsgx-ae-pce libsgx-ae-qe3 libsgx-ae-qve \
+libsgx-aesm-ecdsa-plugin libsgx-aesm-launch-plugin libsgx-aesm-pce-plugin \
+libsgx-aesm-quote-ex-plugin libsgx-dcap-default-qpl libsgx-dcap-ql \
+libsgx-dcap-quote-verify libsgx-enclave-common libsgx-launch libsgx-pce-logic \
+libsgx-qe3-logic libsgx-quote-ex libsgx-ra-network libsgx-ra-uefi \
+libsgx-uae-service libsgx-urts sgx-ra-service sgx-aesm-service \
+&& yum install -y sgxsdk
+```

--- a/go/enclave/main/entry.sh
+++ b/go/enclave/main/entry.sh
@@ -1,20 +1,30 @@
 #!/bin/sh
 set -e
+#
+# This script is the entry point for starting the enclave under a Docker container.
+# It allows running SGX sdk using different parameters.
+#
 
+# It's expected to be a link between the /dev/sgx_enclave Docker device and the container /dev/sgx/enclave
 mkdir -p /dev/sgx
 if [ ! -L /dev/sgx/enclave ]; then
 	ln -s /dev/sgx_enclave /dev/sgx/enclave
 fi
 
+# If the PCCS_ADDR, the host is provided
+# Do not use the default PCCS_URL defined in /etc/sgx_default_qcnl.conf
+# Particularly used in Alibaba cloud
 if [ -n "${PCCS_ADDR}" ]; then
 	PCCS_URL=https://${PCCS_ADDR}/sgx/certification/v3/
 fi
 
+# Install the libsgx-dcap-default-qpl and redefine /etc/sgx_default_qcnl.conf (Alibaba)
 if [ -n "${PCCS_URL}" ]; then
 	apt-get install -qq libsgx-dcap-default-qpl
 	echo "PCCS_URL: ${PCCS_URL}"
 	echo "PCCS_URL=${PCCS_URL}\nUSE_SECURE_CERT=FALSE" > /etc/sgx_default_qcnl.conf
 else
+# Otherwise use the Azure library
 	apt-get install -qq az-dcap-client
 fi
 

--- a/go/enclave/main/entry.sh
+++ b/go/enclave/main/entry.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -e
+
+mkdir -p /dev/sgx
+if [ ! -L /dev/sgx/enclave ]; then
+	ln -s /dev/sgx_enclave /dev/sgx/enclave
+fi
+
+if [ -n "${PCCS_ADDR}" ]; then
+	PCCS_URL=https://${PCCS_ADDR}/sgx/certification/v3/
+fi
+
+if [ -n "${PCCS_URL}" ]; then
+	apt-get install -qq libsgx-dcap-default-qpl
+	echo "PCCS_URL: ${PCCS_URL}"
+	echo "PCCS_URL=${PCCS_URL}\nUSE_SECURE_CERT=FALSE" > /etc/sgx_default_qcnl.conf
+else
+	apt-get install -qq az-dcap-client
+fi
+
+"$@"

--- a/testnet/docker-compose.debug.yml
+++ b/testnet/docker-compose.debug.yml
@@ -12,15 +12,15 @@ services:
       - "6061:6061"
       - "10000:10000"
     environment:
-      MGMTCONTRACTADDR: some_address
-      PKSTRING: some_string
-      L1HOST: some_host
-      L1PORT: some_port
-      ISGENESIS: some_bool
-      NODETYPE: some_string
-      PROFILERENABLED: some_bool
-      P2PPUBLICADDRESS: some_string
-      LOGLEVEL: some_int
+      - MGMTCONTRACTADDR=some_address
+      - PKSTRING=some_string
+      - L1HOST=some_host
+      - L1PORT=some_port
+      - ISGENESIS=some_bool
+      - NODETYPE=some_string
+      - PROFILERENABLED=some_bool
+      - P2PPUBLICADDRESS=some_string
+      - LOGLEVEL=some_int
     image: testnetobscuronet.azurecr.io/obscuronet/host:latest
     entrypoint: [
       "/home/go-obscuro/go/host/main/main",
@@ -45,15 +45,15 @@ services:
       - "6060:6060"
       - "2345:2345"
     environment:
-      MGMTCONTRACTADDR: some_address
-      HOCERC20ADDR: some_address
-      POCERC20ADDR: some_address
-      HOSTID: some_address
-      NODETYPE: some_string
-      PROFILERENABLED: some_bool
-      P2PPUBLICADDRESS: some_string
-      LOGLEVEL: some_int
-      SEQUENCERID: some_address
+      - MGMTCONTRACTADDR=some_address
+      - HOCERC20ADDR=some_address
+      - POCERC20ADDR=some_address
+      - HOSTID=some_address
+      - NODETYPE=some_string
+      - PROFILERENABLED=some_bool
+      - P2PPUBLICADDRESS=some_string
+      - LOGLEVEL=some_int
+      - SEQUENCERID=some_address
     image: testnetobscuronet.azurecr.io/obscuronet/enclave_debug:latest
     entrypoint: [
       "dlv",

--- a/testnet/docker-compose.dev-testnet.yml
+++ b/testnet/docker-compose.dev-testnet.yml
@@ -14,15 +14,15 @@ services:
       - "6061:6061"
       - "10000:10000"
     environment:
-      MGMTCONTRACTADDR: some_address
-      PKSTRING: some_string
-      L1HOST: some_host
-      L1PORT: some_port
-      ISGENESIS: some_bool
-      NODETYPE: some_string
-      PROFILERENABLED: some_bool
-      P2PPUBLICADDRESS: some_string
-      LOGLEVEL: some_int
+      - MGMTCONTRACTADDR=some_address
+      - PKSTRING=some_string
+      - L1HOST=some_host
+      - L1PORT=some_port
+      - ISGENESIS=some_bool
+      - NODETYPE=some_string
+      - PROFILERENABLED=some_bool
+      - P2PPUBLICADDRESS=some_string
+      - LOGLEVEL=some_int
     image: testnetobscuronet.azurecr.io/obscuronet/dev_host:latest
     entrypoint: [
       "/home/go-obscuro/go/host/main/main",
@@ -49,16 +49,16 @@ services:
     ports:
       - "6060:6060"
     environment:
-      MGMTCONTRACTADDR: some_address
-      HOCERC20ADDR: some_address
-      POCERC20ADDR: some_address
-      HOSTID: some_address
-      NODETYPE: some_string
-      OE_SIMULATION: 0
-      PROFILERENABLED: some_bool
-      P2PPUBLICADDRESS: some_string
-      LOGLEVEL: some_int
-      SEQUENCERID: some_address
+      - MGMTCONTRACTADDR=some_address
+      - HOCERC20ADDR=some_address
+      - POCERC20ADDR=some_address
+      - HOSTID=some_address
+      - NODETYPE=some_string
+      - OE_SIMULATION=0
+      - PROFILERENABLED=some_bool
+      - P2PPUBLICADDRESS=some_string
+      - LOGLEVEL=some_int
+      - SEQUENCERID=some_address
     image: testnetobscuronet.azurecr.io/obscuronet/dev_enclave:latest
     entrypoint: [
                  "ego", "run", "/home/obscuro/go-obscuro/go/enclave/main/main",
@@ -85,7 +85,7 @@ services:
     networks:
       - default
     environment:
-      EDG_EDB_CERT_DNS: edgelessdb
+      - EDG_EDB_CERT_DNS=edgelessdb
     ports:
       - "3306:3306"
       - "8080:8080"

--- a/testnet/docker-compose.non-sgx.yml
+++ b/testnet/docker-compose.non-sgx.yml
@@ -12,16 +12,16 @@ services:
       - "6061:6061"
       - "10000:10000"
     environment:
-      MGMTCONTRACTADDR: some_address
-      PKSTRING: some_string
-      L1HOST: some_host
-      L1PORT: some_port
-      HOSTID: some_address
-      ISGENESIS: some_bool
-      NODETYPE: some_string
-      PROFILERENABLED: some_bool
-      P2PPUBLICADDRESS: some_string
-      LOGLEVEL: some_int
+      - MGMTCONTRACTADDR=some_address
+      - PKSTRING=some_string
+      - L1HOST=some_host
+      - L1PORT=some_port
+      - HOSTID=some_address
+      - ISGENESIS=some_bool
+      - NODETYPE=some_string
+      - PROFILERENABLED=some_bool
+      - P2PPUBLICADDRESS=some_string
+      - LOGLEVEL=some_int
     image: testnetobscuronet.azurecr.io/obscuronet/host:latest
     entrypoint: [
       "/home/go-obscuro/go/host/main/main",
@@ -45,15 +45,15 @@ services:
     ports:
       - "6060:6060"
     environment:
-      MGMTCONTRACTADDR: some_address
-      HOCERC20ADDR: some_address
-      POCERC20ADDR: some_address
-      HOSTID: some_address
-      NODETYPE: some_string
-      PROFILERENABLED: some_bool
-      P2PPUBLICADDRESS: some_string
-      LOGLEVEL: some_int
-      SEQUENCERID: some_address
+     - MGMTCONTRACTADDR=some_address
+     - HOCERC20ADDR=some_address
+     - POCERC20ADDR=some_address
+     - HOSTID=some_address
+     - NODETYPE=some_string
+     - PROFILERENABLED=some_bool
+     - P2PPUBLICADDRESS=some_string
+     - LOGLEVEL=some_int
+     - SEQUENCERID=some_address
     image: testnetobscuronet.azurecr.io/obscuronet/enclave:latest
     entrypoint: [
                  "ego", "run", "/home/obscuro/go-obscuro/go/enclave/main/main",

--- a/testnet/docker-compose.non-sgx.yml
+++ b/testnet/docker-compose.non-sgx.yml
@@ -56,6 +56,7 @@ services:
       SEQUENCERID: some_address
     image: testnetobscuronet.azurecr.io/obscuronet/enclave:latest
     entrypoint: [
+                 "./home/obscuro/go-obscuro/go/enclave/main/entry.sh",
                  "ego", "run", "/home/obscuro/go-obscuro/go/enclave/main/main",
                  "--hostID=$HOSTID",
                  "--address=:11000",

--- a/testnet/docker-compose.non-sgx.yml
+++ b/testnet/docker-compose.non-sgx.yml
@@ -56,7 +56,6 @@ services:
       SEQUENCERID: some_address
     image: testnetobscuronet.azurecr.io/obscuronet/enclave:latest
     entrypoint: [
-                 "./home/obscuro/go-obscuro/go/enclave/main/entry.sh",
                  "ego", "run", "/home/obscuro/go-obscuro/go/enclave/main/main",
                  "--hostID=$HOSTID",
                  "--address=:11000",

--- a/testnet/docker-compose.yml
+++ b/testnet/docker-compose.yml
@@ -59,6 +59,7 @@ services:
       P2PPUBLICADDRESS: some_string
       LOGLEVEL: some_int
       SEQUENCERID: some_address
+      PCCS_URL: some_address
     image: testnetobscuronet.azurecr.io/obscuronet/enclave:latest
     entrypoint: [
                  "ego", "run", "/home/obscuro/go-obscuro/go/enclave/main/main",
@@ -86,6 +87,7 @@ services:
       - default
     environment:
       EDG_EDB_CERT_DNS: edgelessdb
+      PCCS_URL: some_address
     ports:
       - "3306:3306"
       - "8080:8080"

--- a/testnet/docker-compose.yml
+++ b/testnet/docker-compose.yml
@@ -41,9 +41,9 @@ services:
     ]
 
   enclave:
-    privileged: true
-    volumes:
-      - /dev/sgx:/dev/sgx
+    devices:
+      - /dev/sgx_enclave
+      - /dev/sgx_provision
     networks:
       - default
     ports:

--- a/testnet/docker-compose.yml
+++ b/testnet/docker-compose.yml
@@ -49,17 +49,17 @@ services:
     ports:
       - "6060:6060"
     environment:
-      MGMTCONTRACTADDR: some_address
-      HOCERC20ADDR: some_address
-      POCERC20ADDR: some_address
-      HOSTID: some_address
-      NODETYPE: some_string
-      OE_SIMULATION: 0
-      PROFILERENABLED: some_bool
-      P2PPUBLICADDRESS: some_string
-      LOGLEVEL: some_int
-      SEQUENCERID: some_address
-      PCCS_ADDR: some_address
+      - MGMTCONTRACTADDR=some_address
+      - HOCERC20ADDR=some_address
+      - POCERC20ADDR=some_address
+      - HOSTID=some_address
+      - NODETYPE=some_string
+      - OE_SIMULATION=0
+      - PROFILERENABLED=some_bool
+      - P2PPUBLICADDRESS=some_string
+      - LOGLEVEL=some_int
+      - SEQUENCERID=some_address
+      - PCCS_ADDR=some_address
     image: testnetobscuronet.azurecr.io/obscuronet/enclave:latest
     entrypoint: [
               "/home/obscuro/go-obscuro/go/enclave/main/entry.sh",
@@ -87,8 +87,8 @@ services:
     networks:
       - default
     environment:
-      EDG_EDB_CERT_DNS: edgelessdb
-      PCCS_ADDR: some_address
+      - EDG_EDB_CERT_DNS=edgelessdb
+      - PCCS_ADDR=some_address
     ports:
       - "3306:3306"
       - "8080:8080"

--- a/testnet/docker-compose.yml
+++ b/testnet/docker-compose.yml
@@ -62,8 +62,8 @@ services:
       PCCS_URL: some_address
     image: testnetobscuronet.azurecr.io/obscuronet/enclave:latest
     entrypoint: [
-                "/home/obscuro/go-obscuro/go/enclave/main/entry.sh",
-                "ego", "run", "/home/obscuro/go-obscuro/go/enclave/main/main",
+              "/home/obscuro/go-obscuro/go/enclave/main/entry.sh",
+              "ego", "run", "/home/obscuro/go-obscuro/go/enclave/main/main",
                  "--hostID=$HOSTID",
                  "--address=:11000",
                  "--nodeType=$NODETYPE",
@@ -88,7 +88,7 @@ services:
       - default
     environment:
       EDG_EDB_CERT_DNS: edgelessdb
-      PCCS_URL: some_address
+      PCCS_ADDR: some_address
     ports:
       - "3306:3306"
       - "8080:8080"

--- a/testnet/docker-compose.yml
+++ b/testnet/docker-compose.yml
@@ -62,7 +62,8 @@ services:
       PCCS_URL: some_address
     image: testnetobscuronet.azurecr.io/obscuronet/enclave:latest
     entrypoint: [
-                 "ego", "run", "/home/obscuro/go-obscuro/go/enclave/main/main",
+                "/home/obscuro/go-obscuro/go/enclave/main/entry.sh",
+                "ego", "run", "/home/obscuro/go-obscuro/go/enclave/main/main",
                  "--hostID=$HOSTID",
                  "--address=:11000",
                  "--nodeType=$NODETYPE",

--- a/testnet/docker-compose.yml
+++ b/testnet/docker-compose.yml
@@ -59,7 +59,7 @@ services:
       P2PPUBLICADDRESS: some_string
       LOGLEVEL: some_int
       SEQUENCERID: some_address
-      PCCS_URL: some_address
+      PCCS_ADDR: some_address
     image: testnetobscuronet.azurecr.io/obscuronet/enclave:latest
     entrypoint: [
               "/home/obscuro/go-obscuro/go/enclave/main/entry.sh",

--- a/testnet/docker-compose.yml
+++ b/testnet/docker-compose.yml
@@ -14,15 +14,15 @@ services:
       - "6061:6061"
       - "10000:10000"
     environment:
-      MGMTCONTRACTADDR: some_address
-      PKSTRING: some_string
-      L1HOST: some_host
-      L1PORT: some_port
-      ISGENESIS: some_bool
-      NODETYPE: some_string
-      PROFILERENABLED: some_bool
-      P2PPUBLICADDRESS: some_string
-      LOGLEVEL: some_int
+      - MGMTCONTRACTADDR=some_address
+      - PKSTRING=some_string
+      - L1HOST=some_host
+      - L1PORT=some_port
+      - ISGENESIS=some_bool
+      - NODETYPE=some_string
+      - PROFILERENABLED=some_bool
+      - P2PPUBLICADDRESS=some_string
+      - LOGLEVEL=some_int
     image: testnetobscuronet.azurecr.io/obscuronet/host:latest
     entrypoint: [
       "/home/go-obscuro/go/host/main/main",
@@ -49,12 +49,12 @@ services:
     ports:
       - "6060:6060"
     environment:
+      - OE_SIMULATION=0
       - MGMTCONTRACTADDR=some_address
       - HOCERC20ADDR=some_address
       - POCERC20ADDR=some_address
       - HOSTID=some_address
       - NODETYPE=some_string
-      - OE_SIMULATION=0
       - PROFILERENABLED=some_bool
       - P2PPUBLICADDRESS=some_string
       - LOGLEVEL=some_int

--- a/testnet/docker-compose.yml
+++ b/testnet/docker-compose.yml
@@ -59,7 +59,7 @@ services:
       - P2PPUBLICADDRESS=some_string
       - LOGLEVEL=some_int
       - SEQUENCERID=some_address
-      - PCCS_ADDR=some_address
+      - PCCS_ADDR
     image: testnetobscuronet.azurecr.io/obscuronet/enclave:latest
     entrypoint: [
               "/home/obscuro/go-obscuro/go/enclave/main/entry.sh",
@@ -88,7 +88,7 @@ services:
       - default
     environment:
       - EDG_EDB_CERT_DNS=edgelessdb
-      - PCCS_ADDR=some_address
+      - PCCS_ADDR
     ports:
       - "3306:3306"
       - "8080:8080"

--- a/testnet/start-obscuro-node.sh
+++ b/testnet/start-obscuro-node.sh
@@ -44,6 +44,8 @@ help_and_exit() {
     echo ""
     echo "  p2p_public_address *Optional* Set host p2p public address. Defaults to 127.0.0.1:10000"
     echo ""
+    echo "  pccs_url           *Optional* Set the enclave Provision Certificate Cache Service. Defaults to https://127.0.0.1:8081/sgx/certification/v3/"
+    echo ""
     echo "  profiler_enabled   *Optional* Enables the profiler in the host + enclave. Defaults to false"
     echo ""
     echo "  debug_enclave      *Optional* Dev mode, with a dlv debugger remote attach on port 2345"
@@ -73,6 +75,7 @@ host_id=0x0654D8B60033144D567f25bF41baC1FB0D60F23B
 pk_string=8ead642ca80dadb0f346a66cd6aa13e08a8ac7b5c6f7578d4bac96f5db01ac99
 log_level=4
 sequencer_id=0x0654D8B60033144D567f25bF41baC1FB0D60F23B
+pccs_url="https://127.0.0.1:8081/sgx/certification/v3/"
 
 
 # Fetch options
@@ -98,6 +101,7 @@ do
             --debug_enclave)            debug_enclave=${value} ;;
             --dev_testnet)              dev_testnet=${value} ;;
             --sequencerID)              sequencer_id=${value} ;;
+            --pccs_url)                 pccs_url=${value} ;;
 
             --help)                     help_and_exit ;;
             *)
@@ -124,6 +128,7 @@ echo "LOGLEVEL=${log_level}" >> "${testnet_path}/.env"
 echo "PROFILERENABLED=${profiler_enabled}" >> "${testnet_path}/.env"
 echo "P2PPUBLICADDRESS=${p2p_public_address}" >> "${testnet_path}/.env"
 echo "SEQUENCERID=${sequencer_id}" >> "${testnet_path}/.env"
+echo "PCCS_URL=${pccs_url}" >> "${testnet_path}/.env"
 
 
 if ${debug_enclave} ;

--- a/testnet/start-obscuro-node.sh
+++ b/testnet/start-obscuro-node.sh
@@ -44,7 +44,7 @@ help_and_exit() {
     echo ""
     echo "  p2p_public_address *Optional* Set host p2p public address. Defaults to 127.0.0.1:10000"
     echo ""
-    echo "  pccs_url           *Optional* Set the enclave Provision Certificate Cache Service. Defaults to https://127.0.0.1:8081/sgx/certification/v3/"
+    echo "  pccs_addr           *Optional* Set the enclave Provision Certificate Cache Service. Defaults to 127.0.0.1:8081"
     echo ""
     echo "  profiler_enabled   *Optional* Enables the profiler in the host + enclave. Defaults to false"
     echo ""
@@ -75,7 +75,7 @@ host_id=0x0654D8B60033144D567f25bF41baC1FB0D60F23B
 pk_string=8ead642ca80dadb0f346a66cd6aa13e08a8ac7b5c6f7578d4bac96f5db01ac99
 log_level=4
 sequencer_id=0x0654D8B60033144D567f25bF41baC1FB0D60F23B
-pccs_url="https://127.0.0.1:8081/sgx/certification/v3/"
+pccs_addr="127.0.0.1:8081"
 
 
 # Fetch options
@@ -101,7 +101,7 @@ do
             --debug_enclave)            debug_enclave=${value} ;;
             --dev_testnet)              dev_testnet=${value} ;;
             --sequencerID)              sequencer_id=${value} ;;
-            --pccs_url)                 pccs_url=${value} ;;
+            --pccs_addr)                pccs_addr=${value} ;;
 
             --help)                     help_and_exit ;;
             *)
@@ -128,7 +128,7 @@ echo "LOGLEVEL=${log_level}" >> "${testnet_path}/.env"
 echo "PROFILERENABLED=${profiler_enabled}" >> "${testnet_path}/.env"
 echo "P2PPUBLICADDRESS=${p2p_public_address}" >> "${testnet_path}/.env"
 echo "SEQUENCERID=${sequencer_id}" >> "${testnet_path}/.env"
-echo "PCCS_URL=${pccs_url}" >> "${testnet_path}/.env"
+echo "PCCS_ADDR=${pccs_addr}" >> "${testnet_path}/.env"
 
 
 if ${debug_enclave} ;


### PR DESCRIPTION
### Why is this change needed?

- https://github.com/obscuronet/obscuro-internal/issues/1273
- In Alibabaclound the PCCS must be specified as the default values don't work.
- Fixed docker-compose env var ingestion ( it was failing to load variables that were not immediately used in the entry command of the container)
- Enclave now starts with an` entry.sh` so it can handle the PCCS address ( needed for ali baba and if you have a custom remote attestation url)
- Enclave is no longer running under docker privileged mode ( changed to used devices like sugested by the edgeless systems )
- Remove the entry point in the docker files as it's misleading that the image may run without any flags

### What changes were made as part of this PR:

- Provide a high level list of the changes made

### Definition of done

- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
- [ ] End-to-end tests run if required (see below)

### End-to-end tests

Running the end-to-end tests in the [obscuro-test repo](https://github.com/obscuronet/obscuro-test) is currently at the 
discretion of the developer prior to merging a PR. The intention is not to slow down development by having the longer 
running end-to-end tests as a PR gate run on each branch commit etc. To manually trigger a run pre-merge;

- Go to [run_local_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_local_tests.yml)
- Click the "Run workflow" button
- Use the main branch of obscuro-test 
- Enter the name of the PR branch for go-obscuro
- Run the workflow

The run takes approximately 20 minutes and any failure will be reported in the workflow output. Should the tests fail 
the docker container output for the local testnet and all test artifacts will be added to the run and can be downloaded
for debugging and analysis, with a retention period of 2 days. 

Note that every PR merge to main will also trigger a run of post-merge tests, so even if you do not manually trigger 
pre-merge, tests will be run post-merge. The intention being to catch any issues fast on main to allow for quick 
resolution. The post-merge test output can be seen at 
[run_merge_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_merge_tests.yml) and will show both 
the PR number and author in the list of runs. 


