### PR TITLE
Uses known registry address

### DIFF
--- a/.github/workflows/manual-deploy-dev-obscuroscan.yml
+++ b/.github/workflows/manual-deploy-dev-obscuroscan.yml
@@ -30,20 +30,20 @@ jobs:
       - name: 'Build and push image'
         uses: azure/docker-login@v1
         with:
-          login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
+          login-server: testnetobscuronet.azurecr.io
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
       - run: |
-          docker build -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/dev_testnet_obscuroscan:latest -f testnet/obscuroscan.Dockerfile  .
-          docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/dev_testnet_obscuroscan:latest
+          docker build -t testnetobscuronet.azurecr.io/obscuronet/dev_testnet_obscuroscan:latest -f testnet/obscuroscan.Dockerfile  .
+          docker push testnetobscuronet.azurecr.io/obscuronet/dev_testnet_obscuroscan:latest
 
       - name: 'Deploy to Azure Container Instances'
         uses: 'azure/aci-deploy@v1'
         with:
           resource-group: ${{ secrets.RESOURCE_GROUP }}
           dns-name-label: dev-testnet-obscuroscan
-          image: ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/dev_testnet_obscuroscan:latest
-          registry-login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
+          image: testnetobscuronet.azurecr.io/obscuronet/dev_testnet_obscuroscan:latest
+          registry-login-server: testnetobscuronet.azurecr.io
           registry-username: ${{ secrets.REGISTRY_USERNAME }}
           registry-password: ${{ secrets.REGISTRY_PASSWORD }}
           name: dev-testnet-obscuroscan

--- a/.github/workflows/manual-deploy-dev-testnet.yml
+++ b/.github/workflows/manual-deploy-dev-testnet.yml
@@ -34,20 +34,20 @@ jobs:
       - name: 'Build and push l1 dev image'
         uses: azure/docker-login@v1
         with:
-          login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
+          login-server: testnetobscuronet.azurecr.io
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
       - run: |
-          docker build -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/dev_testnet_l1network:latest -f testnet/gethnetwork.Dockerfile  .
-          docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/dev_testnet_l1network:latest
+          docker build -t testnetobscuronet.azurecr.io/obscuronet/dev_testnet_l1network:latest -f testnet/gethnetwork.Dockerfile  .
+          docker push testnetobscuronet.azurecr.io/obscuronet/dev_testnet_l1network:latest
 
       - name: 'Deploy to Azure Container Instances'
         uses: 'azure/aci-deploy@v1'
         with:
           resource-group: ${{ secrets.RESOURCE_GROUP }}
           dns-name-label: dev-testnet-gethnetwork
-          image: ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/dev_testnet_l1network:latest
-          registry-login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
+          image: testnetobscuronet.azurecr.io/obscuronet/dev_testnet_l1network:latest
+          registry-login-server: testnetobscuronet.azurecr.io
           registry-username: ${{ secrets.REGISTRY_USERNAME }}
           registry-password: ${{ secrets.REGISTRY_PASSWORD }}
           name: dev-testnet-gethnetwork
@@ -79,22 +79,22 @@ jobs:
       - name: 'Build and push obscuro node images'
         uses: azure/docker-login@v1
         with:
-          login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
+          login-server: testnetobscuronet.azurecr.io
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
       - run: |
-          docker build -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/dev_enclave:latest -f dockerfiles/enclave.Dockerfile  .
-          docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/dev_enclave:latest
-          docker build -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/dev_host:latest -f dockerfiles/host.Dockerfile .
-          docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/dev_host:latest
-          docker build -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/dev_contractdeployer:latest -f testnet/contractdeployer.Dockerfile .
-          docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/dev_contractdeployer:latest
+          docker build -t testnetobscuronet.azurecr.io/obscuronet/dev_enclave:latest -f dockerfiles/enclave.Dockerfile  .
+          docker push testnetobscuronet.azurecr.io/obscuronet/dev_enclave:latest
+          docker build -t testnetobscuronet.azurecr.io/obscuronet/dev_host:latest -f dockerfiles/host.Dockerfile .
+          docker push testnetobscuronet.azurecr.io/obscuronet/dev_host:latest
+          docker build -t testnetobscuronet.azurecr.io/obscuronet/dev_contractdeployer:latest -f testnet/contractdeployer.Dockerfile .
+          docker push testnetobscuronet.azurecr.io/obscuronet/dev_contractdeployer:latest
 
       - name: 'Deploy Contracts'
         id: deployContracts
         shell: bash
         run: |
