### PR TITLE
Do not store rollups on enclave

### DIFF
--- a/go/enclave/db/interfaces.go
+++ b/go/enclave/db/interfaces.go
@@ -41,11 +41,6 @@ type BatchResolver interface {
 	StoreBatch(batch *core.Batch, receipts []*types.Receipt) error
 }
 
-type RollupResolver interface {
-	// StoreRollup stores a rollup.
-	StoreRollup(rollup *core.Rollup) error
-}
-
 type HeadsAfterL1BlockStorage interface {
 	// FetchHeadBatchForBlock returns the hash of the head batch at a given L1 block.
 	FetchHeadBatchForBlock(blockHash common.L1RootHash) (*core.Batch, error)
@@ -99,7 +94,6 @@ type CrossChainMessagesStorage interface {
 type Storage interface {
 	BlockResolver
 	BatchResolver
-	RollupResolver
 	SharedSecretStorage
 	HeadsAfterL1BlockStorage
 	TransactionStorage

--- a/go/enclave/enclave_test.go
+++ b/go/enclave/enclave_test.go
@@ -517,9 +517,6 @@ func createFakeGenesis(enclave common.Enclave, addresses []genesis.Account) erro
 	}
 
 	// We update the database
-	if err = enclave.(*enclaveImpl).storage.StoreRollup(genesisRollup); err != nil {
-		return err
-	}
 	if err = enclave.(*enclaveImpl).storage.StoreBatch(genesisBatch, nil); err != nil {
 		return err
 	}
@@ -580,9 +577,6 @@ func injectNewBlockAndChangeBalance(enclave common.Enclave, funds []genesis.Acco
 	}
 
 	// We update the database.
-	if err = enclave.(*enclaveImpl).storage.StoreRollup(rollup); err != nil {
-		return err
-	}
 	if err = enclave.(*enclaveImpl).storage.StoreBatch(batch, nil); err != nil {
 		return err
 	}

--- a/go/enclave/l2chain/l2_chain.go
+++ b/go/enclave/l2chain/l2_chain.go
@@ -805,10 +805,6 @@ func (lc *L2Chain) processRollups(block *common.L1Block) error {
 				return fmt.Errorf("could not store batch. Cause: %w", err)
 			}
 		}
-
-		if err = lc.storage.StoreRollup(rollup); err != nil {
-			return fmt.Errorf("could not store rollup. Cause: %w", err)
-		}
 	}
 
 	newHeadRollup := currentHeadRollup

--- a/go/host/rpc/clientapi/client_api_eth.go
+++ b/go/host/rpc/clientapi/client_api_eth.go
@@ -184,7 +184,7 @@ func (api *EthereumAPI) FeeHistory(context.Context, rpc.DecimalOrHex, rpc.BlockN
 }
 
 // Converts a batch header to a key/value map.
-// TODO - Include all the fields of the rollup header that do not exist in the Geth block headers as well (not just withdrawals).
+// TODO - Include all the fields of the batch header that do not exist in the Geth block headers as well (not just withdrawals).
 func headerToMap(header *common.BatchHeader) map[string]interface{} {
 	return map[string]interface{}{
 		// The fields present in Geth's `types/Header` struct.


### PR DESCRIPTION
### Why is this change needed?

We were storing the rollups on the enclave, but they weren't used for anything.

### What changes were made as part of this PR:

- Provide a high level list of the changes made

### Definition of done

- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
- [ ] End-to-end tests run if required (see below)

### End-to-end tests

Running the end-to-end tests in the [obscuro-test repo](https://github.com/obscuronet/obscuro-test) is currently at the 
discretion of the developer prior to merging a PR. The intention is not to slow down development by having the longer 
running end-to-end tests as a PR gate run on each branch commit etc. To manually trigger a run pre-merge;

- Go to [run_local_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_local_tests.yml)
- Click the "Run workflow" button
- Use the main branch of obscuro-test 
- Enter the name of the PR branch for go-obscuro
- Run the workflow

The run takes approximately 20 minutes and any failure will be reported in the workflow output. Should the tests fail 
the docker container output for the local testnet and all test artifacts will be added to the run and can be downloaded
for debugging and analysis, with a retention period of 2 days. 

Note that every PR merge to main will also trigger a run of post-merge tests, so even if you do not manually trigger 
pre-merge, tests will be run post-merge. The intention being to catch any issues fast on main to allow for quick 
resolution. The post-merge test output can be seen at 
[run_merge_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_merge_tests.yml) and will show both 
the PR number and author in the list of runs. 


