### PR TITLE
Docker builds now run in parallell

### DIFF
--- a/.github/workflows/docker/docker-compose.dev-testnet.build.yml
+++ b/.github/workflows/docker/docker-compose.dev-testnet.build.yml
@@ -3,7 +3,7 @@
 version: '3.9'
 services:
   gethnetwork:
-    image: "testnetobscuronet.azurecr.io/obscuronet/gethnetwork:latest"
+    image: "testnetobscuronet.azurecr.io/obscuronet/dev_testnet_l1network:latest"
     build:
       context: ../../../
       dockerfile: ./testnet/gethnetwork.Dockerfile

--- a/.github/workflows/docker/docker-compose.dev-testnet.build.yml
+++ b/.github/workflows/docker/docker-compose.dev-testnet.build.yml
@@ -5,20 +5,20 @@ services:
   gethnetwork:
     image: "testnetobscuronet.azurecr.io/obscuronet/gethnetwork:latest"
     build:
-      context: ../../../go-obscuro/
+      context: ../../../
       dockerfile: ./testnet/gethnetwork.Dockerfile
   host:
     image: "testnetobscuronet.azurecr.io/obscuronet/dev_host:latest"
     build:
-      context: ../../../go-obscuro/
+      context: ../../../
       dockerfile: ./dockerfiles/host.Dockerfile
   contractdeployer:
     image: "testnetobscuronet.azurecr.io/obscuronet/dev_contractdeployer:latest"
     build:
-      context: ../../../go-obscuro/
+      context: ../../../
       dockerfile: ./testnet/contractdeployer.Dockerfile
   enclave:
     image: "testnetobscuronet.azurecr.io/obscuronet/dev_enclave:latest"
     build:
-      context: ../../../go-obscuro/
+      context: ../../../
       dockerfile: ./dockerfiles/enclave.Dockerfile

--- a/.github/workflows/docker/docker-compose.dev-testnet.build.yml
+++ b/.github/workflows/docker/docker-compose.dev-testnet.build.yml
@@ -1,0 +1,24 @@
+# This compose parallelizes the builds of images for deployments
+
+version: '3.9'
+services:
+  gethnetwork:
+    image: "testnetobscuronet.azurecr.io/obscuronet/gethnetwork:latest"
+    build:
+      context: ../../../go-obscuro/
+      dockerfile: ./testnet/gethnetwork.Dockerfile
+  host:
+    image: "testnetobscuronet.azurecr.io/obscuronet/dev_host:latest"
+    build:
+      context: ../../../go-obscuro/
+      dockerfile: ./dockerfiles/host.Dockerfile
+  contractdeployer:
+    image: "testnetobscuronet.azurecr.io/obscuronet/dev_contractdeployer:latest"
+    build:
+      context: ../../../go-obscuro/
+      dockerfile: ./testnet/contractdeployer.Dockerfile
+  enclave:
+    image: "testnetobscuronet.azurecr.io/obscuronet/dev_enclave:latest"
+    build:
+      context: ../../../go-obscuro/
+      dockerfile: ./dockerfiles/enclave.Dockerfile

--- a/.github/workflows/docker/docker-compose.testnet.build.yml
+++ b/.github/workflows/docker/docker-compose.testnet.build.yml
@@ -1,0 +1,19 @@
+# This compose parallelizes the builds of images for deployments
+
+version: '3.9'
+services:
+  host:
+    image: "testnetobscuronet.azurecr.io/obscuronet/host:latest"
+    build:
+      context: ../../
+      dockerfile: ../../dockerfiles/host.Dockerfile
+  contractdeployer:
+    image: "testnetobscuronet.azurecr.io/obscuronet/contractdeployer:latest"
+    build:
+      context: ../../
+      dockerfile: ../../testnet/contractdeployer.Dockerfile
+  enclave:
+    image: "testnetobscuronet.azurecr.io/obscuronet/enclave:latest"
+    build:
+      context: ../../
+      dockerfile: ../../dockerfiles/enclave.Dockerfile

