### PR TITLE
Added layer 2 deployment and updated bits around it.

### DIFF
--- a/contracts/deployment_scripts/layer2/001_deploy_tokens.ts
+++ b/contracts/deployment_scripts/layer2/001_deploy_tokens.ts
@@ -1,0 +1,38 @@
+import {HardhatRuntimeEnvironment} from 'hardhat/types';
+import {DeployFunction} from 'hardhat-deploy/types';
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+    const { 
+        deployments, 
+        getNamedAccounts
+    } = hre;
+
+    const {deployer} = await getNamedAccounts();
+
+    await deployments.deploy('L2HOCERC20', {
+        from: deployer,
+        contract: "WrappedERC20",
+        args: [ "HOC", "HOC", "1000000000000000000000000000000" ],
+        log: true,
+    });
+
+    await deployments.deploy('L2POCERC20', {
+        from: deployer,
+        contract: "WrappedERC20",
+        args: [ "POC", "POC" ],
+        log: true,
+    });
+
+    await deployments.execute('L2HOCERC20', {
+        from: deployer
+    }, "issueFor", deployer, "1000000000000000000000000000000");
+
+
+    await deployments.execute('L2POCERC20', {
+        from: deployer
+    }, "issueFor", deployer, "1000000000000000000000000000000");
+};
+
+export default func;
+func.tags = ['L2HPERC20', 'L2HPERC20_deploy'];
+func.dependencies = ['ObscuroBridge'];

--- a/contracts/deployment_scripts/layer2/001_deploy_tokens.ts
+++ b/contracts/deployment_scripts/layer2/001_deploy_tokens.ts
@@ -12,27 +12,28 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     await deployments.deploy('L2HOCERC20', {
         from: deployer,
         contract: "WrappedERC20",
-        args: [ "HOC", "HOC", "1000000000000000000000000000000" ],
-        log: true,
+        args: [ "HOC", "HOC" ],
+        log: true
     });
 
     await deployments.deploy('L2POCERC20', {
         from: deployer,
         contract: "WrappedERC20",
         args: [ "POC", "POC" ],
-        log: true,
+        log: true
     });
 
     await deployments.execute('L2HOCERC20', {
-        from: deployer
+        from: deployer,
+        log: true
     }, "issueFor", deployer, "1000000000000000000000000000000");
 
 
     await deployments.execute('L2POCERC20', {
-        from: deployer
+        from: deployer,
+        log: true
     }, "issueFor", deployer, "1000000000000000000000000000000");
 };
 
 export default func;
 func.tags = ['L2HPERC20', 'L2HPERC20_deploy'];
-func.dependencies = ['ObscuroBridge'];

--- a/contracts/deployment_scripts/layer2/001_deploy_tokens.ts
+++ b/contracts/deployment_scripts/layer2/001_deploy_tokens.ts
@@ -7,32 +7,35 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
         getNamedAccounts
     } = hre;
 
-    const {deployer} = await getNamedAccounts();
+    const {
+        deployer,
+        hocowner,
+        pocowner,
+    } = await getNamedAccounts();
 
     await deployments.deploy('L2HOCERC20', {
-        from: deployer,
+        from: hocowner,
         contract: "WrappedERC20",
         args: [ "HOC", "HOC" ],
         log: true
     });
 
+    await deployments.execute('L2HOCERC20', {
+        from: hocowner,
+        log: true
+    }, "issueFor", hocowner, "1000000000000000000000000000000");
+
     await deployments.deploy('L2POCERC20', {
-        from: deployer,
+        from: pocowner,
         contract: "WrappedERC20",
         args: [ "POC", "POC" ],
         log: true
     });
 
-    await deployments.execute('L2HOCERC20', {
-        from: deployer,
-        log: true
-    }, "issueFor", deployer, "1000000000000000000000000000000");
-
-
     await deployments.execute('L2POCERC20', {
-        from: deployer,
+        from: pocowner,
         log: true
-    }, "issueFor", deployer, "1000000000000000000000000000000");
+    }, "issueFor", pocowner, "1000000000000000000000000000000");
 };
 
 export default func;

