### PR TITLE
Add a single start script to launch testnet with default arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,35 +333,13 @@ images are created from the working directory of the repository checkout. To bui
 docker images repository use;
 
 ```
-cd ./testnet && ./testnet-local-build_images.sh 
+cd ./testnet && ./testnet-local-start.sh 
 ```
 
-The above will perform all the relevant builds and ensure the images are ready for running each component, and takes 
-~4-5 mins to complete. The following images are created;
+The above will perform all the relevant builds and ensure the images are ready for running each component. 
+Will then start each component with the alloted defaults. ~3-6 mins to complete depending on the build time. 
 
-```
-testnetobscuronet.azurecr.io/obscuronet/enclave            # the enclave 
-testnetobscuronet.azurecr.io/obscuronet/gethnetwork        # the L1 network 
-testnetobscuronet.azurecr.io/obscuronet/host               # the host
-testnetobscuronet.azurecr.io/obscuronet/obscuroscan        # the obscuroscan server
-testnetobscuronet.azurecr.io/obscuronet/contractdeployer   # deploys the management contract to the host
-```
-
-To start the test network locally run the below scripts. Note that it is recommended to use the scripts with arguments 
-as detailed below. The arguments are set to correspond to valid pre-determined public / private key pair values for 
-contract deployment and roll up publishing. Using these values, and starting with a nonce of zero, means the addresses 
-of the contracts deployed are known a-priori, and so can be supplied in the `start-obscuro-node.sh` script as shown. As 
-only a single Obscuro node is started, it must be set as a genesis node and as the sequencer.
-
-```
-./testnet-local-gethnetwork.sh --pkaddresses=0x13E23Ca74DE0206C56ebaE8D51b5622EFF1E9944,0x0654D8B60033144D567f25bF41baC1FB0D60F23B
-./testnet-deploy-contracts.sh --l1host=gethnetwork --pkstring=f52e5418e349dccdda29b6ac8b0abe6576bb7713886aa85abea6181ba731f9bb
-./start-obscuro-node.sh --sgx_enabled=false --l1host=gethnetwork --mgmtcontractaddr=0xeDa66Cc53bd2f26896f6Ba6b736B1Ca325DE04eF --hocerc20addr=0xC0370e0b5C1A41D447BDdA655079A1B977C71aA9 --pocerc20addr=0x51D43a3Ca257584E770B6188232b199E76B022A2 --is_genesis=true --node_type=sequencer
-./testnet-deploy-l2-contracts.sh --l2host=testnet-host-1 --l1host=gethnetwork
-./start-obscuroscan.sh --rpcServerAddress=http://testnet-host-1:13000 --receivingPort=8098
-```
-
-where;
+The defaults used are:
 
 - `0x13E23Ca74DE0206C56ebaE8D51b5622EFF1E9944` is the public address of the pre-funded account on the L1 network used 
 to deploy the Obscuro Management and the ERC20 contracts

--- a/testnet/testnet-local-eth2network.sh
+++ b/testnet/testnet-local-eth2network.sh
@@ -53,7 +53,7 @@ then
 fi
 
 # start the geth network
-echo "Starting the gethnetwork.."
+echo "Starting the eth2network.."
 docker network create --driver bridge node_network || true
 docker run --name=eth2network -d \
   --network=node_network \

--- a/testnet/testnet-local-start.sh
+++ b/testnet/testnet-local-start.sh
@@ -12,13 +12,13 @@ start_path="$(cd "$(dirname "${0}")" && pwd)"
 testnet_path="${start_path}"
 
 echo [`date +"%T"`] "Building the required docker images"
-${testnet_path}/testnet-local-build_images.sh
+${testnet_path}/testnet-local-build_images.sh --parallel=false
 
 echo [`date +"%T"`] "Starting up the L1 network"
 ${testnet_path}/testnet-local-eth2network.sh --pkaddresses=0x13E23Ca74DE0206C56ebaE8D51b5622EFF1E9944,0x0654D8B60033144D567f25bF41baC1FB0D60F23B
 
 echo [`date +"%T"`] "Sleeping to wait for L1 network to be up"
-sleep 75
+${testnet_path}/wait-eth2network-healthy.sh --host=127.0.0.1
 
 echo [`date +"%T"`] "Deploying the l1 contracts"
 ${testnet_path}/testnet-deploy-contracts.sh --l1host=eth2network -pkstring=f52e5418e349dccdda29b6ac8b0abe6576bb7713886aa85abea6181ba731f9bb

