### PR TITLE
Adds native transfers to the tx injector

### DIFF
--- a/go/obsclient/authclient.go
+++ b/go/obsclient/authclient.go
@@ -140,7 +140,7 @@ func (ac *AuthObsClient) EstimateGas(ctx context.Context, msg *ethereum.CallMsg)
 	return hexutil.DecodeUint64(result)
 }
 
-func (ac *AuthObsClient) EstimateGasAndGasPrice(txData types.TxData) (types.TxData, error) {
+func (ac *AuthObsClient) EstimateGasAndGasPrice(txData types.TxData) types.TxData {
 	unEstimatedTx := types.NewTx(txData)
 	gasPrice := gethcommon.Big1 // constant gas price atm
 
@@ -161,5 +161,5 @@ func (ac *AuthObsClient) EstimateGasAndGasPrice(txData types.TxData) (types.TxDa
 		To:       unEstimatedTx.To(),
 		Value:    unEstimatedTx.Value(),
 		Data:     unEstimatedTx.Data(),
-	}, nil
+	}
 }

--- a/integration/simulation/transaction_injector.go
+++ b/integration/simulation/transaction_injector.go
@@ -134,6 +134,11 @@ func (ti *TransactionInjector) Start() {
 	})
 
 	wg.Go(func() error {
+		ti.issueRandomValueTransfers()
+		return nil
+	})
+
+	wg.Go(func() error {
 		ti.issueInvalidL2Txs()
 		return nil
 	})
@@ -147,6 +152,55 @@ func (ti *TransactionInjector) Stop() {
 	for range ti.fullyStoppedChan {
 		ti.logger.Info("TransactionInjector stopped successfully")
 		return
+	}
+}
+
+// issueRandomValueTransfers creates and issues a number of L2 value transfer transactions proportional to the simulation time, such that they can be processed
+func (ti *TransactionInjector) issueRandomValueTransfers() {
+	for txCounter := 0; ti.shouldKeepIssuing(txCounter); txCounter++ {
+		fromWallet := ti.rndObsWallet()
+		toWallet := ti.rndObsWallet()
+		obscuroClient := ti.rpcHandles.ObscuroWalletRndClient(fromWallet)
+		// We avoid transfers to self, unless there is only a single L2 wallet.
+		for len(ti.wallets.SimObsWallets) > 1 && fromWallet.Address().Hex() == toWallet.Address().Hex() {
+			toWallet = ti.rndObsWallet()
+		}
+		toWalletAddr := toWallet.Address()
+		txData := &types.LegacyTx{
+			Nonce:    fromWallet.GetNonceAndIncrement(),
+			Value:    big.NewInt(int64(testcommon.RndBtw(1, 500))),
+			Gas:      uint64(1_000_000),
+			GasPrice: gethcommon.Big1,
+			To:       &toWalletAddr,
+		}
+		//tx := ti.newObscuroTransferTx(fromWallet, toWallet.Address(), testcommon.RndBtw(1, 500))
+		tx, err := obscuroClient.EstimateGasAndGasPrice(txData)
+		if err != nil {
+			panic(err)
+		}
+		signedTx, err := fromWallet.SignTransaction(tx)
+		if err != nil {
+			panic(err)
+		}
+		ti.logger.Info(fmt.Sprintf(
+			"Transfer transaction injected into L2. Hash: %d. From address: %d. To address: %d",
+			common.ShortHash(signedTx.Hash()),
+			common.ShortAddress(fromWallet.Address()),
+			common.ShortAddress(toWallet.Address()),
+		))
+
+		ti.stats.Transfer()
+
+		err = obscuroClient.SendTransaction(ti.ctx, signedTx)
+		if err != nil {
+			ti.logger.Info("Failed to issue transfer via RPC.", log.ErrKey, err)
+			continue
+		}
+
+		// todo - retrieve receipt
+
+		go ti.TxTracker.trackNativeValueTransferL2Tx(signedTx)
+		sleepRndBtw(ti.avgBlockDuration/4, ti.avgBlockDuration)
 	}
 }
 

--- a/integration/simulation/transaction_injector.go
+++ b/integration/simulation/transaction_injector.go
@@ -173,7 +173,7 @@ func (ti *TransactionInjector) issueRandomValueTransfers() {
 			GasPrice: gethcommon.Big1,
 			To:       &toWalletAddr,
 		}
