### PR TITLE
No need to manage a mempool on non-sequencer nodes

### DIFF
--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -314,15 +314,8 @@ func (e *enclaveImpl) SubmitTx(tx common.EncryptedTx) (common.EncryptedResponseS
 
 func (e *enclaveImpl) SubmitBatch(extBatch *common.ExtBatch) error {
 	batch := core.ToBatch(extBatch, e.transactionBlobCrypto)
-	batchHeader, err := e.chain.UpdateL2Chain(batch)
-	if err != nil {
+	if err := e.chain.UpdateL2Chain(batch); err != nil {
 		return fmt.Errorf("could not update L2 chain based on batch. Cause: %w", err)
-	}
-
-	// We remove any transactions considered immune to re-orgs from the mempool.
-	err = e.removeOldMempoolTxs(batchHeader)
-	if err != nil {
-		e.logger.Crit("Could not remove transactions from mempool.", log.ErrKey, err)
 	}
 
 	return nil

--- a/go/enclave/l2chain/l2_chain.go
+++ b/go/enclave/l2chain/l2_chain.go
@@ -114,22 +114,22 @@ func (lc *L2Chain) ProcessL1Block(block types.Block, receipts types.Receipts, is
 }
 
 // UpdateL2Chain updates the L2 chain based on the received batch.
-func (lc *L2Chain) UpdateL2Chain(batch *core.Batch) (*common.BatchHeader, error) {
+func (lc *L2Chain) UpdateL2Chain(batch *core.Batch) error {
 	lc.blockProcessingMutex.Lock()
 	defer lc.blockProcessingMutex.Unlock()
 
 	if err := lc.checkAndStoreBatch(batch); err != nil {
-		return nil, err
+		return err
 	}
 
 	// If this is the genesis batch, we commit the genesis state.
 	if batch.IsGenesis() {
 		if err := lc.genesis.CommitGenesisState(lc.storage); err != nil {
-			return nil, fmt.Errorf("could not apply genesis state. Cause: %w", err)
+			return fmt.Errorf("could not apply genesis state. Cause: %w", err)
 		}
 	}
 
-	return batch.Header, nil
+	return nil
 }
 
 func (lc *L2Chain) GetBalance(accountAddress gethcommon.Address, blockNumber *gethrpc.BlockNumber) (*gethcommon.Address, *hexutil.Big, error) {

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -226,8 +226,6 @@ func (h *host) EnclaveClient() common.Enclave {
 func (h *host) SubmitAndBroadcastTx(encryptedParams common.EncryptedParamsSendRawTx) (common.EncryptedResponseSendRawTx, error) {
 	encryptedTx := common.EncryptedTx(encryptedParams)
 
-	// TODO - #718 - We only need to submit to the enclave as the sequencer. But we still need to return the encrypted
-	//  transaction hash, so some round-trip to the enclave is required.
 	encryptedResponse, err := h.enclaveClient.SubmitTx(encryptedTx)
 	if err != nil {
 		return nil, fmt.Errorf("could not submit transaction. Cause: %w", err)


### PR DESCRIPTION
### Why is this change needed?

- Provide a description and a link to the underlying ticket

### What changes were made as part of this PR:

- Provide a high level list of the changes made

### Definition of done

- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
- [ ] End-to-end tests run if required (see below)

### End-to-end tests

Running the end-to-end tests in the [obscuro-test repo](https://github.com/obscuronet/obscuro-test) is currently at the 
discretion of the developer prior to merging a PR. The intention is not to slow down development by having the longer 
running end-to-end tests as a PR gate run on each branch commit etc. To manually trigger a run pre-merge;

- Go to [run_local_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_local_tests.yml)
- Click the "Run workflow" button
- Use the main branch of obscuro-test 
- Enter the name of the PR branch for go-obscuro
- Run the workflow

The run takes approximately 20 minutes and any failure will be reported in the workflow output. Should the tests fail 
the docker container output for the local testnet and all test artifacts will be added to the run and can be downloaded
for debugging and analysis, with a retention period of 2 days. 

Note that every PR merge to main will also trigger a run of post-merge tests, so even if you do not manually trigger 
pre-merge, tests will be run post-merge. The intention being to catch any issues fast on main to allow for quick 
resolution. The post-merge test output can be seen at 
[run_merge_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_merge_tests.yml) and will show both 
the PR number and author in the list of runs. 


