### PR TITLE
Store batches from rollups. Check batches at same height are consistent.

### DIFF
--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/obscuronet/go-obscuro/go/enclave/l2chain"
+
 	"github.com/obscuronet/go-obscuro/go/enclave/genesis"
 
 	"github.com/obscuronet/go-obscuro/go/enclave/core"
@@ -37,7 +39,6 @@ import (
 	"github.com/obscuronet/go-obscuro/go/enclave/db"
 	"github.com/obscuronet/go-obscuro/go/enclave/events"
 	"github.com/obscuronet/go-obscuro/go/enclave/mempool"
-	"github.com/obscuronet/go-obscuro/go/enclave/rollupchain"
 	"github.com/obscuronet/go-obscuro/go/enclave/rpc"
 	"github.com/obscuronet/go-obscuro/go/ethadapter/erc20contractlib"
 	"github.com/obscuronet/go-obscuro/go/ethadapter/mgmtcontractlib"
@@ -60,7 +61,7 @@ type enclaveImpl struct {
 	subscriptionManager  *events.SubscriptionManager
 	crossChainProcessors *crosschain.Processors
 
-	chain *rollupchain.RollupChain
+	chain *l2chain.L2Chain
 
 	txCh   chan *common.L2Tx
 	exitCh chan bool
@@ -137,7 +138,7 @@ func NewEnclave(
 		if config.GenesisJSON == nil {
 			logger.Crit("enclave is configured to validate blocks, but genesis JSON is nil")
 		}
-		l1Blockchain = rollupchain.NewL1Blockchain(config.GenesisJSON, logger)
+		l1Blockchain = l2chain.NewL1Blockchain(config.GenesisJSON, logger)
 	} else {
 		logger.Info("validateBlocks is set to false. L1 blocks will not be validated.")
 	}
@@ -183,7 +184,7 @@ func NewEnclave(
 	crossChainProcessors := crosschain.New(&config.MessageBusAddress, storage, big.NewInt(config.ObscuroChainID), logger)
 
 	subscriptionManager := events.NewSubscriptionManager(&rpcEncryptionManager, storage, logger)
-	chain := rollupchain.New(
+	chain := l2chain.New(
 		config.HostID,
 		config.NodeType,
 		storage,

--- a/go/enclave/l2chain/README.md
+++ b/go/enclave/l2chain/README.md
@@ -1,5 +1,5 @@
 This is where the bulk of the Obscuro specific logic is.
-The entry point is the `RollupChain`.
+The entry point is the `L2Chain`.
 
 Ethereum Blocks and Rollups produced by peers are fed into this datastructure, and it decides which is the canonical chain, 
 it produces rollups, and is able provide information when requested via RPC. 

--- a/go/enclave/l2chain/chain_test.go
+++ b/go/enclave/l2chain/chain_test.go
@@ -1,4 +1,4 @@
-package rollupchain
+package l2chain
 
 import (
 	"math/big"
@@ -22,7 +22,7 @@ func TestInvalidBlocksAreRejected(t *testing.T) {
 		t.Errorf("could not parse genesis JSON: %v", err)
 	}
 	logger := log.New(log.DeployerCmp, int(gethlog.LvlDebug), log.SysOut)
-	chain := RollupChain{l1Blockchain: NewL1Blockchain(genesisJSON, logger)}
+	chain := L2Chain{l1Blockchain: NewL1Blockchain(genesisJSON, logger)}
 
 	invalidHeaders := []types.Header{
 		{ParentHash: common.HexToHash("0x0")},                                                            // Unknown ancestor.

--- a/go/enclave/l2chain/l1_blockchain.go
+++ b/go/enclave/l2chain/l1_blockchain.go
@@ -1,4 +1,4 @@
-package rollupchain
+package l2chain
 
 import (
 	"os"

--- a/go/enclave/l2chain/l2_chain.go
+++ b/go/enclave/l2chain/l2_chain.go
@@ -1,4 +1,4 @@
-package rollupchain
+package l2chain
 
 import (
 	"bytes"
@@ -37,8 +37,8 @@ import (
 	gethrpc "github.com/ethereum/go-ethereum/rpc"
 )
 
-// RollupChain represents the canonical chain, and manages the state.
-type RollupChain struct {
+// L2Chain represents the canonical chain, and manages the state.
+type L2Chain struct {
 	hostID      gethcommon.Address
 	nodeType    common.NodeType
 	chainConfig *params.ChainConfig
@@ -74,8 +74,8 @@ func New(
 	sequencerID gethcommon.Address,
 	genesis *genesis.Genesis,
 	logger gethlog.Logger,
-) *RollupChain {
-	return &RollupChain{
+) *L2Chain {
+	return &L2Chain{
 		hostID:               hostID,
 		nodeType:             nodeType,
 		storage:              storage,
@@ -95,18 +95,18 @@ func New(
 }
 
 // ProcessL1Block is used to update the enclave with an additional L1 block.
-func (rc *RollupChain) ProcessL1Block(block types.Block, receipts types.Receipts, isLatest bool) (*common.L2RootHash, *core.Batch, error) {
-	rc.blockProcessingMutex.Lock()
-	defer rc.blockProcessingMutex.Unlock()
+func (lc *L2Chain) ProcessL1Block(block types.Block, receipts types.Receipts, isLatest bool) (*common.L2RootHash, *core.Batch, error) {
+	lc.blockProcessingMutex.Lock()
+	defer lc.blockProcessingMutex.Unlock()
 
 	// We update the L1 chain state.
-	err := rc.updateL1State(block, receipts, isLatest)
+	err := lc.updateL1State(block, receipts, isLatest)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	// We update the L1 and L2 chain heads.
-	newL2Head, producedBatch, err := rc.updateL1AndL2Heads(&block, isLatest)
+	newL2Head, producedBatch, err := lc.updateL1AndL2Heads(&block, isLatest)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -114,17 +114,17 @@ func (rc *RollupChain) ProcessL1Block(block types.Block, receipts types.Receipts
 }
 
 // UpdateL2Chain updates the L2 chain based on the received batch.
-func (rc *RollupChain) UpdateL2Chain(batch *core.Batch) (*common.BatchHeader, error) {
-	rc.blockProcessingMutex.Lock()
-	defer rc.blockProcessingMutex.Unlock()
+func (lc *L2Chain) UpdateL2Chain(batch *core.Batch) (*common.BatchHeader, error) {
+	lc.blockProcessingMutex.Lock()
+	defer lc.blockProcessingMutex.Unlock()
 
-	if err := rc.checkAndStoreBatch(batch); err != nil {
+	if err := lc.checkAndStoreBatch(batch); err != nil {
 		return nil, err
 	}
 
 	// If this is the genesis batch, we commit the genesis state.
 	if batch.IsGenesis() {
-		if err := rc.genesis.CommitGenesisState(rc.storage); err != nil {
+		if err := lc.genesis.CommitGenesisState(lc.storage); err != nil {
 			return nil, fmt.Errorf("could not apply genesis state. Cause: %w", err)
 		}
 	}
@@ -132,15 +132,15 @@ func (rc *RollupChain) UpdateL2Chain(batch *core.Batch) (*common.BatchHeader, er
 	return batch.Header, nil
 }
 
-func (rc *RollupChain) GetBalance(accountAddress gethcommon.Address, blockNumber *gethrpc.BlockNumber) (*gethcommon.Address, *hexutil.Big, error) {
+func (lc *L2Chain) GetBalance(accountAddress gethcommon.Address, blockNumber *gethrpc.BlockNumber) (*gethcommon.Address, *hexutil.Big, error) {
 	// get account balance at certain block/height
-	balance, err := rc.GetBalanceAtBlock(accountAddress, blockNumber)
+	balance, err := lc.GetBalanceAtBlock(accountAddress, blockNumber)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	// check if account is a contract
-	isAddrContract, err := rc.isAccountContractAtBlock(accountAddress, blockNumber)
+	isAddrContract, err := lc.isAccountContractAtBlock(accountAddress, blockNumber)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -149,15 +149,15 @@ func (rc *RollupChain) GetBalance(accountAddress gethcommon.Address, blockNumber
 	address := accountAddress
 	// If the accountAddress is a contract, encrypt with the address of the contract owner
 	if isAddrContract {
-		txHash, err := rc.storage.GetContractCreationTx(accountAddress)
+		txHash, err := lc.storage.GetContractCreationTx(accountAddress)
 		if err != nil {
 			return nil, nil, err
 		}
-		transaction, _, _, _, err := rc.storage.GetTransaction(*txHash)
+		transaction, _, _, _, err := lc.storage.GetTransaction(*txHash)
 		if err != nil {
 			return nil, nil, err
 		}
-		signer := types.NewLondonSigner(rc.chainConfig.ChainID)
+		signer := types.NewLondonSigner(lc.chainConfig.ChainID)
 
 		sender, err := signer.Sender(transaction)
 		if err != nil {
@@ -170,8 +170,8 @@ func (rc *RollupChain) GetBalance(accountAddress gethcommon.Address, blockNumber
 }
 
 // GetBalanceAtBlock returns the balance of an account at a certain height
-func (rc *RollupChain) GetBalanceAtBlock(accountAddr gethcommon.Address, blockNumber *gethrpc.BlockNumber) (*hexutil.Big, error) {
-	chainState, err := rc.getChainStateAtBlock(blockNumber)
+func (lc *L2Chain) GetBalanceAtBlock(accountAddr gethcommon.Address, blockNumber *gethrpc.BlockNumber) (*hexutil.Big, error) {
+	chainState, err := lc.getChainStateAtBlock(blockNumber)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get blockchain state - %w", err)
 	}
@@ -180,43 +180,43 @@ func (rc *RollupChain) GetBalanceAtBlock(accountAddr gethcommon.Address, blockNu
 }
 
 // ExecuteOffChainTransaction executes non-state changing transactions at a given block height (eth_call)
-func (rc *RollupChain) ExecuteOffChainTransaction(apiArgs *gethapi.TransactionArgs, blockNumber *gethrpc.BlockNumber) (*gethcore.ExecutionResult, error) {
-	result, err := rc.ExecuteOffChainTransactionAtBlock(apiArgs, blockNumber)
+func (lc *L2Chain) ExecuteOffChainTransaction(apiArgs *gethapi.TransactionArgs, blockNumber *gethrpc.BlockNumber) (*gethcore.ExecutionResult, error) {
+	result, err := lc.ExecuteOffChainTransactionAtBlock(apiArgs, blockNumber)
 	if err != nil {
-		rc.logger.Error(fmt.Sprintf("!OffChain: Failed to execute contract %s.", apiArgs.To), log.ErrKey, err.Error())
+		lc.logger.Error(fmt.Sprintf("!OffChain: Failed to execute contract %s.", apiArgs.To), log.ErrKey, err.Error())
 		return nil, err
 	}
 
 	// the execution might have succeeded (err == nil) but the evm contract logic might have failed (result.Failed() == true)
 	if result.Failed() {
-		rc.logger.Error(fmt.Sprintf("!OffChain: Failed to execute contract %s.", apiArgs.To), log.ErrKey, result.Err)
+		lc.logger.Error(fmt.Sprintf("!OffChain: Failed to execute contract %s.", apiArgs.To), log.ErrKey, result.Err)
 		return nil, result.Err
 	}
 
-	rc.logger.Trace(fmt.Sprintf("!OffChain result: %s", hexutils.BytesToHex(result.ReturnData)))
+	lc.logger.Trace(fmt.Sprintf("!OffChain result: %s", hexutils.BytesToHex(result.ReturnData)))
 
 	return result, nil
 }
 
-func (rc *RollupChain) ExecuteOffChainTransactionAtBlock(apiArgs *gethapi.TransactionArgs, blockNumber *gethrpc.BlockNumber) (*gethcore.ExecutionResult, error) {
+func (lc *L2Chain) ExecuteOffChainTransactionAtBlock(apiArgs *gethapi.TransactionArgs, blockNumber *gethrpc.BlockNumber) (*gethcore.ExecutionResult, error) {
 	// TODO review this during gas mechanics implementation
-	callMsg, err := apiArgs.ToMessage(rc.GlobalGasCap, rc.BaseFee)
+	callMsg, err := apiArgs.ToMessage(lc.GlobalGasCap, lc.BaseFee)
 	if err != nil {
 		return nil, fmt.Errorf("unable to convert TransactionArgs to Message - %w", err)
 	}
 
 	// fetch the chain state at given batch
-	blockState, err := rc.getChainStateAtBlock(blockNumber)
+	blockState, err := lc.getChainStateAtBlock(blockNumber)
 	if err != nil {
 		return nil, err
 	}
 
-	batch, err := rc.getBatch(*blockNumber)
+	batch, err := lc.getBatch(*blockNumber)
 	if err != nil {
 		return nil, fmt.Errorf("unable to fetch head state batch. Cause: %w", err)
 	}
 
-	rc.logger.Trace(
+	lc.logger.Trace(
 		fmt.Sprintf("!OffChain call: contractAddress=%s, from=%s, data=%s, batch=b_%d, state=%s",
 			callMsg.To(),
 			callMsg.From(),
@@ -225,7 +225,7 @@ func (rc *RollupChain) ExecuteOffChainTransactionAtBlock(apiArgs *gethapi.Transa
 			batch.Header.Root.Hex()),
 	)
 
-	result, err := evm.ExecuteOffChainCall(&callMsg, blockState, batch.Header, rc.storage, rc.chainConfig, rc.logger)
+	result, err := evm.ExecuteOffChainCall(&callMsg, blockState, batch.Header, lc.storage, lc.chainConfig, lc.logger)
 	if err != nil {
 		// also return the result as the result can be evaluated on some errors like ErrIntrinsicGas
 		return result, err
@@ -235,15 +235,15 @@ func (rc *RollupChain) ExecuteOffChainTransactionAtBlock(apiArgs *gethapi.Transa
 	if result.Failed() {
 		// do not return an error
 		// the result object should be evaluated upstream
-		rc.logger.Error(fmt.Sprintf("!OffChain: Failed to execute contract %s.", callMsg.To()), log.ErrKey, result.Err)
+		lc.logger.Error(fmt.Sprintf("!OffChain: Failed to execute contract %s.", callMsg.To()), log.ErrKey, result.Err)
 	}
 
 	return result, nil
 }
 
-func (rc *RollupChain) updateL1State(block types.Block, receipts types.Receipts, isLatest bool) error {
+func (lc *L2Chain) updateL1State(block types.Block, receipts types.Receipts, isLatest bool) error {
 	// We check whether we've already processed the block.
-	_, err := rc.storage.FetchBlock(block.Hash())
+	_, err := lc.storage.FetchBlock(block.Hash())
 	if err == nil {
 		return common.ErrBlockAlreadyProcessed
 	}
@@ -253,23 +253,23 @@ func (rc *RollupChain) updateL1State(block types.Block, receipts types.Receipts,
 
 	// Reject block if not provided with matching receipts.
 	// This needs to happen before saving the block as otherwise it will be considered as processed.
-	if rc.crossChainProcessors.Enabled() && !crosschain.VerifyReceiptHash(&block, receipts) {
+	if lc.crossChainProcessors.Enabled() && !crosschain.VerifyReceiptHash(&block, receipts) {
 		return errors.New("receipts do not match receipt_root in block")
 	}
 
 	// We insert the block into the L1 chain and store it.
-	ingestionType, err := rc.insertBlockIntoL1Chain(&block, isLatest)
+	ingestionType, err := lc.insertBlockIntoL1Chain(&block, isLatest)
 	if err != nil {
 		// Do not store the block if the L1 chain insertion failed
 		return err
 	}
-	rc.logger.Trace("block inserted successfully",
+	lc.logger.Trace("block inserted successfully",
 		"height", block.NumberU64(), "hash", block.Hash(), "ingestionType", ingestionType)
 
-	rc.storage.StoreBlock(&block)
+	lc.storage.StoreBlock(&block)
 
 	// This requires block to be stored first ... but can permanently fail a block
-	err = rc.crossChainProcessors.Remote.StoreCrossChainMessages(&block, receipts)
+	err = lc.crossChainProcessors.Remote.StoreCrossChainMessages(&block, receipts)
 	if err != nil {
 		return errors.New("failed to process cross chain messages")
 	}
@@ -279,15 +279,15 @@ func (rc *RollupChain) updateL1State(block types.Block, receipts types.Receipts,
 
 // Inserts the block into the L1 chain if it exists and the block is not the genesis block
 // note: this method shouldn't be called for blocks we've seen before
-func (rc *RollupChain) insertBlockIntoL1Chain(block *types.Block, isLatest bool) (*blockIngestionType, error) {
-	if rc.l1Blockchain != nil {
-		_, err := rc.l1Blockchain.InsertChain(types.Blocks{block})
+func (lc *L2Chain) insertBlockIntoL1Chain(block *types.Block, isLatest bool) (*blockIngestionType, error) {
+	if lc.l1Blockchain != nil {
+		_, err := lc.l1Blockchain.InsertChain(types.Blocks{block})
 		if err != nil {
 			return nil, fmt.Errorf("block was invalid: %w", err)
 		}
 	}
 	// todo: this is minimal L1 tracking/validation, and should be removed when we are using geth's blockchain or lightchain structures for validation
-	prevL1Head, err := rc.storage.FetchHeadBlock()
+	prevL1Head, err := lc.storage.FetchHeadBlock()
 
 	if err != nil {
 		if errors.Is(err, errutil.ErrNotFound) {
@@ -298,11 +298,11 @@ func (rc *RollupChain) insertBlockIntoL1Chain(block *types.Block, isLatest bool)
 
 		// we do a basic sanity check, comparing the received block to the head block on the chain
 	} else if block.ParentHash() != prevL1Head.Hash() {
-		lcaBlock, err := gethutil.LCA(block, prevL1Head, rc.storage)
+		lcaBlock, err := gethutil.LCA(block, prevL1Head, lc.storage)
 		if err != nil {
 			return nil, common.ErrBlockAncestorNotFound
 		}
-		rc.logger.Trace("parent not found",
+		lc.logger.Trace("parent not found",
 			"blkHeight", block.NumberU64(), "blkHash", block.Hash(),
 			"l1HeadHeight", prevL1Head.NumberU64(), "l1HeadHash", prevL1Head.Hash(),
 			"lcaHeight", lcaBlock.NumberU64(), "lcaHash", lcaBlock.Hash(),
@@ -314,7 +314,7 @@ func (rc *RollupChain) insertBlockIntoL1Chain(block *types.Block, isLatest bool)
 			//   then why is ingested block's parent not the prev l1 head
 			// lca > prevL1Head:
 			//   this would imply ingested block is earlier on the same branch as l1 head, but ingested block should not have been seen before
-			rc.logger.Error("unexpected blockchain state, incoming block is not child of L1 head and not an earlier fork of L1 head",
+			lc.logger.Error("unexpected blockchain state, incoming block is not child of L1 head and not an earlier fork of L1 head",
 				"blkHeight", block.NumberU64(), "blkHash", block.Hash(),
 				"l1HeadHeight", prevL1Head.NumberU64(), "l1HeadHash", prevL1Head.Hash(),
 				"lcaHeight", lcaBlock.NumberU64(), "lcaHash", lcaBlock.Hash(),
@@ -331,16 +331,16 @@ func (rc *RollupChain) insertBlockIntoL1Chain(block *types.Block, isLatest bool)
 }
 
 // Updates the L1 and L2 chain heads, and returns the new L2 head hash and the produced batch, if there is one.
-func (rc *RollupChain) updateL1AndL2Heads(block *types.Block, isLatestBlock bool) (*common.L2RootHash, *core.Batch, error) {
+func (lc *L2Chain) updateL1AndL2Heads(block *types.Block, isLatestBlock bool) (*common.L2RootHash, *core.Batch, error) {
 	// We process the rollups, updating the head rollup associated with the L1 block as we go.
-	if err := rc.processRollups(block); err != nil {
+	if err := lc.processRollups(block); err != nil {
 		// TODO - #718 - Determine correct course of action if one or more rollups are invalid.
-		rc.logger.Error("could not process rollups", log.ErrKey, err)
+		lc.logger.Error("could not process rollups", log.ErrKey, err)
 	}
 
 	// We determine whether we have produced a genesis batch yet.
 	genesisBatchStored := true
-	l2Head, err := rc.storage.FetchHeadBatchForBlock(block.ParentHash())
+	l2Head, err := lc.storage.FetchHeadBatchForBlock(block.ParentHash())
 	if err != nil {
 		if !errors.Is(err, errutil.ErrNotFound) {
 			return nil, nil, fmt.Errorf("could not retrieve current head batch. Cause: %w", err)
@@ -351,15 +351,15 @@ func (rc *RollupChain) updateL1AndL2Heads(block *types.Block, isLatestBlock bool
 	// If there is an L2 head, we retrieve its stored receipts.
 	var l2HeadTxReceipts types.Receipts
 	if genesisBatchStored {
-		if l2HeadTxReceipts, err = rc.storage.GetReceiptsByHash(*l2Head.Hash()); err != nil {
+		if l2HeadTxReceipts, err = lc.storage.GetReceiptsByHash(*l2Head.Hash()); err != nil {
 			return nil, nil, fmt.Errorf("could not fetch batch receipts. Cause: %w", err)
 		}
 	}
 
 	// If we're the sequencer and we're on the latest block, we produce a new L2 head to replace the old one.
 	var producedBatch *core.Batch
-	if rc.nodeType == common.Sequencer && isLatestBlock {
-		l2Head, l2HeadTxReceipts, err = rc.produceAndStoreBatch(block, genesisBatchStored)
+	if lc.nodeType == common.Sequencer && isLatestBlock {
+		l2Head, l2HeadTxReceipts, err = lc.produceAndStoreBatch(block, genesisBatchStored)
 		if err != nil {
 			return nil, nil, fmt.Errorf("could not produce and store new batch. Cause: %w", err)
 		}
@@ -368,10 +368,10 @@ func (rc *RollupChain) updateL1AndL2Heads(block *types.Block, isLatestBlock bool
 
 	// We update the L1 and L2 chain heads.
 	if l2Head != nil {
-		if err = rc.storage.UpdateHeadBatch(block.Hash(), l2Head, l2HeadTxReceipts); err != nil {
+		if err = lc.storage.UpdateHeadBatch(block.Hash(), l2Head, l2HeadTxReceipts); err != nil {
 			return nil, nil, fmt.Errorf("could not store new head. Cause: %w", err)
 		}
-		if err = rc.storage.UpdateL1Head(block.Hash()); err != nil {
+		if err = lc.storage.UpdateL1Head(block.Hash()); err != nil {
 			return nil, nil, fmt.Errorf("could not store new L1 head. Cause: %w", err)
 		}
 	}
@@ -384,21 +384,21 @@ func (rc *RollupChain) updateL1AndL2Heads(block *types.Block, isLatestBlock bool
 }
 
 // Produces a new batch, signs it and stores it.
-func (rc *RollupChain) produceAndStoreBatch(block *common.L1Block, genesisBatchStored bool) (*core.Batch, types.Receipts, error) {
-	l2Head, err := rc.produceBatch(block, genesisBatchStored)
+func (lc *L2Chain) produceAndStoreBatch(block *common.L1Block, genesisBatchStored bool) (*core.Batch, types.Receipts, error) {
+	l2Head, err := lc.produceBatch(block, genesisBatchStored)
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not produce batch. Cause: %w", err)
 	}
 
-	if err = rc.signBatch(l2Head); err != nil {
+	if err = lc.signBatch(l2Head); err != nil {
 		return nil, nil, fmt.Errorf("could not sign batch. Cause: %w", err)
 	}
 
-	l2HeadTxReceipts, err := rc.getTxReceipts(l2Head)
+	l2HeadTxReceipts, err := lc.getTxReceipts(l2Head)
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not get batch transaction receipts. Cause: %w", err)
 	}
-	if err = rc.storage.StoreBatch(l2Head, l2HeadTxReceipts); err != nil {
+	if err = lc.storage.StoreBatch(l2Head, l2HeadTxReceipts); err != nil {
 		return nil, nil, fmt.Errorf("failed to store batch. Cause: %w", err)
 	}
 
@@ -406,15 +406,15 @@ func (rc *RollupChain) produceAndStoreBatch(block *common.L1Block, genesisBatchS
 }
 
 // Creates a genesis batch linked to the provided L1 block and signs it.
-func (rc *RollupChain) produceGenesisBatch(blkHash common.L1RootHash) (*core.Batch, error) {
-	preFundGenesisState, err := rc.genesis.GetGenesisRoot(rc.storage)
+func (lc *L2Chain) produceGenesisBatch(blkHash common.L1RootHash) (*core.Batch, error) {
+	preFundGenesisState, err := lc.genesis.GetGenesisRoot(lc.storage)
 	if err != nil {
 		return nil, err
 	}
 
 	genesisBatch := &core.Batch{
 		Header: &common.BatchHeader{
-			Agg:         rc.hostID,
+			Agg:         lc.hostID,
 			ParentHash:  common.L2RootHash{},
 			L1Proof:     blkHash,
 			Root:        *preFundGenesisState,
@@ -428,18 +428,18 @@ func (rc *RollupChain) produceGenesisBatch(blkHash common.L1RootHash) (*core.Bat
 	}
 
 	// TODO: Figure out a better way to bootstrap the system contracts.
-	deployTx, err := rc.crossChainProcessors.Local.GenerateMessageBusDeployTx()
+	deployTx, err := lc.crossChainProcessors.Local.GenerateMessageBusDeployTx()
 	if err != nil {
-		rc.logger.Crit("Could not create message bus deployment transaction", "Error", err)
+		lc.logger.Crit("Could not create message bus deployment transaction", "Error", err)
 	}
 
 	// Add transaction to mempool so it gets processed when it can.
 	// Should be the first transaction to be processed.
-	if err := rc.mempool.AddMempoolTx(deployTx); err != nil {
-		rc.logger.Crit("Cannot create synthetic transaction for deploying the message bus contract on :|")
+	if err := lc.mempool.AddMempoolTx(deployTx); err != nil {
+		lc.logger.Crit("Cannot create synthetic transaction for deploying the message bus contract on :|")
 	}
 
-	if err = rc.genesis.CommitGenesisState(rc.storage); err != nil {
+	if err = lc.genesis.CommitGenesisState(lc.storage); err != nil {
 		return nil, fmt.Errorf("could not apply genesis preallocation. Cause: %w", err)
 	}
 	return genesisBatch, nil
@@ -448,15 +448,15 @@ func (rc *RollupChain) produceGenesisBatch(blkHash common.L1RootHash) (*core.Bat
 // This is where transactions are executed and the state is calculated.
 // Obscuro includes a message bus embedded in the platform, and this method is responsible for transferring messages as well.
 // The batch can be a final batch as received from peers or the batch under construction.
-func (rc *RollupChain) processState(batch *core.Batch, txs []*common.L2Tx, stateDB *state.StateDB) (common.L2RootHash, []*common.L2Tx, []*types.Receipt, []*types.Receipt) {
+func (lc *L2Chain) processState(batch *core.Batch, txs []*common.L2Tx, stateDB *state.StateDB) (common.L2RootHash, []*common.L2Tx, []*types.Receipt, []*types.Receipt) {
 	var executedTransactions []*common.L2Tx
 	var txReceipts []*types.Receipt
 
-	txResults := evm.ExecuteTransactions(txs, stateDB, batch.Header, rc.storage, rc.chainConfig, 0, rc.logger)
+	txResults := evm.ExecuteTransactions(txs, stateDB, batch.Header, lc.storage, lc.chainConfig, 0, lc.logger)
 	for _, tx := range txs {
 		result, f := txResults[tx.Hash()]
 		if !f {
-			rc.logger.Crit("There should be an entry for each transaction ")
+			lc.logger.Crit("There should be an entry for each transaction ")
 		}
 		rec, foundReceipt := result.(*types.Receipt)
 		if foundReceipt {
@@ -464,56 +464,56 @@ func (rc *RollupChain) processState(batch *core.Batch, txs []*common.L2Tx, state
 			txReceipts = append(txReceipts, rec)
 		} else {
 			// Exclude all errors
-			rc.logger.Info(fmt.Sprintf("Excluding transaction %s from batch b_%d. Cause: %s", tx.Hash().Hex(), common.ShortHash(*batch.Hash()), result))
+			lc.logger.Info(fmt.Sprintf("Excluding transaction %s from batch b_%d. Cause: %s", tx.Hash().Hex(), common.ShortHash(*batch.Hash()), result))
 		}
 	}
 
 	// always process deposits last, either on top of the rollup produced speculatively or the newly created rollup
 	// process deposits from the fromBlock of the parent to the current block (which is the fromBlock of the new rollup)
-	parent, err := rc.storage.FetchBatch(batch.Header.ParentHash)
+	parent, err := lc.storage.FetchBatch(batch.Header.ParentHash)
 	if err != nil {
-		rc.logger.Crit("Sanity check. Rollup has no parent.", log.ErrKey, err)
+		lc.logger.Crit("Sanity check. Rollup has no parent.", log.ErrKey, err)
 	}
 
-	parentProof, err := rc.storage.FetchBlock(parent.Header.L1Proof)
+	parentProof, err := lc.storage.FetchBlock(parent.Header.L1Proof)
 	if err != nil {
-		rc.logger.Crit(fmt.Sprintf("Could not retrieve a proof for batch %s", batch.Hash()), log.ErrKey, err)
+		lc.logger.Crit(fmt.Sprintf("Could not retrieve a proof for batch %s", batch.Hash()), log.ErrKey, err)
 	}
-	batchProof, err := rc.storage.FetchBlock(batch.Header.L1Proof)
+	batchProof, err := lc.storage.FetchBlock(batch.Header.L1Proof)
 	if err != nil {
-		rc.logger.Crit(fmt.Sprintf("Could not retrieve a proof for batch %s", batch.Hash()), log.ErrKey, err)
+		lc.logger.Crit(fmt.Sprintf("Could not retrieve a proof for batch %s", batch.Hash()), log.ErrKey, err)
 	}
 
 	// TODO: Remove this depositing logic once the new bridge is added.
-	depositTxs := rc.bridge.ExtractDeposits(
+	depositTxs := lc.bridge.ExtractDeposits(
 		parentProof,
 		batchProof,
-		rc.storage,
+		lc.storage,
 		stateDB,
 	)
 
-	depositResponses := evm.ExecuteTransactions(depositTxs, stateDB, batch.Header, rc.storage, rc.chainConfig, len(executedTransactions), rc.logger)
+	depositResponses := evm.ExecuteTransactions(depositTxs, stateDB, batch.Header, lc.storage, lc.chainConfig, len(executedTransactions), lc.logger)
 	depositReceipts := make([]*types.Receipt, len(depositResponses))
 	if len(depositResponses) != len(depositTxs) {
-		rc.logger.Crit("Sanity check. Some deposit transactions failed.")
+		lc.logger.Crit("Sanity check. Some deposit transactions failed.")
 	}
 	i := 0
 	for _, resp := range depositResponses {
 		rec, ok := resp.(*types.Receipt)
 		if !ok {
 			// TODO - Handle the case of an error (e.g. insufficient funds).
-			rc.logger.Crit("Sanity check. Expected a receipt", log.ErrKey, resp)
+			lc.logger.Crit("Sanity check. Expected a receipt", log.ErrKey, resp)
 		}
 		depositReceipts[i] = rec
 		i++
 	}
 
-	messages := rc.crossChainProcessors.Local.RetrieveInboundMessages(parentProof, batchProof, stateDB)
-	transactions := rc.crossChainProcessors.Local.CreateSyntheticTransactions(messages, stateDB)
-	syntheticTransactionsResponses := evm.ExecuteTransactions(transactions, stateDB, batch.Header, rc.storage, rc.chainConfig, len(executedTransactions), rc.logger)
+	messages := lc.crossChainProcessors.Local.RetrieveInboundMessages(parentProof, batchProof, stateDB)
+	transactions := lc.crossChainProcessors.Local.CreateSyntheticTransactions(messages, stateDB)
+	syntheticTransactionsResponses := evm.ExecuteTransactions(transactions, stateDB, batch.Header, lc.storage, lc.chainConfig, len(executedTransactions), lc.logger)
 	synthReceipts := make([]*types.Receipt, len(syntheticTransactionsResponses))
 	if len(syntheticTransactionsResponses) != len(transactions) {
-		rc.logger.Crit("Sanity check. Some synthetic transactions failed.")
+		lc.logger.Crit("Sanity check. Some synthetic transactions failed.")
 	}
 
 	i = 0
@@ -521,15 +521,15 @@ func (rc *RollupChain) processState(batch *core.Batch, txs []*common.L2Tx, state
 		rec, ok := resp.(*types.Receipt)
 		if !ok { // Еxtract reason for failing deposit.
 			// TODO - Handle the case of an error (e.g. insufficient funds).
-			rc.logger.Crit("Sanity check. Expected a receipt", log.ErrKey, resp)
+			lc.logger.Crit("Sanity check. Expected a receipt", log.ErrKey, resp)
 		}
 
 		if rec.Status == 0 { // Synthetic transactions should not fail. In case of failure get the revert reason.
 			failingTx := transactions[i]
 			txCallMessage := types.NewMessage(
-				rc.crossChainProcessors.Local.GetOwner(),
+				lc.crossChainProcessors.Local.GetOwner(),
 				failingTx.To(),
-				stateDB.GetNonce(rc.crossChainProcessors.Local.GetOwner()),
+				stateDB.GetNonce(lc.crossChainProcessors.Local.GetOwner()),
 				failingTx.Value(),
 				failingTx.Gas(),
 				gethcommon.Big0,
@@ -540,8 +540,8 @@ func (rc *RollupChain) processState(batch *core.Batch, txs []*common.L2Tx, state
 				false)
 
 			clonedDB := stateDB.Copy()
-			res, err := evm.ExecuteOffChainCall(&txCallMessage, clonedDB, batch.Header, rc.storage, rc.chainConfig, rc.logger)
-			rc.logger.Crit("Synthetic transaction failed!", log.ErrKey, err, "result", res)
+			res, err := evm.ExecuteOffChainCall(&txCallMessage, clonedDB, batch.Header, lc.storage, lc.chainConfig, lc.logger)
+			lc.logger.Crit("Synthetic transaction failed!", log.ErrKey, err, "result", res)
 		}
 
 		synthReceipts[i] = rec
@@ -550,7 +550,7 @@ func (rc *RollupChain) processState(batch *core.Batch, txs []*common.L2Tx, state
 
 	rootHash, err := stateDB.Commit(true)
 	if err != nil {
-		rc.logger.Crit("could not commit to state DB. ", log.ErrKey, err)
+		lc.logger.Crit("could not commit to state DB. ", log.ErrKey, err)
 	}
 
 	sort.Sort(sortByTxIndex(txReceipts))
@@ -561,14 +561,14 @@ func (rc *RollupChain) processState(batch *core.Batch, txs []*common.L2Tx, state
 }
 
 // Checks the internal validity of the batch.
-func (rc *RollupChain) isInternallyValidBatch(batch *core.Batch) (types.Receipts, error) {
-	stateDB, err := rc.storage.CreateStateDB(batch.Header.ParentHash)
+func (lc *L2Chain) isInternallyValidBatch(batch *core.Batch) (types.Receipts, error) {
+	stateDB, err := lc.storage.CreateStateDB(batch.Header.ParentHash)
 	if err != nil {
 		return nil, fmt.Errorf("could not create stateDB. Cause: %w", err)
 	}
 
 	// calculate the state to compare with what is in the batch
-	rootHash, executedTxs, txReceipts, depositReceipts := rc.processState(batch, batch.Transactions, stateDB)
+	rootHash, executedTxs, txReceipts, depositReceipts := lc.processState(batch, batch.Transactions, stateDB)
 	if len(executedTxs) != len(batch.Transactions) {
 		return nil, fmt.Errorf("all transactions that are included in a batch must be executed")
 	}
@@ -581,7 +581,7 @@ func (rc *RollupChain) isInternallyValidBatch(batch *core.Batch) (types.Receipts
 	}
 
 	// Check that the withdrawals in the header match the withdrawals as calculated.
-	withdrawals := rc.bridge.BatchPostProcessingWithdrawals(batch, stateDB, toReceiptMap(txReceipts))
+	withdrawals := lc.bridge.BatchPostProcessingWithdrawals(batch, stateDB, toReceiptMap(txReceipts))
 	for i, w := range withdrawals {
 		hw := batch.Header.Withdrawals[i]
 		if hw.Amount.Cmp(w.Amount) != 0 || hw.Recipient != w.Recipient || hw.Contract != w.Contract {
@@ -603,7 +603,7 @@ func (rc *RollupChain) isInternallyValidBatch(batch *core.Batch) (types.Receipts
 	}
 
 	// Check that the signature is valid.
-	if err = rc.checkSequencerSignature(batch.Hash(), &batch.Header.Agg, batch.Header.R, batch.Header.S); err != nil {
+	if err = lc.checkSequencerSignature(batch.Hash(), &batch.Header.Agg, batch.Header.R, batch.Header.S); err != nil {
 		return nil, fmt.Errorf("verify batch r_%d: invalid signature. Cause: %w", common.ShortHash(*batch.Hash()), err)
 	}
 
@@ -613,25 +613,25 @@ func (rc *RollupChain) isInternallyValidBatch(batch *core.Batch) (types.Receipts
 }
 
 // Returns the receipts for the transactions in the batch.
-func (rc *RollupChain) getTxReceipts(batch *core.Batch) ([]*types.Receipt, error) {
+func (lc *L2Chain) getTxReceipts(batch *core.Batch) ([]*types.Receipt, error) {
 	if batch.IsGenesis() {
 		return nil, nil
 	}
 
-	stateDB, err := rc.storage.CreateStateDB(batch.Header.ParentHash)
+	stateDB, err := lc.storage.CreateStateDB(batch.Header.ParentHash)
 	if err != nil {
 		return nil, fmt.Errorf("could not create stateDB. Cause: %w", err)
 	}
 
 	// calculate the state to compare with what is in the batch
-	_, _, txReceipts, _ := rc.processState(batch, batch.Transactions, stateDB) //nolint:dogsled
+	_, _, txReceipts, _ := lc.processState(batch, batch.Transactions, stateDB) //nolint:dogsled
 	return txReceipts, nil
 }
 
-func (rc *RollupChain) signBatch(batch *core.Batch) error {
+func (lc *L2Chain) signBatch(batch *core.Batch) error {
 	var err error
 	h := batch.Hash()
-	batch.Header.R, batch.Header.S, err = ecdsa.Sign(rand.Reader, rc.enclavePrivateKey, h[:])
+	batch.Header.R, batch.Header.S, err = ecdsa.Sign(rand.Reader, lc.enclavePrivateKey, h[:])
 	if err != nil {
 		return fmt.Errorf("could not sign batch. Cause: %w", err)
 	}
@@ -639,18 +639,18 @@ func (rc *RollupChain) signBatch(batch *core.Batch) error {
 }
 
 // Checks that the header is signed validly by the sequencer.
-func (rc *RollupChain) checkSequencerSignature(headerHash *gethcommon.Hash, aggregator *gethcommon.Address, sigR *big.Int, sigS *big.Int) error {
+func (lc *L2Chain) checkSequencerSignature(headerHash *gethcommon.Hash, aggregator *gethcommon.Address, sigR *big.Int, sigS *big.Int) error {
 	// Batches and rollups should only be produced by the sequencer.
 	// TODO - #718 - Sequencer identities should be retrieved from the L1 management contract.
-	if !bytes.Equal(aggregator.Bytes(), rc.sequencerID.Bytes()) {
-		return fmt.Errorf("expected batch to be produced by sequencer %s, but was produced by %s", rc.sequencerID.Hex(), aggregator.Hex())
+	if !bytes.Equal(aggregator.Bytes(), lc.sequencerID.Bytes()) {
+		return fmt.Errorf("expected batch to be produced by sequencer %s, but was produced by %s", lc.sequencerID.Hex(), aggregator.Hex())
 	}
 
 	if sigR == nil || sigS == nil {
 		return fmt.Errorf("missing signature on batch")
 	}
 
-	pubKey, err := rc.storage.FetchAttestedKey(*aggregator)
+	pubKey, err := lc.storage.FetchAttestedKey(*aggregator)
 	if err != nil {
 		return fmt.Errorf("could not retrieve attested key for aggregator %s. Cause: %w", aggregator, err)
 	}
@@ -662,11 +662,11 @@ func (rc *RollupChain) checkSequencerSignature(headerHash *gethcommon.Hash, aggr
 }
 
 // Retrieves the batch with the given height, with special handling for earliest/latest/pending .
-func (rc *RollupChain) getBatch(height gethrpc.BlockNumber) (*core.Batch, error) {
+func (lc *L2Chain) getBatch(height gethrpc.BlockNumber) (*core.Batch, error) {
 	var batch *core.Batch
 	switch height {
 	case gethrpc.EarliestBlockNumber:
-		genesisBatch, err := rc.storage.FetchBatchByHeight(0)
+		genesisBatch, err := lc.storage.FetchBatchByHeight(0)
 		if err != nil {
 			return nil, fmt.Errorf("could not retrieve genesis rollup. Cause: %w", err)
 		}
@@ -675,13 +675,13 @@ func (rc *RollupChain) getBatch(height gethrpc.BlockNumber) (*core.Batch, error)
 		// TODO - Depends on the current pending rollup; leaving it for a different iteration as it will need more thought.
 		return nil, fmt.Errorf("requested balance for pending block. This is not handled currently")
 	case gethrpc.LatestBlockNumber:
-		headBatch, err := rc.storage.FetchHeadBatch()
+		headBatch, err := lc.storage.FetchHeadBatch()
 		if err != nil {
 			return nil, fmt.Errorf("batch with requested height %d was not found. Cause: %w", height, err)
 		}
 		batch = headBatch
 	default:
-		maybeBatch, err := rc.storage.FetchBatchByHeight(uint64(height))
+		maybeBatch, err := lc.storage.FetchBatchByHeight(uint64(height))
 		if err != nil {
 			return nil, fmt.Errorf("batch with requested height %d could not be retrieved. Cause: %w", height, err)
 		}
@@ -691,13 +691,13 @@ func (rc *RollupChain) getBatch(height gethrpc.BlockNumber) (*core.Batch, error)
 }
 
 // Creates either a genesis or regular (i.e. post-genesis) batch.
-func (rc *RollupChain) produceBatch(block *types.Block, genesisBatchStored bool) (*core.Batch, error) {
+func (lc *L2Chain) produceBatch(block *types.Block, genesisBatchStored bool) (*core.Batch, error) {
 	// We handle producing the genesis batch as a special case.
 	if !genesisBatchStored {
-		return rc.produceGenesisBatch(block.Hash())
+		return lc.produceGenesisBatch(block.Hash())
 	}
 
-	headBatch, err := rc.storage.FetchHeadBatchForBlock(block.ParentHash())
+	headBatch, err := lc.storage.FetchHeadBatchForBlock(block.ParentHash())
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve head batch. Cause: %w", err)
 	}
@@ -707,42 +707,42 @@ func (rc *RollupChain) produceBatch(block *types.Block, genesisBatchStored bool)
 	var newBatchState *state.StateDB
 
 	// Create a new batch based on the fromBlock of inclusion of the previous, including all new transactions
-	batch, err := core.EmptyBatch(rc.hostID, headBatch.Header, block.Hash())
+	batch, err := core.EmptyBatch(lc.hostID, headBatch.Header, block.Hash())
 	if err != nil {
 		return nil, fmt.Errorf("could not create batch. Cause: %w", err)
 	}
 
-	newBatchTxs, err = rc.mempool.CurrentTxs(headBatch, rc.storage)
+	newBatchTxs, err = lc.mempool.CurrentTxs(headBatch, lc.storage)
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve current transactions. Cause: %w", err)
 	}
 
-	newBatchState, err = rc.storage.CreateStateDB(batch.Header.ParentHash)
+	newBatchState, err = lc.storage.CreateStateDB(batch.Header.ParentHash)
 	if err != nil {
 		return nil, fmt.Errorf("could not create stateDB. Cause: %w", err)
 	}
 
-	rootHash, successfulTxs, txReceipts, depositReceipts := rc.processState(batch, newBatchTxs, newBatchState)
+	rootHash, successfulTxs, txReceipts, depositReceipts := lc.processState(batch, newBatchTxs, newBatchState)
 
 	batch.Header.Root = rootHash
 	batch.Transactions = successfulTxs
 
 	// Postprocessing - withdrawals
 	txReceiptsMap := toReceiptMap(txReceipts)
-	batch.Header.Withdrawals = rc.bridge.BatchPostProcessingWithdrawals(batch, newBatchState, txReceiptsMap)
-	crossChainMessages, err := rc.crossChainProcessors.Local.ExtractOutboundMessages(txReceipts)
+	batch.Header.Withdrawals = lc.bridge.BatchPostProcessingWithdrawals(batch, newBatchState, txReceiptsMap)
+	crossChainMessages, err := lc.crossChainProcessors.Local.ExtractOutboundMessages(txReceipts)
 	if err != nil {
-		rc.logger.Crit("Extracting messages L2->L1 failed", err, log.CmpKey, log.CrossChainCmp)
+		lc.logger.Crit("Extracting messages L2->L1 failed", err, log.CmpKey, log.CrossChainCmp)
 	}
 
 	batch.Header.CrossChainMessages = crossChainMessages
 
-	rc.logger.Trace(fmt.Sprintf("Added %d cross chain messages to batch. Equivalent withdrawals in header - %d",
+	lc.logger.Trace(fmt.Sprintf("Added %d cross chain messages to batch. Equivalent withdrawals in header - %d",
 		len(batch.Header.CrossChainMessages), len(batch.Header.Withdrawals)), log.CmpKey, log.CrossChainCmp)
 
-	crossChainBind, err := rc.storage.FetchBlock(batch.Header.L1Proof)
+	crossChainBind, err := lc.storage.FetchBlock(batch.Header.L1Proof)
 	if err != nil {
-		rc.logger.Crit("Failed to extract batch proof that should exist!")
+		lc.logger.Crit("Failed to extract batch proof that should exist!")
 	}
 
 	batch.Header.LatestInboudCrossChainHash = crossChainBind.Hash()
@@ -762,7 +762,7 @@ func (rc *RollupChain) produceBatch(block *types.Block, genesisBatchStored bool)
 		batch.Header.TxHash = types.DeriveSha(types.Transactions(successfulTxs), trie.NewStackTrie(nil))
 	}
 
-	rc.logger.Trace("Create batch.",
+	lc.logger.Trace("Create batch.",
 		"State", gethlog.Lazy{Fn: func() string {
 			return strings.Replace(string(newBatchState.Dump(&state.DumpConfig{})), "\n", "", -1)
 		}},
@@ -773,15 +773,15 @@ func (rc *RollupChain) produceBatch(block *types.Block, genesisBatchStored bool)
 
 // Returns the state of the chain at height
 // TODO make this cacheable
-func (rc *RollupChain) getChainStateAtBlock(blockNumber *gethrpc.BlockNumber) (*state.StateDB, error) {
+func (lc *L2Chain) getChainStateAtBlock(blockNumber *gethrpc.BlockNumber) (*state.StateDB, error) {
 	// We retrieve the batch of interest.
-	batch, err := rc.getBatch(*blockNumber)
+	batch, err := lc.getBatch(*blockNumber)
 	if err != nil {
 		return nil, err
 	}
 
 	// We get that of the chain at that height
-	blockchainState, err := rc.storage.CreateStateDB(*batch.Hash())
+	blockchainState, err := lc.storage.CreateStateDB(*batch.Hash())
 	if err != nil {
 		return nil, fmt.Errorf("could not create stateDB. Cause: %w", err)
 	}
@@ -794,8 +794,8 @@ func (rc *RollupChain) getChainStateAtBlock(blockNumber *gethrpc.BlockNumber) (*
 }
 
 // Returns the whether the account is a contract or not at a certain height
-func (rc *RollupChain) isAccountContractAtBlock(accountAddr gethcommon.Address, blockNumber *gethrpc.BlockNumber) (bool, error) {
-	chainState, err := rc.getChainStateAtBlock(blockNumber)
+func (lc *L2Chain) isAccountContractAtBlock(accountAddr gethcommon.Address, blockNumber *gethrpc.BlockNumber) (bool, error) {
+	chainState, err := lc.getChainStateAtBlock(blockNumber)
 	if err != nil {
 		return false, fmt.Errorf("unable to get blockchain state - %w", err)
 	}
@@ -805,14 +805,14 @@ func (rc *RollupChain) isAccountContractAtBlock(accountAddr gethcommon.Address, 
 
 // Validates and stores the rollup in a given block.
 // TODO - #718 - Design a mechanism to detect a case where the rollups never contain any batches (despite batches arriving via P2P).
-func (rc *RollupChain) processRollups(block *common.L1Block) error {
+func (lc *L2Chain) processRollups(block *common.L1Block) error {
 	l1ParentHash := block.ParentHash()
-	currentHeadRollup, err := rc.storage.FetchHeadRollupForBlock(&l1ParentHash)
+	currentHeadRollup, err := lc.storage.FetchHeadRollupForBlock(&l1ParentHash)
 	if err != nil && !errors.Is(err, errutil.ErrNotFound) {
 		return fmt.Errorf("could not fetch current L2 head rollup")
 	}
 
-	rollups := rc.bridge.ExtractRollups(block, rc.storage)
+	rollups := lc.bridge.ExtractRollups(block, lc.storage)
 	sort.Slice(rollups, func(i, j int) bool {
 		// Ascending order sort.
 		return rollups[i].Header.Number.Cmp(rollups[j].Header.Number) < 0
@@ -824,7 +824,7 @@ func (rc *RollupChain) processRollups(block *common.L1Block) error {
 	}
 
 	for idx, rollup := range rollups {
-		if err = rc.checkSequencerSignature(rollup.Hash(), &rollup.Header.Agg, rollup.Header.R, rollup.Header.S); err != nil {
+		if err = lc.checkSequencerSignature(rollup.Hash(), &rollup.Header.Agg, rollup.Header.R, rollup.Header.S); err != nil {
 			return fmt.Errorf("rollup signature was invalid. Cause: %w", err)
 		}
 
@@ -833,18 +833,18 @@ func (rc *RollupChain) processRollups(block *common.L1Block) error {
 			if idx != 0 {
 				previousRollup = rollups[idx-1]
 			}
-			if err = rc.checkRollupsCorrectlyChained(rollup, previousRollup); err != nil {
+			if err = lc.checkRollupsCorrectlyChained(rollup, previousRollup); err != nil {
 				return err
 			}
 		}
 
 		for _, batch := range rollup.Batches {
-			if err = rc.checkAndStoreBatch(batch); err != nil {
+			if err = lc.checkAndStoreBatch(batch); err != nil {
 				return fmt.Errorf("could not store batch. Cause: %w", err)
 			}
 		}
 
-		if err = rc.storage.StoreRollup(rollup); err != nil {
+		if err = lc.storage.StoreRollup(rollup); err != nil {
 			return fmt.Errorf("could not store rollup. Cause: %w", err)
 		}
 	}
@@ -855,7 +855,7 @@ func (rc *RollupChain) processRollups(block *common.L1Block) error {
 	}
 	if newHeadRollup != nil {
 		l1Head := block.Hash()
-		if err = rc.storage.UpdateHeadRollup(&l1Head, newHeadRollup.Hash()); err != nil {
+		if err = lc.storage.UpdateHeadRollup(&l1Head, newHeadRollup.Hash()); err != nil {
 			return fmt.Errorf("could not update L2 head rollup. Cause: %w", err)
 		}
 	}
@@ -867,7 +867,7 @@ func (rc *RollupChain) processRollups(block *common.L1Block) error {
 //   - Has a number exactly 1 higher than the previous rollup
 //   - Links to the previous rollup by hash
 //   - Has a first batch whose parent is the head batch of the previous rollup
-func (rc *RollupChain) checkRollupsCorrectlyChained(rollup *core.Rollup, previousRollup *core.Rollup) error {
+func (lc *L2Chain) checkRollupsCorrectlyChained(rollup *core.Rollup, previousRollup *core.Rollup) error {
 	if big.NewInt(0).Sub(rollup.Header.Number, previousRollup.Header.Number).Cmp(big.NewInt(1)) != 0 {
 		return fmt.Errorf("found gap in rollups between rollup %d and rollup %d",
 			previousRollup.Header.Number, rollup.Header.Number)
@@ -888,25 +888,25 @@ func (rc *RollupChain) checkRollupsCorrectlyChained(rollup *core.Rollup, previou
 
 // Checks the batch. If we've not seen a batch at this height before, we store it. If we have seen a batch at this
 // height before, we validate it against the other received batch at the same height.
-func (rc *RollupChain) checkAndStoreBatch(batch *core.Batch) error {
+func (lc *L2Chain) checkAndStoreBatch(batch *core.Batch) error {
 	// We check the batch.
 	var txReceipts types.Receipts
 	// TODO - #718 - Determine what level of checking we should perform on the genesis batch.
 	if !batch.IsGenesis() {
 		var err error
-		txReceipts, err = rc.isInternallyValidBatch(batch)
+		txReceipts, err = lc.isInternallyValidBatch(batch)
 		if err != nil {
 			return fmt.Errorf("batch was invalid. Cause: %w", err)
 		}
 
 		// We check that we've stored the batch's parent.
-		if _, err = rc.storage.FetchBatch(batch.Header.ParentHash); err != nil {
+		if _, err = lc.storage.FetchBatch(batch.Header.ParentHash); err != nil {
 			return fmt.Errorf("could not retrieve parent batch. Cause: %w", err)
 		}
 	}
 
 	// If we've stored a batch at this height before, we ensure that it has the same transactions.
-	_, err := rc.storage.FetchBatchByHeight(batch.NumberU64())
+	_, err := lc.storage.FetchBatchByHeight(batch.NumberU64())
 	if err != nil && !errors.Is(err, errutil.ErrNotFound) {
 		return fmt.Errorf("could not fetch batch. Cause: %w", err)
 	}
@@ -917,10 +917,10 @@ func (rc *RollupChain) checkAndStoreBatch(batch *core.Batch) error {
 	//}
 
 	// We store the batch and update the head batch for that L1 block.
-	if err = rc.storage.StoreBatch(batch, txReceipts); err != nil {
+	if err = lc.storage.StoreBatch(batch, txReceipts); err != nil {
 		return fmt.Errorf("failed to store batch. Cause: %w", err)
 	}
-	if err = rc.storage.UpdateHeadBatch(batch.Header.L1Proof, batch, txReceipts); err != nil {
+	if err = lc.storage.UpdateHeadBatch(batch.Header.L1Proof, batch, txReceipts); err != nil {
 		return fmt.Errorf("could not store new L2 head. Cause: %w", err)
 	}
 

--- a/go/enclave/rollupchain/rollup_chain.go
+++ b/go/enclave/rollupchain/rollup_chain.go
@@ -834,6 +834,7 @@ func (rc *RollupChain) isAccountContractAtBlock(accountAddr gethcommon.Address, 
 }
 
 // Validates and stores the rollup in a given block.
+// TODO - #718 - Design a mechanism to detect a case where the rollups never contain any batches (despite batches arriving via P2P).
 func (rc *RollupChain) processRollups(block *common.L1Block) error {
 	l1ParentHash := block.ParentHash()
 	currentHeadRollup, err := rc.storage.FetchHeadRollupForBlock(&l1ParentHash)


### PR DESCRIPTION
### Why is this change needed?

- Provide a description and a link to the underlying ticket

### What changes were made as part of this PR:

- Provide a high level list of the changes made

### Definition of done

- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
- [ ] End-to-end tests run if required (see below)

### End-to-end tests

Running the end-to-end tests in the [obscuro-test repo](https://github.com/obscuronet/obscuro-test) is currently at the 
discretion of the developer prior to merging a PR. The intention is not to slow down development by having the longer 
running end-to-end tests as a PR gate run on each branch commit etc. To manually trigger a run pre-merge;

- Go to [run_local_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_local_tests.yml)
- Click the "Run workflow" button
- Use the main branch of obscuro-test 
- Enter the name of the PR branch for go-obscuro
- Run the workflow

The run takes approximately 20 minutes and any failure will be reported in the workflow output. Should the tests fail 
the docker container output for the local testnet and all test artifacts will be added to the run and can be downloaded
for debugging and analysis, with a retention period of 2 days. 

Note that every PR merge to main will also trigger a run of post-merge tests, so even if you do not manually trigger 
pre-merge, tests will be run post-merge. The intention being to catch any issues fast on main to allow for quick 
resolution. The post-merge test output can be seen at 
[run_merge_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_merge_tests.yml) and will show both 
the PR number and author in the list of runs. 


