### PR TITLE
Rollup lookup should not assume that L1 blocks go back to genesis

### DIFF
--- a/go/enclave/l2chain/l2_chain.go
+++ b/go/enclave/l2chain/l2_chain.go
@@ -932,7 +932,7 @@ func (oc *ObscuroChain) getLatestRollupBeforeBlock(block *common.L1Block) (*core
 				// We have now checked through the entire (relevant) history of the L1 and no rollups were found.
 				return nil, errNoRollupFound
 			}
-			return nil, fmt.Errorf("could not fetch prev block - %w", err)
+			return nil, fmt.Errorf("could not fetch parent block - %w", err)
 		}
 	}
 }

--- a/go/enclave/l2chain/l2_chain.go
+++ b/go/enclave/l2chain/l2_chain.go
@@ -37,7 +37,7 @@ import (
 	gethrpc "github.com/ethereum/go-ethereum/rpc"
 )
 
-var errNoRollupFound = errors.New("no rollups found")
+var errNoRollupFound = errors.New("no rollup found")
 
 // ObscuroChain represents the canonical L2 chain, and manages the state.
 type ObscuroChain struct {

--- a/go/enclave/l2chain/l2_chain.go
+++ b/go/enclave/l2chain/l2_chain.go
@@ -861,8 +861,8 @@ func (oc *ObscuroChain) isAccountContractAtBlock(accountAddr gethcommon.Address,
 // TODO - #718 - Design a mechanism to detect a case where the rollups never contain any batches (despite batches arriving via P2P).
 func (oc *ObscuroChain) processRollups(block *common.L1Block) error {
 	latestRollup, err := oc.getLatestRollupBeforeBlock(block)
-	if err != nil {
-		return fmt.Errorf("could not retrieve latest rollup for block. Cause: %w", err)
+	if err != nil && !errors.Is(err, noRollupFoundError) {
+		return fmt.Errorf("unexpected error retrieving latest rollup for block. Cause: %w", err)
 	}
 
 	rollups := oc.rollupExtractor.ExtractRollups(block, oc.storage)
@@ -910,6 +910,8 @@ func (oc *ObscuroChain) processRollups(block *common.L1Block) error {
 	return nil
 }
 
+var noRollupFoundError = errors.New("no rollups found")
+
 // Given a block, returns the latest rollup in the canonical chain for that block (excluding those in the block itself).
 func (oc *ObscuroChain) getLatestRollupBeforeBlock(block *common.L1Block) (*core.Rollup, error) {
 	for {
@@ -926,7 +928,7 @@ func (oc *ObscuroChain) getLatestRollupBeforeBlock(block *common.L1Block) (*core
 		if err != nil {
 			// No rollup found - no more blocks available (enclave does not read the L1 chain from genesis if it knows
 			// when management contract was deployed, so we don't keep going to block zero, we just stop when the blocks run out)
-			return nil, nil //nolint:nilnil
+			return nil, noRollupFoundError
 		}
 	}
 }

--- a/go/enclave/l2chain/l2_chain.go
+++ b/go/enclave/l2chain/l2_chain.go
@@ -861,7 +861,7 @@ func (oc *ObscuroChain) isAccountContractAtBlock(accountAddr gethcommon.Address,
 // TODO - #718 - Design a mechanism to detect a case where the rollups never contain any batches (despite batches arriving via P2P).
 func (oc *ObscuroChain) processRollups(block *common.L1Block) error {
 	latestRollup, err := oc.getLatestRollupBeforeBlock(block)
-	if err != nil && !errors.Is(err, noRollupFoundError) {
+	if err != nil && !errors.Is(err, errNoRollupFound) {
 		return fmt.Errorf("unexpected error retrieving latest rollup for block. Cause: %w", err)
 	}
 
@@ -910,7 +910,7 @@ func (oc *ObscuroChain) processRollups(block *common.L1Block) error {
 	return nil
 }
 
-var noRollupFoundError = errors.New("no rollups found")
+var errNoRollupFound = errors.New("no rollups found")
 
 // Given a block, returns the latest rollup in the canonical chain for that block (excluding those in the block itself).
 func (oc *ObscuroChain) getLatestRollupBeforeBlock(block *common.L1Block) (*core.Rollup, error) {
@@ -928,7 +928,7 @@ func (oc *ObscuroChain) getLatestRollupBeforeBlock(block *common.L1Block) (*core
 		if err != nil {
 			// No rollup found - no more blocks available (enclave does not read the L1 chain from genesis if it knows
 			// when management contract was deployed, so we don't keep going to block zero, we just stop when the blocks run out)
-			return nil, noRollupFoundError
+			return nil, errNoRollupFound
 		}
 	}
 }


### PR DESCRIPTION
### Why this change is needed

We were sometimes seeing failures before rollups were published where the rollup lookup would try to go back to genesis but it would run out of L1 blocks because the enclave didn't start from genesis, it started from the mgmt contract deployment block.

### What changes were made as part of this PR

Return rollup not found when the L1 blocks run out.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


