### PR TITLE
Temporarily allow product key sealing of EDB credentials

### DIFF
--- a/go/enclave/db/sql/edgelessdb.go
+++ b/go/enclave/db/sql/edgelessdb.go
@@ -257,7 +257,8 @@ func performHandshake(edbCfg *EdgelessDBConfig, logger gethlog.Logger) (*Edgeles
 	if err != nil {
 		return nil, err
 	}
-	err = egoutils.SealAndPersist(string(edbCredsJSON), edbCredentialsFilepath)
+	// todo: #1377 the credentials must be sealed with the enclave unique ID in production, not just the product key
+	err = egoutils.SealAndPersist(string(edbCredsJSON), edbCredentialsFilepath, true)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Why is this change needed?

- While we continue developing the upgrade process for nodes in production we need a solution that allows testnet nodes to be upgraded without losing access to their state
- Sealing the EDB credentials with the enclave product key rather than the enclave unique ID provides some security but a determined attacker with insider access would be able to access the secrets so this is solely a stop-gap solution for testnet
- A task has been created here https://github.com/obscuronet/obscuro-internal/issues/1377 with todos in the code that point to that to ensure this doesn't get left in

### What changes were made as part of this PR:

- Change the code to seal EDB credentials with product key rather than unique ID
- Make it clear with the code and the todo comments that this is a temporary solution that will be rectified before mainnet

### Definition of done

- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
- [ ] End-to-end tests run if required (see below)

### End-to-end tests

Running the end-to-end tests in the [obscuro-test repo](https://github.com/obscuronet/obscuro-test) is currently at the 
discretion of the developer prior to merging a PR. The intention is not to slow down development by having the longer 
running end-to-end tests as a PR gate run on each branch commit etc. To manually trigger a run pre-merge;

- Go to [run_local_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_local_tests.yml)
- Click the "Run workflow" button
- Use the main branch of obscuro-test 
- Enter the name of the PR branch for go-obscuro
- Run the workflow

The run takes approximately 20 minutes and any failure will be reported in the workflow output. Should the tests fail 
the docker container output for the local testnet and all test artifacts will be added to the run and can be downloaded
for debugging and analysis, with a retention period of 2 days. 

Note that every PR merge to main will also trigger a run of post-merge tests, so even if you do not manually trigger 
pre-merge, tests will be run post-merge. The intention being to catch any issues fast on main to allow for quick 
resolution. The post-merge test output can be seen at 
[run_merge_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_merge_tests.yml) and will show both 
the PR number and author in the list of runs. 


