### PR TITLE
Fixes the enclave start

### DIFF
--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -254,7 +254,7 @@ jobs:
               --resource-group Testnet \
               --lb-name ${{needs.build.outputs.RESOURCE_TESTNET_NAME}}-loadbalancer
 
-  wait-node-up:
+  check-node-up:
     needs:
       - build
       - deploy
@@ -270,7 +270,7 @@ jobs:
   deploy-l2-contracts:
     needs:
       - build
-      - wait-node-up
+      - check-node-up
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -254,7 +254,7 @@ jobs:
               --resource-group Testnet \
               --lb-name ${{needs.build.outputs.RESOURCE_TESTNET_NAME}}-loadbalancer
 
-  check-node-up:
+  check-obscuro-is-healthy:
     needs:
       - build
       - deploy
@@ -270,7 +270,7 @@ jobs:
   deploy-l2-contracts:
     needs:
       - build
-      - check-node-up
+      - check-obscuro-is-healthy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/manual-upgrade-testnet-l2.yml
+++ b/.github/workflows/manual-upgrade-testnet-l2.yml
@@ -127,7 +127,7 @@ jobs:
               docker compose up host enclave
             '
 
-  check-node-up:
+  check-obscuro-is-healthy:
     needs:
       - build
       - deploy

--- a/.github/workflows/manual-upgrade-testnet-l2.yml
+++ b/.github/workflows/manual-upgrade-testnet-l2.yml
@@ -127,7 +127,7 @@ jobs:
               docker compose up host enclave
             '
 
-  wait-node-up:
+  check-node-up:
     needs:
       - build
       - deploy

--- a/dockerfiles/enclave.Dockerfile
+++ b/dockerfiles/enclave.Dockerfile
@@ -26,6 +26,7 @@ FROM ghcr.io/edgelesssys/ego-deploy:latest
 
 # Copy just the binary for the enclave into this build stage
 COPY --from=0 /home/obscuro/go-obscuro/go/enclave/main/main home/obscuro/go-obscuro/go/enclave/main/main
+COPY --from=0 /home/obscuro/go-obscuro/go/enclave/main/entry.sh home/obscuro/go-obscuro/go/enclave/main/entry.sh
 WORKDIR /home/obscuro/go-obscuro/go/enclave/main
 RUN mkdir -p /home/obscuro/data
 


### PR DESCRIPTION
### Why is this change needed?

- Provide a description and a link to the underlying ticket

### What changes were made as part of this PR:

- Provide a high level list of the changes made

### Definition of done

- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
- [ ] End-to-end tests run if required (see below)

### End-to-end tests

Running the end-to-end tests in the [obscuro-test repo](https://github.com/obscuronet/obscuro-test) is currently at the 
discretion of the developer prior to merging a PR. The intention is not to slow down development by having the longer 
running end-to-end tests as a PR gate run on each branch commit etc. To manually trigger a run pre-merge;

- Go to [run_local_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_local_tests.yml)
- Click the "Run workflow" button
- Use the main branch of obscuro-test 
- Enter the name of the PR branch for go-obscuro
- Run the workflow

The run takes approximately 20 minutes and any failure will be reported in the workflow output. Should the tests fail 
the docker container output for the local testnet and all test artifacts will be added to the run and can be downloaded
for debugging and analysis, with a retention period of 2 days. 

Note that every PR merge to main will also trigger a run of post-merge tests, so even if you do not manually trigger 
pre-merge, tests will be run post-merge. The intention being to catch any issues fast on main to allow for quick 
resolution. The post-merge test output can be seen at 
[run_merge_tests](https://github.com/obscuronet/obscuro-test/actions/workflows/run_merge_tests.yml) and will show both 
the PR number and author in the list of runs. 