--- a/contracts/deployment_scripts/layer2/001_deploy_tokens.ts
+++ b/contracts/deployment_scripts/layer2/001_deploy_tokens.ts
@@ -15,6 +15,8 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
     console.log(`HOC = ${hocowner}  POC=${pocowner}`);
 
+
+    // Create the keys for the hoc and poc owner accounts.
     await hre.run('obscuro:wallet-extension:add-key', {address: hocowner});
     await hre.run('obscuro:wallet-extension:add-key', {address: pocowner});
 
@@ -25,6 +27,8 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
         log: true
     });
 
+    // Mint the initial supply. This is different to the older smart contracts that had a
+    // static supply minted on contract creation
     await deployments.execute('L2HOCERC20', {
         from: hocowner,
         log: true
@@ -37,6 +41,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
         log: true
     });
 
+    // Mint initial supply for POC too.
     await deployments.execute('L2POCERC20', {
         from: pocowner,
         log: true

--- a/contracts/deployment_scripts/layer2/001_deploy_tokens.ts
+++ b/contracts/deployment_scripts/layer2/001_deploy_tokens.ts
@@ -13,6 +13,11 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
         pocowner,
     } = await getNamedAccounts();
 
+    console.log(`HOC = ${hocowner}  POC=${pocowner}`);
+
+    await hre.run('obscuro:wallet-extension:add-key', {address: hocowner});
+    await hre.run('obscuro:wallet-extension:add-key', {address: pocowner});
+
     await deployments.deploy('L2HOCERC20', {
         from: hocowner,
         contract: "WrappedERC20",

--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -41,14 +41,11 @@ const config: HardhatUserConfig = {
     deployer: { // Addressed used for deploying.
         default: 0,
     },
-    sequencer:{ // For management contract.
+    hocowner: {
         default: 1,
     },
-    hocowner: {
-        default: 2,
-    },
     pocowner: {
-        default: 3,
+        default: 2,
     },
   }
 };

--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -44,6 +44,12 @@ const config: HardhatUserConfig = {
     sequencer:{ // For management contract.
         default: 1,
     },
+    hocowner: {
+        default: 2,
+    },
+    pocowner: {
+        default: 3,
+    },
   }
 };
 

--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -8,6 +8,7 @@ import 'hardhat-deploy';
 
 import './tasks/wallet-extension';
 import * as abigen from './tasks/abigen';
+import './tasks/obscuro-deploy';
 
 import * as fs from "fs";
 

--- a/contracts/tasks/obscuro-deploy.ts
+++ b/contracts/tasks/obscuro-deploy.ts
@@ -10,22 +10,30 @@ task("obscuro:deploy", "Prepares for deploying.")
     const rpcURL = (hre.network.config as HardhatNetworkUserConfig).obscuroEncRpcUrl;
     
     if (!rpcURL) {
+        console.log(`obscuro:deploy requires "obscuroEncRpcUrl" to be set as part of the selected network's config.`)
         return;
     } 
     
+    // Start a wallet extension as a child process
+    // This process is auto signaled to terminate when this process dies
     await hre.run("obscuro:wallet-extension:start:local", {
         rpcUrl : rpcURL,
         withStdOut: true
     });    
 
+    // Trigger shutdown on CTRL + C
     process.on('SIGINT', ()=>exit(1));
 
+    // Automatically provision a viewing key for the deployer account
     const { deployer } = await hre.getNamedAccounts();
     await hre.run('obscuro:wallet-extension:add-key', {address: deployer});
 
+    // Execute the deploy task provided by the HH deploy plugin.
     await hre.run('deploy');
 });
 
