### PR TITLE
Fix solidity compilation warnings for unused calldata. Warnings are now treated as errors.

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -27,3 +27,13 @@ The command internally uses the abi and bytecode exporter plugins and searches t
 
 
 Additionally you can pass the `noCompile` flag which will disable running the contract compilation beforehand. This allows to build go bindings for abi/bins where the actual solidity source files are missing.
+
+## Compilation
+
+The following command compiles the solidity contracts and produces artifacts for them:
+
+```shell
+npx hardhat compile
+```
+
+[https://www.npmjs.com/package/hardhat-ignore-warnings](The ignore warnings plugin) can be used to configure the behavior of the `compile` task in regards to warnings and errors.

--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -4,7 +4,10 @@ import "@nomicfoundation/hardhat-toolbox";
 import "hardhat-abi-exporter";
 import "@solidstate/hardhat-bytecode-exporter";
 
+// Hardhat-deploy plugin - https://www.npmjs.com/package/hardhat-deploy
 import 'hardhat-deploy';
+// Hardhat ignore warnings plugin - https://www.npmjs.com/package/hardhat-ignore-warnings
+import 'hardhat-ignore-warnings';
 
 import './tasks/wallet-extension';
 import * as abigen from './tasks/abigen';
@@ -47,6 +50,13 @@ const config: HardhatUserConfig = {
     pocowner: {
         default: 2,
     },
+  },
+  // For help configuring - https://www.npmjs.com/package/hardhat-ignore-warnings
+  warnings : {
+    '*' : {
+      default: 'warn',
+      'unused-param' : 'off'
+    }
   }
 };
 

--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -53,7 +53,7 @@ const config: HardhatUserConfig = {
   },
   // For help configuring - https://www.npmjs.com/package/hardhat-ignore-warnings
   warnings : {
-    '*' : {
+    'src/management/**' : {
       default: 'warn',
       'unused-param' : 'off'
     }

--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -53,9 +53,8 @@ const config: HardhatUserConfig = {
   },
   // For help configuring - https://www.npmjs.com/package/hardhat-ignore-warnings
   warnings : {
-    'src/management/**' : {
-      default: 'warn',
-      'unused-param' : 'off'
+    '*' : {
+      default: 'error'
     }
   }
 };

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -20,5 +20,8 @@
     "node-docker-api": "^1.1.22",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.4"
+  },
+  "dependencies": {
+    "hardhat-ignore-warnings": "^0.2.6"
   }
 }

--- a/contracts/src/management/ManagementContract.sol
+++ b/contracts/src/management/ManagementContract.sol
@@ -146,7 +146,7 @@ contract ManagementContract {
         }
     }
 
-    function AddRollup(Structs.MetaRollup calldata r, string calldata _rollupData, Structs.HeaderCrossChainData calldata crossChainData) public {
+    function AddRollup(Structs.MetaRollup calldata r, string calldata /* rollupData */, Structs.HeaderCrossChainData calldata crossChainData) public {
         // TODO How to ensure the sender without hashing the calldata ?
         // bytes32 derp = keccak256(abi.encodePacked(ParentHash, AggregatorID, L1Block, Number, rollupData));
 
@@ -180,7 +180,7 @@ contract ManagementContract {
     }
 
     // InitializeNetworkSecret kickstarts the network secret, can only be called once
-    function InitializeNetworkSecret(address _aggregatorID, bytes calldata _initSecret, string memory _hostAddress, string calldata _genesisAttestation) public {
+    function InitializeNetworkSecret(address _aggregatorID, bytes calldata /* _initSecret */, string memory _hostAddress, string calldata /* _genesisAttestation */) public {
         require(!networkSecretInitialized);
 
         // network can no longer be initialized


### PR DESCRIPTION
### Why is this change needed?

https://github.com/obscuronet/obscuro-internal/issues/1360

### What changes were made as part of this PR:

- Provide a high level list of the changes made

### Definition of done

- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
- [ ] End-to-end tests run if required (see below)

### End-to-end tests

Running the end-to-end tests in the [obscuro-test repo](https://github.com/obscuronet/obscuro-test) is currently at the 
discretion of the developer prior to merging a PR. The intention is not to slow down development by having the longer 
running end-to-end tests as a PR gate run on each branch commit etc. To manually trigger a run pre-merge;

- Go to [run_local_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_local_tests.yml)
- Click the "Run workflow" button
- Use the main branch of obscuro-test 
- Enter the name of the PR branch for go-obscuro
- Run the workflow

The run takes approximately 20 minutes and any failure will be reported in the workflow output. Should the tests fail 
the docker container output for the local testnet and all test artifacts will be added to the run and can be downloaded
for debugging and analysis, with a retention period of 2 days. 

Note that every PR merge to main will also trigger a run of post-merge tests, so even if you do not manually trigger 
pre-merge, tests will be run post-merge. The intention being to catch any issues fast on main to allow for quick 
resolution. The post-merge test output can be seen at 
[run_merge_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_merge_tests.yml) and will show both 
the PR number and author in the list of runs. 


