### PR TITLE
Propagates container start error

### DIFF
--- a/go/common/host/host.go
+++ b/go/common/host/host.go
@@ -19,7 +19,7 @@ type Host interface {
 	EnclaveClient() common.Enclave
 
 	// Start initializes the main loop of the host.
-	Start()
+	Start() error
 	// SubmitAndBroadcastTx submits an encrypted transaction to the enclave, and broadcasts it to the other hosts on the network.
 	SubmitAndBroadcastTx(encryptedParams common.EncryptedParamsSendRawTx) (common.EncryptedResponseSendRawTx, error)
 	// ReceiveTx processes a transaction received from a peer host.

--- a/go/enclave/container/enclave_container.go
+++ b/go/enclave/container/enclave_container.go
@@ -30,7 +30,7 @@ func (e *EnclaveContainer) Start() error {
 	if err != nil {
 		return err
 	}
-	e.Logger.Info("Obscuro enclave service started.")
+	e.Logger.Info("obscuro enclave RPC service started.")
 	return nil
 }
 

--- a/go/host/container/host_container.go
+++ b/go/host/container/host_container.go
@@ -38,12 +38,22 @@ type HostContainer struct {
 }
 
 func (h *HostContainer) Start() error {
-	fmt.Println("Starting Obscuro host...")
-	h.logger.Info("Starting Obscuro host...")
 	h.metricsService.Start()
+
 	// make sure the rpc server has a host to render requests
-	h.host.Start()
-	h.rpcServer.Start()
+	err := h.host.Start()
+	if err != nil {
+		return err
+	}
+	h.logger.Info("Started Obscuro host...")
+	fmt.Println("Started Obscuro host...")
+
+	err = h.rpcServer.Start()
+	if err != nil {
+		return err
+	}
+	h.logger.Info("Started Obscuro host RPC Server...")
+	fmt.Println("Started Obscuro host RPC Server...")
 	return nil
 }
 

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -133,12 +133,12 @@ func NewHost(
 }
 
 // Start validates the host config and starts the Host in a go routine - immediately returns after
-func (h *host) Start() {
+func (h *host) Start() error {
 	h.validateConfig()
 
 	tomlConfig, err := toml.Marshal(h.config)
 	if err != nil {
-		h.logger.Crit("could not print host config")
+		return fmt.Errorf("could not print host config - %w", err)
 	}
 	h.logger.Info("Host started with following config", log.CfgKey, string(tomlConfig))
 
@@ -165,6 +165,8 @@ func (h *host) Start() {
 		// start the host's main processing loop
 		h.startProcessing()
 	}()
+
+	return nil
 }
 
 func (h *host) broadcastSecret() error {

--- a/go/host/rpc/clientrpc/rpc_server.go
+++ b/go/host/rpc/clientrpc/rpc_server.go
@@ -15,7 +15,7 @@ const (
 
 // Server is the layer responsible for handling RPC requests from Obscuro client applications.
 type Server interface {
-	Start()
+	Start() error
 	Stop()
 	RegisterAPIs(apis []rpc.API)
 }
@@ -55,11 +55,8 @@ func (s *serverImpl) RegisterAPIs(apis []rpc.API) {
 	s.node.RegisterAPIs(apis)
 }
 
-func (s *serverImpl) Start() {
-	// make sure you *have* registered apis
-	if err := s.node.Start(); err != nil {
-		s.logger.Crit("could not start node client server.", log.ErrKey, err)
-	}
+func (s *serverImpl) Start() error {
+	return s.node.Start()
 }
 
 func (s *serverImpl) Stop() {

--- a/integration/simulation/network/inmemory.go
+++ b/integration/simulation/network/inmemory.go
@@ -99,7 +99,12 @@ func (n *basicNetworkOfInMemoryNodes) Create(params *params.SimParams, stats *st
 
 	for _, m := range obscuroNodes {
 		t := m
-		go t.Start()
+		go func() {
+			err := t.Start()
+			if err != nil {
+				panic(err)
+			}
+		}()
 		time.Sleep(params.AvgBlockDuration / 3)
 	}
 

--- a/integration/simulation/network/obscuro_node_utils.go
+++ b/integration/simulation/network/obscuro_node_utils.go
@@ -71,7 +71,12 @@ func startInMemoryObscuroNodes(params *params.SimParams, genesisJSON []byte, l1C
 	// start each obscuro node
 	for _, m := range obscuroNodes {
 		t := m
-		go t.Start()
+		go func() {
+			err := t.Start()
+			if err != nil {
+				panic(err)
+			}
+		}()
 	}
 
 	// Create a handle to each node


### PR DESCRIPTION
### Why is this change needed?

- https://github.com/obscuronet/obscuro-internal/issues/1315

### What changes were made as part of this PR:

- Provide a high level list of the changes made

### Definition of done

- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
- [ ] End-to-end tests run if required (see below)

### End-to-end tests

Running the end-to-end tests in the [obscuro-test repo](https://github.com/obscuronet/obscuro-test) is currently at the 
discretion of the developer prior to merging a PR. The intention is not to slow down development by having the longer 
running end-to-end tests as a PR gate run on each branch commit etc. To manually trigger a run pre-merge;

- Go to [run_local_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_local_tests.yml)
- Click the "Run workflow" button
- Use the main branch of obscuro-test 
- Enter the name of the PR branch for go-obscuro
- Run the workflow

The run takes approximately 20 minutes and any failure will be reported in the workflow output. Should the tests fail 
the docker container output for the local testnet and all test artifacts will be added to the run and can be downloaded
for debugging and analysis, with a retention period of 2 days. 

Note that every PR merge to main will also trigger a run of post-merge tests, so even if you do not manually trigger 
pre-merge, tests will be run post-merge. The intention being to catch any issues fast on main to allow for quick 
resolution. The post-merge test output can be seen at 
[run_merge_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_merge_tests.yml) and will show both 
the PR number and author in the list of runs. 


