### PR TITLE
Remove unnecessary start method from enclave interface

### DIFF
--- a/go/common/enclave.go
+++ b/go/common/enclave.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
@@ -33,9 +32,6 @@ type Enclave interface {
 
 	// InitEnclave - initialise an enclave with a seed received by another enclave
 	InitEnclave(secret EncryptedSharedEnclaveSecret) error
-
-	// Start - start speculative execution
-	Start(block types.Block) error
 
 	// SubmitL1Block - Used for the host to submit L1 blocks to the enclave, these may be:
 	//  a. historic block - if the enclave is behind and in the process of catching up with the L1 state

--- a/go/common/rpc/generated/enclave.proto
+++ b/go/common/rpc/generated/enclave.proto
@@ -18,9 +18,6 @@ service EnclaveProto {
   // Init - initialise an enclave with a seed received by another enclave
   rpc InitEnclave(InitEnclaveRequest) returns (InitEnclaveResponse) {}
 
-  // Start - start speculative execution
-  rpc Start(StartRequest) returns (StartResponse) {}
-
   // SubmitL1Block - Used for the host to submit blocks to the enclave, these may be:
   //  a. historic block - if the enclave is behind and in the process of catching up with the L1 state
   //  b. the latest block published by the L1, to which the enclave should respond with a rollup

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -237,16 +237,6 @@ func (e *enclaveImpl) StopClient() error {
 	return nil // The enclave is local so there is no client to stop
 }
 
-func (e *enclaveImpl) Start(block types.Block) error {
-	// todo - reinstate after TN1
-	/*	if e.config.SpeculativeExecution {
-			//start the speculative rollup execution loop on its own go routine
-			go e.start(block)
-		}
-	*/
-	return nil
-}
-
 // SubmitL1Block is used to update the enclave with an additional L1 block.
 func (e *enclaveImpl) SubmitL1Block(block types.Block, receipts types.Receipts, isLatest bool) (*common.BlockSubmissionResponse, error) {
 	// We update the enclave state based on the L1 block.
@@ -1122,69 +1112,5 @@ type processingEnvironment struct {
 	processedTxs    []*nodecommon.L2Tx               // txs that were already processed
 	processedTxsMap map[common.Hash]*nodecommon.L2Tx // structure used to prevent duplicates
 	state           *state.StateDB                   // the state as calculated from the previous rollup and the processed transactions
-}
-*/
-/*
-func (e *enclaveImpl) start(block types.Block) {
-	env := processingEnvironment{processedTxsMap: make(map[common.Hash]*nodecommon.L2Tx)}
-	// determine whether the block where the speculative execution will start already contains Obscuro state
-	blockState, f := e.storage.FetchBlockState(block.Hash())
-	if f {
-		env.headRollup, _ = e.storage.FetchRollup(blockState.HeadRollup)
-		if env.headRollup != nil {
-			env.state = e.storage.CreateStateDB(env.headRollup.Hash())
-		}
-	}
-
-	for {
-		select {
-		// A new winner was found after gossiping. Start speculatively executing incoming transactions to already have a rollup ready when the next round starts.
-		case winnerRollup := <-e.roundWinnerCh:
-			hash := winnerRollup.Hash()
-			env.header = obscurocore.NewHeader(&hash, winnerRollup.Header.Number.Uint64()+1, e.config.HostID)
-			env.headRollup = winnerRollup
-			env.state = e.storage.CreateStateDB(winnerRollup.Hash())
-			common.TraceWithID(e.nodeShortID, "Create new speculative env  r_%d(%d).",
-				obscurocommon.ShortHash(winnerRollup.Header.Hash()),
-				winnerRollup.Header.Number,
-			))
-
-			// determine the transactions that were not yet included
-			env.processedTxs = currentTxs(winnerRollup, e.mempool.FetchMempoolTxs(), e.storage)
-			env.processedTxsMap = obscurocore.MakeMap(env.processedTxs)
-
-			// calculate the State after executing them
-			evm.ExecuteTransactions(env.processedTxs, env.state, env.headRollup.Header, e.storage, e.config.ObscuroChainID, 0)
-
-		case tx := <-e.txCh:
-			// only process transactions if there is already a rollup to use as parent
-			if env.headRollup != nil {
-				_, found := env.processedTxsMap[tx.Hash()]
-				if !found {
-					env.processedTxsMap[tx.Hash()] = tx
-					env.processedTxs = append(env.processedTxs, tx)
-					evm.ExecuteTransactions([]*nodecommon.L2Tx{tx}, env.state, env.header, e.storage, e.config.ObscuroChainID, 0)
-				}
-			}
-
-		case <-e.speculativeWorkInCh:
-			if env.header == nil {
-				e.speculativeWorkOutCh <- speculativeWork{found: false}
-			} else {
-				b := make([]*nodecommon.L2Tx, 0, len(env.processedTxs))
-				b = append(b, env.processedTxs...)
-				e.speculativeWorkOutCh <- speculativeWork{
-					found: true,
-					r:     env.headRollup,
-					s:     env.state,
-					h:     env.header,
-					txs:   b,
-				}
-			}
-
-		case <-e.exitCh:
-			return
-		}
-	}
 }
 */

--- a/go/enclave/rpc_server.go
+++ b/go/enclave/rpc_server.go
@@ -95,15 +95,6 @@ func (s *RPCServer) InitEnclave(_ context.Context, request *generated.InitEnclav
 	return &generated.InitEnclaveResponse{Error: errStr}, nil
 }
 
-func (s *RPCServer) Start(_ context.Context, request *generated.StartRequest) (*generated.StartResponse, error) {
-	bl := s.decodeBlock(request.EncodedBlock)
-	err := s.enclave.Start(bl)
-	if err != nil {
-		return nil, err
-	}
-	return &generated.StartResponse{}, nil
-}
-
 func (s *RPCServer) SubmitL1Block(_ context.Context, request *generated.SubmitBlockRequest) (*generated.SubmitBlockResponse, error) {
 	bl := s.decodeBlock(request.EncodedBlock)
 	receipts := s.decodeReceipts(request.EncodedReceipts)

--- a/go/host/rpc/enclaverpc/enclave_client.go
+++ b/go/host/rpc/enclaverpc/enclave_client.go
@@ -129,23 +129,6 @@ func (c *Client) InitEnclave(secret common.EncryptedSharedEnclaveSecret) error {
 	return nil
 }
 
-func (c *Client) Start(block types.Block) error {
-	timeoutCtx, cancel := context.WithTimeout(context.Background(), c.config.EnclaveRPCTimeout)
-	defer cancel()
-
-	var buffer bytes.Buffer
-	if err := block.EncodeRLP(&buffer); err != nil {
-		return fmt.Errorf("could not encode block. Cause: %w", err)
-	}
-
-	_, err := c.protoClient.Start(timeoutCtx, &generated.StartRequest{EncodedBlock: buffer.Bytes()})
-	if err != nil {
-		return fmt.Errorf("could not start enclave. Cause: %w", err)
-	}
-
-	return nil
-}
-
 func (c *Client) SubmitL1Block(block types.Block, receipts types.Receipts, isLatest bool) (*common.BlockSubmissionResponse, error) {
 	timeoutCtx, cancel := context.WithTimeout(context.Background(), c.config.EnclaveRPCTimeout)
 	defer cancel()


### PR DESCRIPTION
### Why is this change needed?

- This method originally existed to tell enclave to start doing speculative execution but its lifecycle doesn't require that prompt (and it's not relevant anymore).
- Enclave starts up -> self-heals if its persistence is in a bad state -> starts processing RPC requests from host

### What changes were made as part of this PR:

- Remove enclave's unused `Start()` method

### Definition of done

- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
- [ ] End-to-end tests run if required (see below)

### End-to-end tests

Running the end-to-end tests in the [obscuro-test repo](https://github.com/obscuronet/obscuro-test) is currently at the 
discretion of the developer prior to merging a PR. The intention is not to slow down development by having the longer 
running end-to-end tests as a PR gate run on each branch commit etc. To manually trigger a run pre-merge;

- Go to [run_local_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_local_tests.yml)
- Click the "Run workflow" button
- Use the main branch of obscuro-test 
- Enter the name of the PR branch for go-obscuro
- Run the workflow

The run takes approximately 20 minutes and any failure will be reported in the workflow output. Should the tests fail 
the docker container output for the local testnet and all test artifacts will be added to the run and can be downloaded
for debugging and analysis, with a retention period of 2 days. 

Note that every PR merge to main will also trigger a run of post-merge tests, so even if you do not manually trigger 
pre-merge, tests will be run post-merge. The intention being to catch any issues fast on main to allow for quick 
resolution. The post-merge test output can be seen at 
[run_merge_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_merge_tests.yml) and will show both 
the PR number and author in the list of runs. 


