### PR TITLE
Aggressive enclave logging to track what what it is processing

### DIFF
--- a/go/enclave/l2chain/l2_chain.go
+++ b/go/enclave/l2chain/l2_chain.go
@@ -102,12 +102,14 @@ func (oc *ObscuroChain) ProcessL1Block(block types.Block, receipts types.Receipt
 	defer oc.blockProcessingMutex.Unlock()
 
 	// We update the L1 chain state.
+	oc.logger.Info("updateL1State (entered mutex)", "blk", block.NumberU64(), "blkHash", block.Hash())
 	l1IngestionType, err := oc.updateL1State(block, receipts, isLatest)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	// We update the L1 and L2 chain heads.
+	oc.logger.Info("updateL1AndL2Heads", "blk", block.NumberU64(), "blkHash", block.Hash())
 	newL2Head, producedBatch, err := oc.updateL1AndL2Heads(&block, l1IngestionType)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
### Why this change is needed

We're struggling to debug issue where network seizes up after a short time.

### What changes were made as part of this PR

Add aggressive logging for L1 block processing and validator batch receipts. We can remove/thin out once we've stabilised main.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


