### PR TITLE
Fix wallet extension flakyness

### DIFF
--- a/tools/walletextension/test/utils.go
+++ b/tools/walletextension/test/utils.go
@@ -21,7 +21,6 @@ import (
 	"github.com/obscuronet/go-obscuro/tools/walletextension"
 	"github.com/obscuronet/go-obscuro/tools/walletextension/common"
 
-	gethcommon "github.com/ethereum/go-ethereum/common"
 	gethlog "github.com/ethereum/go-ethereum/log"
 	gethnode "github.com/ethereum/go-ethereum/node"
 	gethrpc "github.com/ethereum/go-ethereum/rpc"
@@ -138,7 +137,7 @@ func prepareRequestBody(method string, params interface{}) []byte {
 }
 
 // Generates a new account and registers it with the node.
-func registerPrivateKey(t *testing.T, walletHTTPPort, walletWSPort int, useWS bool) (gethcommon.Address, []byte) {
+func registerPrivateKey(t *testing.T, walletHTTPPort, walletWSPort int, useWS bool) []byte {
 	accountPrivateKey, err := crypto.GenerateKey()
 	if err != nil {
 		t.Fatalf(err.Error())
@@ -149,7 +148,7 @@ func registerPrivateKey(t *testing.T, walletHTTPPort, walletWSPort int, useWS bo
 	signature := signViewingKey(accountPrivateKey, viewingKeyBytes)
 	submitViewingKey(accountAddr.String(), walletHTTPPort, walletWSPort, signature, useWS)
 
-	return accountAddr, viewingKeyBytes
+	return viewingKeyBytes
 }
 
 // Generates a viewing key.

--- a/tools/walletextension/test/wallet_extension_test.go
+++ b/tools/walletextension/test/wallet_extension_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"github.com/obscuronet/go-obscuro/integration"
+	"github.com/obscuronet/go-obscuro/tools/walletextension/accountmanager"
 	"math/big"
 	"strings"
 	"testing"
@@ -15,8 +17,6 @@ import (
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 
-	"github.com/obscuronet/go-obscuro/tools/walletextension/accountmanager"
-
 	"github.com/obscuronet/go-obscuro/go/rpc"
 	"github.com/obscuronet/go-obscuro/tools/walletextension"
 )
@@ -26,15 +26,44 @@ const (
 	dummyParams      = "dummyParams"
 	magicNumber      = 123789
 	jsonKeyTopics    = "topics"
+	_hostWSPort      = integration.StartPortWalletExtensionUnitTest
+	_testOffset      = 100
 )
 
 var dummyHash = gethcommon.BigToHash(big.NewInt(magicNumber))
 
-func TestCanInvokeNonSensitiveMethodsWithoutViewingKey(t *testing.T) {
-	createDummyHost(t)
-	createWalExt(t, createWalExtCfg())
+type testHelper struct {
+	hostPort       int
+	walletHTTPPort int
+	walletWSPort   int
+}
 
-	respBody, _ := makeWSEthJSONReq(rpc.ChainID, []interface{}{})
+func TestWalletExtension(t *testing.T) {
+	createDummyHost(t, _hostWSPort)
+	createWalExt(t, createWalExtCfg(_hostWSPort, _hostWSPort+1, _hostWSPort+2))
+
+	h := &testHelper{
+		hostPort:       _hostWSPort,
+		walletHTTPPort: _hostWSPort + 1,
+		walletWSPort:   _hostWSPort + 2,
+	}
+
+	for name, test := range map[string]func(t *testing.T, testHelper *testHelper){
+		"canInvokeNonSensitiveMethodsWithoutViewingKey":               canInvokeNonSensitiveMethodsWithoutViewingKey,
+		"canInvokeSensitiveMethodsWithViewingKey":                     canInvokeSensitiveMethodsWithViewingKey,
+		"cannotInvokeSensitiveMethodsWithViewingKeyForAnotherAccount": cannotInvokeSensitiveMethodsWithViewingKeyForAnotherAccount,
+		"canInvokeSensitiveMethodsAfterSubmittingMultipleViewingKeys": canInvokeSensitiveMethodsAfterSubmittingMultipleViewingKeys,
+		"cannotSubscribeOverHTTP":                                     cannotSubscribeOverHTTP,
+		"canRegisterViewingKeyAndMakeRequestsOverWebsockets":          canRegisterViewingKeyAndMakeRequestsOverWebsockets,
+	} {
+		t.Run(name, func(t *testing.T) {
+			test(t, h)
+		})
+	}
+}
+
+func canInvokeNonSensitiveMethodsWithoutViewingKey(t *testing.T, testHelper *testHelper) {
+	respBody, _ := makeWSEthJSONReq(testHelper.hostPort, rpc.ChainID, []interface{}{})
 	validateJSONResponse(t, respBody)
 
 	if !strings.Contains(string(respBody), l2ChainIDHex) {
@@ -42,24 +71,8 @@ func TestCanInvokeNonSensitiveMethodsWithoutViewingKey(t *testing.T) {
 	}
 }
 
-func TestCannotInvokeSensitiveMethodsWithoutViewingKey(t *testing.T) {
-	createDummyHost(t)
-	createWalExt(t, createWalExtCfg())
-
-	for _, method := range rpc.SensitiveMethods {
-		// We use a websocket request because one of the sensitive methods, eth_subscribe, requires it.
-		respBody, _ := makeWSEthJSONReq(method, []interface{}{})
-		if !strings.Contains(string(respBody), fmt.Sprintf(accountmanager.ErrNoViewingKey, method)) {
-			t.Fatalf("expected response containing '%s', got '%s'", fmt.Sprintf(accountmanager.ErrNoViewingKey, method), string(respBody))
-		}
-	}
-}
-
-func TestCanInvokeSensitiveMethodsWithViewingKey(t *testing.T) {
-	createDummyHost(t)
-	createWalExt(t, createWalExtCfg())
-
-	_, viewingKeyBytes := registerPrivateKey(t, false)
+func canInvokeSensitiveMethodsWithViewingKey(t *testing.T, testHelper *testHelper) {
+	_, viewingKeyBytes := registerPrivateKey(t, testHelper.walletHTTPPort, testHelper.walletWSPort, false)
 	dummyAPI.setViewingKey(viewingKeyBytes)
 
 	for _, method := range rpc.SensitiveMethods {
@@ -68,7 +81,7 @@ func TestCanInvokeSensitiveMethodsWithViewingKey(t *testing.T) {
 			continue
 		}
 
-		respBody := makeHTTPEthJSONReq(method, []interface{}{map[string]interface{}{"params": dummyParams}})
+		respBody := makeHTTPEthJSONReq(testHelper.walletHTTPPort, method, []interface{}{map[string]interface{}{"params": dummyParams}})
 		validateJSONResponse(t, respBody)
 
 		if !strings.Contains(string(respBody), dummyParams) {
@@ -77,11 +90,8 @@ func TestCanInvokeSensitiveMethodsWithViewingKey(t *testing.T) {
 	}
 }
 
-func TestCannotInvokeSensitiveMethodsWithViewingKeyForAnotherAccount(t *testing.T) {
-	createDummyHost(t)
-	createWalExt(t, createWalExtCfg())
-
-	registerPrivateKey(t, false)
+func cannotInvokeSensitiveMethodsWithViewingKeyForAnotherAccount(t *testing.T, testHelper *testHelper) {
+	registerPrivateKey(t, testHelper.walletHTTPPort, testHelper.walletWSPort, false)
 
 	// We set the API to decrypt with a key different to the viewing key we just submitted.
 	arbitraryPrivateKey, err := crypto.GenerateKey()
@@ -97,21 +107,18 @@ func TestCannotInvokeSensitiveMethodsWithViewingKeyForAnotherAccount(t *testing.
 			continue
 		}
 
-		respBody := makeHTTPEthJSONReq(method, []interface{}{map[string]interface{}{}})
+		respBody := makeHTTPEthJSONReq(testHelper.walletHTTPPort, method, []interface{}{map[string]interface{}{}})
 		if !strings.Contains(string(respBody), errFailedDecrypt) {
 			t.Fatalf("expected response containing '%s', got '%s'", errFailedDecrypt, string(respBody))
 		}
 	}
 }
 
-func TestCanInvokeSensitiveMethodsAfterSubmittingMultipleViewingKeys(t *testing.T) {
-	createDummyHost(t)
-	createWalExt(t, createWalExtCfg())
-
+func canInvokeSensitiveMethodsAfterSubmittingMultipleViewingKeys(t *testing.T, testHelper *testHelper) {
 	// We submit viewing keys for ten arbitrary accounts.
 	var viewingKeys [][]byte
 	for i := 0; i < 10; i++ {
-		_, viewingKeyBytes := registerPrivateKey(t, false)
+		_, viewingKeyBytes := registerPrivateKey(t, testHelper.walletHTTPPort, testHelper.walletWSPort, false)
 		viewingKeys = append(viewingKeys, viewingKeyBytes)
 	}
 
@@ -119,7 +126,7 @@ func TestCanInvokeSensitiveMethodsAfterSubmittingMultipleViewingKeys(t *testing.
 	arbitraryViewingKey := viewingKeys[len(viewingKeys)/2]
 	dummyAPI.setViewingKey(arbitraryViewingKey)
 
-	respBody := makeHTTPEthJSONReq(rpc.GetBalance, []interface{}{map[string]interface{}{"params": dummyParams}})
+	respBody := makeHTTPEthJSONReq(testHelper.walletHTTPPort, rpc.GetBalance, []interface{}{map[string]interface{}{"params": dummyParams}})
 	validateJSONResponse(t, respBody)
 
 	if !strings.Contains(string(respBody), dummyParams) {
@@ -127,64 +134,16 @@ func TestCanInvokeSensitiveMethodsAfterSubmittingMultipleViewingKeys(t *testing.
 	}
 }
 
-func TestCanCallWithoutSettingFromField(t *testing.T) {
-	createDummyHost(t)
-	createWalExt(t, createWalExtCfg())
-
-	vkAddress, viewingKeyBytes := registerPrivateKey(t, false)
-	dummyAPI.setViewingKey(viewingKeyBytes)
-
-	for _, method := range []string{rpc.Call, rpc.EstimateGas} {
-		respBody := makeHTTPEthJSONReq(method, []interface{}{map[string]interface{}{
-			"To":    "0xf3a8bd422097bFdd9B3519Eaeb533393a1c561aC",
-			"data":  "0x70a0823100000000000000000000000013e23ca74de0206c56ebae8d51b5622eff1e9944",
-			"value": nil,
-			"Value": "",
-		}})
-		validateJSONResponse(t, respBody)
-
-		// RPCCall and RPCEstimateGas payload might be manipulated ( added the From field information )
-		if !strings.Contains(strings.ToLower(string(respBody)), strings.ToLower(vkAddress.Hex())) {
-			t.Fatalf("expected response containing '%s', got '%s'", strings.ToLower(vkAddress.Hex()), string(respBody))
-		}
-	}
-}
-
-func TestKeysAreReloadedWhenWalletExtensionRestarts(t *testing.T) {
-	createDummyHost(t)
-	walExtCfg := createWalExtCfg()
-	shutdown := createWalExt(t, walExtCfg)
-
-	_, viewingKeyBytes := registerPrivateKey(t, false)
-	dummyAPI.setViewingKey(viewingKeyBytes)
-
-	// We shut down the wallet extension and restart it with the same config, forcing the viewing keys to be reloaded.
-	shutdown()
-	createWalExt(t, walExtCfg)
-
-	respBody := makeHTTPEthJSONReq(rpc.GetBalance, []interface{}{map[string]interface{}{"params": dummyParams}})
-	validateJSONResponse(t, respBody)
-
-	if !strings.Contains(string(respBody), dummyParams) {
-		t.Fatalf("expected response containing '%s', got '%s'", dummyParams, string(respBody))
-	}
-}
-
-func TestCannotSubscribeOverHTTP(t *testing.T) {
-	createDummyHost(t)
-	createWalExt(t, createWalExtCfg())
-
-	respBody := makeHTTPEthJSONReq(rpc.Subscribe, []interface{}{rpc.SubscriptionTypeLogs})
+func cannotSubscribeOverHTTP(t *testing.T, testHelper *testHelper) {
+	respBody := makeHTTPEthJSONReq(testHelper.walletHTTPPort, rpc.Subscribe, []interface{}{rpc.SubscriptionTypeLogs})
+	fmt.Println(respBody)
 	if string(respBody) != walletextension.ErrSubscribeFailHTTP+"\n" {
 		t.Fatalf("expected response of '%s', got '%s'", walletextension.ErrSubscribeFailHTTP, string(respBody))
 	}
 }
 
-func TestCanRegisterViewingKeyAndMakeRequestsOverWebsockets(t *testing.T) {
-	createDummyHost(t)
-	createWalExt(t, createWalExtCfg())
-
-	_, viewingKeyBytes := registerPrivateKey(t, true)
+func canRegisterViewingKeyAndMakeRequestsOverWebsockets(t *testing.T, testHelper *testHelper) {
+	_, viewingKeyBytes := registerPrivateKey(t, testHelper.walletHTTPPort, testHelper.walletWSPort, true)
 	dummyAPI.setViewingKey(viewingKeyBytes)
 
 	for _, method := range rpc.SensitiveMethods {
@@ -193,7 +152,7 @@ func TestCanRegisterViewingKeyAndMakeRequestsOverWebsockets(t *testing.T) {
 			continue
 		}
 
-		respBody, _ := makeWSEthJSONReq(method, []interface{}{map[string]interface{}{"params": dummyParams}})
+		respBody, _ := makeWSEthJSONReq(testHelper.walletWSPort, method, []interface{}{map[string]interface{}{"params": dummyParams}})
 		validateJSONResponse(t, respBody)
 
 		if !strings.Contains(string(respBody), dummyParams) {
@@ -204,15 +163,60 @@ func TestCanRegisterViewingKeyAndMakeRequestsOverWebsockets(t *testing.T) {
 	}
 }
 
-func TestCanSubscribeForLogsOverWebsockets(t *testing.T) {
-	createDummyHost(t)
-	createWalExt(t, createWalExtCfg())
+func TestCannotInvokeSensitiveMethodsWithoutViewingKey(t *testing.T) {
+	hostPort := _hostWSPort + _testOffset
+	walletHTTPPort := hostPort + 1
+	walletWSPort := hostPort + 2
 
-	_, viewingKeyBytes := registerPrivateKey(t, false)
+	createDummyHost(t, hostPort)
+	createWalExt(t, createWalExtCfg(hostPort, walletHTTPPort, walletWSPort))
+
+	for _, method := range rpc.SensitiveMethods {
+		// We use a websocket request because one of the sensitive methods, eth_subscribe, requires it.
+		respBody, _ := makeWSEthJSONReq(walletWSPort, method, []interface{}{})
+		if !strings.Contains(string(respBody), fmt.Sprintf(accountmanager.ErrNoViewingKey, method)) {
+			t.Fatalf("expected response containing '%s', got '%s'", fmt.Sprintf(accountmanager.ErrNoViewingKey, method), string(respBody))
+		}
+	}
+}
+
+func TestKeysAreReloadedWhenWalletExtensionRestarts(t *testing.T) {
+	hostPort := _hostWSPort + _testOffset*2
+	walletHTTPPort := hostPort + 1
+	walletWSPort := hostPort + 2
+
+	createDummyHost(t, hostPort)
+	walExtCfg := createWalExtCfg(hostPort, walletHTTPPort, walletWSPort)
+	shutdown := createWalExt(t, walExtCfg)
+
+	_, viewingKeyBytes := registerPrivateKey(t, walletHTTPPort, walletWSPort, false)
+	dummyAPI.setViewingKey(viewingKeyBytes)
+
+	// We shut down the wallet extension and restart it with the same config, forcing the viewing keys to be reloaded.
+	shutdown()
+	createWalExt(t, walExtCfg)
+
+	respBody := makeHTTPEthJSONReq(walletHTTPPort, rpc.GetBalance, []interface{}{map[string]interface{}{"params": dummyParams}})
+	validateJSONResponse(t, respBody)
+
+	if !strings.Contains(string(respBody), dummyParams) {
+		t.Fatalf("expected response containing '%s', got '%s'", dummyParams, string(respBody))
+	}
+}
+
+func TestCanSubscribeForLogsOverWebsockets(t *testing.T) {
+	hostPort := _hostWSPort + _testOffset*3
+	walletHTTPPort := hostPort + 1
+	walletWSPort := hostPort + 2
+
+	createDummyHost(t, hostPort)
+	createWalExt(t, createWalExtCfg(hostPort, walletHTTPPort, walletWSPort))
+
+	_, viewingKeyBytes := registerPrivateKey(t, walletHTTPPort, walletWSPort, false)
 	dummyAPI.setViewingKey(viewingKeyBytes)
 
 	filter := common.FilterCriteriaJSON{Topics: []interface{}{dummyHash}}
-	resp, conn := makeWSEthJSONReq(rpc.Subscribe, []interface{}{rpc.SubscriptionTypeLogs, filter})
+	resp, conn := makeWSEthJSONReq(walletWSPort, rpc.Subscribe, []interface{}{rpc.SubscriptionTypeLogs, filter})
 	validateSubscriptionResponse(t, resp)
 
 	logsJSON := readMessagesForDuration(t, conn, time.Second)

--- a/tools/walletextension/test/wallet_extension_test.go
+++ b/tools/walletextension/test/wallet_extension_test.go
@@ -26,7 +26,7 @@ const (
 	magicNumber      = 123789
 	jsonKeyTopics    = "topics"
 	_hostWSPort      = integration.StartPortWalletExtensionUnitTest
-	_testOffset      = 100
+	_testOffset      = 100 // offset each test by a multiplier of the offset to avoid port colision. ie: 	hostPort := _hostWSPort + _testOffset*2
 )
 
 var dummyHash = gethcommon.BigToHash(big.NewInt(magicNumber))

--- a/tools/walletextension/test/wallet_extension_test.go
+++ b/tools/walletextension/test/wallet_extension_test.go
@@ -4,21 +4,20 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"github.com/obscuronet/go-obscuro/integration"
-	"github.com/obscuronet/go-obscuro/tools/walletextension/accountmanager"
 	"math/big"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/obscuronet/go-obscuro/go/common"
-	wecommon "github.com/obscuronet/go-obscuro/tools/walletextension/common"
+	"github.com/obscuronet/go-obscuro/go/rpc"
+	"github.com/obscuronet/go-obscuro/integration"
+	"github.com/obscuronet/go-obscuro/tools/walletextension"
+	"github.com/obscuronet/go-obscuro/tools/walletextension/accountmanager"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/crypto"
-
-	"github.com/obscuronet/go-obscuro/go/rpc"
-	"github.com/obscuronet/go-obscuro/tools/walletextension"
+	wecommon "github.com/obscuronet/go-obscuro/tools/walletextension/common"
 )
 
 const (
@@ -72,7 +71,7 @@ func canInvokeNonSensitiveMethodsWithoutViewingKey(t *testing.T, testHelper *tes
 }
 
 func canInvokeSensitiveMethodsWithViewingKey(t *testing.T, testHelper *testHelper) {
-	_, viewingKeyBytes := registerPrivateKey(t, testHelper.walletHTTPPort, testHelper.walletWSPort, false)
+	viewingKeyBytes := registerPrivateKey(t, testHelper.walletHTTPPort, testHelper.walletWSPort, false)
 	dummyAPI.setViewingKey(viewingKeyBytes)
 
 	for _, method := range rpc.SensitiveMethods {
@@ -118,7 +117,7 @@ func canInvokeSensitiveMethodsAfterSubmittingMultipleViewingKeys(t *testing.T, t
 	// We submit viewing keys for ten arbitrary accounts.
 	var viewingKeys [][]byte
 	for i := 0; i < 10; i++ {
-		_, viewingKeyBytes := registerPrivateKey(t, testHelper.walletHTTPPort, testHelper.walletWSPort, false)
+		viewingKeyBytes := registerPrivateKey(t, testHelper.walletHTTPPort, testHelper.walletWSPort, false)
 		viewingKeys = append(viewingKeys, viewingKeyBytes)
 	}
 
@@ -143,7 +142,7 @@ func cannotSubscribeOverHTTP(t *testing.T, testHelper *testHelper) {
 }
 
 func canRegisterViewingKeyAndMakeRequestsOverWebsockets(t *testing.T, testHelper *testHelper) {
-	_, viewingKeyBytes := registerPrivateKey(t, testHelper.walletHTTPPort, testHelper.walletWSPort, true)
+	viewingKeyBytes := registerPrivateKey(t, testHelper.walletHTTPPort, testHelper.walletWSPort, true)
 	dummyAPI.setViewingKey(viewingKeyBytes)
 
 	for _, method := range rpc.SensitiveMethods {
@@ -189,7 +188,7 @@ func TestKeysAreReloadedWhenWalletExtensionRestarts(t *testing.T) {
 	walExtCfg := createWalExtCfg(hostPort, walletHTTPPort, walletWSPort)
 	shutdown := createWalExt(t, walExtCfg)
 
-	_, viewingKeyBytes := registerPrivateKey(t, walletHTTPPort, walletWSPort, false)
+	viewingKeyBytes := registerPrivateKey(t, walletHTTPPort, walletWSPort, false)
 	dummyAPI.setViewingKey(viewingKeyBytes)
 
 	// We shut down the wallet extension and restart it with the same config, forcing the viewing keys to be reloaded.
@@ -212,7 +211,7 @@ func TestCanSubscribeForLogsOverWebsockets(t *testing.T) {
 	createDummyHost(t, hostPort)
 	createWalExt(t, createWalExtCfg(hostPort, walletHTTPPort, walletWSPort))
 
-	_, viewingKeyBytes := registerPrivateKey(t, walletHTTPPort, walletWSPort, false)
+	viewingKeyBytes := registerPrivateKey(t, walletHTTPPort, walletWSPort, false)
 	dummyAPI.setViewingKey(viewingKeyBytes)
 
 	filter := common.FilterCriteriaJSON{Topics: []interface{}{dummyHash}}


### PR DESCRIPTION
### Why this change is needed

Fixes the port management in the tests which lead to flaky fails.
Also fixes the messages that would kill the logs in the CI
```
ERROR[02-07|15:20:41.572] could not read request: websocket: close 1006 (abnormal closure): unexpected EOF cmp=wallet_extension
ERROR[02-07|15:20:41.572] could not write error message to websocket cmp=wallet_extension err="write tcp 127.0.0.1:40001->127.0.0.1:63737: write: broken pipe"
```

### What changes were made as part of this PR

Please provide a high level list of the changes made

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [x] PR checks reviewed and performed 


