### PR TITLE
Fixes the PCCS setting for testnet and for dev testnet

### DIFF
--- a/testnet/docker-compose.dev-testnet.yml
+++ b/testnet/docker-compose.dev-testnet.yml
@@ -59,6 +59,7 @@ services:
       - P2PPUBLICADDRESS=some_string
       - LOGLEVEL=some_int
       - SEQUENCERID=some_address
+      - PCCS_ADDR
     image: testnetobscuronet.azurecr.io/obscuronet/dev_enclave:latest
     entrypoint: [
                  "ego", "run", "/home/obscuro/go-obscuro/go/enclave/main/main",
@@ -86,6 +87,7 @@ services:
       - default
     environment:
       - EDG_EDB_CERT_DNS=edgelessdb
+      - PCCS_ADDR
     ports:
       - "3306:3306"
       - "8080:8080"

--- a/testnet/start-obscuro-node.sh
+++ b/testnet/start-obscuro-node.sh
@@ -132,8 +132,11 @@ echo "P2PPUBLICADDRESS=${p2p_public_address}" >> "${testnet_path}/.env"
 echo "SEQUENCERID=${sequencer_id}" >> "${testnet_path}/.env"
 
 # only set the env var if it's defined
-if [[ ! -z ${pccs_addr} ]]; then # if not not set check is awful
-    echo "PCCS_ADDR=${pccs_addr}" >> "${testnet_path}/.env"
+if [ -z ${pccs_addr+x} ];
+then
+  echo "pccs_addr not set";
+else
+  echo "PCCS_ADDR=${pccs_addr}" >> "${testnet_path}/.env"
 fi
 
 if ${debug_enclave} ;

--- a/testnet/start-obscuro-node.sh
+++ b/testnet/start-obscuro-node.sh
@@ -44,7 +44,7 @@ help_and_exit() {
     echo ""
     echo "  p2p_public_address *Optional* Set host p2p public address. Defaults to 127.0.0.1:10000"
     echo ""
-    echo "  pccs_addr           *Optional* Set the enclave Provision Certificate Cache Service. Defaults to 127.0.0.1:8081"
+    echo "  pccs_addr           *Optional* Set the enclave Provision Certificate Cache Service. Default to None"
     echo ""
     echo "  profiler_enabled   *Optional* Enables the profiler in the host + enclave. Defaults to false"
     echo ""
@@ -75,7 +75,6 @@ host_id=0x0654D8B60033144D567f25bF41baC1FB0D60F23B
 pk_string=8ead642ca80dadb0f346a66cd6aa13e08a8ac7b5c6f7578d4bac96f5db01ac99
 log_level=4
 sequencer_id=0x0654D8B60033144D567f25bF41baC1FB0D60F23B
-pccs_addr="127.0.0.1:8081"
 
 
 # Fetch options
@@ -131,8 +130,11 @@ echo "LOGLEVEL=${log_level}" >> "${testnet_path}/.env"
 echo "PROFILERENABLED=${profiler_enabled}" >> "${testnet_path}/.env"
 echo "P2PPUBLICADDRESS=${p2p_public_address}" >> "${testnet_path}/.env"
 echo "SEQUENCERID=${sequencer_id}" >> "${testnet_path}/.env"
-echo "PCCS_ADDR=${pccs_addr}" >> "${testnet_path}/.env"
 
+# only set the env var if it's defined
+if [[ ! -z ${pccs_addr} ]]; then # if not not set check is awful
+    echo "PCCS_ADDR=${pccs_addr}" >> "${testnet_path}/.env"
+fi
 
 if ${debug_enclave} ;
 then


### PR DESCRIPTION
### Why is this change needed?

- Provide a description and a link to the underlying ticket

### What changes were made as part of this PR:

- Provide a high level list of the changes made

### Definition of done

- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
- [ ] End-to-end tests run if required (see below)

### End-to-end tests

Running the end-to-end tests in the [obscuro-test repo](https://github.com/obscuronet/obscuro-test) is currently at the 
discretion of the developer prior to merging a PR. The intention is not to slow down development by having the longer 
running end-to-end tests as a PR gate run on each branch commit etc. To manually trigger a run pre-merge;

- Go to [run_local_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_local_tests.yml)
- Click the "Run workflow" button
- Use the main branch of obscuro-test 
- Enter the name of the PR branch for go-obscuro
- Run the workflow

The run takes approximately 20 minutes and any failure will be reported in the workflow output. Should the tests fail 
the docker container output for the local testnet and all test artifacts will be added to the run and can be downloaded
for debugging and analysis, with a retention period of 2 days. 

Note that every PR merge to main will also trigger a run of post-merge tests, so even if you do not manually trigger 
pre-merge, tests will be run post-merge. The intention being to catch any issues fast on main to allow for quick 
resolution. The post-merge test output can be seen at 
[run_merge_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_merge_tests.yml) and will show both 
the PR number and author in the list of runs. 


