### PR TITLE
RPC server is injected into the Host

### DIFF
--- a/go/host/container/host_container.go
+++ b/go/host/container/host_container.go
@@ -4,14 +4,14 @@ import (
 	"fmt"
 
 	"github.com/obscuronet/go-obscuro/go/common"
-	"github.com/obscuronet/go-obscuro/go/common/metrics"
-
 	"github.com/obscuronet/go-obscuro/go/common/log"
+	"github.com/obscuronet/go-obscuro/go/common/metrics"
 	"github.com/obscuronet/go-obscuro/go/config"
 	"github.com/obscuronet/go-obscuro/go/ethadapter"
 	"github.com/obscuronet/go-obscuro/go/ethadapter/mgmtcontractlib"
 	"github.com/obscuronet/go-obscuro/go/host"
 	"github.com/obscuronet/go-obscuro/go/host/p2p"
+	"github.com/obscuronet/go-obscuro/go/host/rpc/clientrpc"
 	"github.com/obscuronet/go-obscuro/go/host/rpc/enclaverpc"
 	"github.com/obscuronet/go-obscuro/go/wallet"
 
@@ -23,6 +23,7 @@ type HostContainer struct {
 	host           commonhost.Host
 	logger         gethlog.Logger
 	metricsService *metrics.Service
+	rpcServer      clientrpc.Server
 }
 
 func (h *HostContainer) Start() error {
@@ -72,26 +73,29 @@ func NewHostContainerFromConfig(parsedConfig *config.HostInputConfig) *HostConta
 	p2pLogger := logger.New(log.CmpKey, log.P2PCmp)
 	metricsService := metrics.New(cfg.MetricsEnabled, cfg.MetricsHTTPPort, logger)
 	aggP2P := p2p.NewSocketP2PLayer(cfg, p2pLogger, metricsService.Registry())
+	rpcServer := clientrpc.NewServer(cfg, logger)
 
-	return NewHostContainer(cfg, aggP2P, l1Client, enclaveClient, ethWallet, logger, metricsService)
+	return NewHostContainer(cfg, aggP2P, l1Client, enclaveClient, ethWallet, rpcServer, logger, metricsService)
 }
 
 // NewHostContainer builds a host container with dependency injection rather than from config.
 // Useful for testing etc. (want to be able to pass in logger, and also have option to mock out dependencies)
 func NewHostContainer(
-	cfg *config.HostConfig, // provides various parameters that the host needs to function
-	p2p commonhost.P2P, // provides the inbound and outbound p2p communication layer
-	l1Client ethadapter.EthClient, // provides inbound and outbound L1 connectivity
-	enclaveClient common.Enclave, // provides RPC connection to this host's Enclave
-	hostWallet wallet.Wallet, // provides an L1 wallet for the host's transactions
-	logger gethlog.Logger, // provides logging with context
+	cfg *config.HostConfig,          // provides various parameters that the host needs to function
+	p2p commonhost.P2P,              // provides the inbound and outbound p2p communication layer
+	l1Client ethadapter.EthClient,   // provides inbound and outbound L1 connectivity
+	enclaveClient common.Enclave,    // provides RPC connection to this host's Enclave
+	hostWallet wallet.Wallet,        // provides an L1 wallet for the host's transactions
+	rpcServer clientrpc.Server,      // For communication with Obscuro client applications
+	logger gethlog.Logger,           // provides logging with context
 	metricsService *metrics.Service, // provides the metrics service for other packages to use
 ) *HostContainer {
 	mgmtContractLib := mgmtcontractlib.NewMgmtContractLib(&cfg.RollupContractAddress, logger)
-	h := host.NewHost(cfg, p2p, l1Client, enclaveClient, hostWallet, mgmtContractLib, logger, metricsService.Registry())
+	h := host.NewHost(cfg, p2p, l1Client, enclaveClient, rpcServer, hostWallet, mgmtContractLib, logger, metricsService.Registry())
 	return &HostContainer{
 		host:           h,
 		logger:         logger,
+		rpcServer:      rpcServer,
 		metricsService: metricsService,
 	}
 }

--- a/go/host/container/host_container.go
+++ b/go/host/container/host_container.go
@@ -81,13 +81,13 @@ func NewHostContainerFromConfig(parsedConfig *config.HostInputConfig) *HostConta
 // NewHostContainer builds a host container with dependency injection rather than from config.
 // Useful for testing etc. (want to be able to pass in logger, and also have option to mock out dependencies)
 func NewHostContainer(
-	cfg *config.HostConfig,          // provides various parameters that the host needs to function
-	p2p commonhost.P2P,              // provides the inbound and outbound p2p communication layer
-	l1Client ethadapter.EthClient,   // provides inbound and outbound L1 connectivity
-	enclaveClient common.Enclave,    // provides RPC connection to this host's Enclave
-	hostWallet wallet.Wallet,        // provides an L1 wallet for the host's transactions
-	rpcServer clientrpc.Server,      // For communication with Obscuro client applications
-	logger gethlog.Logger,           // provides logging with context
+	cfg *config.HostConfig, // provides various parameters that the host needs to function
+	p2p commonhost.P2P, // provides the inbound and outbound p2p communication layer
+	l1Client ethadapter.EthClient, // provides inbound and outbound L1 connectivity
+	enclaveClient common.Enclave, // provides RPC connection to this host's Enclave
+	hostWallet wallet.Wallet, // provides an L1 wallet for the host's transactions
+	rpcServer clientrpc.Server, // For communication with Obscuro client applications
+	logger gethlog.Logger, // provides logging with context
 	metricsService *metrics.Service, // provides the metrics service for other packages to use
 ) *HostContainer {
 	mgmtContractLib := mgmtcontractlib.NewMgmtContractLib(&cfg.RollupContractAddress, logger)

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -88,6 +88,7 @@ func NewHost(
 	p2p hostcommon.P2P,
 	ethClient ethadapter.EthClient,
 	enclaveClient common.Enclave,
+	rpcServer clientrpc.Server,
 	ethWallet wallet.Wallet,
 	mgmtContractLib mgmtcontractlib.MgmtContractLib,
 	logger gethlog.Logger,
@@ -118,6 +119,8 @@ func NewHost(
 		// Initialize the host DB
 		db: database,
 
+		rpcServer: rpcServer, // use injected RPC server
+
 		mgmtContractLib: mgmtContractLib, // library that provides a handler for Management Contract
 		ethWallet:       ethWallet,       // the host's ethereum wallet
 		logEventManager: events.NewLogEventManager(logger),
@@ -128,7 +131,7 @@ func NewHost(
 	}
 
 	if config.HasClientRPCHTTP || config.HasClientRPCWebsockets {
-		rpcAPIs := []rpc.API{
+		host.rpcServer.RegisterAPIs([]rpc.API{
 			{
 				Namespace: APINamespaceObscuro,
 				Version:   APIVersion1,
@@ -165,8 +168,7 @@ func NewHost(
 				Service:   clientapi.NewFilterAPI(host, logger),
 				Public:    true,
 			},
-		}
-		host.rpcServer = clientrpc.NewServer(config, rpcAPIs, logger)
+		})
 	}
 
 	var prof *profiler.Profiler

--- a/integration/simulation/network/network_utils.go
+++ b/integration/simulation/network/network_utils.go
@@ -21,6 +21,7 @@ import (
 	"github.com/obscuronet/go-obscuro/integration/simulation/params"
 
 	"github.com/obscuronet/go-obscuro/go/ethadapter"
+	"github.com/obscuronet/go-obscuro/go/host/rpc/clientrpc"
 
 	"github.com/obscuronet/go-obscuro/go/config"
 
@@ -103,7 +104,8 @@ func createInMemObscuroNode(
 	// create an in memory obscuro node
 	hostLogger := testlog.Logger().New(log.NodeIDKey, id, log.CmpKey, log.HostCmp)
 	metricsService := metrics.New(hostConfig.MetricsEnabled, hostConfig.MetricsHTTPPort, hostLogger)
-	inMemNode := host.NewHost(hostConfig, mockP2P, ethClient, enclaveClient, ethWallet, mgmtContractLib, hostLogger, metricsService.Registry())
+	rpcServer := clientrpc.NewServer(hostConfig, hostLogger)
+	inMemNode := host.NewHost(hostConfig, mockP2P, ethClient, enclaveClient, rpcServer, ethWallet, mgmtContractLib, hostLogger, metricsService.Registry())
 	mockP2P.CurrentNode = inMemNode
 	return inMemNode
 }
@@ -151,8 +153,9 @@ func createSocketObscuroNode(
 	// create a socket P2P layer
 	p2pLogger := hostLogger.New(log.CmpKey, log.P2PCmp)
 	nodeP2p := p2p.NewSocketP2PLayer(hostConfig, p2pLogger, metricsService.Registry())
+	rpcServer := clientrpc.NewServer(hostConfig, hostLogger)
 
-	return host.NewHost(hostConfig, nodeP2p, ethClient, enclaveClient, ethWallet, mgmtContractLib, hostLogger, metricsService.Registry())
+	return host.NewHost(hostConfig, nodeP2p, ethClient, enclaveClient, rpcServer, ethWallet, mgmtContractLib, hostLogger, metricsService.Registry())
 }
 
 func defaultMockEthNodeCfg(nrNodes int, avgBlockDuration time.Duration) ethereummock.MiningConfig {


### PR DESCRIPTION
### Why is this change needed?

- Host now receives an RPC server from the Host Container

### What changes were made as part of this PR:

- Provide a high level list of the changes made

### Definition of done

- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
- [ ] End-to-end tests run if required (see below)

### End-to-end tests

Running the end-to-end tests in the [obscuro-test repo](https://github.com/obscuronet/obscuro-test) is currently at the 
discretion of the developer prior to merging a PR. The intention is not to slow down development by having the longer 
running end-to-end tests as a PR gate run on each branch commit etc. To manually trigger a run pre-merge;

- Go to [run_local_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_local_tests.yml)
- Click the "Run workflow" button
- Use the main branch of obscuro-test 
- Enter the name of the PR branch for go-obscuro
- Run the workflow

The run takes approximately 20 minutes and any failure will be reported in the workflow output. Should the tests fail 
the docker container output for the local testnet and all test artifacts will be added to the run and can be downloaded
for debugging and analysis, with a retention period of 2 days. 

Note that every PR merge to main will also trigger a run of post-merge tests, so even if you do not manually trigger 
pre-merge, tests will be run post-merge. The intention being to catch any issues fast on main to allow for quick 
resolution. The post-merge test output can be seen at 
[run_merge_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_merge_tests.yml) and will show both 
the PR number and author in the list of runs. 


