### PR TITLE
Upgrade flow for testnet

### DIFF
--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -21,6 +21,11 @@ on:
         type: boolean
         default: false
         required: true
+      github_deploy_number:
+        description: 'Github Deployment Number'
+        type: number
+        default: 0
+        required: true
 
 
 jobs:
@@ -92,16 +97,16 @@ jobs:
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
 
-      - name: 'Build and push obscuro node images'
-        run: |
-          docker build -t ${{env.L2_ENCLAVE_DOCKER_BUILD_TAG}} -f dockerfiles/enclave.Dockerfile  .
-          docker push ${{env.L2_ENCLAVE_DOCKER_BUILD_TAG}}
-          docker build -t ${{env.L2_ENCLAVE_DOCKER_BUILD_TAG}} -f dockerfiles/host.Dockerfile .
-          docker push ${{env.L2_ENCLAVE_DOCKER_BUILD_TAG}}
-          docker build -t ${{env.L2_CONTRACTDEPLOYER_DOCKER_BUILD_TAG}} -f testnet/contractdeployer.Dockerfile .
-          docker push ${{env.L2_CONTRACTDEPLOYER_DOCKER_BUILD_TAG}}
-          docker build -t ${{env.L2_HARDHATDEPLOYER_DOCKER_BUILD_TAG}} -f testnet/hardhatdeployer.Dockerfile .
-          docker push ${{env.L2_HARDHATDEPLOYER_DOCKER_BUILD_TAG}}
+#      - name: 'Build and push obscuro node images'
+#        run: |
+#          docker build -t ${{env.L2_ENCLAVE_DOCKER_BUILD_TAG}} -f dockerfiles/enclave.Dockerfile  .
+#          docker push ${{env.L2_ENCLAVE_DOCKER_BUILD_TAG}}
+#          docker build -t ${{env.L2_ENCLAVE_DOCKER_BUILD_TAG}} -f dockerfiles/host.Dockerfile .
+#          docker push ${{env.L2_ENCLAVE_DOCKER_BUILD_TAG}}
+#          docker build -t ${{env.L2_CONTRACTDEPLOYER_DOCKER_BUILD_TAG}} -f testnet/contractdeployer.Dockerfile .
+#          docker push ${{env.L2_CONTRACTDEPLOYER_DOCKER_BUILD_TAG}}
+#          docker build -t ${{env.L2_HARDHATDEPLOYER_DOCKER_BUILD_TAG}} -f testnet/hardhatdeployer.Dockerfile .
+#          docker push ${{env.L2_HARDHATDEPLOYER_DOCKER_BUILD_TAG}}
 
       - name: 'Deploy Contracts'
         if: ${{ github.event.inputs.reset }}
@@ -250,7 +255,7 @@ jobs:
         uses: azure/CLI@v1
         with:
           inlineScript: |
-            az vm run-command invoke -g Testnet -n "${{needs.build.outputs.RESOURCE_STARTING_NAME}}-${{ matrix.host_id }}-${{ GITHUB.RUN_NUMBER }}"  \
+            az vm run-command invoke -g Testnet -n "${{needs.build.outputs.RESOURCE_STARTING_NAME}}-${{ matrix.host_id }}-${{ github.event.inputs.github_deploy_number }}"  \
             --command-id RunShellScript \
             --scripts '
               cd /home/obscuro/go-obscuro/testnet/ \
@@ -298,9 +303,17 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: "Wait until obscuro node is healthy"
+        if: ${{ github.event.inputs.reset }}
         shell: bash
         run: |
