### PR TITLE
Adds comments to clarify some of the log events logic.

### DIFF
--- a/go/enclave/events/subscription_manager.go
+++ b/go/enclave/events/subscription_manager.go
@@ -298,6 +298,11 @@ func (s *SubscriptionManager) getNumberOfSubsThreadsafe() int {
 //   - One of the log's user addresses matches the subscription's account
 //   - The log matches the filter
 func isRelevant(logItem *types.Log, userAddrs []string, account *gethcommon.Address, filter *filters.FilterCriteria) bool {
+	filteredLogs := filterLogs([]*types.Log{logItem}, filter.FromBlock, filter.ToBlock, filter.Addresses, filter.Topics)
+	if len(filteredLogs) == 0 {
+		return false
+	}
+
 	// If there are no user addresses, this is a lifecycle event, and is therefore relevant to everyone.
 	if len(userAddrs) == 0 {
 		return true
@@ -305,8 +310,7 @@ func isRelevant(logItem *types.Log, userAddrs []string, account *gethcommon.Addr
 
 	for _, addr := range userAddrs {
 		if addr == account.Hex() {
-			filteredLogs := filterLogs([]*types.Log{logItem}, filter.FromBlock, filter.ToBlock, filter.Addresses, filter.Topics)
-			return len(filteredLogs) != 0
+			return true
 		}
 	}
 

--- a/go/enclave/events/subscription_manager.go
+++ b/go/enclave/events/subscription_manager.go
@@ -298,17 +298,15 @@ func (s *SubscriptionManager) getNumberOfSubsThreadsafe() int {
 //   - One of the log's user addresses matches the subscription's account
 //   - The log matches the filter
 func isRelevant(logItem *types.Log, userAddrs []string, account *gethcommon.Address, filter *filters.FilterCriteria) bool {
-	filteredLogs := filterLogs([]*types.Log{logItem}, filter.FromBlock, filter.ToBlock, filter.Addresses, filter.Topics)
-	logMatchesFilter := len(filteredLogs) != 0
-
 	// If there are no user addresses, this is a lifecycle event, and is therefore relevant to everyone.
 	if len(userAddrs) == 0 {
-		return logMatchesFilter
+		return true
 	}
 
 	for _, addr := range userAddrs {
 		if addr == account.Hex() {
-			return logMatchesFilter
+			filteredLogs := filterLogs([]*types.Log{logItem}, filter.FromBlock, filter.ToBlock, filter.Addresses, filter.Topics)
+			return len(filteredLogs) != 0
 		}
 	}
 

--- a/go/rpc/encrypted_client.go
+++ b/go/rpc/encrypted_client.go
@@ -166,6 +166,9 @@ func (c *EncRPCClient) Subscribe(ctx context.Context, result interface{}, namesp
 		return nil, err
 	}
 
+	// We need to return the subscription ID, to allow unsubscribing. However, the client API has already converted
+	// from a subscription ID to a subscription object under the hood, so we can't retrieve the subscription ID.
+	// To hack around this, we always return the subscription ID as the first message on the newly-created subscription.
 	err = c.setResultToSubID(clientChannel, result, subscription)
 	if err != nil {
 		subscription.Unsubscribe()
@@ -232,7 +235,7 @@ func (c *EncRPCClient) createAuthenticatedLogSubscription(args []interface{}) (*
 
 	// TODO - Consider switching to using the common.FilterCriteriaJSON type. Should allow us to avoid RLP serialisation.
 	// We marshal the filter criteria from a map to JSON, then back from JSON into a FilterCriteria. This is
-	// because the filter criteria arrives as a map, and there is no way to convert it to a map directly into a
+	// because the filter criteria arrives as a map, and there is no way to convert it from a map directly into a
 	// FilterCriteria.
 	filterCriteriaJSON, err := json.Marshal(args[1])
 	if err != nil {


### PR DESCRIPTION
### Why is this change needed?

Adds comments to clarify some of the log events logic.

### What changes were made as part of this PR:

- Provide a high level list of the changes made

### Definition of done

- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
- [ ] End-to-end tests run if required (see below)

### End-to-end tests

Running the end-to-end tests in the [obscuro-test repo](https://github.com/obscuronet/obscuro-test) is currently at the 
discretion of the developer prior to merging a PR. The intention is not to slow down development by having the longer 
running end-to-end tests as a PR gate run on each branch commit etc. To manually trigger a run pre-merge;

- Go to [run_local_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_local_tests.yml)
- Click the "Run workflow" button
- Use the main branch of obscuro-test 
- Enter the name of the PR branch for go-obscuro
- Run the workflow

The run takes approximately 20 minutes and any failure will be reported in the workflow output. Should the tests fail 
the docker container output for the local testnet and all test artifacts will be added to the run and can be downloaded
for debugging and analysis, with a retention period of 2 days. 

Note that every PR merge to main will also trigger a run of post-merge tests, so even if you do not manually trigger 
pre-merge, tests will be run post-merge. The intention being to catch any issues fast on main to allow for quick 
resolution. The post-merge test output can be seen at 
[run_merge_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_merge_tests.yml) and will show both 
the PR number and author in the list of runs. 