--- a/testnet/testnet-start.sh
+++ b/testnet/testnet-start.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 start_path="$(cd "$(dirname "${0}")" && pwd)"
 testnet_path="${start_path}"
 
-echo date +"%T" "Clean all running docker containers"
+echo [`date +"%T"`] "Clean all running docker containers"
 for i in `docker ps -a | awk '{ print $1 } ' | grep -v CONTAINER`; do
   docker stop $i && docker rm $i;
 done

--- a/testnet/testnet-start.sh
+++ b/testnet/testnet-start.sh
@@ -11,11 +11,6 @@ set -euo pipefail
 start_path="$(cd "$(dirname "${0}")" && pwd)"
 testnet_path="${start_path}"
 
-echo [`date +"%T"`] "Clean all running docker containers"
-for i in `docker ps -a | awk '{ print $1 } ' | grep -v CONTAINER`; do
-  docker stop $i && docker rm $i;
-done
-
 echo [`date +"%T"`] "Building the required docker images"
 ${testnet_path}/testnet-local-build_images.sh
 

--- a/testnet/testnet-start.sh
+++ b/testnet/testnet-start.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+#
+# This script starts a local testnet using the recommended / default arguments
+#
+
+echo Building the required docker images
+./testnet-local-build_images.sh
+
+echo Starting up the L1 network
+./testnet-local-eth2network.sh --pkaddresses=0x13E23Ca74DE0206C56ebaE8D51b5622EFF1E9944,0x0654D8B60033144D567f25bF41baC1FB0D60F23B
+
+echo Deploying the l1 contracts
+./testnet-deploy-contracts.sh --l1host=-eth2network -pkstring=f52e5418e349dccdda29b6ac8b0abe6576bb7713886aa85abea6181ba731f9bb
+
+echo Starting up the Obscuro node
+./start-obscuro-node.sh --sgx_enabled=false --l1host=eth2network --mgmtcontractaddr=0xeDa66Cc53bd2f26896f6Ba6b736B1Ca325DE04eF --hocerc20addr=0xC0370e0b5C1A41D447BDdA655079A1B977C71aA9 --pocerc20addr=0x51D43a3Ca257584E770B6188232b199E76B022A2 --is_genesis=true --node_type=sequencer
+
+echo Deploying the L2 contracts
+./testnet-deploy-l2-contracts.sh --l2host=testnet-host-1 --l1host=eth2network
+
+echo Starting obscuroscan
+./start-obscuroscan.sh --rpcServerAddress=http://testnet-host-1:13000 --receivingPort=8098
+

--- a/testnet/testnet-start.sh
+++ b/testnet/testnet-start.sh
@@ -11,6 +11,11 @@ set -euo pipefail
 start_path="$(cd "$(dirname "${0}")" && pwd)"
 testnet_path="${start_path}"
 
+echo "Clean all running docker containers"
+for i in `docker ps -a | awk '{ print $1 } ' | grep -v CONTAINER`; do
+  docker stop $i && docker rm $i;
+done
+
 echo Building the required docker images
 ${testnet_path}/testnet-local-build_images.sh
 

--- a/testnet/testnet-start.sh
+++ b/testnet/testnet-start.sh
@@ -21,7 +21,7 @@ echo [`date +"%T"`] "Sleeping to wait for L1 network to be up"
 sleep 75
 
 echo [`date +"%T"`] "Deploying the l1 contracts"
-${testnet_path}/testnet-deploy-contracts.sh --l1host=-eth2network -pkstring=f52e5418e349dccdda29b6ac8b0abe6576bb7713886aa85abea6181ba731f9bb
+${testnet_path}/testnet-deploy-contracts.sh --l1host=eth2network -pkstring=f52e5418e349dccdda29b6ac8b0abe6576bb7713886aa85abea6181ba731f9bb
 
 echo [`date +"%T"`] "Starting up the Obscuro node"
 ${testnet_path}/start-obscuro-node.sh --sgx_enabled=false --l1host=eth2network --mgmtcontractaddr=0xeDa66Cc53bd2f26896f6Ba6b736B1Ca325DE04eF --hocerc20addr=0xC0370e0b5C1A41D447BDdA655079A1B977C71aA9 --pocerc20addr=0x51D43a3Ca257584E770B6188232b199E76B022A2 --is_genesis=true --node_type=sequencer

