### PR TITLE
Adds todo to handle failure to publish rollup to L1

### DIFF
--- a/go/host/host.go
+++ b/go/host/host.go
@@ -520,6 +520,8 @@ func (h *host) publishRollup(producedRollup *common.ExtRollup) {
 	}
 
 	// fire-and-forget (track the receipt asynchronously)
+	// TODO - #718 - Now we have a single sequencer, it is problematic if rollup publication fails. Handle this case
+	//  better.
 	err = h.signAndBroadcastL1Tx(rollupTx, l1TxTriesRollup, false)
 	if err != nil {
 		h.logger.Error("could not issue rollup tx", log.ErrKey, err)
@@ -574,7 +576,7 @@ func (h *host) signAndBroadcastL1Tx(tx types.TxData, tries uint64, awaitReceipt 
 	// else just watch for receipt asynchronously and log if it fails
 	go func() {
 		// todo: consider how to handle the various ways that L1 transactions could fail to improve node operator QoL
-		err := h.waitForReceipt(signedTx.Hash())
+		err = h.waitForReceipt(signedTx.Hash())
 		if err != nil {
 			h.logger.Error("L1 transaction failed", log.ErrKey, err)
 		}


### PR DESCRIPTION
### Why is this change needed?

- Provide a description and a link to the underlying ticket

### What changes were made as part of this PR:

- Provide a high level list of the changes made

### Definition of done

- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
- [ ] End-to-end tests run if required (see below)

### End-to-end tests

Running the end-to-end tests in the [obscuro-test repo](https://github.com/obscuronet/obscuro-test) is currently at the 
discretion of the developer prior to merging a PR. The intention is not to slow down development by having the longer 
running end-to-end tests as a PR gate run on each branch commit etc. To manually trigger a run pre-merge;

- Go to [run_local_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_local_tests.yml)
- Click the "Run workflow" button
- Use the main branch of obscuro-test 
- Enter the name of the PR branch for go-obscuro
- Run the workflow

The run takes approximately 20 minutes and any failure will be reported in the workflow output. Should the tests fail 
the docker container output for the local testnet and all test artifacts will be added to the run and can be downloaded
for debugging and analysis, with a retention period of 2 days. 

Note that every PR merge to main will also trigger a run of post-merge tests, so even if you do not manually trigger 
pre-merge, tests will be run post-merge. The intention being to catch any issues fast on main to allow for quick 
resolution. The post-merge test output can be seen at 
[run_merge_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_merge_tests.yml) and will show both 
the PR number and author in the list of runs. 


