### PR TITLE
Wallet extension now supports --host cli arg.

### DIFF
--- a/tools/walletextension/common/constants.go
+++ b/tools/walletextension/common/constants.go
@@ -1,7 +1,7 @@
 package common
 
 const (
-	Localhost = "0.0.0.0"
+	Localhost = "127.0.0.1"
 
 	JSONKeyAddress      = "address"
 	JSONKeyData         = "data"

--- a/tools/walletextension/main/cli.go
+++ b/tools/walletextension/main/cli.go
@@ -9,6 +9,9 @@ import (
 
 const (
 	// Flag names, defaults and usages.
+	walletExtensionHostName    = "host"
+	walletExtensionHostDefault = "127.0.0.1"
+	walletExtensionHostUsage   = "The host where the wallet extension should open the port."
 	walletExtensionPortName    = "port"
 	walletExtensionPortDefault = 3000
 	walletExtensionPortUsage   = "The port on which to serve the wallet extension. Default: 3000."
@@ -39,6 +42,7 @@ const (
 )
 
 func parseCLIArgs() walletextension.Config {
+	walletExtensionHost := flag.String(walletExtensionHostName, walletExtensionHostDefault, walletExtensionHostUsage)
 	walletExtensionPort := flag.Int(walletExtensionPortName, walletExtensionPortDefault, walletExtensionPortUsage)
 	walletExtensionPortWS := flag.Int(walletExtensionPortWSName, walletExtensionPortWSDefault, walletExtensionPortWSUsage)
 	nodeHost := flag.String(nodeHostName, nodeHostDefault, nodeHostUsage)
@@ -49,6 +53,7 @@ func parseCLIArgs() walletextension.Config {
 	flag.Parse()
 
 	return walletextension.Config{
+		WalletExtensionHost:     *walletExtensionHost,
 		WalletExtensionPort:     *walletExtensionPort,
 		WalletExtensionPortWS:   *walletExtensionPortWS,
 		NodeRPCHTTPAddress:      fmt.Sprintf("%s:%d", *nodeHost, *nodeHTTPPort),

--- a/tools/walletextension/main/main.go
+++ b/tools/walletextension/main/main.go
@@ -58,7 +58,7 @@ func main() {
 	walletExtension := walletextension.NewWalletExtension(config, logger)
 	defer walletExtension.Shutdown()
 
-	go walletExtension.Serve(common.Localhost, config.WalletExtensionPort, config.WalletExtensionPortWS)
+	go walletExtension.Serve(config.WalletExtensionHost, config.WalletExtensionPort, config.WalletExtensionPortWS)
 
 	walletExtensionAddr := fmt.Sprintf("%s:%d", common.Localhost, config.WalletExtensionPort)
 	fmt.Printf("💡 Wallet extension started - visit http://%s/viewingkeys/ to generate an ephemeral viewing key.\n", walletExtensionAddr)

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -408,6 +408,7 @@ func (we *WalletExtension) handleSubmitViewingKey(userConn userconn.UserConn) {
 
 // Config contains the configuration required by the WalletExtension.
 type Config struct {
+	WalletExtensionHost     string
 	WalletExtensionPort     int
 	WalletExtensionPortWS   int
 	NodeRPCHTTPAddress      string


### PR DESCRIPTION
### Why is this change needed?

https://github.com/obscuronet/obscuro-internal/issues/1358

### What changes were made as part of this PR:

- Provide a high level list of the changes made

### Definition of done

- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
- [ ] End-to-end tests run if required (see below)

### End-to-end tests

Running the end-to-end tests in the [obscuro-test repo](https://github.com/obscuronet/obscuro-test) is currently at the 
discretion of the developer prior to merging a PR. The intention is not to slow down development by having the longer 
running end-to-end tests as a PR gate run on each branch commit etc. To manually trigger a run pre-merge;

- Go to [run_local_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_local_tests.yml)
- Click the "Run workflow" button
- Use the main branch of obscuro-test 
- Enter the name of the PR branch for go-obscuro
- Run the workflow

The run takes approximately 20 minutes and any failure will be reported in the workflow output. Should the tests fail 
the docker container output for the local testnet and all test artifacts will be added to the run and can be downloaded
for debugging and analysis, with a retention period of 2 days. 

Note that every PR merge to main will also trigger a run of post-merge tests, so even if you do not manually trigger 
pre-merge, tests will be run post-merge. The intention being to catch any issues fast on main to allow for quick 
resolution. The post-merge test output can be seen at 
[run_merge_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_merge_tests.yml) and will show both 
the PR number and author in the list of runs. 