-		//tx := ti.newObscuroTransferTx(fromWallet, toWallet.Address(), testcommon.RndBtw(1, 500))
+		// tx := ti.newObscuroTransferTx(fromWallet, toWallet.Address(), testcommon.RndBtw(1, 500))
 		tx, err := obscuroClient.EstimateGasAndGasPrice(txData)
 		if err != nil {
 			panic(err)

--- a/integration/simulation/transaction_injector.go
+++ b/integration/simulation/transaction_injector.go
@@ -173,11 +173,8 @@ func (ti *TransactionInjector) issueRandomValueTransfers() {
 			GasPrice: gethcommon.Big1,
 			To:       &toWalletAddr,
 		}
-		// tx := ti.newObscuroTransferTx(fromWallet, toWallet.Address(), testcommon.RndBtw(1, 500))
-		tx, err := obscuroClient.EstimateGasAndGasPrice(txData)
-		if err != nil {
-			panic(err)
-		}
+
+		tx := obscuroClient.EstimateGasAndGasPrice(txData)
 		signedTx, err := fromWallet.SignTransaction(tx)
 		if err != nil {
 			panic(err)
@@ -206,8 +203,6 @@ func (ti *TransactionInjector) issueRandomValueTransfers() {
 
 // issueRandomTransfers creates and issues a number of L2 transfer transactions proportional to the simulation time, such that they can be processed
 func (ti *TransactionInjector) issueRandomTransfers() {
-	var err error
-
 	for txCounter := 0; ti.shouldKeepIssuing(txCounter); txCounter++ {
 		fromWallet := ti.rndObsWallet()
 		toWallet := ti.rndObsWallet()
@@ -217,10 +212,7 @@ func (ti *TransactionInjector) issueRandomTransfers() {
 			toWallet = ti.rndObsWallet()
 		}
 		tx := ti.newObscuroTransferTx(fromWallet, toWallet.Address(), testcommon.RndBtw(1, 500))
-		tx, err = obscuroClient.EstimateGasAndGasPrice(tx)
-		if err != nil {
-			panic(err)
-		}
+		tx = obscuroClient.EstimateGasAndGasPrice(tx)
 		signedTx, err := fromWallet.SignTransaction(tx)
 		if err != nil {
 			panic(err)

--- a/integration/simulation/transaction_injector_tracker.go
+++ b/integration/simulation/transaction_injector_tracker.go
@@ -11,11 +11,12 @@ import (
 )
 
 type txInjectorTracker struct {
-	l1TransactionsLock       sync.RWMutex
-	L1Transactions           []ethadapter.L1Transaction
-	l2TransactionsLock       sync.RWMutex
-	TransferL2Transactions   []*common.L2Tx
-	WithdrawalL2Transactions []*common.L2Tx
+	l1TransactionsLock                sync.RWMutex
+	L1Transactions                    []ethadapter.L1Transaction
+	l2TransactionsLock                sync.RWMutex
+	TransferL2Transactions            []*common.L2Tx
+	NativeValueTransferL2Transactions []*common.L2Tx
+	WithdrawalL2Transactions          []*common.L2Tx
 }
 
 func newCounter() *txInjectorTracker {
@@ -47,14 +48,20 @@ func (m *txInjectorTracker) trackTransferL2Tx(tx *common.L2Tx) {
 	m.TransferL2Transactions = append(m.TransferL2Transactions, tx)
 }
 
+func (m *txInjectorTracker) trackNativeValueTransferL2Tx(tx *common.L2Tx) {
+	m.l2TransactionsLock.Lock()
+	defer m.l2TransactionsLock.Unlock()
+	m.NativeValueTransferL2Transactions = append(m.TransferL2Transactions, tx)
+}
+
 // GetL1Transactions returns all generated L1 L2Txs
 func (m *txInjectorTracker) GetL1Transactions() []ethadapter.L1Transaction {
 	return m.L1Transactions
 }
 
 // GetL2Transactions returns all generated non-WithdrawalTx transactions, excluding prefund and ERC20 deploy transactions.
-func (m *txInjectorTracker) GetL2Transactions() ([]*common.L2Tx, []*common.L2Tx) {
-	return m.TransferL2Transactions, m.WithdrawalL2Transactions
+func (m *txInjectorTracker) GetL2Transactions() ([]*common.L2Tx, []*common.L2Tx, []*common.L2Tx) {
+	return m.TransferL2Transactions, m.WithdrawalL2Transactions, m.NativeValueTransferL2Transactions
 }
 
 // GetL2WithdrawalRequests returns generated stored WithdrawalTx transactions, excluding prefund and ERC20 deploy transactions.

--- a/tools/networkmanager/inject_txs.go
+++ b/tools/networkmanager/inject_txs.go
@@ -205,19 +205,19 @@ func checkL2TxsSuccessful(ctx context.Context, rpcHandles *network.RPCHandles, t
 	injectedNativeTransfers := len(txInjector.TxTracker.NativeValueTransferL2Transactions)
 	notFoundTransfers, notFoundWithdrawals, notFoundNativeTransfers := simulation.FindNotIncludedL2Txs(ctx, 0, rpcHandles, txInjector)
 
-	if notFoundTransfers != 0 {
+	if notFoundTransfers > 0 {
 		println(fmt.Sprintf("Injected %d transfers into the L2 but %d were missing.", injectedTransfers, notFoundTransfers))
 	} else {
 		println(fmt.Sprintf("Successfully injected %d transfers into the L1.", injectedTransfers))
 	}
 
-	if notFoundWithdrawals != 0 {
+	if notFoundWithdrawals > 0 {
 		println(fmt.Sprintf("Injected %d withdrawals into the L2 but %d were missing.", injectedWithdrawals, notFoundWithdrawals))
 	} else {
 		println(fmt.Sprintf("Successfully injected %d withdrawals into the L1.", injectedWithdrawals))
 	}
 
-	if notFoundNativeTransfers != 0 {
+	if notFoundNativeTransfers > 0 {
 		println(fmt.Sprintf("Injected %d native transfers into the L2 but %d were missing.", injectedNativeTransfers, notFoundNativeTransfers))
 	} else {
 		println(fmt.Sprintf("Successfully injected %d withdrawals into the L1.", injectedNativeTransfers))

--- a/tools/networkmanager/inject_txs.go
+++ b/tools/networkmanager/inject_txs.go
@@ -202,7 +202,8 @@ func checkDepositsSuccessful(txInjector *simulation.TransactionInjector, l1Clien
 func checkL2TxsSuccessful(ctx context.Context, rpcHandles *network.RPCHandles, txInjector *simulation.TransactionInjector) {
 	injectedTransfers := len(txInjector.TxTracker.TransferL2Transactions)
 	injectedWithdrawals := len(txInjector.TxTracker.WithdrawalL2Transactions)
-	notFoundTransfers, notFoundWithdrawals := simulation.FindNotIncludedL2Txs(ctx, 0, rpcHandles, txInjector)
+	injectedNativeTransfers := len(txInjector.TxTracker.NativeValueTransferL2Transactions)
+	notFoundTransfers, notFoundWithdrawals, notFoundNativeTransfers := simulation.FindNotIncludedL2Txs(ctx, 0, rpcHandles, txInjector)
 
 	if notFoundTransfers != 0 {
 		println(fmt.Sprintf("Injected %d transfers into the L2 but %d were missing.", injectedTransfers, notFoundTransfers))
@@ -214,5 +215,11 @@ func checkL2TxsSuccessful(ctx context.Context, rpcHandles *network.RPCHandles, t
 		println(fmt.Sprintf("Injected %d withdrawals into the L2 but %d were missing.", injectedWithdrawals, notFoundWithdrawals))
 	} else {
 		println(fmt.Sprintf("Successfully injected %d withdrawals into the L1.", injectedWithdrawals))
+	}
+
+	if notFoundNativeTransfers != 0 {
+		println(fmt.Sprintf("Injected %d native transfers into the L2 but %d were missing.", injectedNativeTransfers, notFoundNativeTransfers))
+	} else {
+		println(fmt.Sprintf("Successfully injected %d withdrawals into the L1.", injectedNativeTransfers))
 	}
 }


### PR DESCRIPTION
### Why is this change needed?

- https://github.com/obscuronet/obscuro-internal/issues/1294

### What changes were made as part of this PR:

- Provide a high level list of the changes made

### Definition of done

- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
- [ ] End-to-end tests run if required (see below)

### End-to-end tests

Running the end-to-end tests in the [obscuro-test repo](https://github.com/obscuronet/obscuro-test) is currently at the 
discretion of the developer prior to merging a PR. The intention is not to slow down development by having the longer 
running end-to-end tests as a PR gate run on each branch commit etc. To manually trigger a run pre-merge;

- Go to [run_local_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_local_tests.yml)
- Click the "Run workflow" button
- Use the main branch of obscuro-test 
- Enter the name of the PR branch for go-obscuro
- Run the workflow

The run takes approximately 20 minutes and any failure will be reported in the workflow output. Should the tests fail 
the docker container output for the local testnet and all test artifacts will be added to the run and can be downloaded
for debugging and analysis, with a retention period of 2 days. 

Note that every PR merge to main will also trigger a run of post-merge tests, so even if you do not manually trigger 
pre-merge, tests will be run post-merge. The intention being to catch any issues fast on main to allow for quick 
resolution. The post-merge test output can be seen at 
[run_merge_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_merge_tests.yml) and will show both 
the PR number and author in the list of runs. 