+// This extends the hardhat config object for networks to have a key for
+// the encrypted rpc endpoint of obscuro nodes.
 declare module 'hardhat/types/config' {
     interface HardhatNetworkUserConfig {
         obscuroEncRpcUrl?: string

--- a/contracts/tasks/obscuro-deploy.ts
+++ b/contracts/tasks/obscuro-deploy.ts
@@ -1,0 +1,33 @@
+import { task } from "hardhat/config";
+import 'hardhat/types/config';
+
+import {on, exit} from 'process';
+import { HardhatNetworkUserConfig } from "hardhat/types/config";
+
+task("obscuro:deploy", "Prepares for deploying.")
+.setAction(async function(args, hre, runSuper) {
+
+    const rpcURL = (hre.network.config as HardhatNetworkUserConfig).obscuroEncRpcUrl;
+    
+    if (!rpcURL) {
+        return;
+    } 
+    
+    await hre.run("obscuro:wallet-extension:start:local", {
+        rpcUrl : rpcURL,
+        withStdOut: true
+    });    
+
+    process.on('SIGINT', ()=>exit(1));
+
+    const { deployer } = await hre.getNamedAccounts();
+    await hre.run('obscuro:wallet-extension:add-key', {address: deployer});
+
+    await hre.run('deploy');
+});
+
+declare module 'hardhat/types/config' {
+    interface HardhatNetworkUserConfig {
+        obscuroEncRpcUrl?: string
+      }    
+}

--- a/go/enclave/genesis/genesis_test.go
+++ b/go/enclave/genesis/genesis_test.go
@@ -18,7 +18,7 @@ func TestDefaultGenesis(t *testing.T) {
 		t.Fatalf("unexpected error %s", err)
 	}
 
-	if len(gen.Accounts) != 1 {
+	if len(gen.Accounts) != 3 {
 		t.Fatal("unexpected number of accounts")
 	}
 

--- a/go/enclave/genesis/testnet_genesis.go
+++ b/go/enclave/genesis/testnet_genesis.go
@@ -15,6 +15,14 @@ var TestnetGenesis = Genesis{
 			Address: gethcommon.HexToAddress("0xA58C60cc047592DE97BF1E8d2f225Fc5D959De77"),
 			Amount:  parseHugeNumber("7500000000000000000000000000000"),
 		},
+		{
+			Address: gethcommon.HexToAddress("0x987E0a0692475bCc5F13D97E700bb43c1913EFfe"),
+			Amount:  parseHugeNumber("7500000000000000000000000000000"),
+		},
+		{
+			Address: gethcommon.HexToAddress("0xDEe530E22045939e6f6a0A593F829e35A140D3F1"),
+			Amount:  parseHugeNumber("7500000000000000000000000000000"),
+		},
 	},
 }
 

--- a/go/enclave/genesis/testnet_genesis.go
+++ b/go/enclave/genesis/testnet_genesis.go
@@ -15,14 +15,16 @@ var TestnetGenesis = Genesis{
 			Address: gethcommon.HexToAddress("0xA58C60cc047592DE97BF1E8d2f225Fc5D959De77"),
 			Amount:  parseHugeNumber("7500000000000000000000000000000"),
 		},
-		{
+		// TODO: Remove the following when the bridge is updated!
+		{ // Address for HOC owner
 			Address: gethcommon.HexToAddress("0x987E0a0692475bCc5F13D97E700bb43c1913EFfe"),
 			Amount:  parseHugeNumber("7500000000000000000000000000000"),
 		},
-		{
+		{ // Address for POC owner
 			Address: gethcommon.HexToAddress("0xDEe530E22045939e6f6a0A593F829e35A140D3F1"),
 			Amount:  parseHugeNumber("7500000000000000000000000000000"),
 		},
+		// TODO: Remove
 	},
 }
 

--- a/testnet/testnet-deploy-l2-contracts.sh
+++ b/testnet/testnet-deploy-l2-contracts.sh
@@ -32,7 +32,9 @@ testnet_path="${start_path}"
 # Define defaults
 l2port=13001
 # todo: get rid of these defaults and require them to be passed in, using github secrets for testnet values (requires bridge.go changes)
-pkstring="8dfb8083da6275ae3e4f41e3e8a8c19d028d32c9247e24530933782f2a05035b"
+deployer_pkstring="8dfb8083da6275ae3e4f41e3e8a8c19d028d32c9247e24530933782f2a05035b"
+hocpkstring="6e384a07a01263518a09a5424c7b6bbfc3604ba7d93f47e3a455cbdd7f9f0682"
+pocpkstring="4bfe14725e685901c062ccd4e220c61cf9c189897b6c78bd18d7f51291b2b8f8"
 docker_image="testnetobscuronet.azurecr.io/obscuronet/hardhatdeployer:latest"
 
 # Fetch options
@@ -45,6 +47,8 @@ do
             --l2host)                   l2host=${value} ;;
             --l2port)                   l2port=${value} ;;
             --pkstring)                 pkstring=${value} ;;