--- a/testnet/testnet-start.sh
+++ b/testnet/testnet-start.sh
@@ -11,27 +11,29 @@ set -euo pipefail
 start_path="$(cd "$(dirname "${0}")" && pwd)"
 testnet_path="${start_path}"
 
-echo "Clean all running docker containers"
+echo date +"%T" "Clean all running docker containers"
 for i in `docker ps -a | awk '{ print $1 } ' | grep -v CONTAINER`; do
   docker stop $i && docker rm $i;
 done
 
-echo Building the required docker images
+echo [`date +"%T"`] "Building the required docker images"
 ${testnet_path}/testnet-local-build_images.sh
 
-echo Starting up the L1 network
+echo [`date +"%T"`] "Starting up the L1 network"
 ${testnet_path}/testnet-local-eth2network.sh --pkaddresses=0x13E23Ca74DE0206C56ebaE8D51b5622EFF1E9944,0x0654D8B60033144D567f25bF41baC1FB0D60F23B
+
+echo [`date +"%T"`] "Sleeping to wait for L1 network to be up"
 sleep 75
 
-echo Deploying the l1 contracts
+echo [`date +"%T"`] "Deploying the l1 contracts"
 ${testnet_path}/testnet-deploy-contracts.sh --l1host=-eth2network -pkstring=f52e5418e349dccdda29b6ac8b0abe6576bb7713886aa85abea6181ba731f9bb
 
-echo Starting up the Obscuro node
+echo [`date +"%T"`] "Starting up the Obscuro node"
 ${testnet_path}/start-obscuro-node.sh --sgx_enabled=false --l1host=eth2network --mgmtcontractaddr=0xeDa66Cc53bd2f26896f6Ba6b736B1Ca325DE04eF --hocerc20addr=0xC0370e0b5C1A41D447BDdA655079A1B977C71aA9 --pocerc20addr=0x51D43a3Ca257584E770B6188232b199E76B022A2 --is_genesis=true --node_type=sequencer
 
-echo Deploying the L2 contracts
+echo [`date +"%T"`] "Deploying the L2 contracts"
 ${testnet_path}/testnet-deploy-l2-contracts.sh --l2host=testnet-host-1 --l1host=eth2network
 
-echo Starting obscuroscan
+echo [`date +"%T"`] "Starting obscuroscan"
 ${testnet_path}/start-obscuroscan.sh --rpcServerAddress=http://testnet-host-1:13000 --receivingPort=8098
 

--- a/testnet/testnet-start.sh
+++ b/testnet/testnet-start.sh
@@ -16,6 +16,7 @@ ${testnet_path}/testnet-local-build_images.sh
 
 echo Starting up the L1 network
 ${testnet_path}/testnet-local-eth2network.sh --pkaddresses=0x13E23Ca74DE0206C56ebaE8D51b5622EFF1E9944,0x0654D8B60033144D567f25bF41baC1FB0D60F23B
+sleep 75
 
 echo Deploying the l1 contracts
 ${testnet_path}/testnet-deploy-contracts.sh --l1host=-eth2network -pkstring=f52e5418e349dccdda29b6ac8b0abe6576bb7713886aa85abea6181ba731f9bb

--- a/testnet/testnet-start.sh
+++ b/testnet/testnet-start.sh
@@ -4,21 +4,28 @@
 # This script starts a local testnet using the recommended / default arguments
 #
 
+# Ensure any fail is loud and explicit
+set -euo pipefail
+
+# Define local usage vars
+start_path="$(cd "$(dirname "${0}")" && pwd)"
+testnet_path="${start_path}"
+
 echo Building the required docker images
-./testnet-local-build_images.sh
+${testnet_path}/testnet-local-build_images.sh
 
 echo Starting up the L1 network
-./testnet-local-eth2network.sh --pkaddresses=0x13E23Ca74DE0206C56ebaE8D51b5622EFF1E9944,0x0654D8B60033144D567f25bF41baC1FB0D60F23B
+${testnet_path}/testnet-local-eth2network.sh --pkaddresses=0x13E23Ca74DE0206C56ebaE8D51b5622EFF1E9944,0x0654D8B60033144D567f25bF41baC1FB0D60F23B
 
 echo Deploying the l1 contracts
-./testnet-deploy-contracts.sh --l1host=-eth2network -pkstring=f52e5418e349dccdda29b6ac8b0abe6576bb7713886aa85abea6181ba731f9bb
+${testnet_path}/testnet-deploy-contracts.sh --l1host=-eth2network -pkstring=f52e5418e349dccdda29b6ac8b0abe6576bb7713886aa85abea6181ba731f9bb
 
 echo Starting up the Obscuro node
