### PR TITLE
In sims, check that txs are included in rollups

### DIFF
--- a/go/common/rollups.go
+++ b/go/common/rollups.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"sort"
 	"sync/atomic"
 )
 
@@ -22,18 +21,4 @@ func (r *ExtRollup) Hash() L2RootHash {
 	v := r.Header.Hash()
 	r.hash.Store(v)
 	return v
-}
-
-// ExtRollupFromExtBatches converts a set of ExtBatch into an ExtRollup. The hash of the head batch (the one with the
-// highest number) is stored in the ExtRollup header's `HeadBatchHash` field.
-func ExtRollupFromExtBatches(batches []*ExtBatch) *ExtRollup {
-	sort.Slice(batches, func(i, j int) bool {
-		// Ascending order sort.
-		return batches[i].Header.Number.Cmp(batches[j].Header.Number) < 0
-	})
-
-	return &ExtRollup{
-		Header:  batches[len(batches)-1].Header.ToRollupHeader(),
-		Batches: batches,
-	}
 }

--- a/go/common/rpc/converters.go
+++ b/go/common/rpc/converters.go
@@ -187,7 +187,7 @@ func ToBatchHeaderMsg(header *common.BatchHeader) *generated.BatchHeaderMsg { //
 		MixDigest:                   header.MixDigest.Bytes(),
 		BaseFee:                     baseFee,
 		CrossChainMessages:          ToCrossChainMsgs(header.CrossChainMessages),
-		LatestInboundCrossChainHash: header.LatestInboudCrossChainHash.Bytes(),
+		LatestInboundCrossChainHash: header.LatestInboundCrossChainHash.Bytes(),
 	}
 
 	if header.LatestInboundCrossChainHeight != nil {
@@ -246,7 +246,7 @@ func FromBatchHeaderMsg(header *generated.BatchHeaderMsg) *common.BatchHeader { 
 		MixDigest:                     gethcommon.BytesToHash(header.MixDigest),
 		BaseFee:                       big.NewInt(int64(header.BaseFee)),
 		CrossChainMessages:            FromCrossChainMsgs(header.CrossChainMessages),
-		LatestInboudCrossChainHash:    gethcommon.BytesToHash(header.LatestInboundCrossChainHash),
+		LatestInboundCrossChainHash:   gethcommon.BytesToHash(header.LatestInboundCrossChainHash),
 		LatestInboundCrossChainHeight: big.NewInt(0).SetBytes(header.LatestInboundCrossChainHeight),
 	}
 }

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -490,6 +490,8 @@ func (h *host) processL1BlockTransactions(b *types.Block) {
 
 // Publishes a rollup to the L1.
 func (h *host) publishRollup(producedRollup *common.ExtRollup) {
+	println(fmt.Sprintf("jjj publishing rollup with hash %s and parent hash %s", producedRollup.Hash(), producedRollup.Header.ParentHash))
+
 	encodedRollup, err := common.EncodeRollup(producedRollup)
 	if err != nil {
 		h.logger.Crit("could not encode rollup.", log.ErrKey, err)

--- a/go/host/rpc/clientapi/client_api_eth.go
+++ b/go/host/rpc/clientapi/client_api_eth.go
@@ -209,7 +209,7 @@ func headerToMap(header *common.BatchHeader) map[string]interface{} {
 		"agg":                     header.Agg,
 		"l1Proof":                 header.L1Proof,
 		"crossChainMessages":      header.CrossChainMessages,
-		"inboundCrossChainHash":   header.LatestInboudCrossChainHash,
+		"inboundCrossChainHash":   header.LatestInboundCrossChainHash,
 		"inboundCrossChainHeight": header.LatestInboundCrossChainHeight,
 	}
 }

--- a/integration/datagenerator/batch.go
+++ b/integration/datagenerator/batch.go
@@ -26,7 +26,7 @@ func RandomBatch(block *types.Block) common.ExtBatch {
 
 	if block != nil {
 		extBatch.Header.LatestInboundCrossChainHeight = block.Number()
-		extBatch.Header.LatestInboudCrossChainHash = block.Hash()
+		extBatch.Header.LatestInboundCrossChainHash = block.Hash()
 	}
 
 	return extBatch

--- a/integration/simulation/transaction_injector_tracker.go
+++ b/integration/simulation/transaction_injector_tracker.go
@@ -51,7 +51,7 @@ func (m *txInjectorTracker) GetL1Transactions() []ethadapter.L1Transaction {
 	return m.L1Transactions
 }
 
-// GetL2Transactions returns all generated non-WithdrawalTx transactions, excluding prefund and ERC20 deploy transactions.
+// GetL2Transactions returns all generated transactions, excluding prefund and ERC20 deploy transactions.
 func (m *txInjectorTracker) GetL2Transactions() ([]*common.L2Tx, []*common.L2Tx, []*common.L2Tx) {
 	return m.TransferL2Transactions, m.WithdrawalL2Transactions, m.NativeValueTransferL2Transactions
 }


### PR DESCRIPTION
### Why is this change needed?

- Provide a description and a link to the underlying ticket

### What changes were made as part of this PR:

- Provide a high level list of the changes made

### Definition of done

- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
- [ ] End-to-end tests run if required (see below)

### End-to-end tests

Running the end-to-end tests in the [obscuro-test repo](https://github.com/obscuronet/obscuro-test) is currently at the 
discretion of the developer prior to merging a PR. The intention is not to slow down development by having the longer 
running end-to-end tests as a PR gate run on each branch commit etc. To manually trigger a run pre-merge;

- Go to [run_local_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_local_tests.yml)
- Click the "Run workflow" button
- Use the main branch of obscuro-test 
- Enter the name of the PR branch for go-obscuro
- Run the workflow

The run takes approximately 20 minutes and any failure will be reported in the workflow output. Should the tests fail 
the docker container output for the local testnet and all test artifacts will be added to the run and can be downloaded
for debugging and analysis, with a retention period of 2 days. 

Note that every PR merge to main will also trigger a run of post-merge tests, so even if you do not manually trigger 
pre-merge, tests will be run post-merge. The intention being to catch any issues fast on main to allow for quick 
resolution. The post-merge test output can be seen at 
[run_merge_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_merge_tests.yml) and will show both 
the PR number and author in the list of runs. 