+            --hocpkstring)              hocpkstring=${value} ;;
+            --pocpkstring)              pocpkstring=${value} ;;
             --docker_image)             docker_image=${value} ;;
             --help)                     help_and_exit ;;
             *)
@@ -52,7 +56,7 @@ do
 done
 
 # ensure required fields
-if [[ -z ${l2host:-} || -z ${pkstring:-} ]];
+if [[ -z ${l2host:-} || -z ${pkstring:-} || -z ${hocpkstring:-} || -z ${pocpkstring:-} ]];
 then
     help_and_exit
 fi
@@ -67,7 +71,12 @@ network_cfg='{
             "live" : false,
             "saveDeployments" : true,
             "deploy": [ "deployment_scripts/layer2" ],
-            "accounts": [ "'${pkstring}'" ]
+            "accounts": [ 
+                "'${deployer_pkstring}'",
+                "'${deployer_pkstring}'",
+                "'${hocpkstring}'",
+                "'${pocpkstring}'"
+            ]
         }
     }'
 

--- a/testnet/testnet-deploy-l2-contracts.sh
+++ b/testnet/testnet-deploy-l2-contracts.sh
@@ -32,10 +32,8 @@ testnet_path="${start_path}"
 # Define defaults
 l2port=13001
 # todo: get rid of these defaults and require them to be passed in, using github secrets for testnet values (requires bridge.go changes)
-hocpkstring="6e384a07a01263518a09a5424c7b6bbfc3604ba7d93f47e3a455cbdd7f9f0682"
-pocpkstring="4bfe14725e685901c062ccd4e220c61cf9c189897b6c78bd18d7f51291b2b8f8"
-hocerc20address="0xf3a8bd422097bFdd9B3519Eaeb533393a1c561aC"
-docker_image="testnetobscuronet.azurecr.io/obscuronet/contractdeployer:latest"
+pkstring="8dfb8083da6275ae3e4f41e3e8a8c19d028d32c9247e24530933782f2a05035b"
+docker_image="testnetobscuronet.azurecr.io/obscuronet/hardhatdeployer:latest"
 
 # Fetch options
 for argument in "$@"
@@ -46,8 +44,7 @@ do
     case "$key" in
             --l2host)                   l2host=${value} ;;
             --l2port)                   l2port=${value} ;;
-            --hocpkstring)              hocpkstring=${value} ;;
-            --pocpkstring)              pocpkstring=${value} ;;
+            --pkstring)                 pkstring=${value} ;;
             --docker_image)             docker_image=${value} ;;
             --help)                     help_and_exit ;;
             *)
@@ -55,33 +52,33 @@ do
 done
 
 # ensure required fields
-if [[ -z ${l2host:-} || -z ${hocpkstring:-} || -z ${pocpkstring:-}  ]];
+if [[ -z ${l2host:-} || -z ${pkstring:-} ]];
 then
     help_and_exit
 fi
 
 # deploy contracts to the obscuro network
