### PR TITLE
Store the L2 head hash directly in the enclave

### DIFF
--- a/go/enclave/db/rawdb/accessors_chain.go
+++ b/go/enclave/db/rawdb/accessors_chain.go
@@ -176,6 +176,9 @@ func readBatchBodyRLP(db ethdb.KeyValueReader, hash common.L2RootHash) (rlp.RawV
 }
 
 func WriteL2HeadBatch(db ethdb.KeyValueWriter, l1Head common.L1RootHash, l2Head common.L2RootHash) error {
+	if err := db.Put(headBatchHash, l2Head.Bytes()); err != nil {
+		return fmt.Errorf("could not put chain heads in DB. Cause: %w", err)
+	}
 	if err := db.Put(headBatchAfterL1BlockKey(l1Head), l2Head.Bytes()); err != nil {
 		return fmt.Errorf("could not put chain heads in DB. Cause: %w", err)
 	}
@@ -189,7 +192,16 @@ func WriteL2HeadRollup(db ethdb.KeyValueWriter, l1Head *common.L1RootHash, l2Hea
 	return nil
 }
 
-func ReadL2HeadBatch(kv ethdb.KeyValueReader, l1Head common.L1RootHash) (*common.L2RootHash, error) {
+func ReadL2HeadBatch(kv ethdb.KeyValueReader) (*common.L2RootHash, error) {
+	data, err := kv.Get(headBatchHash)
+	if err != nil {
+		return nil, errutil.ErrNotFound
+	}
+	l2Head := gethcommon.BytesToHash(data)
+	return &l2Head, nil
+}
+
+func ReadL2HeadBatchForBlock(kv ethdb.KeyValueReader, l1Head common.L1RootHash) (*common.L2RootHash, error) {
 	data, err := kv.Get(headBatchAfterL1BlockKey(l1Head))
 	if err != nil {
 		return nil, errutil.ErrNotFound

--- a/go/enclave/db/rawdb/schema.go
+++ b/go/enclave/db/rawdb/schema.go
@@ -8,7 +8,8 @@ import (
 )
 
 var (
-	sharedSecret = []byte("SharedSecret")
+	sharedSecret  = []byte("SharedSecret")
+	headBatchHash = []byte("HeadBatch") // headBatchHashPrefix -> curr L2 head batch hash
 
 	attestationKeyPrefix           = []byte("oAK")  // attestationKeyPrefix + address -> key
 	syntheticTransactionsKeyPrefix = []byte("oSTX") // attestationKeyPrefix + address -> key

--- a/go/enclave/db/storage.go
+++ b/go/enclave/db/storage.go
@@ -44,11 +44,14 @@ func NewStorage(backingDB ethdb.Database, chainConfig *params.ChainConfig, logge
 }
 
 func (s *storageImpl) FetchHeadBatch() (*core.Batch, error) {
-	l1Head := rawdb.ReadHeadHeaderHash(s.db)
-	if (bytes.Equal(l1Head.Bytes(), gethcommon.Hash{}.Bytes())) {
+	headHash, err := obscurorawdb.ReadL2HeadBatch(s.db)
+	if err != nil {
+		return nil, err
+	}
+	if (bytes.Equal(headHash.Bytes(), gethcommon.Hash{}.Bytes())) {
 		return nil, fmt.Errorf("could not fetch L1 head hash")
 	}
-	return s.FetchHeadBatchForBlock(l1Head)
+	return s.FetchBatch(*headHash)
 }
 
 func (s *storageImpl) FetchBatch(hash common.L2RootHash) (*core.Batch, error) {
@@ -146,7 +149,7 @@ func (s *storageImpl) assertSecretAvailable() {
 }
 
 func (s *storageImpl) FetchHeadBatchForBlock(blockHash common.L1RootHash) (*core.Batch, error) {
-	l2HeadBatch, err := obscurorawdb.ReadL2HeadBatch(s.db, blockHash)
+	l2HeadBatch, err := obscurorawdb.ReadL2HeadBatchForBlock(s.db, blockHash)
 	if err != nil {
 		return nil, fmt.Errorf("could not read L2 head batch for block. Cause: %w", err)
 	}

--- a/go/enclave/l2chain/l2_chain.go
+++ b/go/enclave/l2chain/l2_chain.go
@@ -340,7 +340,7 @@ func (lc *L2Chain) updateL1AndL2Heads(block *types.Block, isLatestBlock bool) (*
 
 	// We determine whether we have produced a genesis batch yet.
 	genesisBatchStored := true
-	l2Head, err := lc.storage.FetchHeadBatch()
+	l2Head, err := lc.storage.FetchHeadBatchForBlock(block.ParentHash())
 	if err != nil {
 		if !errors.Is(err, errutil.ErrNotFound) {
 			return nil, nil, fmt.Errorf("could not retrieve current head batch. Cause: %w", err)
@@ -662,7 +662,7 @@ func (lc *L2Chain) produceBatch(block *types.Block, genesisBatchStored bool) (*c
 		return lc.produceGenesisBatch(block.Hash())
 	}
 
-	headBatch, err := lc.storage.FetchHeadBatch()
+	headBatch, err := lc.storage.FetchHeadBatchForBlock(block.ParentHash())
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve head batch. Cause: %w", err)
 	}

--- a/go/enclave/l2chain/l2_chain.go
+++ b/go/enclave/l2chain/l2_chain.go
@@ -340,7 +340,7 @@ func (lc *L2Chain) updateL1AndL2Heads(block *types.Block, isLatestBlock bool) (*
 
 	// We determine whether we have produced a genesis batch yet.
 	genesisBatchStored := true
-	l2Head, err := lc.storage.FetchHeadBatchForBlock(block.ParentHash())
+	l2Head, err := lc.storage.FetchHeadBatch()
 	if err != nil {
 		if !errors.Is(err, errutil.ErrNotFound) {
 			return nil, nil, fmt.Errorf("could not retrieve current head batch. Cause: %w", err)
@@ -662,7 +662,7 @@ func (lc *L2Chain) produceBatch(block *types.Block, genesisBatchStored bool) (*c
 		return lc.produceGenesisBatch(block.Hash())
 	}
 
-	headBatch, err := lc.storage.FetchHeadBatchForBlock(block.ParentHash())
+	headBatch, err := lc.storage.FetchHeadBatch()
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve head batch. Cause: %w", err)
 	}


### PR DESCRIPTION
### Why is this change needed?

- Currently the enclave's view on what is the head of the L2 chain is determined by the head of the L1 chain and the mappings from L1 block -> head L2 hash for that block.
- This is a relic from the POBI design and no longer needed
- It makes it hard to rewind the head to rebuild state after recovering from an ungraceful shutdown
- Note: this change does not get rid of the mapping which is a tricker thread to pull at, it just stops treating it as the source of truth for current head of L2 chain

### What changes were made as part of this PR:

- Add new DB entry for the batch hash at the head of the L2 chain

### Definition of done

- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
- [ ] End-to-end tests run if required (see below)

### End-to-end tests

Running the end-to-end tests in the [obscuro-test repo](https://github.com/obscuronet/obscuro-test) is currently at the 
discretion of the developer prior to merging a PR. The intention is not to slow down development by having the longer 
running end-to-end tests as a PR gate run on each branch commit etc. To manually trigger a run pre-merge;

- Go to [run_local_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_local_tests.yml)
- Click the "Run workflow" button
- Use the main branch of obscuro-test 
- Enter the name of the PR branch for go-obscuro
- Run the workflow

The run takes approximately 20 minutes and any failure will be reported in the workflow output. Should the tests fail 
the docker container output for the local testnet and all test artifacts will be added to the run and can be downloaded
for debugging and analysis, with a retention period of 2 days. 

Note that every PR merge to main will also trigger a run of post-merge tests, so even if you do not manually trigger 
pre-merge, tests will be run post-merge. The intention being to catch any issues fast on main to allow for quick 
resolution. The post-merge test output can be seen at 
[run_merge_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_merge_tests.yml) and will show both 
the PR number and author in the list of runs. 


