### PR TITLE
Overriden how transaction receipt is marshalled to json.

### DIFF
--- a/go/common/json_types.go
+++ b/go/common/json_types.go
@@ -1,0 +1,49 @@
+package common
+
+import (
+	"bytes"
+	"encoding/json"
+
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+type ReceiptJSON struct {
+	Type              hexutil.Uint64      `json:"type,omitempty"`
+	PostState         hexutil.Bytes       `json:"root"`
+	Status            hexutil.Uint64      `json:"status"`
+	CumulativeGasUsed hexutil.Uint64      `json:"cumulativeGasUsed" gencodec:"required"`
+	Bloom             types.Bloom         `json:"logsBloom"         gencodec:"required"`
+	Logs              []*types.Log        `json:"logs"              gencodec:"required"`
+	TxHash            gethcommon.Hash     `json:"transactionHash" gencodec:"required"`
+	ContractAddress   *gethcommon.Address `json:"contractAddress"`
+	GasUsed           hexutil.Uint64      `json:"gasUsed" gencodec:"required"`
+	BlockHash         gethcommon.Hash     `json:"blockHash,omitempty"`
+	BlockNumber       *hexutil.Big        `json:"blockNumber,omitempty"`
+	TransactionIndex  hexutil.Uint        `json:"transactionIndex"`
+}
+
+// MarshalReceipt - serializes a compliant receipt and returns it.
+// Cloned from the standard geth marshal function, but fixed issue with
+// the returned contract address being returned as zero address instead of nil.
+func MarshalReceipt(r *types.Receipt) ([]byte, error) {
+	var enc ReceiptJSON
+	enc.Type = hexutil.Uint64(r.Type)
+	enc.PostState = r.PostState
+	enc.Status = hexutil.Uint64(r.Status)
+	enc.CumulativeGasUsed = hexutil.Uint64(r.CumulativeGasUsed)
+	enc.Bloom = r.Bloom
+	enc.Logs = r.Logs
+	enc.TxHash = r.TxHash
+	// Contract address should only be set for receipts of transactions that initialize a contract.
+	// Otherwise return nil to match receipts returned by other testnets.
+	if !bytes.Equal(r.ContractAddress.Bytes(), gethcommon.BigToAddress(gethcommon.Big0).Bytes()) {
+		enc.ContractAddress = &r.ContractAddress
+	}
+	enc.GasUsed = hexutil.Uint64(r.GasUsed)
+	enc.BlockHash = r.BlockHash
+	enc.BlockNumber = (*hexutil.Big)(r.BlockNumber)
+	enc.TransactionIndex = hexutil.Uint(r.TransactionIndex)
+	return json.Marshal(&enc)
+}

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -510,10 +510,12 @@ func (e *enclaveImpl) GetTransactionReceipt(encryptedParams common.EncryptedPara
 	}
 
 	// We marshal the receipt to JSON.
-	txReceiptBytes, err := txReceipt.MarshalJSON()
+	txReceiptBytes, err := common.MarshalReceipt(txReceipt)
 	if err != nil {
 		return nil, fmt.Errorf("could not marshal transaction receipt to JSON in eth_getTransactionReceipt request. Cause: %w", err)
 	}
+
+	fmt.Println(string(txReceiptBytes))
 
 	// We encrypt the receipt.
 	encryptedTxReceipt, err := e.rpcEncryptionManager.EncryptWithViewingKey(sender, txReceiptBytes)


### PR DESCRIPTION
### Why is this change needed?

Fix for #970 

### What changes were made as part of this PR:

Changed how receipt is being marshalled. Using a cloned function instead of the standard one in the geth library which is not compliant with the library. **It is a bit of a hack, which makes me uneasy, but there is no other way to encode null**

### Definition of done

- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
- [ ] End-to-end tests run if required (see below)

### End-to-end tests

Running the end-to-end tests in the [obscuro-test repo](https://github.com/obscuronet/obscuro-test) is currently at the 
discretion of the developer prior to merging a PR. The intention is not to slow down development by having the longer 
running end-to-end tests as a PR gate run on each branch commit etc. To manually trigger a run pre-merge;

- Go to [run_local_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_local_tests.yml)
- Click the "Run workflow" button
- Use the main branch of obscuro-test 
- Enter the name of the PR branch for go-obscuro
- Run the workflow

The run takes approximately 20 minutes and any failure will be reported in the workflow output. Should the tests fail 
the docker container output for the local testnet and all test artifacts will be added to the run and can be downloaded
for debugging and analysis, with a retention period of 2 days. 

Note that every PR merge to main will also trigger a run of post-merge tests, so even if you do not manually trigger 
pre-merge, tests will be run post-merge. The intention being to catch any issues fast on main to allow for quick 
resolution. The post-merge test output can be seen at 
[run_merge_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_merge_tests.yml) and will show both 
the PR number and author in the list of runs. 


