### PR TITLE
Improved validation of incoming rollups

### DIFF
--- a/go/common/utils.go
+++ b/go/common/utils.go
@@ -1,9 +1,7 @@
 package common
 
 import (
-	"math"
 	"math/big"
-	"math/rand"
 	"sync/atomic"
 	"time"
 
@@ -40,10 +38,6 @@ func Schedule(delay time.Duration, fun ScheduledFunc) {
 		ticker.Stop()
 		fun()
 	}()
-}
-
-func GenerateNonce() Nonce {
-	return uint64(rand.Int63n(math.MaxInt64)) //nolint:gosec
 }
 
 func MaxInt(x, y uint32) uint32 {

--- a/go/enclave/core/rollup.go
+++ b/go/enclave/core/rollup.go
@@ -38,6 +38,12 @@ func (r *Rollup) Hash() *common.L2RootHash {
 func (r *Rollup) NumberU64() uint64 { return r.Header.Number.Uint64() }
 func (r *Rollup) Number() *big.Int  { return new(big.Int).Set(r.Header.Number) }
 
+// IsGenesis indicates whether the rollup is the genesis rollup.
+// TODO - #718 - Change this to a check against a hardcoded genesis hash.
+func (r *Rollup) IsGenesis() bool {
+	return r.Header.Number.Cmp(big.NewInt(int64(common.L2GenesisHeight))) == 0
+}
+
 func (r *Rollup) ToExtRollup(transactionBlobCrypto crypto.TransactionBlobCrypto) *common.ExtRollup {
 	txHashes := make([]gethcommon.Hash, len(r.Transactions))
 	for idx, tx := range r.Transactions {

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -624,7 +624,7 @@ func (rc *RollupChain) isInternallyValidBatch(batch *core.Batch) (types.Receipts
 	}
 
 	// Check that the signature is valid.
-	if err = rc.validateSequencerSig(batch.Hash(), &batch.Header.Agg, batch.Header.R, batch.Header.S); err != nil {
+	if err = rc.checkSignedBySequencer(batch.Hash(), &batch.Header.Agg, batch.Header.R, batch.Header.S); err != nil {
 		return nil, fmt.Errorf("verify batch r_%d: invalid signature. Cause: %w", common.ShortHash(*batch.Hash()), err)
 	}
 
@@ -683,7 +683,7 @@ func (rc *RollupChain) signBatch(batch *core.Batch) error {
 }
 
 // Checks that the header is signed validly by the sequencer.
-func (rc *RollupChain) validateSequencerSig(headerHash *gethcommon.Hash, aggregator *gethcommon.Address, sigR *big.Int, sigS *big.Int) error {
+func (rc *RollupChain) checkSignedBySequencer(headerHash *gethcommon.Hash, aggregator *gethcommon.Address, sigR *big.Int, sigS *big.Int) error {
 	// Batches and rollups should only be produced by the sequencer.
 	// TODO - #718 - Sequencer identities should be retrieved from the L1 management contract.
 	if !bytes.Equal(aggregator.Bytes(), rc.sequencerID.Bytes()) {
@@ -849,13 +849,12 @@ func (rc *RollupChain) isAccountContractAtBlock(accountAddr gethcommon.Address, 
 
 // Validates and stores the rollup in a given block.
 func (rc *RollupChain) processRollups(block *common.L1Block, currentHeadRollup *core.Rollup) error {
-	// We extract the rollups from the block.
 	rollups := rc.bridge.ExtractRollups(block, rc.storage)
 	if len(rollups) == 0 {
 		return nil
 	}
 
-	// We sort the rollups by number in ascending order, in order to process them in the correct order.
+	// We sort the rollups in order to process them in the correct order.
 	sort.Slice(rollups, func(i, j int) bool {
 		return rollups[i].Header.Number.Cmp(rollups[j].Header.Number) < 0
 	})
@@ -865,37 +864,23 @@ func (rc *RollupChain) processRollups(block *common.L1Block, currentHeadRollup *
 		return fmt.Errorf("received rollup with number %d but no genesis rollup is stored", rollups[0].Number())
 	}
 
-	// We check if there are any gaps in the received rollups.
 	for idx, rollup := range rollups {
-		// We can skip the checks below for the genesis rollup.
-		if idx == 0 && currentHeadRollup == nil {
-			continue
+		if !rollup.IsGenesis() {
+			previousRollup := currentHeadRollup
+			if idx != 0 {
+				previousRollup = rollups[idx-1]
+			}
+			if err := rc.checkRollupChain(rollup, previousRollup); err != nil {
+				return err
+			}
 		}
 
-		previousRollup := currentHeadRollup
-		if idx != 0 {
-			previousRollup = rollups[idx-1]
-		}
-
-		if big.NewInt(0).Sub(rollup.Header.Number, previousRollup.Header.Number).Cmp(big.NewInt(1)) != 0 {
-			return fmt.Errorf("found gap in block rollups between rollup %d and rollup %d",
-				previousRollup.Header.Number, rollup.Header.Number)
-		}
-
-		if rollup.Header.ParentHash != *previousRollup.Hash() {
-			return fmt.Errorf("found gap in block rollups. Rollup %d did not reference rollup %d by hash",
-				previousRollup.Header.Number, rollup.Header.Number)
-		}
-	}
-
-	// We check each rollup.
-	for _, rollup := range rollups {
-		// We check that the rollup is signed by the sequencer.
-		if err := rc.validateSequencerSig(rollup.Hash(), &rollup.Header.Agg, rollup.Header.R, rollup.Header.S); err != nil {
+		if err := rc.checkSignedBySequencer(rollup.Hash(), &rollup.Header.Agg, rollup.Header.R, rollup.Header.S); err != nil {
 			return fmt.Errorf("rollup signature was invalid. Cause: %w", err)
 		}
 
 		if err := rc.checkRollupAgainstBatches(rollup); err != nil {
+			// TODO - #718 - Determine how to handle this critical error case.
 			rc.logger.Error("could not check rollups against batches", log.ErrKey, err)
 		}
 
@@ -911,10 +896,25 @@ func (rc *RollupChain) processRollups(block *common.L1Block, currentHeadRollup *
 	return nil
 }
 
+func (rc *RollupChain) checkRollupChain(rollup *core.Rollup, previousRollup *core.Rollup) error {
+	if big.NewInt(0).Sub(rollup.Header.Number, previousRollup.Header.Number).Cmp(big.NewInt(1)) != 0 {
+		return fmt.Errorf("found gap in block rollups between rollup %d and rollup %d",
+			previousRollup.Header.Number, rollup.Header.Number)
+	}
+
+	if rollup.Header.ParentHash != *previousRollup.Hash() {
+		return fmt.Errorf("found gap in block rollups. Rollup %d did not reference rollup %d by hash",
+			previousRollup.Header.Number, rollup.Header.Number)
+	}
+	return nil
+}
+
 // TODO - #718 - Additional validation of the rollup against the batch.
 // TODO - #718 - Refactor this logic once there are multiple batches for a single rollup.
 func (rc *RollupChain) checkRollupAgainstBatches(rollup *core.Rollup) error {
 	// We validate the rollup against the corresponding batch.
+	// TODO - #718 - Handle case where rollup is received ahead of batch (currently, we simply log an error in the
+	//  calling method).
 	batch, err := rc.storage.FetchBatch(*rollup.Hash())
 	if err != nil {
 		return fmt.Errorf("could not retrieve batch for rollup. Cause: %w", err)

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -870,12 +870,13 @@ func (rc *RollupChain) processRollups(block *common.L1Block, parentHeadRollup *c
 		if idx+1 >= len(rollups) {
 			break
 		}
-		if rollup.Header.Number.Cmp(rollups[idx+1].Header.Number) == 0 {
-			return fmt.Errorf("duplicates rollups found in block; two rollups with number %d", rollup.Header.Number)
+		if big.NewInt(0).Sub(rollups[idx+1].Header.Number, rollup.Header.Number).Cmp(big.NewInt(1)) != 0 {
+			return fmt.Errorf("found gap in block rollups between rollup %d and rollup %d",
+				rollup.Header.Number, rollups[idx+1].Header.Number)
 		}
 	}
 
-	// todo - joel - check for missing numbers and missing links
+	// todo - joel - check for missing hash links
 
 	// We check each rollup.
 	for _, rollup := range rollups {

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -786,8 +786,9 @@ func (h *host) checkBlockForSecretResponse(block *types.Block) bool {
 // Handles an incoming set of batches. There are two possibilities:
 // (1) There are no gaps in the historical chain of batches. The new batches can be added immediately
 // (2) There are gaps in the historical chain of batches. To avoid an inconsistent state (i.e. one where we have stored
-// a batch without its parent), we request the sequencer to resend the batches we've just received, plus any missing
-// historical batches, then discard the received batches. We will store all of these at once when we receive them
+//
+//	a batch without its parent), we request the sequencer to resend the batches we've just received, plus any missing
+//	historical batches, then discard the received batches. We will store all of these at once when we receive them
 func (h *host) handleBatches(encodedBatchMsg *common.EncodedBatchMsg) error {
 	var batchMsg *hostcommon.BatchMsg
 	err := rlp.DecodeBytes(*encodedBatchMsg, &batchMsg)
@@ -798,7 +799,7 @@ func (h *host) handleBatches(encodedBatchMsg *common.EncodedBatchMsg) error {
 	for _, batch := range batchMsg.Batches {
 		// TODO - #718 - Consider moving to a model where the enclave manages the entire state, to avoid inconsistency.
 
-		// If we do not have the block the rollup is tied to, we skip processing the batches for now. We'll catch them
+		// If we do not have the block the batch is tied to, we skip processing the batches for now. We'll catch them
 		// up later, once we've received the L1 block.
 		_, err = h.db.GetBlockHeader(batch.Header.L1Proof)
 		if err != nil {


### PR DESCRIPTION
### Why is this change needed?

Improve validation of rollups in a block, including checking them against batches.

This PR does _not_ handle the case where a rollup is received before the batch required to validate it. For now, an error is logged. This work will be done in a follow-up.

### What changes were made as part of this PR:

- Provide a high level list of the changes made

### Definition of done

- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
- [ ] End-to-end tests run if required (see below)

### End-to-end tests

Running the end-to-end tests in the [obscuro-test repo](https://github.com/obscuronet/obscuro-test) is currently at the 
discretion of the developer prior to merging a PR. The intention is not to slow down development by having the longer 
running end-to-end tests as a PR gate run on each branch commit etc. To manually trigger a run pre-merge;

- Go to [run_local_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_local_tests.yml)
- Click the "Run workflow" button
- Use the main branch of obscuro-test 
- Enter the name of the PR branch for go-obscuro
- Run the workflow

The run takes approximately 20 minutes and any failure will be reported in the workflow output. Should the tests fail 
the docker container output for the local testnet and all test artifacts will be added to the run and can be downloaded
for debugging and analysis, with a retention period of 2 days. 

Note that every PR merge to main will also trigger a run of post-merge tests, so even if you do not manually trigger 
pre-merge, tests will be run post-merge. The intention being to catch any issues fast on main to allow for quick 
resolution. The post-merge test output can be seen at 
[run_merge_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_merge_tests.yml) and will show both 
the PR number and author in the list of runs. 