-          ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-0-${{needs.build.outputs.RESOURCE_TESTNET_NAME}}-${{ GITHUB.RUN_NUMBER }}.uksouth.cloudapp.azure.com
+          ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-0-${{needs.build.outputs.RESOURCE_TESTNET_NAME}}-${{ GITHUB.RUN_NUMBER }}.uksouth.cloudapp.azure.com   
+
+      - name: "Wait until obscuro node is healthy"
+        if: ${{ ! github.event.inputs.reset }}
+        shell: bash
+        run: |
+          ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-0-${{needs.build.outputs.RESOURCE_TESTNET_NAME}}-${{ github.event.inputs.github_deploy_number }}.uksouth.cloudapp.azure.com
+  
 
   deploy-l2-contracts:
     if: ${{ github.event.inputs.reset }}

--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -1,9 +1,9 @@
-# Deploys an Obscuro network on Azure for Testnet and Dev Testnet
+# Deploys or Updates an Obscuro network on Azure for Testnet and Dev Testnet
 #
 # The Obscuro network is composed of 2 obscuro nodes running on individual vms with SGX
 #
 
-name: '[M] Deploy Testnet L2'
+name: '[M] Upgrade Testnet L2'
 
 on:
   workflow_dispatch:
@@ -16,6 +16,11 @@ on:
         options:
           - 'dev-testnet'
           - 'testnet'
+      reset:
+        description: 'Reset testnet ?'
+        type: boolean
+        default: false
+        required: true
 
 
 jobs:
@@ -54,7 +59,7 @@ jobs:
           echo "RESOURCE_STARTING_NAME=T" >> $GITHUB_ENV
           echo "RESOURCE_TESTNET_NAME=testnet" >> $GITHUB_ENV
           echo "L1_HOST=testnet-gethnetwork.uksouth.azurecontainer.io" >> $GITHUB_ENV
-          
+
       - name: 'Sets env vars for dev-tesnet'
         if: ${{ github.event.inputs.testnet_type == 'dev-testnet' }}
         run: |
@@ -66,7 +71,7 @@ jobs:
           echo "RESOURCE_STARTING_NAME=D" >> $GITHUB_ENV
           echo "RESOURCE_TESTNET_NAME=devtestnet" >> $GITHUB_ENV
           echo "L1_HOST=dev-testnet-gethnetwork.uksouth.azurecontainer.io" >> $GITHUB_ENV
-          
+
       - name: 'Output env vars'
         id: outputVars
         run: |
@@ -78,7 +83,7 @@ jobs:
           echo "RESOURCE_STARTING_NAME=${{env.RESOURCE_STARTING_NAME}}" >> $GITHUB_OUTPUT
           echo "RESOURCE_TESTNET_NAME=${{env.RESOURCE_TESTNET_NAME}}" >> $GITHUB_OUTPUT
           echo "L1_HOST=${{env.L1_HOST}}" >> $GITHUB_OUTPUT
-          
+
 
       - name: 'Login to Azure docker registry'
         uses: azure/docker-login@v1
@@ -99,6 +104,7 @@ jobs:
           docker push ${{env.L2_HARDHATDEPLOYER_DOCKER_BUILD_TAG}}
 
       - name: 'Deploy Contracts'
+        if: ${{ github.event.inputs.reset }}
         id: deployContracts
         shell: bash
         run: |
@@ -114,6 +120,7 @@ jobs:
 
       # This will fail some deletions due to resource dependencies ( ie. you must first delete the vm before deleting the disk)
       - name: 'Delete deployed VMs'
+        if: ${{ github.event.inputs.reset }}
         uses: azure/CLI@v1
         with:
           inlineScript: |
@@ -121,6 +128,7 @@ jobs:
 
       # This will clean up any lingering dependencies - might fail if there are no resources to cleanup
       - name: 'Delete VMs dependencies'
+        if: ${{ github.event.inputs.reset }}
         uses: azure/CLI@v1
         with:
           inlineScript: |
@@ -171,6 +179,7 @@ jobs:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: 'Create VM for Obscuro node-${{ matrix.host_id }} on Azure'
+        if: ${{ github.event.inputs.reset }}
         uses: azure/CLI@v1
         with:
           inlineScript: |