-echo "Deploying HOC ERC20 contract to the obscuro network..."
-docker network create --driver bridge node_network || true
-docker run --name=hocL2deployer \
-    --network=node_network \
-    --entrypoint /home/go-obscuro/tools/contractdeployer/main/main \
-     "${docker_image}" \
-    --nodeHost=${l2host} \
-    --nodePort=${l2port} \
-    --contractName="Layer2ERC20" \
-    --privateKey=${hocpkstring}\
-    --constructorParams="Hocus,HOC,1000000000000000000000000000000"
-echo ""
+echo "Deploying Token ERC20 contract to the obscuro network..."
 
-echo "Deploying POC ERC20 contract to the obscuro network..."
-docker run --name=pocL2deployer \
+network_cfg='{ 
+        "layer2" : {
+            "obscuroEncRpcUrl" : '"\"ws://${l2host}:${l2port}\""',
+            "url": "http://127.0.0.1:3000",
+            "live" : false,
+            "saveDeployments" : true,
+            "deploy": [ "deployment_scripts/layer2" ],
+            "accounts": [ "'${pkstring}'" ]
+        }
+    }'
+
+# deploy contracts to the geth network
+echo "Creating docker network..."
+docker network create --driver bridge node_network || true
+
+echo "Deploying contracts to Layer 2 using obscuro hardhat container..."
+docker run --name=hh-l2-deployer \
     --network=node_network \
-    --entrypoint /home/go-obscuro/tools/contractdeployer/main/main \
-     "${docker_image}" \
-    --nodeHost=${l2host} \
-    --nodePort=${l2port} \
-    --contractName="Layer2ERC20" \
-    --privateKey=${pocpkstring}\
-    --constructorParams="Pocus,POC,1000000000000000000000000000000"
-echo ""
+    -e NETWORK_JSON="${network_cfg}" \
+    "${docker_image}" \
+    obscuro:deploy \
+    --network layer2

--- a/testnet/testnet-deploy-l2-contracts.sh
+++ b/testnet/testnet-deploy-l2-contracts.sh
@@ -56,7 +56,7 @@ do
 done
 
 # ensure required fields
-if [[ -z ${l2host:-} || -z ${pkstring:-} || -z ${hocpkstring:-} || -z ${pocpkstring:-} ]];
+if [[ -z ${l2host:-} || -z ${deployer_pkstring:-} || -z ${hocpkstring:-} || -z ${pocpkstring:-} ]];
 then
     help_and_exit
 fi
@@ -72,7 +72,6 @@ network_cfg='{
             "saveDeployments" : true,
             "deploy": [ "deployment_scripts/layer2" ],
             "accounts": [ 
-                "'${deployer_pkstring}'",
                 "'${deployer_pkstring}'",
                 "'${hocpkstring}'",
                 "'${pocpkstring}'"


### PR DESCRIPTION
### Why is this change needed?

Replicating the current deployment that the contrat deployer produces using the new hardhat deployer. ERC20 contract addresses do not match.

### What changes were made as part of this PR:

- Provide a high level list of the changes made

### Definition of done

- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
- [ ] End-to-end tests run if required (see below)

### End-to-end tests

Running the end-to-end tests in the [obscuro-test repo](https://github.com/obscuronet/obscuro-test) is currently at the 
discretion of the developer prior to merging a PR. The intention is not to slow down development by having the longer 
running end-to-end tests as a PR gate run on each branch commit etc. To manually trigger a run pre-merge;

- Go to [run_local_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_local_tests.yml)
- Click the "Run workflow" button
- Use the main branch of obscuro-test 
- Enter the name of the PR branch for go-obscuro
- Run the workflow

The run takes approximately 20 minutes and any failure will be reported in the workflow output. Should the tests fail 
the docker container output for the local testnet and all test artifacts will be added to the run and can be downloaded
for debugging and analysis, with a retention period of 2 days. 

Note that every PR merge to main will also trigger a run of post-merge tests, so even if you do not manually trigger 
pre-merge, tests will be run post-merge. The intention being to catch any issues fast on main to allow for quick 
resolution. The post-merge test output can be seen at 
[run_merge_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_merge_tests.yml) and will show both 
the PR number and author in the list of runs. 


