### PR TITLE
Added a docker image for the wallet extension.

### DIFF
--- a/testnet/testnet-local-build_images.sh
+++ b/testnet/testnet-local-build_images.sh
@@ -20,6 +20,7 @@ command() {
     echo $@ completed
 }
 
+command docker build -t testnetobscuronet.azurecr.io/obscuronet/walletextension:latest -f "${testnet_path}/walletextension.Dockerfile" "${root_path}" &
 command docker build -t testnetobscuronet.azurecr.io/obscuronet/gethnetwork:latest -f "${testnet_path}/gethnetwork.Dockerfile" "${root_path}" &
 command docker build -t testnetobscuronet.azurecr.io/obscuronet/host:latest -f "${root_path}/dockerfiles/host.Dockerfile" "${root_path}" &
 command docker build -t testnetobscuronet.azurecr.io/obscuronet/contractdeployer:latest -f "${testnet_path}/contractdeployer.Dockerfile" "${root_path}" &

--- a/testnet/walletextension.Dockerfile
+++ b/testnet/walletextension.Dockerfile
@@ -1,0 +1,25 @@
+# deploys one contract and outputs the address
+#
+FROM golang:1.17-alpine
+
+# set the base libs to build / run
+RUN apk add build-base bash git
+ENV CGO_ENABLED=1
+
+# create the base directory
+RUN mkdir /home/go-obscuro
+
+# cache the go mod packaging
+COPY ./go.mod /home/go-obscuro
+COPY ./go.sum /home/go-obscuro
+WORKDIR /home/go-obscuro
+RUN go get -d -v ./...
+
+# make sure the geth network code is available
+COPY . /home/go-obscuro
+
+# build the contract deployer exec
+WORKDIR /home/go-obscuro/tools/walletextension/main
+RUN go build -o ../bin/wallet_extension_linux
+WORKDIR /home/go-obscuro/tools/walletextension/bin
+ENTRYPOINT [ "./wallet_extension_linux" ]

--- a/tools/walletextension/common/constants.go
+++ b/tools/walletextension/common/constants.go
@@ -1,7 +1,7 @@
 package common
 
 const (
-	Localhost = "127.0.0.1"
+	Localhost = "0.0.0.0"
 
 	JSONKeyAddress      = "address"
 	JSONKeyData         = "data"


### PR DESCRIPTION
### Why is this change needed?

- Provide a description and a link to the underlying ticket

### What changes were made as part of this PR:

- Provide a high level list of the changes made

### Definition of done

- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
- [ ] End-to-end tests run if required (see below)

### End-to-end tests

Running the end-to-end tests in the [obscuro-test repo](https://github.com/obscuronet/obscuro-test) is currently at the 
discretion of the developer prior to merging a PR. The intention is not to slow down development by having the longer 
running end-to-end tests as a PR gate run on each branch commit etc. To manually trigger a run pre-merge;

- Go to [run_local_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_local_tests.yml)
- Click the "Run workflow" button
- Use the main branch of obscuro-test 
- Enter the name of the PR branch for go-obscuro
- Run the workflow

The run takes approximately 20 minutes and any failure will be reported in the workflow output. Should the tests fail 
the docker container output for the local testnet and all test artifacts will be added to the run and can be downloaded
for debugging and analysis, with a retention period of 2 days. 

Note that every PR merge to main will also trigger a run of post-merge tests, so even if you do not manually trigger 
pre-merge, tests will be run post-merge. The intention being to catch any issues fast on main to allow for quick 
resolution. The post-merge test output can be seen at 
[run_merge_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_merge_tests.yml) and will show both 
the PR number and author in the list of runs. 


