### PR TITLE
Testnet metrics are pushed to datadog

### DIFF
--- a/.github/workflows/manual-deploy-dev-testnet.yml
+++ b/.github/workflows/manual-deploy-dev-testnet.yml
@@ -207,6 +207,9 @@ jobs:
                -v /proc/:/host/proc/:ro \
                -v /opt/datadog-agent/run:/opt/datadog-agent/run:rw \
                -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
+               -l com.datadoghq.ad.check_names='["openmetrics"]' \
+               -l com.datadoghq.ad.init_configs='[{}]' \
+               -l com.datadoghq.ad.instances='["{\"openmetrics_endpoint\":\"http://%%host%%:14000/debug/metrics \",\"namespace\":\"obscuro_namespace\",\"metrics\":[\".*\"]}"]' \
                datadog/agent:latest \
             && cd /home/obscuro/go-obscuro/testnet/ \
             && ./start-obscuro-node.sh \

--- a/.github/workflows/manual-deploy-dev-testnet.yml
+++ b/.github/workflows/manual-deploy-dev-testnet.yml
@@ -196,6 +196,7 @@ jobs:
             && sudo apt-get update \
             && sudo apt-get install -y jq \
             && curl -fsSL https://get.docker.com -o get-docker.sh && sh ./get-docker.sh \
+            && docker network create --driver bridge node_network || true \
             && docker run -d --name datadog-agent \
                --network node_network \
                -e DD_API_KEY=${{ secrets.DD_API_KEY }} \

--- a/.github/workflows/manual-deploy-dev-testnet.yml
+++ b/.github/workflows/manual-deploy-dev-testnet.yml
@@ -207,9 +207,6 @@ jobs:
                -v /proc/:/host/proc/:ro \
                -v /opt/datadog-agent/run:/opt/datadog-agent/run:rw \
                -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
-               -l com.datadoghq.ad.check_names='["openmetrics"]' \
-               -l com.datadoghq.ad.init_configs='[{}]' \
-               -l com.datadoghq.ad.instances='["{\"openmetrics_endpoint\":\"http://%%host%%:14000/debug/metrics \",\"namespace\":\"obscuro_namespace\",\"metrics\":[\".*\"]}"]' \
                datadog/agent:latest \
             && cd /home/obscuro/go-obscuro/testnet/ \
             && ./start-obscuro-node.sh \

--- a/.github/workflows/manual-deploy-dev-testnet.yml
+++ b/.github/workflows/manual-deploy-dev-testnet.yml
@@ -197,6 +197,7 @@ jobs:
             && sudo apt-get install -y jq \
             && curl -fsSL https://get.docker.com -o get-docker.sh && sh ./get-docker.sh \
             && docker run -d --name datadog-agent \
+               --network node_network \
                -e DD_API_KEY=${{ secrets.DD_API_KEY }} \
                -e DD_LOGS_ENABLED=true \
                -e DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true \

--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -160,9 +160,6 @@ jobs:
                -v /proc/:/host/proc/:ro \
                -v /opt/datadog-agent/run:/opt/datadog-agent/run:rw \
                -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
-               -l com.datadoghq.ad.check_names='["openmetrics"]' \
-               -l com.datadoghq.ad.init_configs='[{}]' \
-               -l com.datadoghq.ad.instances='["{\"openmetrics_endpoint\":\"http://%%host%%:14000/debug/metrics \",\"namespace\":\"obscuro_namespace\",\"metrics\":[\".*\"]}"]' \
                datadog/agent:latest \
             && cd /home/obscuro/go-obscuro/testnet/ \
             && ./start-obscuro-node.sh \

--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -160,6 +160,9 @@ jobs:
                -v /proc/:/host/proc/:ro \
                -v /opt/datadog-agent/run:/opt/datadog-agent/run:rw \
                -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
+               -l com.datadoghq.ad.check_names='["openmetrics"]' \
+               -l com.datadoghq.ad.init_configs='[{}]' \
+               -l com.datadoghq.ad.instances='["{\"openmetrics_endpoint\":\"http://%%host%%:14000/debug/metrics \",\"namespace\":\"obscuro_namespace\",\"metrics\":[\".*\"]}"]' \
                datadog/agent:latest \
             && cd /home/obscuro/go-obscuro/testnet/ \
             && ./start-obscuro-node.sh \

--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -150,6 +150,7 @@ jobs:
             && sudo apt-get install -y jq \
             && curl -fsSL https://get.docker.com -o get-docker.sh && sh ./get-docker.sh \
             && docker run -d --name datadog-agent \
+               --network node_network \
                -e DD_API_KEY=${{ secrets.DD_API_KEY }} \
                -e DD_LOGS_ENABLED=true \
                -e DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true \

--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -149,6 +149,7 @@ jobs:
             && sudo apt-get update \
             && sudo apt-get install -y jq \
             && curl -fsSL https://get.docker.com -o get-docker.sh && sh ./get-docker.sh \
