### PR TITLE
Add sleep to stagger AZ CLI requests on parallel node creation

### DIFF
--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -164,6 +164,12 @@ jobs:
         run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF_NAME})"
         id: extract_branch
 
+        # The Azure API will sometimes supersede PUT requests that come in close together. This sleep will stagger the VM requests.
+        # It expects host_id to be an int and then multiplies it by 30s (i.e. host 0: sleep 0, host 1: sleep 30,...)
+      - name: 'Stagger VM creation'
+        shell: bash
+        run: sleep `expr ${matrix.host_id} \* 30`
+
       - name: 'Login via Azure CLI'
         uses: azure/login@v1
         with:


### PR DESCRIPTION
### Why this change is needed

We are seeing AZ failures fairly often when deploying testnets, seems to be caused by the service not dealing well with requests in quick succession (https://github.com/Azure/azure-cli/issues/21156). So we are staggering the node setups to avoid conflicts.

### What changes were made as part of this PR

Add node_id * 30 seconds sleep to each node before VM creation.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [x] PR checks reviewed and performed 


