### PR TITLE
Attempt to fix github sleep step bash syntax

### DIFF
--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -168,7 +168,7 @@ jobs:
         # It expects host_id to be an int and then multiplies it by 30s (i.e. host 0: sleep 0, host 1: sleep 30,...)
       - name: 'Stagger VM creation'
         shell: bash
-        run: sleep `expr ${matrix.host_id} \* 30`
+        run: sleep `expr ${{matrix.host_id}} \* 30`
 
       - name: 'Login via Azure CLI'
         uses: azure/login@v1


### PR DESCRIPTION
### Why this change is needed

bash snippet in https://github.com/obscuronet/go-obscuro/pull/1098 had bad syntax:
<img width="985" alt="Screenshot 2023-02-08 at 13 37 54" src="https://user-images.githubusercontent.com/98158711/217546361-d6268407-77a4-4823-85a0-7916cd6eff29.png">


### What changes were made as part of this PR

Try using double braces like the other variables lower in the script.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [x] PR checks reviewed and performed 