-          ./testnet/testnet-deploy-contracts.sh --l1host=${{ github.event.inputs.L1HOST }} --pkstring=${{ secrets.GETHNETWORK_PREFUNDED_PKSTR_WORKER }} --docker_image=${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/dev_contractdeployer:latest
+          ./testnet/testnet-deploy-contracts.sh --l1host=${{ github.event.inputs.L1HOST }} --pkstring=${{ secrets.GETHNETWORK_PREFUNDED_PKSTR_WORKER }} --docker_image=testnetobscuronet.azurecr.io/obscuronet/dev_contractdeployer:latest
           source ./testnet/.env
           echo "MGMTCONTRACTADDR=$MGMTCONTRACTADDR" >> $GITHUB_ENV
           echo "HOCERC20ADDR=$HOCERC20ADDR" >> $GITHUB_ENV
@@ -261,7 +261,7 @@ jobs:
         id: deployL2Contracts
         shell: bash
         run: |
-          ./testnet/testnet-deploy-l2-contracts.sh --l2host=dev-obscuronode-0-testnet-${{ GITHUB.RUN_NUMBER }}.uksouth.cloudapp.azure.com --docker_image=${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/dev_contractdeployer:latest
+          ./testnet/testnet-deploy-l2-contracts.sh --l2host=dev-obscuronode-0-testnet-${{ GITHUB.RUN_NUMBER }}.uksouth.cloudapp.azure.com --docker_image=testnetobscuronet.azurecr.io/obscuronet/dev_contractdeployer:latest
 
   deploy-faucet:
     runs-on: ubuntu-latest

--- a/.github/workflows/manual-deploy-obscuroscan.yml
+++ b/.github/workflows/manual-deploy-obscuroscan.yml
@@ -19,7 +19,7 @@ on:
 
 env:
   AZURE_WEBAPP_NAME: testnet-obscuroscan
-  CONTAINER_REGISTRY: ${{ secrets.REGISTRY_LOGIN_SERVER }}  # set secret with Container Registry URL, example : xyz.azurecr.io 
+  CONTAINER_REGISTRY: testnetobscuronet.azurecr.io  # set secret with Container Registry URL, example : xyz.azurecr.io 
   AZURE_RESOURCE_GROUP: testnet   # set this to your Azure Resource group's name - Needed only if you are provisioning the app in the workflow
   AZURE_APP_PLAN: obscuroscan-plan  # set this to your App service plan's name - Needed only if you are provisioning the app in the workflow
   
@@ -31,22 +31,22 @@ jobs:
     - name: Azure authentication
       uses: azure/login@v1
       with:
-        login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
+        login-server: testnetobscuronet.azurecr.io
         creds: ${{ secrets.AZURE_CREDENTIALS }}
     - name: ACR authentication
       uses: azure/docker-login@v1
       with:
-        login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
+        login-server: testnetobscuronet.azurecr.io
         username: ${{ secrets.REGISTRY_USERNAME }}
         password: ${{ secrets.REGISTRY_PASSWORD }}    
     - name: Docker Build & Push to ACR
       run: |
-        docker build -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/obscuro_testnet_obscuroscan:latest -f testnet/obscuroscan.Dockerfile  .
-        docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/obscuro_testnet_obscuroscan:latest
+        docker build -t testnetobscuronet.azurecr.io/obscuronet/obscuro_testnet_obscuroscan:latest -f testnet/obscuroscan.Dockerfile  .
+        docker push testnetobscuronet.azurecr.io/obscuronet/obscuro_testnet_obscuroscan:latest
 
     - name: 'Deploy to Azure Web App for Container'
       uses: azure/webapps-deploy@v2
       with: 
         app-name: ${{ env.AZURE_WEBAPP_NAME }} 
-        images: ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/obscuro_testnet_obscuroscan:latest
+        images: testnetobscuronet.azurecr.io/obscuronet/obscuro_testnet_obscuroscan:latest
         startup-command: './tools/obscuroscan/main/main --rpcServerAddress http://testnet.obscu.ro:13000 --address 0.0.0.0:80'

--- a/.github/workflows/manual-deploy-testnet-l1.yml
+++ b/.github/workflows/manual-deploy-testnet-l1.yml
@@ -45,20 +45,20 @@ jobs:
       - name: 'Build and push image'
         uses: azure/docker-login@v1
         with:
-          login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
+          login-server: testnetobscuronet.azurecr.io
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
       - run: |
-          docker build -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/testnet_l1network:latest -f testnet/gethnetwork.Dockerfile  .
-          docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/testnet_l1network:latest
+          docker build -t testnetobscuronet.azurecr.io/obscuronet/testnet_l1network:latest -f testnet/gethnetwork.Dockerfile  .
+          docker push testnetobscuronet.azurecr.io/obscuronet/testnet_l1network:latest
 
       - name: 'Deploy to Azure Container Instances'
         uses: 'azure/aci-deploy@v1'
         with:
           resource-group: ${{ secrets.RESOURCE_GROUP }}
           dns-name-label: testnet-gethnetwork
-          image: ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/testnet_l1network:latest
-          registry-login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
+          image: testnetobscuronet.azurecr.io/obscuronet/testnet_l1network:latest
+          registry-login-server: testnetobscuronet.azurecr.io
           registry-username: ${{ secrets.REGISTRY_USERNAME }}
           registry-password: ${{ secrets.REGISTRY_PASSWORD }}
           name: testnet-gethnetwork

--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -33,16 +33,16 @@ jobs:
       - name: 'Build and push obscuro node images'
         uses: azure/docker-login@v1
         with:
-          login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
+          login-server: testnetobscuronet.azurecr.io
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
       - run: |
-          docker build -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/enclave:latest -f dockerfiles/enclave.Dockerfile  .
-          docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/enclave:latest
-          docker build -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/host:latest -f dockerfiles/host.Dockerfile .
-          docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/host:latest
-          docker build -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/contractdeployer:latest -f testnet/contractdeployer.Dockerfile .
-          docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/obscuronet/contractdeployer:latest
+          docker build -t testnetobscuronet.azurecr.io/obscuronet/enclave:latest -f dockerfiles/enclave.Dockerfile  .
+          docker push testnetobscuronet.azurecr.io/obscuronet/enclave:latest
+          docker build -t testnetobscuronet.azurecr.io/obscuronet/host:latest -f dockerfiles/host.Dockerfile .
+          docker push testnetobscuronet.azurecr.io/obscuronet/host:latest
+          docker build -t testnetobscuronet.azurecr.io/obscuronet/contractdeployer:latest -f testnet/contractdeployer.Dockerfile .
+          docker push testnetobscuronet.azurecr.io/obscuronet/contractdeployer:latest
 
       - name: 'Deploy Contracts'
         id: deployContracts


### PR DESCRIPTION
### Why is this change needed?

- As per title, stops using a secret for the registry name

### What changes were made as part of this PR:

- Provide a high level list of the changes made

### Definition of done

- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
- [ ] End-to-end tests run if required (see below)

### End-to-end tests

Running the end-to-end tests in the [obscuro-test repo](https://github.com/obscuronet/obscuro-test) is currently at the 
discretion of the developer prior to merging a PR. The intention is not to slow down development by having the longer 
running end-to-end tests as a PR gate run on each branch commit etc. To manually trigger a run pre-merge;

- Go to [run_local_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_local_tests.yml)
- Click the "Run workflow" button
- Use the main branch of obscuro-test 
- Enter the name of the PR branch for go-obscuro
- Run the workflow

The run takes approximately 20 minutes and any failure will be reported in the workflow output. Should the tests fail 
the docker container output for the local testnet and all test artifacts will be added to the run and can be downloaded
for debugging and analysis, with a retention period of 2 days. 

Note that every PR merge to main will also trigger a run of post-merge tests, so even if you do not manually trigger 
pre-merge, tests will be run post-merge. The intention being to catch any issues fast on main to allow for quick 
resolution. The post-merge test output can be seen at 
[run_merge_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_merge_tests.yml) and will show both 
the PR number and author in the list of runs. 


