### PR TITLE
Now that batches are contained in rollups, confirm batches as they come in

### DIFF
--- a/go/enclave/db/interfaces.go
+++ b/go/enclave/db/interfaces.go
@@ -39,6 +39,8 @@ type BatchResolver interface {
 	FetchHeadBatch() (*core.Batch, error)
 	// StoreBatch stores a batch.
 	StoreBatch(batch *core.Batch, receipts []*types.Receipt) error
+	// ConfirmBatch marks a batch as confirmed.
+	ConfirmBatch(batch *core.Batch) error
 }
 
 type RollupResolver interface {

--- a/go/enclave/db/rawdb/accessors_chain.go
+++ b/go/enclave/db/rawdb/accessors_chain.go
@@ -15,6 +15,9 @@ import (
 	"github.com/obscuronet/go-obscuro/go/enclave/core"
 )
 
+// Indicates that a batch has been confirmed.
+const batchConfirmed byte = 1
+
 func ReadBatch(db ethdb.KeyValueReader, hash common.L2RootHash) (*core.Batch, error) {
 	header, err := readBatchHeader(db, hash)
 	if err != nil {
@@ -51,6 +54,14 @@ func WriteBatch(db ethdb.KeyValueWriter, batch *core.Batch) error {
 	}
 	if err := writeBatchBody(db, *batch.Hash(), batch.Transactions); err != nil {
 		return fmt.Errorf("could not write body. Cause: %w", err)
+	}
+	return nil
+}
+
+func ConfirmBatch(db ethdb.KeyValueWriter, batch *core.Batch) error {
+	key := batchConfirmationKey(batch.Hash())
+	if err := db.Put(key, []byte{batchConfirmed}); err != nil {
+		return fmt.Errorf("could not put batch confirmation in DB. Cause: %w", err)
 	}
 	return nil
 }

--- a/go/enclave/db/rawdb/schema.go
+++ b/go/enclave/db/rawdb/schema.go
@@ -13,10 +13,11 @@ var (
 	attestationKeyPrefix           = []byte("oAK")  // attestationKeyPrefix + address -> key
 	syntheticTransactionsKeyPrefix = []byte("oSTX") // attestationKeyPrefix + address -> key
 
-	batchHeaderPrefix            = []byte("oh")  // batchHeaderPrefix + num (uint64 big endian) + hash -> header
-	batchHashSuffix              = []byte("on")  // batchHeaderPrefix + num (uint64 big endian) + headerHashSuffix -> hash
-	batchBodyPrefix              = []byte("ob")  // batchBodyPrefix + num (uint64 big endian) + hash -> batch body
-	batchNumberPrefix            = []byte("oH")  // batchNumberPrefix + hash -> num (uint64 big endian)
+	batchHeaderPrefix            = []byte("oh") // batchHeaderPrefix + num (uint64 big endian) + hash -> header
+	batchHashSuffix              = []byte("on") // batchHeaderPrefix + num (uint64 big endian) + headerHashSuffix -> hash
+	batchBodyPrefix              = []byte("ob") // batchBodyPrefix + num (uint64 big endian) + hash -> batch body
+	batchNumberPrefix            = []byte("oH") // batchNumberPrefix + hash -> num (uint64 big endian)
+	batchConfirmationPrefix      = []byte("oc")
 	rollupHeaderPrefix           = []byte("rh")  // rollupHeaderPrefix + num (uint64 big endian) + hash -> header
 	rollupBodyPrefix             = []byte("rb")  // rollupBodyPrefix + num (uint64 big endian) + hash -> batch body
 	rollupNumberPrefix           = []byte("rn")  // rollupNumberPrefix + hash -> num (uint64 big endian)
@@ -43,6 +44,11 @@ func batchHeaderKey(hash common.L2RootHash) []byte {
 // For storing and fetching a batch body by batch hash.
 func batchBodyKey(hash common.L2RootHash) []byte {
 	return append(batchBodyPrefix, hash.Bytes()...)
+}
+
+// For storing and fetching the confirmation status of a batch.
+func batchConfirmationKey(hash *common.L2RootHash) []byte {
+	return append(batchConfirmationPrefix, hash.Bytes()...)
 }
 
 // For storing and fetching a batch number by batch hash.

--- a/go/enclave/db/storage.go
+++ b/go/enclave/db/storage.go
@@ -323,6 +323,19 @@ func (s *storageImpl) StoreBatch(batch *core.Batch, receipts []*types.Receipt) e
 	return nil
 }
 
+func (s *storageImpl) ConfirmBatch(batch *core.Batch) error {
+	dbBatch := s.db.NewBatch()
+
+	if err := obscurorawdb.ConfirmBatch(dbBatch, batch); err != nil {
+		return fmt.Errorf("could not write write confirmed batch to storage . Cause: %w", err)
+	}
+
+	if err := dbBatch.Write(); err != nil {
+		return fmt.Errorf("could not write confirmed batch to storage. Cause: %w", err)
+	}
+	return nil
+}
+
 func (s *storageImpl) StoreL1Messages(blockHash common.L1RootHash, messages common.CrossChainMessages) error {
 	return obscurorawdb.StoreL1Messages(s.db, blockHash, messages, s.logger)
 }

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -873,9 +873,6 @@ func (rc *RollupChain) processRollups(block *common.L1Block) error {
 			}
 		}
 
-		// TODO - #718 - Design and introduce an asynchronous mechanism for determining that batches are being
-		//  confirmed in a timely way.
-
 		if err = rc.storage.StoreRollup(rollup); err != nil {
 			return fmt.Errorf("could not store rollup. Cause: %w", err)
 		}


### PR DESCRIPTION
### Why is this change needed?

Previously, we were checking each rollup matched against batches as it came in.

Now that the batches are contained in the rollup, there's no real checking to do - either the rollup contains a batch with a given hash, or it doesn't. The hashing plus the signatures cover cases where an attacker tries to mess with a batch's contents.

The issue is one of timing. A rollup could feasibly arrive before the batch, or vice-versa. I therefore propose to just mark each batch's hash as "confirmed" when it arrives. Then some monitor process can check that batches are being confirmed sufficiently quickly (I haven't actually implemented that here).

### What changes were made as part of this PR:

- Provide a high level list of the changes made

### Definition of done

- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
- [ ] End-to-end tests run if required (see below)

### End-to-end tests

Running the end-to-end tests in the [obscuro-test repo](https://github.com/obscuronet/obscuro-test) is currently at the 
discretion of the developer prior to merging a PR. The intention is not to slow down development by having the longer 
running end-to-end tests as a PR gate run on each branch commit etc. To manually trigger a run pre-merge;

- Go to [run_local_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_local_tests.yml)
- Click the "Run workflow" button
- Use the main branch of obscuro-test 
- Enter the name of the PR branch for go-obscuro
- Run the workflow

The run takes approximately 20 minutes and any failure will be reported in the workflow output. Should the tests fail 
the docker container output for the local testnet and all test artifacts will be added to the run and can be downloaded
for debugging and analysis, with a retention period of 2 days. 

Note that every PR merge to main will also trigger a run of post-merge tests, so even if you do not manually trigger 
pre-merge, tests will be run post-merge. The intention being to catch any issues fast on main to allow for quick 
resolution. The post-merge test output can be seen at 
[run_merge_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_merge_tests.yml) and will show both 
the PR number and author in the list of runs. 