--- a/.github/workflows/docker/docker-compose.testnet.build.yml
+++ b/.github/workflows/docker/docker-compose.testnet.build.yml
@@ -5,15 +5,15 @@ services:
   host:
     image: "testnetobscuronet.azurecr.io/obscuronet/host:latest"
     build:
-      context: ../../
-      dockerfile: ../../dockerfiles/host.Dockerfile
+      context: ../../../
+      dockerfile: ./dockerfiles/host.Dockerfile
   contractdeployer:
     image: "testnetobscuronet.azurecr.io/obscuronet/contractdeployer:latest"
     build:
-      context: ../../
-      dockerfile: ../../testnet/contractdeployer.Dockerfile
+      context: ../../../
+      dockerfile: ./testnet/contractdeployer.Dockerfile
   enclave:
     image: "testnetobscuronet.azurecr.io/obscuronet/enclave:latest"
     build:
-      context: ../../
-      dockerfile: ../../dockerfiles/enclave.Dockerfile
+      context: ../../../
+      dockerfile: ./dockerfiles/enclave.Dockerfile

--- a/.github/workflows/manual-deploy-dev-obscuroscan.yml
+++ b/.github/workflows/manual-deploy-dev-obscuroscan.yml
@@ -30,20 +30,20 @@ jobs:
       - name: 'Build and push image'
         uses: azure/docker-login@v1
         with:
-          login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
+          login-server: testnetobscuronet.azurecr.io
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
       - run: |
-          docker build -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/dev_testnet_obscuroscan:latest -f testnet/obscuroscan.Dockerfile  .
-          docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/dev_testnet_obscuroscan:latest
+          docker build -t testnetobscuronet.azurecr.io/obscuronet/dev_testnet_obscuroscan:latest -f testnet/obscuroscan.Dockerfile  .
+          docker push testnetobscuronet.azurecr.io/obscuronet/dev_testnet_obscuroscan:latest
 
       - name: 'Deploy to Azure Container Instances'
         uses: 'azure/aci-deploy@v1'
         with:
           resource-group: ${{ secrets.RESOURCE_GROUP }}
           dns-name-label: dev-testnet-obscuroscan
-          image: ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/dev_testnet_obscuroscan:latest
-          registry-login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
+          image: testnetobscuronet.azurecr.io/obscuronet/dev_testnet_obscuroscan:latest
+          registry-login-server: testnetobscuronet.azurecr.io
           registry-username: ${{ secrets.REGISTRY_USERNAME }}
           registry-password: ${{ secrets.REGISTRY_PASSWORD }}
           name: dev-testnet-obscuroscan

--- a/.github/workflows/manual-deploy-dev-testnet.yml
+++ b/.github/workflows/manual-deploy-dev-testnet.yml
@@ -18,7 +18,7 @@ on:
         default: 'dev-testnet-gethnetwork.uksouth.azurecontainer.io'
 
 jobs:
-  build-images:
+  build-push-images:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -26,33 +26,38 @@ jobs:
       - name: 'Set up Docker'
         uses: docker/setup-buildx-action@v1
 
-      - name: "Build Containers in parallel"
+      - name: "Build Images in parallel"
         run: |
           cd ./testnet
           docker compose -f ../.github/workflows/docker/docker-compose.dev-testnet.build.yml build --parallel 
-
-  deploy-l1:
-    needs: build-images
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: 'Set up Docker'
-        uses: docker/setup-buildx-action@v1
 
       - name: 'Login via Azure CLI'
         uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
-      - name: 'Build and push l1 dev image'
+      - name: 'Push dev testnet images'
         uses: azure/docker-login@v1
         with:
           login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
       - run: |
