### PR TITLE
Call DB client batches dbBatches to avoid confusion

### DIFF
--- a/go/enclave/db/storage.go
+++ b/go/enclave/db/storage.go
@@ -171,14 +171,14 @@ func (s *storageImpl) FetchLogs(blockHash common.L1RootHash) ([]*types.Log, erro
 }
 
 func (s *storageImpl) UpdateHeadBatch(l1Head common.L1RootHash, l2Head *core.Batch, receipts []*types.Receipt) error {
-	batch := s.db.NewBatch()
+	dbBatch := s.db.NewBatch()
 
-	if err := obscurorawdb.WriteL2HeadBatch(batch, l1Head, *l2Head.Hash()); err != nil {
+	if err := obscurorawdb.WriteL2HeadBatch(dbBatch, l1Head, *l2Head.Hash()); err != nil {
 		return fmt.Errorf("could not write block state. Cause: %w", err)
 	}
 
 	// We update the canonical hash of the batch at this height.
-	if err := obscurorawdb.WriteCanonicalHash(batch, l2Head); err != nil {
+	if err := obscurorawdb.WriteCanonicalHash(dbBatch, l2Head); err != nil {
 		return fmt.Errorf("could not write canonical hash. Cause: %w", err)
 	}
 
@@ -187,31 +187,31 @@ func (s *storageImpl) UpdateHeadBatch(l1Head common.L1RootHash, l2Head *core.Bat
 	for _, receipt := range receipts {
 		logs = append(logs, receipt.Logs...)
 	}
-	if err := obscurorawdb.WriteBlockLogs(batch, l1Head, logs); err != nil {
+	if err := obscurorawdb.WriteBlockLogs(dbBatch, l1Head, logs); err != nil {
 		return fmt.Errorf("could not write block logs. Cause: %w", err)
 	}
 
-	if err := batch.Write(); err != nil {
+	if err := dbBatch.Write(); err != nil {
 		return fmt.Errorf("could not save new head. Cause: %w", err)
 	}
 	return nil
 }
 
 func (s *storageImpl) UpdateHeadRollup(l1Head *common.L1RootHash, l2Head *common.L2RootHash) error {
-	batch := s.db.NewBatch()
-	if err := obscurorawdb.WriteL2HeadRollup(batch, l1Head, l2Head); err != nil {
+	dbBatch := s.db.NewBatch()
+	if err := obscurorawdb.WriteL2HeadRollup(dbBatch, l1Head, l2Head); err != nil {
 		return fmt.Errorf("could not write block state. Cause: %w", err)
 	}
-	if err := batch.Write(); err != nil {
+	if err := dbBatch.Write(); err != nil {
 		return fmt.Errorf("could not save new head. Cause: %w", err)
 	}
 	return nil
 }
 
 func (s *storageImpl) UpdateL1Head(l1Head common.L1RootHash) error {
-	batch := s.db.NewBatch()
-	rawdb.WriteHeadHeaderHash(batch, l1Head)
-	if err := batch.Write(); err != nil {
+	dbBatch := s.db.NewBatch()
+	rawdb.WriteHeadHeaderHash(dbBatch, l1Head)
+	if err := dbBatch.Write(); err != nil {
 		return fmt.Errorf("could not save new L1 head. Cause: %w", err)
 	}
 	return nil
@@ -332,13 +332,13 @@ func (s *storageImpl) GetL1Messages(blockHash common.L1RootHash) (common.CrossCh
 }
 
 func (s *storageImpl) StoreRollup(rollup *core.Rollup) error {
-	batch := s.db.NewBatch()
+	dbBatch := s.db.NewBatch()
 
-	if err := obscurorawdb.WriteRollup(batch, rollup); err != nil {
+	if err := obscurorawdb.WriteRollup(dbBatch, rollup); err != nil {
 		return fmt.Errorf("could not write rollup. Cause: %w", err)
 	}
 
-	if err := batch.Write(); err != nil {
+	if err := dbBatch.Write(); err != nil {
 		return fmt.Errorf("could not write rollup to storage. Cause: %w", err)
 	}
 	return nil


### PR DESCRIPTION
### Why is this change needed?

- Keep meaning to rename these, it's very confusing to have `batch` meaning L2 batches and `batch` mean DB atomic transactions block being used in the same methods.

### What changes were made as part of this PR:

- Rename `batch` -> `dbBatch` where appropriate

### Definition of done

- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
- [ ] End-to-end tests run if required (see below)

### End-to-end tests

Running the end-to-end tests in the [obscuro-test repo](https://github.com/obscuronet/obscuro-test) is currently at the 
discretion of the developer prior to merging a PR. The intention is not to slow down development by having the longer 
running end-to-end tests as a PR gate run on each branch commit etc. To manually trigger a run pre-merge;

- Go to [run_local_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_local_tests.yml)
- Click the "Run workflow" button
- Use the main branch of obscuro-test 
- Enter the name of the PR branch for go-obscuro
- Run the workflow

The run takes approximately 20 minutes and any failure will be reported in the workflow output. Should the tests fail 
the docker container output for the local testnet and all test artifacts will be added to the run and can be downloaded
for debugging and analysis, with a retention period of 2 days. 

Note that every PR merge to main will also trigger a run of post-merge tests, so even if you do not manually trigger 
pre-merge, tests will be run post-merge. The intention being to catch any issues fast on main to allow for quick 
resolution. The post-merge test output can be seen at 
[run_merge_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_merge_tests.yml) and will show both 
the PR number and author in the list of runs. 


