### PR TITLE
Deployments wait until node 0 is healthy

### DIFF
--- a/.github/workflows/manual-deploy-dev-testnet.yml
+++ b/.github/workflows/manual-deploy-dev-testnet.yml
@@ -225,6 +225,7 @@ jobs:
 
 
 
+
   update-loadbalancer:
     needs: deploy-l2
     runs-on: ubuntu-latest
@@ -250,9 +251,20 @@ jobs:
               --resource-group Testnet \
               --lb-name dev-testnet-loadbalancer
 
+  wait-node-up:
+    needs: deploy-l2
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: "Wait until obscuro node is healthy"
+        shell: bash
+        run: |
+          ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=dev-obscuronode-0-testnet-${{ GITHUB.RUN_NUMBER }}.uksouth.cloudapp.azure.com
+
 
   deploy-l2-contracts:
-    needs: deploy-l2
+    needs: wait-node-up
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -201,8 +201,19 @@ jobs:
               --resource-group Testnet \
               --lb-name testnet-loadbalancer
 
+  wait-node-up:
+    needs: deploy-l2
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: "Wait until obscuro node is healthy"
+        shell: bash
+        run: |
+          ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-0-testnet-${{ GITHUB.RUN_NUMBER }}.uksouth.cloudapp.azure.com
+
   deploy-l2-contracts:
-    needs: deploy
+    needs: wait-node-up
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/runner-scripts/wait-node-healthy.sh
+++ b/.github/workflows/runner-scripts/wait-node-healthy.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+#
+# This script checks and waits for an obscuro node to be healthy
+#
+#
+
+help_and_exit() {
+    echo ""
+    echo "Usage: "
+    echo "   ex: "
+    echo "      -  $(basename "${0}") --host=testnet.obscu.ro --port=13000"
+    echo ""
+    echo "  node             *Required* Set the host address"
+    echo ""
+    echo "  port             *Optional* Set the host port. Defaults to 13000"
+    echo ""
+    echo "  timeout          *Optional* Set timeout in seconds. Defaults to 5*60 seconds"
+    echo ""
+    exit 1  # Exit with error explicitly
+}
+# Ensure any fail is loud and explicit
+set -euo pipefail
+
+# Define local usage vars
+start_path="$(cd "$(dirname "${0}")" && pwd)"
+testnet_path="${start_path}"
+
+# Defaults
+port=13000
+timeout=5*60
+
+# Fetch options
+for argument in "$@"
+do
+    key=$(echo $argument | cut -f1 -d=)
+    value=$(echo $argument | cut -f2 -d=)
+
+    case "$key" in
+            --host)                   host=${value} ;;
+            --port)                   port=${value} ;;
+            --timeout)                timeout=${value} ;;
+
+            --help)                     help_and_exit ;;
+            *)
+    esac
+done
+
+if [[ -z ${host:-} ]];
+then
+    help_and_exit
+fi
+
+net_status=""
+time=0
+
+while ! [[ $net_status = *\"OverallHealth\":true* ]]
+do
+    net_status=$(curl -s --request POST "http://${host}:${port}" \
+                 --header 'Content-Type: application/json' \
+                 --data-raw '{ "method":"obscuro_health", "params":null, "id":1, "jsonrpc":"2.0" }')
+     echo $net_status
+
+    sleep 1
+    ((time=time+1))
+
+    if [[ $time == $timeout ]] ;
+    then
+      echo "Node not healthy after timeout!"
+      exit 1
+    fi
+done
+
+echo "Node up and running!"
+exit 0


### PR DESCRIPTION
### Why is this change needed?

- CI now wait for the sequencer to healthy before proceeding
- https://github.com/obscuronet/obscuro-internal/issues/1307

### What changes were made as part of this PR:

- Provide a high level list of the changes made

### Definition of done

- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
- [ ] End-to-end tests run if required (see below)

### End-to-end tests

Running the end-to-end tests in the [obscuro-test repo](https://github.com/obscuronet/obscuro-test) is currently at the 
discretion of the developer prior to merging a PR. The intention is not to slow down development by having the longer 
running end-to-end tests as a PR gate run on each branch commit etc. To manually trigger a run pre-merge;

- Go to [run_local_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_local_tests.yml)
- Click the "Run workflow" button
- Use the main branch of obscuro-test 
- Enter the name of the PR branch for go-obscuro
- Run the workflow

The run takes approximately 20 minutes and any failure will be reported in the workflow output. Should the tests fail 
the docker container output for the local testnet and all test artifacts will be added to the run and can be downloaded
for debugging and analysis, with a retention period of 2 days. 

Note that every PR merge to main will also trigger a run of post-merge tests, so even if you do not manually trigger 
pre-merge, tests will be run post-merge. The intention being to catch any issues fast on main to allow for quick 
resolution. The post-merge test output can be seen at 
[run_merge_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_merge_tests.yml) and will show both 
the PR number and author in the list of runs. 