-          docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/dev_testnet_l1network:latest
+          docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/dev_testnet_l1network:latest      
+          docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/dev_enclave:latest
+          docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/dev_host:latest
+          docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/dev_contractdeployer:latest
+
+  deploy-l1:
+    needs: build-push-images
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: 'Login via Azure CLI'
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: 'Deploy to Azure Container Instances'
         uses: 'azure/aci-deploy@v1'
@@ -88,17 +93,6 @@ jobs:
         uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
-
-      - name: 'Build and push obscuro node images'
-        uses: azure/docker-login@v1
-        with:
-          login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
-          username: ${{ secrets.REGISTRY_USERNAME }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
-      - run: |
-          docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/dev_enclave:latest
-          docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/dev_host:latest
-          docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/dev_contractdeployer:latest
 
       - name: 'Deploy Contracts'
         id: deployContracts

--- a/.github/workflows/manual-deploy-dev-testnet.yml
+++ b/.github/workflows/manual-deploy-dev-testnet.yml
@@ -39,14 +39,14 @@ jobs:
       - name: 'Push dev testnet images'
         uses: azure/docker-login@v1
         with:
-          login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
+          login-server: testnetobscuronet.azurecr.io
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
       - run: |
-          docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/dev_testnet_l1network:latest      
-          docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/dev_enclave:latest
-          docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/dev_host:latest
-          docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/dev_contractdeployer:latest
+          docker push testnetobscuronet.azurecr.io/obscuronet/dev_testnet_l1network:latest      
+          docker push testnetobscuronet.azurecr.io/obscuronet/dev_enclave:latest
+          docker push testnetobscuronet.azurecr.io/obscuronet/dev_host:latest
+          docker push testnetobscuronet.azurecr.io/obscuronet/dev_contractdeployer:latest
 
   deploy-l1:
     needs: build-push-images
@@ -64,8 +64,8 @@ jobs:
         with:
           resource-group: ${{ secrets.RESOURCE_GROUP }}
           dns-name-label: dev-testnet-gethnetwork
-          image: ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/dev_testnet_l1network:latest
-          registry-login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
+          image: testnetobscuronet.azurecr.io/obscuronet/dev_testnet_l1network:latest
+          registry-login-server: testnetobscuronet.azurecr.io
           registry-username: ${{ secrets.REGISTRY_USERNAME }}
           registry-password: ${{ secrets.REGISTRY_PASSWORD }}
           name: dev-testnet-gethnetwork
@@ -98,7 +98,7 @@ jobs:
         id: deployContracts
         shell: bash
         run: |
-          ./testnet/testnet-deploy-contracts.sh --l1host=${{ github.event.inputs.L1HOST }} --pkstring=${{ secrets.GETHNETWORK_PREFUNDED_PKSTR_WORKER }} --docker_image=${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/dev_contractdeployer:latest
+          ./testnet/testnet-deploy-contracts.sh --l1host=${{ github.event.inputs.L1HOST }} --pkstring=${{ secrets.GETHNETWORK_PREFUNDED_PKSTR_WORKER }} --docker_image=testnetobscuronet.azurecr.io/obscuronet/dev_contractdeployer:latest
           source ./testnet/.env
           echo "MGMTCONTRACTADDR=$MGMTCONTRACTADDR" >> $GITHUB_ENV
           echo "HOCERC20ADDR=$HOCERC20ADDR" >> $GITHUB_ENV
@@ -265,7 +265,7 @@ jobs:
         id: deployL2Contracts
         shell: bash
         run: |
-          ./testnet/testnet-deploy-l2-contracts.sh --l2host=dev-obscuronode-0-testnet-${{ GITHUB.RUN_NUMBER }}.uksouth.cloudapp.azure.com --docker_image=${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/dev_contractdeployer:latest
+          ./testnet/testnet-deploy-l2-contracts.sh --l2host=dev-obscuronode-0-testnet-${{ GITHUB.RUN_NUMBER }}.uksouth.cloudapp.azure.com --docker_image=testnetobscuronet.azurecr.io/obscuronet/dev_contractdeployer:latest
 
   deploy-faucet:
     runs-on: ubuntu-latest

--- a/.github/workflows/manual-deploy-dev-testnet.yml
+++ b/.github/workflows/manual-deploy-dev-testnet.yml
@@ -29,7 +29,7 @@ jobs:
       - name: "Build Containers in parallel"
         run: |
           cd ./testnet
-          docker compose -f ./.github/workflows/docker/docker-compose.dev-testnet.build.yml build --parallel 
+          docker compose -f ../.github/workflows/docker/docker-compose.dev-testnet.build.yml build --parallel 
 
   deploy-l1:
     needs: build-images

--- a/.github/workflows/manual-deploy-dev-testnet.yml
+++ b/.github/workflows/manual-deploy-dev-testnet.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: "Build Containers in parallel"
         run: |
-          cd ${{ github.workspace }}/obscuro-test/utils/testnet
+          cd ./testnet
           docker compose -f ./.github/workflows/docker/docker-compose.dev-testnet.build.yml build --parallel 
 
   deploy-l1:

--- a/.github/workflows/manual-deploy-dev-testnet.yml
+++ b/.github/workflows/manual-deploy-dev-testnet.yml
@@ -32,6 +32,7 @@ jobs:
           docker compose -f ./.github/workflows/docker/docker-compose.dev-testnet.build.yml build --parallel 
 
   deploy-l1:
+    needs: build-images
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/manual-deploy-dev-testnet.yml
+++ b/.github/workflows/manual-deploy-dev-testnet.yml
@@ -18,6 +18,17 @@ on:
         default: 'dev-testnet-gethnetwork.uksouth.azurecontainer.io'
 
 jobs:
+  build-images:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: 'Set up Docker + Build Containers'
+        uses: docker/setup-buildx-action@v1
+        run: |
+          cd ${{ github.workspace }}/obscuro-test/utils/testnet
+          docker compose -f ./.github/workflows/docker/docker-compose.dev-testnet.build.yml build --parallel 
+
   deploy-l1:
     runs-on: ubuntu-latest
     steps:
@@ -38,7 +49,6 @@ jobs:
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
       - run: |
-          docker build -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/dev_testnet_l1network:latest -f testnet/gethnetwork.Dockerfile  .
           docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/dev_testnet_l1network:latest
 
       - name: 'Deploy to Azure Container Instances'
@@ -83,11 +93,8 @@ jobs:
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
       - run: |
-          docker build -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/dev_enclave:latest -f dockerfiles/enclave.Dockerfile  .
           docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/dev_enclave:latest
-          docker build -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/dev_host:latest -f dockerfiles/host.Dockerfile .
           docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/dev_host:latest
-          docker build -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/dev_contractdeployer:latest -f testnet/contractdeployer.Dockerfile .
           docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/dev_contractdeployer:latest
 
       - name: 'Deploy Contracts'

--- a/.github/workflows/manual-deploy-dev-testnet.yml
+++ b/.github/workflows/manual-deploy-dev-testnet.yml
@@ -23,8 +23,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: 'Set up Docker + Build Containers'
+      - name: 'Set up Docker'
         uses: docker/setup-buildx-action@v1
+
+      - name: "Build Containers in parallel"
         run: |
           cd ${{ github.workspace }}/obscuro-test/utils/testnet
           docker compose -f ./.github/workflows/docker/docker-compose.dev-testnet.build.yml build --parallel 

--- a/.github/workflows/manual-deploy-obscuroscan.yml
+++ b/.github/workflows/manual-deploy-obscuroscan.yml
@@ -19,7 +19,7 @@ on:
 
 env:
   AZURE_WEBAPP_NAME: testnet-obscuroscan
-  CONTAINER_REGISTRY: ${{ secrets.REGISTRY_LOGIN_SERVER }}  # set secret with Container Registry URL, example : xyz.azurecr.io 
+  CONTAINER_REGISTRY: testnetobscuronet.azurecr.io  # set secret with Container Registry URL, example : xyz.azurecr.io 
   AZURE_RESOURCE_GROUP: testnet   # set this to your Azure Resource group's name - Needed only if you are provisioning the app in the workflow
   AZURE_APP_PLAN: obscuroscan-plan  # set this to your App service plan's name - Needed only if you are provisioning the app in the workflow
   
@@ -31,22 +31,22 @@ jobs:
     - name: Azure authentication
       uses: azure/login@v1
       with:
-        login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
+        login-server: testnetobscuronet.azurecr.io
         creds: ${{ secrets.AZURE_CREDENTIALS }}
     - name: ACR authentication
       uses: azure/docker-login@v1
       with:
-        login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
+        login-server: testnetobscuronet.azurecr.io
         username: ${{ secrets.REGISTRY_USERNAME }}
         password: ${{ secrets.REGISTRY_PASSWORD }}    
     - name: Docker Build & Push to ACR
       run: |
-        docker build -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/obscuro_testnet_obscuroscan:latest -f testnet/obscuroscan.Dockerfile  .
-        docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/obscuro_testnet_obscuroscan:latest
+        docker build -t testnetobscuronet.azurecr.io/obscuronet/obscuro_testnet_obscuroscan:latest -f testnet/obscuroscan.Dockerfile  .
+        docker push testnetobscuronet.azurecr.io/obscuronet/obscuro_testnet_obscuroscan:latest
 
     - name: 'Deploy to Azure Web App for Container'
       uses: azure/webapps-deploy@v2
       with: 
         app-name: ${{ env.AZURE_WEBAPP_NAME }} 
-        images: ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/obscuro_testnet_obscuroscan:latest
+        images: testnetobscuronet.azurecr.io/obscuronet/obscuro_testnet_obscuroscan:latest
         startup-command: './tools/obscuroscan/main/main --rpcServerAddress http://testnet.obscu.ro:13000 --address 0.0.0.0:80'

--- a/.github/workflows/manual-deploy-testnet-l1.yml
+++ b/.github/workflows/manual-deploy-testnet-l1.yml
@@ -45,20 +45,20 @@ jobs:
       - name: 'Build and push image'
         uses: azure/docker-login@v1
         with:
-          login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
+          login-server: testnetobscuronet.azurecr.io
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
       - run: |
-          docker build -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/testnet_l1network:latest -f testnet/gethnetwork.Dockerfile  .
-          docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/testnet_l1network:latest
+          docker build -t testnetobscuronet.azurecr.io/obscuronet/testnet_l1network:latest -f testnet/gethnetwork.Dockerfile  .
+          docker push testnetobscuronet.azurecr.io/obscuronet/testnet_l1network:latest
 
       - name: 'Deploy to Azure Container Instances'
         uses: 'azure/aci-deploy@v1'
         with:
           resource-group: ${{ secrets.RESOURCE_GROUP }}
           dns-name-label: testnet-gethnetwork
-          image: ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/testnet_l1network:latest
-          registry-login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
+          image: testnetobscuronet.azurecr.io/obscuronet/testnet_l1network:latest
+          registry-login-server: testnetobscuronet.azurecr.io
           registry-username: ${{ secrets.REGISTRY_USERNAME }}
           registry-password: ${{ secrets.REGISTRY_PASSWORD }}
           name: testnet-gethnetwork

--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -15,7 +15,7 @@ on:
         default: 'testnet-gethnetwork.uksouth.azurecontainer.io'
 
 jobs:
-  build-images:
+  build-push-images:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -23,12 +23,29 @@ jobs:
       - name: 'Set up Docker'
         uses: docker/setup-buildx-action@v1
 
-      - name: "Build Containers in parallel"
+      - name: 'Login via Azure CLI'
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: "Build images in parallel"
         run: |
           cd ./testnet
-          docker compose -f ../.github/workflows/docker/docker-compose.testnet.build.yml build --parallel 
+          docker compose -f ../.github/workflows/docker/docker-compose.testnet.build.yml build --parallel
+
+      - name: 'Push obscuro node images'
+        uses: azure/docker-login@v1
+        with:
+          login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+      - run: |
+          docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/enclave:latest
+          docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/host:latest
+          docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/contractdeployer:latest    
 
   build:
+    needs: build-push-images
     runs-on: ubuntu-latest
     # Map a step output to a job output
     outputs:
@@ -42,17 +59,6 @@ jobs:
         uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
-
-      - name: 'Build and push obscuro node images'
-        uses: azure/docker-login@v1
-        with:
-          login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
-          username: ${{ secrets.REGISTRY_USERNAME }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
-      - run: |
-          docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/enclave:latest
-          docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/host:latest
-          docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/contractdeployer:latest
 
       - name: 'Deploy Contracts'
         id: deployContracts

--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -15,6 +15,19 @@ on:
         default: 'testnet-gethnetwork.uksouth.azurecontainer.io'
 
 jobs:
+  build-images:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: 'Set up Docker'
+        uses: docker/setup-buildx-action@v1
+
+      - name: "Build Containers in parallel"
+        run: |
+          cd ./testnet
+          docker compose -f ../.github/workflows/docker/docker-compose.testnet.build.yml build --parallel 
+
   build:
     runs-on: ubuntu-latest
     # Map a step output to a job output
@@ -37,11 +50,8 @@ jobs:
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
       - run: |
-          docker build -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/enclave:latest -f dockerfiles/enclave.Dockerfile  .
           docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/enclave:latest
-          docker build -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/host:latest -f dockerfiles/host.Dockerfile .
           docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/host:latest
-          docker build -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/contractdeployer:latest -f testnet/contractdeployer.Dockerfile .
           docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/contractdeployer:latest
 
       - name: 'Deploy Contracts'

--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -36,13 +36,13 @@ jobs:
       - name: 'Push obscuro node images'
         uses: azure/docker-login@v1
         with:
-          login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
+          login-server: testnetobscuronet.azurecr.io
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
       - run: |
-          docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/enclave:latest
-          docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/host:latest
-          docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/contractdeployer:latest    
+          docker push testnetobscuronet.azurecr.io/obscuronet/enclave:latest
+          docker push testnetobscuronet.azurecr.io/obscuronet/host:latest
+          docker push testnetobscuronet.azurecr.io/obscuronet/contractdeployer:latest    
 
   build:
     needs: build-push-images


### PR DESCRIPTION
### Why is this change needed?

- https://github.com/obscuronet/obscuro-internal/issues/1313

### What changes were made as part of this PR:

- Provide a high level list of the changes made

### Definition of done

- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
- [ ] End-to-end tests run if required (see below)

### End-to-end tests

Running the end-to-end tests in the [obscuro-test repo](https://github.com/obscuronet/obscuro-test) is currently at the 
discretion of the developer prior to merging a PR. The intention is not to slow down development by having the longer 
running end-to-end tests as a PR gate run on each branch commit etc. To manually trigger a run pre-merge;

- Go to [run_local_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_local_tests.yml)
- Click the "Run workflow" button
- Use the main branch of obscuro-test 
- Enter the name of the PR branch for go-obscuro
- Run the workflow

The run takes approximately 20 minutes and any failure will be reported in the workflow output. Should the tests fail 
the docker container output for the local testnet and all test artifacts will be added to the run and can be downloaded
for debugging and analysis, with a retention period of 2 days. 

Note that every PR merge to main will also trigger a run of post-merge tests, so even if you do not manually trigger 
pre-merge, tests will be run post-merge. The intention being to catch any issues fast on main to allow for quick 
resolution. The post-merge test output can be seen at 
[run_merge_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_merge_tests.yml) and will show both 
the PR number and author in the list of runs. 


