### PR TITLE
Decouples Host and RPC server

### DIFF
--- a/go/host/container/host_container.go
+++ b/go/host/container/host_container.go
@@ -96,13 +96,13 @@ func NewHostContainerFromConfig(parsedConfig *config.HostInputConfig) *HostConta
 // NewHostContainer builds a host container with dependency injection rather than from config.
 // Useful for testing etc. (want to be able to pass in logger, and also have option to mock out dependencies)
 func NewHostContainer(
-	cfg *config.HostConfig,          // provides various parameters that the host needs to function
-	p2p commonhost.P2P,              // provides the inbound and outbound p2p communication layer
-	l1Client ethadapter.EthClient,   // provides inbound and outbound L1 connectivity
-	enclaveClient common.Enclave,    // provides RPC connection to this host's Enclave
-	hostWallet wallet.Wallet,        // provides an L1 wallet for the host's transactions
-	rpcServer clientrpc.Server,      // For communication with Obscuro client applications
-	logger gethlog.Logger,           // provides logging with context
+	cfg *config.HostConfig, // provides various parameters that the host needs to function
+	p2p commonhost.P2P, // provides the inbound and outbound p2p communication layer
+	l1Client ethadapter.EthClient, // provides inbound and outbound L1 connectivity
+	enclaveClient common.Enclave, // provides RPC connection to this host's Enclave
+	hostWallet wallet.Wallet, // provides an L1 wallet for the host's transactions
+	rpcServer clientrpc.Server, // For communication with Obscuro client applications
+	logger gethlog.Logger, // provides logging with context
 	metricsService *metrics.Service, // provides the metrics service for other packages to use
 ) *HostContainer {
 	mgmtContractLib := mgmtcontractlib.NewMgmtContractLib(&cfg.RollupContractAddress, logger)
@@ -115,7 +115,7 @@ func NewHostContainer(
 		rpcServer:      rpcServer,
 		metricsService: metricsService,
 	}
-	
+
 	if cfg.HasClientRPCHTTP || cfg.HasClientRPCWebsockets {
 		rpcServer.RegisterAPIs([]rpc.API{
 			{

--- a/go/host/container/host_container.go
+++ b/go/host/container/host_container.go
@@ -3,6 +3,7 @@ package container
 import (
 	"fmt"
 
+	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/obscuronet/go-obscuro/go/common"
 	"github.com/obscuronet/go-obscuro/go/common/log"
 	"github.com/obscuronet/go-obscuro/go/common/metrics"
@@ -11,12 +12,22 @@ import (
 	"github.com/obscuronet/go-obscuro/go/ethadapter/mgmtcontractlib"
 	"github.com/obscuronet/go-obscuro/go/host"
 	"github.com/obscuronet/go-obscuro/go/host/p2p"
+	"github.com/obscuronet/go-obscuro/go/host/rpc/clientapi"
 	"github.com/obscuronet/go-obscuro/go/host/rpc/clientrpc"
 	"github.com/obscuronet/go-obscuro/go/host/rpc/enclaverpc"
 	"github.com/obscuronet/go-obscuro/go/wallet"
 
 	gethlog "github.com/ethereum/go-ethereum/log"
 	commonhost "github.com/obscuronet/go-obscuro/go/common/host"
+)
+
+const (
+	APIVersion1             = "1.0"
+	APINamespaceObscuro     = "obscuro"
+	APINamespaceEth         = "eth"
+	APINamespaceObscuroScan = "obscuroscan"
+	APINamespaceNetwork     = "net"
+	APINamespaceTest        = "test"
 )
 
 type HostContainer struct {
@@ -30,12 +41,16 @@ func (h *HostContainer) Start() error {
 	fmt.Println("Starting Obscuro host...")
 	h.logger.Info("Starting Obscuro host...")
 	h.metricsService.Start()
+	// make sure the rpc server has a host to render requests
 	h.host.Start()
+	h.rpcServer.Start()
 	return nil
 }
 
 func (h *HostContainer) Stop() error {
 	h.metricsService.Stop()
+	// make sure the rpc server does not request services from a stopped host
+	h.rpcServer.Stop()
 	h.host.Stop()
 	return nil
 }
@@ -81,21 +96,66 @@ func NewHostContainerFromConfig(parsedConfig *config.HostInputConfig) *HostConta
 // NewHostContainer builds a host container with dependency injection rather than from config.
 // Useful for testing etc. (want to be able to pass in logger, and also have option to mock out dependencies)
 func NewHostContainer(
-	cfg *config.HostConfig, // provides various parameters that the host needs to function
-	p2p commonhost.P2P, // provides the inbound and outbound p2p communication layer
-	l1Client ethadapter.EthClient, // provides inbound and outbound L1 connectivity
-	enclaveClient common.Enclave, // provides RPC connection to this host's Enclave
-	hostWallet wallet.Wallet, // provides an L1 wallet for the host's transactions
-	rpcServer clientrpc.Server, // For communication with Obscuro client applications
-	logger gethlog.Logger, // provides logging with context
+	cfg *config.HostConfig,          // provides various parameters that the host needs to function
+	p2p commonhost.P2P,              // provides the inbound and outbound p2p communication layer
+	l1Client ethadapter.EthClient,   // provides inbound and outbound L1 connectivity
+	enclaveClient common.Enclave,    // provides RPC connection to this host's Enclave
+	hostWallet wallet.Wallet,        // provides an L1 wallet for the host's transactions
+	rpcServer clientrpc.Server,      // For communication with Obscuro client applications
+	logger gethlog.Logger,           // provides logging with context
 	metricsService *metrics.Service, // provides the metrics service for other packages to use
 ) *HostContainer {
 	mgmtContractLib := mgmtcontractlib.NewMgmtContractLib(&cfg.RollupContractAddress, logger)
-	h := host.NewHost(cfg, p2p, l1Client, enclaveClient, rpcServer, hostWallet, mgmtContractLib, logger, metricsService.Registry())
-	return &HostContainer{
+
+	h := host.NewHost(cfg, p2p, l1Client, enclaveClient, hostWallet, mgmtContractLib, logger, metricsService.Registry())
+
+	hostContainer := &HostContainer{
 		host:           h,
 		logger:         logger,
 		rpcServer:      rpcServer,
 		metricsService: metricsService,
 	}
+	
+	if cfg.HasClientRPCHTTP || cfg.HasClientRPCWebsockets {
+		rpcServer.RegisterAPIs([]rpc.API{
+			{
+				Namespace: APINamespaceObscuro,
+				Version:   APIVersion1,
+				Service:   clientapi.NewObscuroAPI(h),
+				Public:    true,
+			},
+			{
+				Namespace: APINamespaceEth,
+				Version:   APIVersion1,
+				Service:   clientapi.NewEthereumAPI(h, logger),
+				Public:    true,
+			},
+			{
+				Namespace: APINamespaceObscuroScan,
+				Version:   APIVersion1,
+				Service:   clientapi.NewObscuroScanAPI(h),
+				Public:    true,
+			},
+			{
+				Namespace: APINamespaceNetwork,
+				Version:   APIVersion1,
+				Service:   clientapi.NewNetworkAPI(h),
+				Public:    true,
+			},
+			{
+				Namespace: APINamespaceTest,
+				Version:   APIVersion1,
+				Service:   clientapi.NewTestAPI(nil, hostContainer),
+				Public:    true,
+			},
+			{
+				Namespace: APINamespaceEth,
+				Version:   APIVersion1,
+				Service:   clientapi.NewFilterAPI(h, logger),
+				Public:    true,
+			},
+		})
+	}
+
+	return hostContainer
 }

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -165,7 +165,6 @@ func (h *host) Start() {
 		// start the host's main processing loop
 		h.startProcessing()
 	}()
-
 }
 
 func (h *host) broadcastSecret() error {

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -23,8 +23,6 @@ import (
 	"github.com/obscuronet/go-obscuro/go/host/batchmanager"
 	"github.com/obscuronet/go-obscuro/go/host/db"
 	"github.com/obscuronet/go-obscuro/go/host/events"
-	"github.com/obscuronet/go-obscuro/go/host/rpc/clientapi"
-	"github.com/obscuronet/go-obscuro/go/host/rpc/clientrpc"
 	"github.com/obscuronet/go-obscuro/go/wallet"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
@@ -34,13 +32,6 @@ import (
 )
 
 const (
-	APIVersion1             = "1.0"
-	APINamespaceObscuro     = "obscuro"
-	APINamespaceEth         = "eth"
-	apiNamespaceObscuroScan = "obscuroscan"
-	apiNamespaceNetwork     = "net"
-	apiNamespaceTest        = "test"
-
 	// Attempts to broadcast the rollup transaction to the L1. Worst-case, equates to 7 seconds, plus time per request.
 	l1TxTriesRollup = 3
 	// Attempts to send secret initialisation, request or response transactions to the L1. Worst-case, equates to 63 seconds, plus time per request.
@@ -59,7 +50,6 @@ type host struct {
 	p2p           hostcommon.P2P       // For communication with other Obscuro nodes
 	ethClient     ethadapter.EthClient // For communication with the L1 node
 	enclaveClient common.Enclave       // For communication with the enclave
-	rpcServer     clientrpc.Server     // For communication with Obscuro client applications
 
 	// control the host lifecycle
 	exitHostCh            chan bool
@@ -88,7 +78,6 @@ func NewHost(
 	p2p hostcommon.P2P,
 	ethClient ethadapter.EthClient,
 	enclaveClient common.Enclave,
-	rpcServer clientrpc.Server,
 	ethWallet wallet.Wallet,
 	mgmtContractLib mgmtcontractlib.MgmtContractLib,
 	logger gethlog.Logger,
@@ -119,8 +108,6 @@ func NewHost(
 		// Initialize the host DB
 		db: database,
 
-		rpcServer: rpcServer, // use injected RPC server
-
 		mgmtContractLib: mgmtContractLib, // library that provides a handler for Management Contract
 		ethWallet:       ethWallet,       // the host's ethereum wallet
 		logEventManager: events.NewLogEventManager(logger),
@@ -128,47 +115,6 @@ func NewHost(
 
 		logger:         logger,
 		metricRegistry: regMetrics,
-	}
-
-	if config.HasClientRPCHTTP || config.HasClientRPCWebsockets {
-		host.rpcServer.RegisterAPIs([]rpc.API{
-			{
-				Namespace: APINamespaceObscuro,
-				Version:   APIVersion1,
-				Service:   clientapi.NewObscuroAPI(host),
-				Public:    true,
-			},
-			{
-				Namespace: APINamespaceEth,
-				Version:   APIVersion1,
-				Service:   clientapi.NewEthereumAPI(host, logger),
-				Public:    true,
-			},
-			{
-				Namespace: apiNamespaceObscuroScan,
-				Version:   APIVersion1,
-				Service:   clientapi.NewObscuroScanAPI(host),
-				Public:    true,
-			},
-			{
-				Namespace: apiNamespaceNetwork,
-				Version:   APIVersion1,
-				Service:   clientapi.NewNetworkAPI(host),
-				Public:    true,
-			},
-			{
-				Namespace: apiNamespaceTest,
-				Version:   APIVersion1,
-				Service:   clientapi.NewTestAPI(host),
-				Public:    true,
-			},
-			{
-				Namespace: APINamespaceEth,
-				Version:   APIVersion1,
-				Service:   clientapi.NewFilterAPI(host, logger),
-				Public:    true,
-			},
-		})
 	}
 
 	var prof *profiler.Profiler
@@ -186,6 +132,7 @@ func NewHost(
 	return host
 }
 
+// Start validates the host config and starts the Host in a go routine - immediately returns after
 func (h *host) Start() {
 	h.validateConfig()
 
@@ -195,33 +142,30 @@ func (h *host) Start() {
 	}
 	h.logger.Info("Host started with following config", log.CfgKey, string(tomlConfig))
 
-	// wait for the Enclave to be available
-	h.waitForEnclave()
+	go func() {
+		// wait for the Enclave to be available
+		h.waitForEnclave()
 
-	// TODO the host should only connect to enclaves with the same ID as the host.ID
-	// TODO Issue: https://github.com/obscuronet/obscuro-internal/issues/1265
+		// TODO the host should only connect to enclaves with the same ID as the host.ID
+		// TODO Issue: https://github.com/obscuronet/obscuro-internal/issues/1265
 
-	// todo: we should try to recover the key from a previous run of the node here? Before generating or requesting the key.
-	if h.config.IsGenesis {
-		err = h.broadcastSecret()
-		if err != nil {
-			h.logger.Crit("Could not broadcast secret", log.ErrKey, err.Error())
+		// todo: we should try to recover the key from a previous run of the node here? Before generating or requesting the key.
+		if h.config.IsGenesis {
+			err = h.broadcastSecret()
+			if err != nil {
+				h.logger.Crit("Could not broadcast secret", log.ErrKey, err.Error())
+			}
+		} else {
+			err = h.requestSecret()
+			if err != nil {
+				h.logger.Crit("Could not request secret", log.ErrKey, err.Error())
+			}
 		}
-	} else {
-		err = h.requestSecret()
-		if err != nil {
-			h.logger.Crit("Could not request secret", log.ErrKey, err.Error())
-		}
-	}
 
-	// start the obscuro RPC endpoints
-	if h.rpcServer != nil {
-		h.rpcServer.Start()
-		h.logger.Info("Started client server.")
-	}
+		// start the host's main processing loop
+		h.startProcessing()
+	}()
 
-	// start the host's main processing loop
-	h.startProcessing()
 }
 
 func (h *host) broadcastSecret() error {
@@ -334,12 +278,6 @@ func (h *host) Stop() {
 	}
 	if err := h.enclaveClient.StopClient(); err != nil {
 		h.logger.Error("failed to stop enclave RPC client", log.ErrKey, err)
-	}
-	if h.rpcServer != nil {
-		// We cannot stop the RPC server synchronously. This is because the host itself is being stopped by an RPC
-		// call, so there is a deadlock. The RPC server is waiting for all connections to close, but a single
-		// connection remains open, waiting for the RPC server to close.
-		go h.rpcServer.Stop()
 	}
 
 	// Leave some time for all processing to finish before exiting the main loop.

--- a/go/host/rpc/clientapi/client_api_obscurotest.go
+++ b/go/host/rpc/clientapi/client_api_obscurotest.go
@@ -1,6 +1,7 @@
 package clientapi
 
 import (
+	"github.com/obscuronet/go-obscuro/go/common/container"
 	"github.com/obscuronet/go-obscuro/go/common/host"
 )
 
@@ -8,17 +9,25 @@ import (
 
 // TestAPI implements JSON RPC operations required for testing.
 type TestAPI struct {
-	host host.Host
+	host      host.Host
+	container container.Container
 }
 
-func NewTestAPI(host host.Host) *TestAPI {
+func NewTestAPI(host host.Host, container container.Container) *TestAPI {
 	return &TestAPI{
-		host: host,
+		host:      host,
+		container: container,
 	}
 }
 
 // StopHost gracefully stops the host.
 // TODO - Investigate how to authenticate this and other sensitive methods in production (Geth uses JWT).
 func (api *TestAPI) StopHost() {
-	api.host.Stop()
+	if api.host != nil {
+		api.host.Stop()
+	}
+
+	if api.container != nil {
+		api.container.Stop()
+	}
 }

--- a/go/host/rpc/clientapi/client_api_obscurotest.go
+++ b/go/host/rpc/clientapi/client_api_obscurotest.go
@@ -28,6 +28,6 @@ func (api *TestAPI) StopHost() {
 	}
 
 	if api.container != nil {
-		api.container.Stop()
+		_ = api.container.Stop()
 	}
 }

--- a/go/host/rpc/clientapi/client_api_obscurotest.go
+++ b/go/host/rpc/clientapi/client_api_obscurotest.go
@@ -22,6 +22,7 @@ func NewTestAPI(host host.Host, container container.Container) *TestAPI {
 
 // StopHost gracefully stops the host.
 // TODO - Investigate how to authenticate this and other sensitive methods in production (Geth uses JWT).
+// TODO - Change inmemory tests to use the host container instead of the host. Remove the `api.host` after. - https://github.com/obscuronet/obscuro-internal/issues/1314
 func (api *TestAPI) StopHost() {
 	if api.host != nil {
 		api.host.Stop()

--- a/integration/simulation/network/network_utils.go
+++ b/integration/simulation/network/network_utils.go
@@ -12,9 +12,9 @@ import (
 	"github.com/obscuronet/go-obscuro/go/common"
 	"github.com/obscuronet/go-obscuro/go/common/log"
 	"github.com/obscuronet/go-obscuro/go/common/metrics"
-	"github.com/obscuronet/go-obscuro/integration/common/testlog"
-
+	"github.com/obscuronet/go-obscuro/go/host/container"
 	"github.com/obscuronet/go-obscuro/go/host/rpc/enclaverpc"
+	"github.com/obscuronet/go-obscuro/integration/common/testlog"
 
 	testcommon "github.com/obscuronet/go-obscuro/integration/common"
 
@@ -104,13 +104,13 @@ func createInMemObscuroNode(
 	// create an in memory obscuro node
 	hostLogger := testlog.Logger().New(log.NodeIDKey, id, log.CmpKey, log.HostCmp)
 	metricsService := metrics.New(hostConfig.MetricsEnabled, hostConfig.MetricsHTTPPort, hostLogger)
-	rpcServer := clientrpc.NewServer(hostConfig, hostLogger)
-	inMemNode := host.NewHost(hostConfig, mockP2P, ethClient, enclaveClient, rpcServer, ethWallet, mgmtContractLib, hostLogger, metricsService.Registry())
+
+	inMemNode := host.NewHost(hostConfig, mockP2P, ethClient, enclaveClient, ethWallet, mgmtContractLib, hostLogger, metricsService.Registry())
 	mockP2P.CurrentNode = inMemNode
 	return inMemNode
 }
 
-func createSocketObscuroNode(
+func createSocketObscuroHostContainer(
 	id int64,
 	isGenesis bool,
 	nodeType common.NodeType,
@@ -123,7 +123,8 @@ func createSocketObscuroNode(
 	mgmtContractLib mgmtcontractlib.MgmtContractLib,
 	ethClient ethadapter.EthClient,
 	l1StartBlk gethcommon.Hash,
-) commonhost.Host {
+) *container.HostContainer {
+
 	hostConfig := &config.HostConfig{
 		ID:                     gethcommon.BigToAddress(big.NewInt(id)),
 		IsGenesis:              isGenesis,
@@ -140,22 +141,16 @@ func createSocketObscuroNode(
 		L1ChainID:              integration.EthereumChainID,
 		ObscuroChainID:         integration.ObscuroChainID,
 		L1StartHash:            l1StartBlk,
+		RollupContractAddress:  *mgmtContractLib.GetContractAddr(),
 	}
 
-	// create an enclave client
-	enclaveClient := enclaverpc.NewClient(hostConfig, testlog.Logger().New(log.NodeIDKey, id))
-
 	hostLogger := testlog.Logger().New(log.NodeIDKey, id, log.CmpKey, log.HostCmp)
-
-	// create the metrics service
 	metricsService := metrics.New(hostConfig.MetricsEnabled, hostConfig.MetricsHTTPPort, hostLogger)
-
-	// create a socket P2P layer
-	p2pLogger := hostLogger.New(log.CmpKey, log.P2PCmp)
-	nodeP2p := p2p.NewSocketP2PLayer(hostConfig, p2pLogger, metricsService.Registry())
+	hostP2P := p2p.NewSocketP2PLayer(hostConfig, hostLogger.New(log.CmpKey, log.P2PCmp), metricsService.Registry())
+	enclaveClient := enclaverpc.NewClient(hostConfig, testlog.Logger().New(log.NodeIDKey, id))
 	rpcServer := clientrpc.NewServer(hostConfig, hostLogger)
 
-	return host.NewHost(hostConfig, nodeP2p, ethClient, enclaveClient, rpcServer, ethWallet, mgmtContractLib, hostLogger, metricsService.Registry())
+	return container.NewHostContainer(hostConfig, hostP2P, ethClient, enclaveClient, ethWallet, rpcServer, hostLogger, metricsService)
 }
 
 func defaultMockEthNodeCfg(nrNodes int, avgBlockDuration time.Duration) ethereummock.MiningConfig {

--- a/integration/simulation/network/network_utils.go
+++ b/integration/simulation/network/network_utils.go
@@ -124,7 +124,6 @@ func createSocketObscuroHostContainer(
 	ethClient ethadapter.EthClient,
 	l1StartBlk gethcommon.Hash,
 ) *container.HostContainer {
-
 	hostConfig := &config.HostConfig{
 		ID:                     gethcommon.BigToAddress(big.NewInt(id)),
 		IsGenesis:              isGenesis,

--- a/integration/simulation/network/network_utils.go
+++ b/integration/simulation/network/network_utils.go
@@ -143,6 +143,7 @@ func createSocketObscuroHostContainer(
 		RollupContractAddress:  *mgmtContractLib.GetContractAddr(),
 	}
 
+	// TODO change this to use the NewHostContainerFromConfig - depends on https://github.com/obscuronet/obscuro-internal/issues/1303
 	hostLogger := testlog.Logger().New(log.NodeIDKey, id, log.CmpKey, log.HostCmp)
 	metricsService := metrics.New(hostConfig.MetricsEnabled, hostConfig.MetricsHTTPPort, hostLogger)
 	hostP2P := p2p.NewSocketP2PLayer(hostConfig, hostLogger.New(log.CmpKey, log.P2PCmp), metricsService.Registry())

--- a/integration/simulation/network/obscuro_node_utils.go
+++ b/integration/simulation/network/obscuro_node_utils.go
@@ -125,10 +125,15 @@ func startStandaloneObscuroNodes(params *params.SimParams, gethClients []ethadap
 		var client rpc.Client
 		var err error
 
-		// create a connection to the created nodes
+		// create a connection to the newly created nodes - panic if no connection is made after some time
+		startTime := time.Now()
 		for connected := false; !connected; time.Sleep(500 * time.Millisecond) {
 			client, err = rpc.NewNetworkClient(rpcAddress)
 			connected = err == nil // The client cannot be created until the node has started.
+			if time.Now().After(startTime.Add(2 * time.Minute)) {
+				testlog.Logger().Crit("failed to create a connect to node after 2 minute")
+			}
+
 			testlog.Logger().Info(fmt.Sprintf("Could not create client %d. Retrying...", i), log.ErrKey, err)
 		}
 

--- a/integration/simulation/network/obscuro_node_utils.go
+++ b/integration/simulation/network/obscuro_node_utils.go
@@ -125,6 +125,7 @@ func startStandaloneObscuroNodes(params *params.SimParams, gethClients []ethadap
 		var client rpc.Client
 		var err error
 
+		// create a connection to the created nodes
 		for connected := false; !connected; time.Sleep(500 * time.Millisecond) {
 			client, err = rpc.NewNetworkClient(rpcAddress)
 			connected = err == nil // The client cannot be created until the node has started.

--- a/integration/simulation/network/obscuro_node_utils.go
+++ b/integration/simulation/network/obscuro_node_utils.go
@@ -117,7 +117,10 @@ func startStandaloneObscuroNodes(params *params.SimParams, gethClients []ethadap
 	// start each obscuro node
 	for _, m := range obscuroNodes {
 		// TODO bubble up errors from the containers/host/enclave Start https://github.com/obscuronet/obscuro-internal/issues/1315
-		_ = m.Start()
+		err := m.Start()
+		if err != nil {
+			testlog.Logger().Crit("unable to start obscuro node ", log.ErrKey, err)
+		}
 		time.Sleep(params.AvgBlockDuration / 3)
 	}
 

--- a/integration/simulation/network/obscuro_node_utils.go
+++ b/integration/simulation/network/obscuro_node_utils.go
@@ -116,7 +116,7 @@ func startStandaloneObscuroNodes(params *params.SimParams, gethClients []ethadap
 
 	// start each obscuro node
 	for _, m := range obscuroNodes {
-		m.Start()
+		_ = m.Start()
 		time.Sleep(params.AvgBlockDuration / 3)
 	}
 

--- a/integration/simulation/network/obscuro_node_utils.go
+++ b/integration/simulation/network/obscuro_node_utils.go
@@ -8,11 +8,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/obscuronet/go-obscuro/go/enclave/container"
-
-	"github.com/obscuronet/go-obscuro/go/enclave"
-
+	"github.com/obscuronet/go-obscuro/go/common/container"
 	"github.com/obscuronet/go-obscuro/go/common/host"
+	"github.com/obscuronet/go-obscuro/go/enclave"
 
 	"github.com/obscuronet/go-obscuro/go/common"
 	"github.com/obscuronet/go-obscuro/integration/common/testlog"
@@ -22,8 +20,6 @@ import (
 	"github.com/obscuronet/go-obscuro/go/wallet"
 
 	"github.com/obscuronet/go-obscuro/go/common/log"
-
-	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/obscuronet/go-obscuro/go/config"
 	"github.com/obscuronet/go-obscuro/integration"
 
@@ -31,6 +27,9 @@ import (
 	"github.com/obscuronet/go-obscuro/go/rpc"
 	"github.com/obscuronet/go-obscuro/integration/simulation/p2p"
 	"github.com/obscuronet/go-obscuro/integration/simulation/params"
+
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	enclavecontainer "github.com/obscuronet/go-obscuro/go/enclave/container"
 )
 
 const (
@@ -87,7 +86,7 @@ func startStandaloneObscuroNodes(params *params.SimParams, gethClients []ethadap
 	// handle to the obscuro clients
 	nodeRPCAddresses := make([]string, params.NumberOfNodes)
 	obscuroClients := make([]rpc.Client, params.NumberOfNodes)
-	obscuroNodes := make([]host.Host, params.NumberOfNodes)
+	obscuroNodes := make([]container.Container, params.NumberOfNodes)
 
 	for i := 0; i < params.NumberOfNodes; i++ {
 		isGenesis := i == 0
@@ -97,7 +96,7 @@ func startStandaloneObscuroNodes(params *params.SimParams, gethClients []ethadap
 		nodeRPCPortWS := params.StartPort + DefaultHostRPCWSOffset + i
 
 		// create an Obscuro node
-		obscuroNodes[i] = createSocketObscuroNode(
+		obscuroNodes[i] = createSocketObscuroHostContainer(
 			int64(i),
 			isGenesis,
 			GetNodeType(i),
@@ -117,8 +116,7 @@ func startStandaloneObscuroNodes(params *params.SimParams, gethClients []ethadap
 
 	// start each obscuro node
 	for _, m := range obscuroNodes {
-		t := m
-		go t.Start()
+		m.Start()
 		time.Sleep(params.AvgBlockDuration / 3)
 	}
 
@@ -127,14 +125,10 @@ func startStandaloneObscuroNodes(params *params.SimParams, gethClients []ethadap
 		var client rpc.Client
 		var err error
 
-		started := false
-		for !started {
+		for connected := false; !connected; time.Sleep(500 * time.Millisecond) {
 			client, err = rpc.NewNetworkClient(rpcAddress)
-			started = err == nil // The client cannot be created until the node has started.
-			if !started {
-				testlog.Logger().Info(fmt.Sprintf("Could not create client %d. Retrying...", i), log.ErrKey, err)
-			}
-			time.Sleep(500 * time.Millisecond)
+			connected = err == nil // The client cannot be created until the node has started.
+			testlog.Logger().Info(fmt.Sprintf("Could not create client %d. Retrying...", i), log.ErrKey, err)
 		}
 
 		obscuroClients[i] = client
@@ -196,7 +190,7 @@ func startRemoteEnclaveServers(params *params.SimParams) {
 		}
 		enclaveLogger := testlog.Logger().New(log.NodeIDKey, i, log.CmpKey, log.EnclaveCmp)
 		encl := enclave.NewEnclave(enclaveConfig, params.MgmtContractLib, params.ERC20ContractLib, enclaveLogger)
-		enclaveContainer := container.EnclaveContainer{
+		enclaveContainer := enclavecontainer.EnclaveContainer{
 			Enclave:   encl,
 			RPCServer: enclave.NewEnclaveRPCServer(enclaveConfig.Address, encl, enclaveLogger),
 			Logger:    enclaveLogger,

--- a/integration/simulation/network/obscuro_node_utils.go
+++ b/integration/simulation/network/obscuro_node_utils.go
@@ -116,6 +116,7 @@ func startStandaloneObscuroNodes(params *params.SimParams, gethClients []ethadap
 
 	// start each obscuro node
 	for _, m := range obscuroNodes {
+		// TODO bubble up errors from the containers/host/enclave Start https://github.com/obscuronet/obscuro-internal/issues/1315
 		_ = m.Start()
 		time.Sleep(params.AvgBlockDuration / 3)
 	}

--- a/integration/simulation/network/socket.go
+++ b/integration/simulation/network/socket.go
@@ -2,8 +2,8 @@ package network
 
 import (
 	"fmt"
-
 	"github.com/obscuronet/go-obscuro/go/obsclient"
+	"time"
 
 	"github.com/obscuronet/go-obscuro/integration/common/testlog"
 
@@ -67,6 +67,19 @@ func (n *networkOfSocketNodes) Create(simParams *params.SimParams, stats *stats.
 	for idx, l2Client := range n.l2Clients {
 		obscuroClients[idx] = obsclient.NewObsClient(l2Client)
 	}
+
+	// make sure the nodes are healthy
+	for _, client := range obscuroClients {
+		startTime := time.Now()
+		healthy := false
+		for ; !healthy; time.Sleep(500 * time.Millisecond) {
+			healthy, _ = client.Health()
+			if time.Now().After(startTime.Add(5 * time.Minute)) {
+				panic("nodes not healthy after 5 minutes")
+			}
+		}
+	}
+
 	walletClients := createAuthClientsPerWallet(n.l2Clients, simParams.Wallets)
 
 	return &RPCHandles{

--- a/integration/simulation/network/socket.go
+++ b/integration/simulation/network/socket.go
@@ -2,16 +2,15 @@ package network
 
 import (
 	"fmt"
-	"github.com/obscuronet/go-obscuro/go/obsclient"
 	"time"
 
 	"github.com/obscuronet/go-obscuro/integration/common/testlog"
 
 	"github.com/obscuronet/go-obscuro/go/ethadapter/erc20contractlib"
 	"github.com/obscuronet/go-obscuro/go/ethadapter/mgmtcontractlib"
-	"github.com/obscuronet/go-obscuro/integration/gethnetwork"
-
+	"github.com/obscuronet/go-obscuro/go/obsclient"
 	"github.com/obscuronet/go-obscuro/go/rpc"
+	"github.com/obscuronet/go-obscuro/integration/gethnetwork"
 
 	"github.com/obscuronet/go-obscuro/go/ethadapter"
 
@@ -74,8 +73,8 @@ func (n *networkOfSocketNodes) Create(simParams *params.SimParams, stats *stats.
 		healthy := false
 		for ; !healthy; time.Sleep(500 * time.Millisecond) {
 			healthy, _ = client.Health()
-			if time.Now().After(startTime.Add(5 * time.Minute)) {
-				panic("nodes not healthy after 5 minutes")
+			if time.Now().After(startTime.Add(3 * time.Minute)) {
+				panic("nodes not healthy after 3 minutes")
 			}
 		}
 	}

--- a/integration/simulation/p2p/in_mem_obscuro_client.go
+++ b/integration/simulation/p2p/in_mem_obscuro_client.go
@@ -51,7 +51,7 @@ func NewInMemObscuroClient(nodeHost hostcommon.Host) rpc.Client {
 		ethAPI:           clientapi.NewEthereumAPI(nodeHost, logger),
 		filterAPI:        clientapi.NewFilterAPI(nodeHost, logger),
 		obscuroScanAPI:   clientapi.NewObscuroScanAPI(nodeHost),
-		testAPI:          clientapi.NewTestAPI(nodeHost),
+		testAPI:          clientapi.NewTestAPI(nodeHost, nil),
 		enclavePublicKey: enclPubKey,
 	}
 }

--- a/tools/walletextension/test/utils.go
+++ b/tools/walletextension/test/utils.go
@@ -13,8 +13,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/obscuronet/go-obscuro/go/host"
-
 	gethlog "github.com/ethereum/go-ethereum/log"
 	"github.com/obscuronet/go-obscuro/go/common/log"
 
@@ -33,6 +31,8 @@ import (
 	"github.com/obscuronet/go-obscuro/tools/walletextension"
 
 	"github.com/gorilla/websocket"
+
+	hostcontainer "github.com/obscuronet/go-obscuro/go/host/container"
 )
 
 const (
@@ -85,14 +85,14 @@ func createDummyHost(t *testing.T) {
 	rpcServerNode, err := gethnode.New(&cfg)
 	rpcServerNode.RegisterAPIs([]gethrpc.API{
 		{
-			Namespace: host.APINamespaceObscuro,
-			Version:   host.APIVersion1,
+			Namespace: hostcontainer.APINamespaceObscuro,
+			Version:   hostcontainer.APIVersion1,
 			Service:   dummyAPI,
 			Public:    true,
 		},
 		{
-			Namespace: host.APINamespaceEth,
-			Version:   host.APIVersion1,
+			Namespace: hostcontainer.APINamespaceEth,
+			Version:   hostcontainer.APIVersion1,
 			Service:   dummyAPI,
 			Public:    true,
 		},

--- a/tools/walletextension/test/utils.go
+++ b/tools/walletextension/test/utils.go
@@ -13,25 +13,20 @@ import (
 	"testing"
 	"time"
 
-	gethlog "github.com/ethereum/go-ethereum/log"
-	"github.com/obscuronet/go-obscuro/go/common/log"
-
-	"github.com/obscuronet/go-obscuro/tools/walletextension/common"
-
-	gethnode "github.com/ethereum/go-ethereum/node"
-	gethrpc "github.com/ethereum/go-ethereum/rpc"
-	"github.com/go-kit/kit/transport/http/jsonrpc"
-	"github.com/obscuronet/go-obscuro/integration"
-
-	gethcommon "github.com/ethereum/go-ethereum/common"
-
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/crypto"
-	enclaverpc "github.com/obscuronet/go-obscuro/go/enclave/rpc"
-	"github.com/obscuronet/go-obscuro/tools/walletextension"
-
+	"github.com/go-kit/kit/transport/http/jsonrpc"
 	"github.com/gorilla/websocket"
+	"github.com/obscuronet/go-obscuro/go/common/log"
+	"github.com/obscuronet/go-obscuro/integration"
+	"github.com/obscuronet/go-obscuro/tools/walletextension"
+	"github.com/obscuronet/go-obscuro/tools/walletextension/common"
 
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	gethlog "github.com/ethereum/go-ethereum/log"
+	gethnode "github.com/ethereum/go-ethereum/node"
+	gethrpc "github.com/ethereum/go-ethereum/rpc"
+	enclaverpc "github.com/obscuronet/go-obscuro/go/enclave/rpc"
 	hostcontainer "github.com/obscuronet/go-obscuro/go/host/container"
 )
 


### PR DESCRIPTION
### Why is this change needed?

- Decouples the Host and the RPC server into the Container Layer
- Starting a network of Socket type container hosts now checks the Health Endpoint before returning

### What changes were made as part of this PR:

- Provide a high level list of the changes made

### Definition of done

- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
- [ ] End-to-end tests run if required (see below)

### End-to-end tests

Running the end-to-end tests in the [obscuro-test repo](https://github.com/obscuronet/obscuro-test) is currently at the 
discretion of the developer prior to merging a PR. The intention is not to slow down development by having the longer 
running end-to-end tests as a PR gate run on each branch commit etc. To manually trigger a run pre-merge;

- Go to [run_local_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_local_tests.yml)
- Click the "Run workflow" button
- Use the main branch of obscuro-test 
- Enter the name of the PR branch for go-obscuro
- Run the workflow

The run takes approximately 20 minutes and any failure will be reported in the workflow output. Should the tests fail 
the docker container output for the local testnet and all test artifacts will be added to the run and can be downloaded
for debugging and analysis, with a retention period of 2 days. 

Note that every PR merge to main will also trigger a run of post-merge tests, so even if you do not manually trigger 
pre-merge, tests will be run post-merge. The intention being to catch any issues fast on main to allow for quick 
resolution. The post-merge test output can be seen at 
[run_merge_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_merge_tests.yml) and will show both 
the PR number and author in the list of runs. 


