### PR TITLE
Testnet Genesis prefunded with 7500000000000000000000000000000 OBS

### DIFF
--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -202,7 +202,7 @@ jobs:
               --lb-name testnet-loadbalancer
 
   wait-node-up:
-    needs: deploy-l2
+    needs: deploy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/go/enclave/genesis/testnet_genesis.go
+++ b/go/enclave/genesis/testnet_genesis.go
@@ -1,6 +1,7 @@
 package genesis
 
 import (
+	"fmt"
 	"math/big"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
@@ -12,7 +13,16 @@ var TestnetGenesis = Genesis{
 	Accounts: []Account{
 		{
 			Address: gethcommon.HexToAddress("0xA58C60cc047592DE97BF1E8d2f225Fc5D959De77"),
-			Amount:  big.NewInt(7_500_000_000_000_000_000),
+			Amount:  parseHugeNumber("7500000000000000000000000000000"),
 		},
 	},
+}
+
+// parseHugeNumber parses number that overflow int64
+func parseHugeNumber(number string) *big.Int {
+	numb, ok := big.NewInt(0).SetString(number, 10)
+	if !ok {
+		panic(fmt.Sprintf("unable to parse number %s", number))
+	}
+	return numb
 }


### PR DESCRIPTION
### Why is this change needed?

- As per title

### What changes were made as part of this PR:

- Provide a high level list of the changes made

### Definition of done

- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
- [ ] End-to-end tests run if required (see below)

### End-to-end tests

Running the end-to-end tests in the [obscuro-test repo](https://github.com/obscuronet/obscuro-test) is currently at the 
discretion of the developer prior to merging a PR. The intention is not to slow down development by having the longer 
running end-to-end tests as a PR gate run on each branch commit etc. To manually trigger a run pre-merge;

- Go to [run_local_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_local_tests.yml)
- Click the "Run workflow" button
- Use the main branch of obscuro-test 
- Enter the name of the PR branch for go-obscuro
- Run the workflow

The run takes approximately 20 minutes and any failure will be reported in the workflow output. Should the tests fail 
the docker container output for the local testnet and all test artifacts will be added to the run and can be downloaded
for debugging and analysis, with a retention period of 2 days. 

Note that every PR merge to main will also trigger a run of post-merge tests, so even if you do not manually trigger 
pre-merge, tests will be run post-merge. The intention being to catch any issues fast on main to allow for quick 
resolution. The post-merge test output can be seen at 
[run_merge_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_merge_tests.yml) and will show both 
the PR number and author in the list of runs. 


