### PR TITLE
Avoid swallowing L1 client error messages

### DIFF
--- a/go/ethadapter/blockprovider.go
+++ b/go/ethadapter/blockprovider.go
@@ -153,11 +153,11 @@ func (e *EthBlockProvider) fetchNextCanonicalBlock(ctx context.Context, fromHeig
 func (e *EthBlockProvider) latestCanonAncestor(blkHash gethcommon.Hash) (*types.Block, error) {
 	blk, err := e.ethClient.BlockByHash(blkHash)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to fetch L1 block with hash=%s - %w", blkHash, err)
 	}
 	canonAtSameHeight, err := e.ethClient.BlockByNumber(blk.Number())
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to fetch L1 block at height=%d - %w", blk.Number(), err)
 	}
 	if blk.Hash() != canonAtSameHeight.Hash() {
 		return e.latestCanonAncestor(blk.ParentHash())

--- a/go/ethadapter/geth_rpc_client.go
+++ b/go/ethadapter/geth_rpc_client.go
@@ -147,7 +147,7 @@ func (e *gethRPCClient) BlockListener() (chan *types.Header, ethereum.Subscripti
 	err = retry.Do(func() error {
 		sub, err = e.client.SubscribeNewHead(ctx, ch)
 		if err != nil {
-			e.logger.Warn("could not subscribe for new head blocks")
+			e.logger.Warn("could not subscribe for new head blocks", log.ErrKey, err)
 		}
 		return err
 	}, retry.NewTimeoutStrategy(connRetryMaxWait, connRetryInterval))


### PR DESCRIPTION
### Why this change is needed

There was an issue with the L1 block provider on testnet and useful information wasn't being logged that might have helped understand the issue.

### What changes were made as part of this PR

Don't swallow errors returned by L1 client when logging

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [x] PR checks reviewed and performed 