@@ -183,6 +192,7 @@ jobs:
             --public-ip-sku Basic --authentication-type password
 
       - name: 'Open Obscuro node-${{ matrix.host_id }} ports on Azure'
+        if: ${{ github.event.inputs.reset }}
         uses: azure/CLI@v1
         with:
           inlineScript: |
@@ -193,6 +203,7 @@ jobs:
         run: if [ 0! = ${{ matrix.host_id }} ]; then sleep 60; fi
 
       - name: 'Start Obscuro node-${{ matrix.host_id }} on Azure'
+        if: ${{ github.event.inputs.reset }}
         uses: azure/CLI@v1
         with:
           inlineScript: |
@@ -232,7 +243,25 @@ jobs:
                --p2p_public_address=obscuronode-${{ matrix.host_id }}-${{needs.build.outputs.RESOURCE_TESTNET_NAME}}-${{ GITHUB.RUN_NUMBER }}.uksouth.cloudapp.azure.com:10000'
 
 
+
+
+      - name: 'Update Obscuro node-${{ matrix.host_id }} on Azure'
+        if: ${{ github.event.inputs.reset }}
+        uses: azure/CLI@v1
+        with:
+          inlineScript: |
+            az vm run-command invoke -g Testnet -n "${{needs.build.outputs.RESOURCE_STARTING_NAME}}-${{ matrix.host_id }}-${{ GITHUB.RUN_NUMBER }}"  \
+            --command-id RunShellScript \
+            --scripts '
+              cd /home/obscuro/go-obscuro/testnet/ \
+              docker compose down host enclave && \
+              docker compose pull && docker compose up host enclave -d
+              '
+
+
+
   update-loadbalancer:
+    if: ${{ github.event.inputs.reset }}
     needs:
       - build
       - deploy
@@ -258,6 +287,7 @@ jobs:
               --nic-name ${{needs.build.outputs.RESOURCE_STARTING_NAME}}-1-${{ GITHUB.RUN_NUMBER }}VMNic \
               --resource-group Testnet \
               --lb-name ${{needs.build.outputs.RESOURCE_TESTNET_NAME}}-loadbalancer
+  
 
   wait-node-up:
     needs:
@@ -273,6 +303,7 @@ jobs:
           ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-0-${{needs.build.outputs.RESOURCE_TESTNET_NAME}}-${{ GITHUB.RUN_NUMBER }}.uksouth.cloudapp.azure.com
 
   deploy-l2-contracts:
+    if: ${{ github.event.inputs.reset }}
     needs:
       - build
       - wait-node-up


### PR DESCRIPTION
### Why is this change needed?

- https://github.com/obscuronet/obscuro-internal/issues/1368
- 
### What changes were made as part of this PR:

- Provide a high level list of the changes made

### Definition of done

- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
- [ ] End-to-end tests run if required (see below)

### End-to-end tests

Running the end-to-end tests in the [obscuro-test repo](https://github.com/obscuronet/obscuro-test) is currently at the 
discretion of the developer prior to merging a PR. The intention is not to slow down development by having the longer 
running end-to-end tests as a PR gate run on each branch commit etc. To manually trigger a run pre-merge;

- Go to [run_local_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_local_tests.yml)
- Click the "Run workflow" button
- Use the main branch of obscuro-test 
- Enter the name of the PR branch for go-obscuro
- Run the workflow

The run takes approximately 20 minutes and any failure will be reported in the workflow output. Should the tests fail 
the docker container output for the local testnet and all test artifacts will be added to the run and can be downloaded
for debugging and analysis, with a retention period of 2 days. 

Note that every PR merge to main will also trigger a run of post-merge tests, so even if you do not manually trigger 
pre-merge, tests will be run post-merge. The intention being to catch any issues fast on main to allow for quick 
resolution. The post-merge test output can be seen at 
[run_merge_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_merge_tests.yml) and will show both 
the PR number and author in the list of runs. 


