### PR TITLE
Requires the full set of batches to be specified when creating a rollup from a set of batches

### DIFF
--- a/go/common/batches.go
+++ b/go/common/batches.go
@@ -26,13 +26,6 @@ func (b *ExtBatch) Hash() L2RootHash {
 	return v
 }
 
-func (b *ExtBatch) ToExtRollup() *ExtRollup {
-	return &ExtRollup{
-		Header:  b.Header.ToRollupHeader(),
-		Batches: []*ExtBatch{b},
-	}
-}
-
 // BatchRequest is used when requesting a range of batches from a peer.
 type BatchRequest struct {
 	Requester        string

--- a/go/common/headers.go
+++ b/go/common/headers.go
@@ -113,11 +113,10 @@ func (b *BatchHeader) Hash() L2RootHash {
 
 func (b *BatchHeader) ToRollupHeader() *RollupHeader {
 	return &RollupHeader{
-		ParentHash: b.ParentHash,
-		UncleHash:  b.UncleHash,
-		Coinbase:   b.Coinbase,
-		Root:       b.Root,
-		// TODO - #718 - Once there are multiple batches per rollup, this conversion will no longer be possible.
+		ParentHash:                    b.ParentHash,
+		UncleHash:                     b.UncleHash,
+		Coinbase:                      b.Coinbase,
+		Root:                          b.Root,
 		HeadBatchHash:                 b.TxHash,
 		ReceiptHash:                   b.ReceiptHash,
 		Bloom:                         b.Bloom,

--- a/go/common/rollups.go
+++ b/go/common/rollups.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"sort"
 	"sync/atomic"
 )
 
@@ -23,11 +24,16 @@ func (r *ExtRollup) Hash() L2RootHash {
 	return v
 }
 
-// ExtRollupFromExtBatches converts a set of ExtBatch into an ExtRollup. The head batch is the one stored in the
-// ExtRollup header's `HeadBatchHash` field.
-func ExtRollupFromExtBatches(headBatch *ExtBatch, additionalBatches []*ExtBatch) *ExtRollup {
+// ExtRollupFromExtBatches converts a set of ExtBatch into an ExtRollup. The hash of the head batch (the one with the
+// highest number) is stored in the ExtRollup header's `HeadBatchHash` field.
+func ExtRollupFromExtBatches(batches []*ExtBatch) *ExtRollup {
+	sort.Slice(batches, func(i, j int) bool {
+		// Ascending order sort.
+		return batches[i].Header.Number.Cmp(batches[j].Header.Number) < 0
+	})
+
 	return &ExtRollup{
-		Header:  headBatch.Header.ToRollupHeader(),
-		Batches: append(additionalBatches, headBatch),
+		Header:  batches[len(batches)-1].Header.ToRollupHeader(),
+		Batches: batches,
 	}
 }

--- a/go/common/rollups.go
+++ b/go/common/rollups.go
@@ -22,3 +22,12 @@ func (r *ExtRollup) Hash() L2RootHash {
 	r.hash.Store(v)
 	return v
 }
+
+// ExtRollupFromExtBatches converts a set of ExtBatch into an ExtRollup. The head batch is the one stored in the
+// ExtRollup header's `HeadBatchHash` field.
+func ExtRollupFromExtBatches(headBatch *ExtBatch, additionalBatches []*ExtBatch) *ExtRollup {
+	return &ExtRollup{
+		Header:  headBatch.Header.ToRollupHeader(),
+		Batches: append(additionalBatches, headBatch),
+	}
+}

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -1062,7 +1062,7 @@ func (e *enclaveImpl) produceBlockSubmissionResponse(block *types.Block, l2Head 
 	var producedExtRollup *common.ExtRollup
 	if producedBatch != nil {
 		producedExtBatch = producedBatch.ToExtBatch(e.transactionBlobCrypto)
-		producedExtRollup = common.ExtRollupFromExtBatches(producedExtBatch, []*common.ExtBatch{})
+		producedExtRollup = common.ExtRollupFromExtBatches([]*common.ExtBatch{producedExtBatch})
 	}
 
 	return &common.BlockSubmissionResponse{

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -1062,7 +1062,7 @@ func (e *enclaveImpl) produceBlockSubmissionResponse(block *types.Block, l2Head 
 	var producedExtRollup *common.ExtRollup
 	if producedBatch != nil {
 		producedExtBatch = producedBatch.ToExtBatch(e.transactionBlobCrypto)
-		producedExtRollup = producedExtBatch.ToExtRollup()
+		producedExtRollup = common.ExtRollupFromExtBatches(producedExtBatch, []*common.ExtBatch{})
 	}
 
 	return &common.BlockSubmissionResponse{

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -841,9 +841,9 @@ func (rc *RollupChain) processRollups(block *common.L1Block) error {
 		return fmt.Errorf("could not fetch current L2 head rollup")
 	}
 
-	// We retrieve the block's rollups, ordered by number.
 	rollups := rc.bridge.ExtractRollups(block, rc.storage)
 	sort.Slice(rollups, func(i, j int) bool {
+		// Ascending order sort.
 		return rollups[i].Header.Number.Cmp(rollups[j].Header.Number) < 0
 	})
 


### PR DESCRIPTION
### Why is this change needed?

- Provide a description and a link to the underlying ticket

### What changes were made as part of this PR:

- Provide a high level list of the changes made

### Definition of done

- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
- [ ] End-to-end tests run if required (see below)

### End-to-end tests

Running the end-to-end tests in the [obscuro-test repo](https://github.com/obscuronet/obscuro-test) is currently at the 
discretion of the developer prior to merging a PR. The intention is not to slow down development by having the longer 
running end-to-end tests as a PR gate run on each branch commit etc. To manually trigger a run pre-merge;

- Go to [run_local_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_local_tests.yml)
- Click the "Run workflow" button
- Use the main branch of obscuro-test 
- Enter the name of the PR branch for go-obscuro
- Run the workflow

The run takes approximately 20 minutes and any failure will be reported in the workflow output. Should the tests fail 
the docker container output for the local testnet and all test artifacts will be added to the run and can be downloaded
for debugging and analysis, with a retention period of 2 days. 

Note that every PR merge to main will also trigger a run of post-merge tests, so even if you do not manually trigger 
pre-merge, tests will be run post-merge. The intention being to catch any issues fast on main to allow for quick 
resolution. The post-merge test output can be seen at 
[run_merge_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_merge_tests.yml) and will show both 
the PR number and author in the list of runs. 


