### PR TITLE
fix bug in rollup backwards search original fix

### DIFF
--- a/go/enclave/db/storage.go
+++ b/go/enclave/db/storage.go
@@ -166,7 +166,7 @@ func (s *storageImpl) FetchHeadRollupForBlock(blockHash *common.L1RootHash) (*co
 	if err != nil {
 		return nil, fmt.Errorf("could not read L2 head rollup for block. Cause: %w", err)
 	}
-	if l2HeadBatch == (&gethcommon.Hash{}) { // empty hash ==> no rollups yet up to this block
+	if *l2HeadBatch == (gethcommon.Hash{}) { // empty hash ==> no rollups yet up to this block
 		return nil, ErrNoRollups
 	}
 	return obscurorawdb.ReadRollup(s.db, *l2HeadBatch)


### PR DESCRIPTION
### Why this change is needed

Despite fix yesterday we were still seeing the enclave scan back to genesis of L1 looking for rollups. This was because of a bad comparison where it was comparing a hash pointer to a hash.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