+             && docker network create --driver bridge node_network || true \
             && docker run -d --name datadog-agent \
                --network node_network \
                -e DD_API_KEY=${{ secrets.DD_API_KEY }} \

--- a/.github/workflows/runner-scripts/wait-node-healthy.sh
+++ b/.github/workflows/runner-scripts/wait-node-healthy.sh
@@ -56,10 +56,10 @@ time=0
 
 while ! [[ $net_status = *\"OverallHealth\":true* ]]
 do
-    net_status=$(curl -s --request POST "http://${host}:${port}" \
+    net_status=$(curl --request POST "http://${host}:${port}" \
                  --header 'Content-Type: application/json' \
-                 --data-raw '{ "method":"obscuro_health", "params":null, "id":1, "jsonrpc":"2.0" }')
-     echo $net_status
+                 --data-raw '{ "method":"obscuro_health", "params":null, "id":1, "jsonrpc":"2.0" }') || true
+    echo $net_status
 
     sleep 1
     ((time=time+1))

--- a/testnet/docker-compose.dev-testnet.yml
+++ b/testnet/docker-compose.dev-testnet.yml
@@ -29,7 +29,7 @@ services:
       com.datadoghq.ad.instances: |
         [
           {
-            "openmetrics_endpoint": "http://%%host%%:14000/debug/metrics/prometheus",
+            "openmetrics_endpoint": "http://host:14000/debug/metrics/prometheus",
             "namespace": "host",
             "metrics": [
               ".*"

--- a/testnet/docker-compose.dev-testnet.yml
+++ b/testnet/docker-compose.dev-testnet.yml
@@ -23,6 +23,19 @@ services:
       - PROFILERENABLED=some_bool
       - P2PPUBLICADDRESS=some_string
       - LOGLEVEL=some_int
+    labels:
+      com.datadoghq.ad.check_names: '["openmetrics"]'
+      com.datadoghq.ad.init_configs: '[{}]'
+      com.datadoghq.ad.instances: |
+        [
+          {
+            "openmetrics_endpoint": "http://%%host%%:14000/debug/metrics/prometheus",
+            "namespace": "host",
+            "metrics": [
+              ".*"
+            ]
+          }
+        ]
     image: testnetobscuronet.azurecr.io/obscuronet/dev_host:latest
     entrypoint: [
       "/home/go-obscuro/go/host/main/main",

--- a/testnet/docker-compose.yml
+++ b/testnet/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       com.datadoghq.ad.instances: |
         [
           {
-            "openmetrics_endpoint": "http://%%host%%:14000/debug/metrics/prometheus",
+            "openmetrics_endpoint": "http://host:14000/debug/metrics/prometheus",
             "namespace": "host",
             "metrics": [
               ".*"

--- a/testnet/docker-compose.yml
+++ b/testnet/docker-compose.yml
@@ -23,6 +23,19 @@ services:
       - PROFILERENABLED=some_bool
       - P2PPUBLICADDRESS=some_string
       - LOGLEVEL=some_int
+    labels:
+      com.datadoghq.ad.check_names: '["openmetrics"]'
+      com.datadoghq.ad.init_configs: '[{}]'
+      com.datadoghq.ad.instances: |
+        [
+          {
+            "openmetrics_endpoint": "http://%%host%%:14000/debug/metrics/prometheus",
+            "namespace": "host",
+            "metrics": [
+              ".*"
+            ]
+          }
+        ]
     image: testnetobscuronet.azurecr.io/obscuronet/host:latest
     entrypoint: [
       "/home/go-obscuro/go/host/main/main",


### PR DESCRIPTION
### Why is this change needed?

- https://github.com/obscuronet/obscuro-internal/issues/1332

### What changes were made as part of this PR:

- Provide a high level list of the changes made

### Definition of done

- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
- [ ] End-to-end tests run if required (see below)

### End-to-end tests

Running the end-to-end tests in the [obscuro-test repo](https://github.com/obscuronet/obscuro-test) is currently at the 
discretion of the developer prior to merging a PR. The intention is not to slow down development by having the longer 
running end-to-end tests as a PR gate run on each branch commit etc. To manually trigger a run pre-merge;

- Go to [run_local_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_local_tests.yml)
- Click the "Run workflow" button
- Use the main branch of obscuro-test 
- Enter the name of the PR branch for go-obscuro
- Run the workflow

The run takes approximately 20 minutes and any failure will be reported in the workflow output. Should the tests fail 
the docker container output for the local testnet and all test artifacts will be added to the run and can be downloaded
for debugging and analysis, with a retention period of 2 days. 

Note that every PR merge to main will also trigger a run of post-merge tests, so even if you do not manually trigger 
pre-merge, tests will be run post-merge. The intention being to catch any issues fast on main to allow for quick 
resolution. The post-merge test output can be seen at 
[run_merge_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_merge_tests.yml) and will show both 
the PR number and author in the list of runs. 


