### PR TITLE
In mem tests now use containers

### DIFF
--- a/go/host/rpc/clientapi/client_api_obscurotest.go
+++ b/go/host/rpc/clientapi/client_api_obscurotest.go
@@ -2,32 +2,23 @@ package clientapi
 
 import (
 	"github.com/obscuronet/go-obscuro/go/common/container"
-	"github.com/obscuronet/go-obscuro/go/common/host"
 )
 
 // TODO - Disable these methods on a non-test node.
 
 // TestAPI implements JSON RPC operations required for testing.
 type TestAPI struct {
-	host      host.Host
 	container container.Container
 }
 
-func NewTestAPI(host host.Host, container container.Container) *TestAPI {
+func NewTestAPI(container container.Container) *TestAPI {
 	return &TestAPI{
-		host:      host,
 		container: container,
 	}
 }
 
 // StopHost gracefully stops the host.
-// TODO - Investigate how to authenticate this and other sensitive methods in production (Geth uses JWT).
-// TODO - Change inmemory tests to use the host container instead of the host. Remove the `api.host` after. - https://github.com/obscuronet/obscuro-internal/issues/1314
 func (api *TestAPI) StopHost() {
-	if api.host != nil {
-		api.host.Stop()
-	}
-
 	if api.container != nil {
 		_ = api.container.Stop()
 	}

--- a/integration/simulation/network/obscuro_node_utils.go
+++ b/integration/simulation/network/obscuro_node_utils.go
@@ -8,30 +8,25 @@ import (
 	"sync"
 	"time"
 
-	"github.com/obscuronet/go-obscuro/go/enclave/genesis"
-
+	"github.com/obscuronet/go-obscuro/go/common"
 	"github.com/obscuronet/go-obscuro/go/common/container"
 	"github.com/obscuronet/go-obscuro/go/common/host"
-	"github.com/obscuronet/go-obscuro/go/enclave"
-
-	"github.com/obscuronet/go-obscuro/go/common"
-	"github.com/obscuronet/go-obscuro/integration/common/testlog"
-
-	"github.com/obscuronet/go-obscuro/go/obsclient"
-
-	"github.com/obscuronet/go-obscuro/go/wallet"
-
 	"github.com/obscuronet/go-obscuro/go/common/log"
 	"github.com/obscuronet/go-obscuro/go/config"
-	"github.com/obscuronet/go-obscuro/integration"
-
+	"github.com/obscuronet/go-obscuro/go/enclave"
+	"github.com/obscuronet/go-obscuro/go/enclave/genesis"
 	"github.com/obscuronet/go-obscuro/go/ethadapter"
+	"github.com/obscuronet/go-obscuro/go/obsclient"
 	"github.com/obscuronet/go-obscuro/go/rpc"
+	"github.com/obscuronet/go-obscuro/go/wallet"
+	"github.com/obscuronet/go-obscuro/integration"
+	"github.com/obscuronet/go-obscuro/integration/common/testlog"
 	"github.com/obscuronet/go-obscuro/integration/simulation/p2p"
 	"github.com/obscuronet/go-obscuro/integration/simulation/params"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	enclavecontainer "github.com/obscuronet/go-obscuro/go/enclave/container"
+	hostcontainer "github.com/obscuronet/go-obscuro/go/host/container"
 )
 
 const (
@@ -41,7 +36,8 @@ const (
 
 func startInMemoryObscuroNodes(params *params.SimParams, genesisJSON []byte, l1Clients []ethadapter.EthClient) []rpc.Client {
 	// Create the in memory obscuro nodes, each connect each to a geth node
-	obscuroNodes := make([]host.Host, params.NumberOfNodes)
+	obscuroNodes := make([]*hostcontainer.HostContainer, params.NumberOfNodes)
+	obscuroHosts := make([]host.Host, params.NumberOfNodes)
 	p2pLayers := make([]*p2p.MockP2P, params.NumberOfNodes)
 	for i := 0; i < params.NumberOfNodes; i++ {
 		isGenesis := i == 0
@@ -62,10 +58,11 @@ func startInMemoryObscuroNodes(params *params.SimParams, genesisJSON []byte, l1C
 			params.L1SetupData.MessageBusAddr,
 			params.L1SetupData.ObscuroStartBlock,
 		)
+		obscuroHosts[i] = obscuroNodes[i].Host()
 	}
 	// make sure the aggregators can talk to each other
 	for i := 0; i < params.NumberOfNodes; i++ {
-		p2pLayers[i].Nodes = obscuroNodes
+		p2pLayers[i].Nodes = obscuroHosts
 	}
 
 	// start each obscuro node

--- a/integration/simulation/p2p/in_mem_obscuro_client.go
+++ b/integration/simulation/p2p/in_mem_obscuro_client.go
@@ -12,12 +12,12 @@ import (
 	"github.com/ethereum/go-ethereum/crypto/ecies"
 	"github.com/obscuronet/go-obscuro/go/common"
 	"github.com/obscuronet/go-obscuro/go/common/log"
+	"github.com/obscuronet/go-obscuro/go/host/container"
 	"github.com/obscuronet/go-obscuro/go/host/rpc/clientapi"
 	"github.com/obscuronet/go-obscuro/go/rpc"
 	"github.com/obscuronet/go-obscuro/integration/common/testlog"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
-	gethlog "github.com/ethereum/go-ethereum/log"
 	gethrpc "github.com/ethereum/go-ethereum/rpc"
 	hostcommon "github.com/obscuronet/go-obscuro/go/common/host"
 )
@@ -37,7 +37,7 @@ type inMemObscuroClient struct {
 	enclavePublicKey *ecies.PublicKey
 }
 
-func NewInMemObscuroClient(nodeHost hostcommon.Host) rpc.Client {
+func NewInMemObscuroClient(hostContainer *container.HostContainer) rpc.Client {
 	logger := testlog.Logger().New(log.CmpKey, log.RPCClientCmp)
 	// todo: this is a convenience for testnet but needs to replaced by a parameter and/or retrieved from the target host
 	enclPubECDSA, err := crypto.DecompressPubkey(gethcommon.Hex2Bytes(enclavePublicKeyHex))
@@ -47,22 +47,13 @@ func NewInMemObscuroClient(nodeHost hostcommon.Host) rpc.Client {
 	enclPubKey := ecies.ImportECDSAPublic(enclPubECDSA)
 
 	return &inMemObscuroClient{
-		obscuroAPI:       clientapi.NewObscuroAPI(nodeHost),
-		ethAPI:           clientapi.NewEthereumAPI(nodeHost, logger),
-		filterAPI:        clientapi.NewFilterAPI(nodeHost, logger),
-		obscuroScanAPI:   clientapi.NewObscuroScanAPI(nodeHost),
-		testAPI:          clientapi.NewTestAPI(nodeHost, nil),
+		obscuroAPI:       clientapi.NewObscuroAPI(hostContainer.Host()),
+		ethAPI:           clientapi.NewEthereumAPI(hostContainer.Host(), logger),
+		filterAPI:        clientapi.NewFilterAPI(hostContainer.Host(), logger),
+		obscuroScanAPI:   clientapi.NewObscuroScanAPI(hostContainer.Host()),
+		testAPI:          clientapi.NewTestAPI(hostContainer),
 		enclavePublicKey: enclPubKey,
 	}
-}
-
-func NewInMemoryEncRPCClient(host hostcommon.Host, viewingKey *rpc.ViewingKey, logger gethlog.Logger) *rpc.EncRPCClient {
-	inMemClient := NewInMemObscuroClient(host)
-	encClient, err := rpc.NewEncRPCClient(inMemClient, viewingKey, logger)
-	if err != nil {
-		panic(err)
-	}
-	return encClient
 }
 
 // Call bypasses RPC, and invokes methods on the node directly.

--- a/integration/simulation/p2p/mock_l2_network.go
+++ b/integration/simulation/p2p/mock_l2_network.go
@@ -6,12 +6,10 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/rlp"
-
+	"github.com/obscuronet/go-obscuro/go/common"
 	"github.com/obscuronet/go-obscuro/go/common/host"
 
 	testcommon "github.com/obscuronet/go-obscuro/integration/common"
-
-	"github.com/obscuronet/go-obscuro/go/common"
 )
 
 // MockP2P - models a full network of in memory nodes including artificial random latencies


### PR DESCRIPTION
### Why is this change needed?

- https://github.com/obscuronet/obscuro-internal/issues/1314

### What changes were made as part of this PR:

- Provide a high level list of the changes made

### Definition of done

- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
- [ ] End-to-end tests run if required (see below)

### End-to-end tests

Running the end-to-end tests in the [obscuro-test repo](https://github.com/obscuronet/obscuro-test) is currently at the 
discretion of the developer prior to merging a PR. The intention is not to slow down development by having the longer 
running end-to-end tests as a PR gate run on each branch commit etc. To manually trigger a run pre-merge;

- Go to [run_local_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_local_tests.yml)
- Click the "Run workflow" button
- Use the main branch of obscuro-test 
- Enter the name of the PR branch for go-obscuro
- Run the workflow

The run takes approximately 20 minutes and any failure will be reported in the workflow output. Should the tests fail 
the docker container output for the local testnet and all test artifacts will be added to the run and can be downloaded
for debugging and analysis, with a retention period of 2 days. 

Note that every PR merge to main will also trigger a run of post-merge tests, so even if you do not manually trigger 
pre-merge, tests will be run post-merge. The intention being to catch any issues fast on main to allow for quick 
resolution. The post-merge test output can be seen at 
[run_merge_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_merge_tests.yml) and will show both 
the PR number and author in the list of runs. 