-./start-obscuro-node.sh --sgx_enabled=false --l1host=eth2network --mgmtcontractaddr=0xeDa66Cc53bd2f26896f6Ba6b736B1Ca325DE04eF --hocerc20addr=0xC0370e0b5C1A41D447BDdA655079A1B977C71aA9 --pocerc20addr=0x51D43a3Ca257584E770B6188232b199E76B022A2 --is_genesis=true --node_type=sequencer
+${testnet_path}/start-obscuro-node.sh --sgx_enabled=false --l1host=eth2network --mgmtcontractaddr=0xeDa66Cc53bd2f26896f6Ba6b736B1Ca325DE04eF --hocerc20addr=0xC0370e0b5C1A41D447BDdA655079A1B977C71aA9 --pocerc20addr=0x51D43a3Ca257584E770B6188232b199E76B022A2 --is_genesis=true --node_type=sequencer
 
 echo Deploying the L2 contracts
-./testnet-deploy-l2-contracts.sh --l2host=testnet-host-1 --l1host=eth2network
+${testnet_path}/testnet-deploy-l2-contracts.sh --l2host=testnet-host-1 --l1host=eth2network
 
 echo Starting obscuroscan
-./start-obscuroscan.sh --rpcServerAddress=http://testnet-host-1:13000 --receivingPort=8098
+${testnet_path}/start-obscuroscan.sh --rpcServerAddress=http://testnet-host-1:13000 --receivingPort=8098
 

--- a/testnet/wait-eth2network-healthy.sh
+++ b/testnet/wait-eth2network-healthy.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+#
+# This script checks and waits for the eth2network to be post-merge ready
+#
+#
+
+help_and_exit() {
+    echo ""
+    echo "Usage: "
+    echo "   ex: "
+    echo "      -  $(basename "${0}") --host=127.0.0.1 --port=8025"
+    echo ""
+    echo "  host             *Required* Set the host address"
+    echo ""
+    echo "  port             *Optional* Set the http host port. Defaults to 8025"
+    echo ""
+    echo "  timeout          *Optional* Set timeout in seconds. Defaults to 5*60 seconds"
+    echo ""
+    exit 1  # Exit with error explicitly
+}
+
+# Ensure any fail is loud and explicit
+set -euo pipefail
+
+# Defaults
+port=8025
+max_attempts=600
+merge_block_height=7
+
+
+# Fetch options
+for argument in "$@"
+do
+    key=$(echo $argument | cut -f1 -d=)
+    value=$(echo $argument | cut -f2 -d=)
+
+    case "$key" in
+            --host)                   host=${value} ;;
+            --port)                   port=${value} ;;
+            --timeout)                max_attempts=${value} ;;
+
+            --help)                     help_and_exit ;;
+            *)
+    esac
+done
+
+if [[ -z ${host:-} ]];
+then
+    help_and_exit
+fi
+
+url="http://${host}:${port}"
+payload='{"jsonrpc": "2.0", "method": "eth_blockNumber", "params": [], "id": 1}'
+
+attempts=0
+while [ $attempts -lt $max_attempts ]; do
+  response=$(curl -s -X POST -H "Content-Type: application/json" -d "$payload" "$url") || true
+  status=$(echo $response | grep -o "result" ) || echo false
+
+  if [ $status ]; then
+    result=$(echo $response | grep -oE '0x[0-9a-fA-F]+')
+    if [ -n "$result" ] && [ $((16#${result:2})) -gt $merge_block_height ]; then
+      echo "Success: Response is 200 OK and block height is greater than $merge_block_height"
+      break
+    else
+      echo "Failed: block height field not found or is not greater than $merge_block_height"
+      echo "Response: $response"
+      attempts=$((attempts + 1))
+      sleep 1
+    fi
+  else
+      echo "Failed: No 200 OK from the eth2network"
+      attempts=$((attempts + 1))
+      sleep 1
+    fi
+done
+
+if [ $attempts -eq $max_attempts ]; then
+  echo "Exceeded maximum number of attempts, giving up"
+fi
+
+echo "Node up and running!"
+exit 0


### PR DESCRIPTION
### Why this change is needed

Makes it easier for everyone to test starting up a local testnet if there is a single start script, e.g. that obscuro-test can call. 



