### PR TITLE
Add integration testing and local network tools

### DIFF
--- a/go/enclave/db/db.go
+++ b/go/enclave/db/db.go
@@ -25,8 +25,8 @@ func CreateDBFromConfig(cfg config.EnclaveConfig, logger gethlog.Logger) (ethdb.
 	if !cfg.WillAttest {
 		// persistent but not secure in an enclave, we'll connect to a throwaway sqlite DB and test out persistence/sql implementations
 		logger.Warn("Attestation is disabled, using a basic sqlite DB for persistence")
-		// todo: for now we pass in an empty dbPath which will provide a throwaway temp file,
-		// 		when we want to test persistence after node restart we should change this path to be config driven
+		// when we want to test persistence after node restart the SqliteDBPath should be set
+		// (if empty string then a temp db file will be created for the lifetime of the enclave)
 		return sql.CreateTemporarySQLiteDB(cfg.SqliteDBPath, logger)
 	}
 

--- a/go/enclave/db/sql/sqlite.go
+++ b/go/enclave/db/sql/sqlite.go
@@ -23,7 +23,7 @@ const (
 // otherwise dbPath is a filepath for the db file, allows for tests that care about persistence between restarts
 func CreateTemporarySQLiteDB(dbPath string, logger gethlog.Logger) (ethdb.Database, error) {
 	if dbPath == "" {
-		tempPath, err := getTempDBFile()
+		tempPath, err := CreateTempDBFile()
 		if err != nil {
 			return nil, fmt.Errorf("failed to create temp sqlite DB file - %w", err)
 		}
@@ -49,7 +49,7 @@ func CreateTemporarySQLiteDB(dbPath string, logger gethlog.Logger) (ethdb.Databa
 	return CreateSQLEthDatabase(db, logger)
 }
 
-func getTempDBFile() (string, error) {
+func CreateTempDBFile() (string, error) {
 	tempDir := filepath.Join("/tmp", tempDirName, randomStr(5))
 	err := os.MkdirAll(tempDir, os.ModePerm)
 	if err != nil {

--- a/integration/common/utils.go
+++ b/integration/common/utils.go
@@ -31,7 +31,7 @@ func RndBtw(min uint64, max uint64) uint64 {
 
 func RndBtwTime(min time.Duration, max time.Duration) time.Duration {
 	if min <= 0 || max <= 0 {
-		panic("invalid durations")
+		panic(fmt.Sprintf("invalid durations min=%s max=%s", min, max))
 	}
 	return time.Duration(RndBtw(uint64(min.Nanoseconds()), uint64(max.Nanoseconds()))) * time.Nanosecond
 }

--- a/integration/networktest/README.md
+++ b/integration/networktest/README.md
@@ -1,0 +1,37 @@
+# Network test
+Network tests provide standard structures for running functional, load and scenario tests against a network.
+
+They are designed to be network agnostic, able to run against both local dev networks and remote testnets.
+
+## Actions
+Tests are structured using "Actions" which can be run in series of parallel in a nested tree down to very small steps.
+
+Action's `Run()` method takes a context and a network connector, it returns a context and potential error. Actions can use 
+the context to pass values to tests that are running later in the flow.
+
+## Running tests
+All tests can be found under the `/tests` directory. They are grouped into a few packages to try to keep similarly used 
+tests together.
+
+### `/helpful`
+These are ad-hoc helpers, for example:
+
+- running a local network indefinitely
+- smoke test that checks a network isn't completely broken
+
+### `/load`
+These tests are designed to apply simulated user activity for a period of time to stress the network.
+
+### `/nodescenario`
+These tests require a network that provides access to its nodes through the `NodeOperator` interface.
+
+They can be used to test scenarios such as rejoining the network after a restart, sequencer failover, nodes losing connectivity.
+
+### `/ci` (coming soon)
+These are the only ones that will run during the CI builds by default, they should be quick and not fragile.
+
+## UserWallet
+In `/userwallet` is a high-level client that bundles a simulated user's private key, an RPC client and manages the nonce and viewing key.
+
+It aims to make testing easier by mimicking the functionality of software and hardware wallets in the real world (a high-level 
+interface for interacting with the crypto chain for a user's account(s))

--- a/integration/networktest/README.md
+++ b/integration/networktest/README.md
@@ -6,8 +6,10 @@ They are designed to be network agnostic, able to run against both local dev net
 ## Actions
 Tests are structured using "Actions" which can be run in series of parallel in a nested tree down to very small steps.
 
-Action's `Run()` method takes a context and a network connector, it returns a context and potential error. Actions can use 
-the context to pass values to tests that are running later in the flow.
+Action's `Run()` method takes a context and a network connector, it returns a context and potential error.
+
+Actions can use the context to pass values to tests that are running later in the flow, so properties that an action require 
+from the context are part of that action's API. We use the ActionKey type for the context keys.
 
 ## Running tests
 All tests can be found under the `/tests` directory. They are grouped into a few packages to try to keep similarly used 

--- a/integration/networktest/actions/context.go
+++ b/integration/networktest/actions/context.go
@@ -4,15 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/obscuronet/go-obscuro/integration/networktest/userwallet"
 	"math/big"
+
+	"github.com/obscuronet/go-obscuro/integration/networktest/userwallet"
 )
 
-var (
-	// KeyNumberOfTestUsers key to an int representing number of test users created/available
-	// (useful for test actions that want to run for all users without having to duplicate config)
-	KeyNumberOfTestUsers = ActionKey("numberOfTestUsers")
-)
+// KeyNumberOfTestUsers key to an int representing number of test users created/available
+// (useful for test actions that want to run for all users without having to duplicate config)
+var KeyNumberOfTestUsers = ActionKey("numberOfTestUsers")
 
 // ActionKey is the type for all test data stored in the context. Go documentation recommends using a typed key rather than string to avoid conflicts.
 type ActionKey string

--- a/integration/networktest/actions/context.go
+++ b/integration/networktest/actions/context.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
-
 	"github.com/obscuronet/go-obscuro/integration/networktest/userwallet"
+	"math/big"
 )
 
-// int representing number of test users created/available (useful for tests that want to run for all users)
-var keyNumberOfTestUsers = ActionKey("numberOfTestUsers")
+var (
+	// KeyNumberOfTestUsers key to an int representing number of test users created/available
+	// (useful for test actions that want to run for all users without having to duplicate config)
+	KeyNumberOfTestUsers = ActionKey("numberOfTestUsers")
+)
 
 // ActionKey is the type for all test data stored in the context. Go documentation recommends using a typed key rather than string to avoid conflicts.
 type ActionKey string
@@ -35,7 +38,7 @@ func userKey(number int) ActionKey {
 }
 
 func FetchNumberOfTestUsers(ctx context.Context) (int, error) {
-	n := ctx.Value(keyNumberOfTestUsers)
+	n := ctx.Value(KeyNumberOfTestUsers)
 	if n == nil {
 		return 0, errors.New("expected at least one test user to be setup but number of test users was not set")
 	}
@@ -44,4 +47,16 @@ func FetchNumberOfTestUsers(ctx context.Context) (int, error) {
 		return 0, fmt.Errorf("expected number of users context value to be non-zero int but it was (%T) %v", n, n)
 	}
 	return numUsers, nil
+}
+
+func FetchBigInt(ctx context.Context, key ActionKey) (*big.Int, error) {
+	v := ctx.Value(key)
+	if v == nil {
+		return nil, fmt.Errorf("no value found for key=%s", key)
+	}
+	typedVal, ok := v.(*big.Int)
+	if !ok {
+		return nil, fmt.Errorf("expected value for key=%s to be *big.Int but was (%T) %v", key, v, v)
+	}
+	return typedVal, nil
 }

--- a/integration/networktest/actions/context.go
+++ b/integration/networktest/actions/context.go
@@ -1,0 +1,47 @@
+package actions
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/obscuronet/go-obscuro/integration/networktest/userwallet"
+)
+
+// int representing number of test users created/available (useful for tests that want to run for all users)
+var keyNumberOfTestUsers = ActionKey("numberOfTestUsers")
+
+// ActionKey is the type for all test data stored in the context. Go documentation recommends using a typed key rather than string to avoid conflicts.
+type ActionKey string
+
+func storeTestUser(ctx context.Context, userNumber int, user *userwallet.UserWallet) context.Context {
+	return context.WithValue(ctx, userKey(userNumber), user)
+}
+
+func FetchTestUser(ctx context.Context, userNumber int) (*userwallet.UserWallet, error) {
+	u := ctx.Value(userKey(userNumber))
+	if u == nil {
+		return nil, fmt.Errorf("no UserWallet found in context for userNumber=%d", userNumber)
+	}
+	user, ok := u.(*userwallet.UserWallet)
+	if !ok {
+		return nil, fmt.Errorf("user retrieved from context was not of expected type UserWallet for userNumber=%d type=%T", userNumber, u)
+	}
+	return user, nil
+}
+
+func userKey(number int) ActionKey {
+	return ActionKey(fmt.Sprintf("testUser%d", number))
+}
+
+func FetchNumberOfTestUsers(ctx context.Context) (int, error) {
+	n := ctx.Value(keyNumberOfTestUsers)
+	if n == nil {
+		return 0, errors.New("expected at least one test user to be setup but number of test users was not set")
+	}
+	numUsers, ok := n.(int)
+	if !ok || numUsers == 0 {
+		return 0, fmt.Errorf("expected number of users context value to be non-zero int but it was (%T) %v", n, n)
+	}
+	return numUsers, nil
+}

--- a/integration/networktest/actions/multiple_actions.go
+++ b/integration/networktest/actions/multiple_actions.go
@@ -1,0 +1,126 @@
+package actions
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/obscuronet/go-obscuro/integration/networktest"
+	"golang.org/x/sync/errgroup"
+)
+
+type MultiAction struct {
+	actions    []networktest.Action
+	isParallel bool
+	name       string
+	start      time.Time
+	end        time.Time
+}
+
+func (m *MultiAction) String() string {
+	return fmt.Sprintf("%s (%d actions in %s)", m.name, len(m.actions), m.executionType())
+}
+
+func (m *MultiAction) Run(ctx context.Context, network networktest.NetworkConnector) (context.Context, error) {
+	m.recordStart()
+	var err error
+	if m.isParallel {
+		ctx, err = m.runParallel(ctx, network)
+	} else {
+		ctx, err = m.runSeries(ctx, network)
+	}
+	if err != nil {
+		return nil, err
+	}
+	m.recordEnd()
+	return ctx, nil
+}
+
+func (m *MultiAction) runSeries(ctx context.Context, network networktest.NetworkConnector) (context.Context, error) {
+	var err error
+	for _, a := range m.actions {
+		start := time.Now()
+		ctx, err = a.Run(ctx, network)
+		if err != nil {
+			fmt.Printf("error %s (%s)\n", err, time.Since(start).Round(time.Millisecond))
+			return ctx, err
+		}
+	}
+	return ctx, nil
+}
+
+func (m *MultiAction) runParallel(ctx context.Context, network networktest.NetworkConnector) (context.Context, error) {
+	grp, _ := errgroup.WithContext(ctx)
+	var err error
+	for _, a := range m.actions {
+		action := a
+		grp.Go(func() error {
+			if _, err = action.Run(ctx, network); err != nil {
+				return err
+			}
+			return nil
+		})
+	}
+	if err = grp.Wait(); err != nil {
+		return nil, err
+	}
+
+	return ctx, nil
+}
+
+func (m *MultiAction) Verify(ctx context.Context, network networktest.NetworkConnector) error {
+	var actionFailures []error
+
+	for _, a := range m.actions {
+		err := a.Verify(ctx, network)
+		if err != nil {
+			actionErr := fmt.Errorf("%s failed - %w", a, err)
+			fmt.Println(actionErr)
+			actionFailures = append(actionFailures, actionErr)
+		}
+	}
+	if len(actionFailures) != 0 {
+		return fmt.Errorf("series failed, %d / %d failed - %s", len(actionFailures), len(m.actions), actionFailures)
+	}
+	return nil
+}
+
+func (m *MultiAction) recordStart() {
+	if m.name != "" {
+		fmt.Printf("START :: %s\n", m)
+	}
+	m.start = time.Now()
+}
+
+func (m *MultiAction) recordEnd() {
+	m.end = time.Now()
+	if m.name != "" {
+		fmt.Printf("END :: %s  [ %s ]\n", m, m.end.Sub(m.start))
+	}
+}
+
+func (m *MultiAction) executionType() string {
+	if m.isParallel {
+		return "parallel"
+	}
+	return "series"
+}
+
+func NamedSeries(name string, actions ...networktest.Action) *MultiAction {
+	return &MultiAction{
+		actions: actions,
+		name:    name,
+	}
+}
+
+func Series(actions ...networktest.Action) *MultiAction {
+	return NamedSeries("", actions...)
+}
+
+func NamedParallel(name string, actions ...networktest.Action) *MultiAction {
+	return &MultiAction{actions: actions, name: name, isParallel: true}
+}
+
+func Parallel(actions ...networktest.Action) *MultiAction {
+	return NamedParallel("", actions...)
+}

--- a/integration/networktest/actions/multiple_actions.go
+++ b/integration/networktest/actions/multiple_actions.go
@@ -80,7 +80,7 @@ func (m *MultiAction) Verify(ctx context.Context, network networktest.NetworkCon
 		action := a
 		grp.Go(func() error {
 			if err = action.Verify(ctx, network); err != nil {
-				actionErr := fmt.Errorf("%s failed - %w", a, err)
+				actionErr := fmt.Errorf("%s failed - %w", action, err)
 				fmt.Println(actionErr)
 
 				mu.Lock()
@@ -95,7 +95,7 @@ func (m *MultiAction) Verify(ctx context.Context, network networktest.NetworkCon
 	if err = grp.Wait(); err != nil {
 		return fmt.Errorf("series failed, %d / %d failed - %s", len(actionFailures), len(m.actions), actionFailures)
 	}
-	
+
 	return nil
 }
 

--- a/integration/networktest/actions/native_fund_actions.go
+++ b/integration/networktest/actions/native_fund_actions.go
@@ -1,0 +1,83 @@
+package actions
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/obscuronet/go-obscuro/integration/networktest"
+	"github.com/obscuronet/go-obscuro/integration/networktest/userwallet"
+)
+
+type SendNativeFunds struct {
+	FromUser int
+	ToUser   int
+	Amount   *big.Int
+
+	user   *userwallet.UserWallet
+	txHash *common.Hash
+}
+
+func (s *SendNativeFunds) String() string {
+	return fmt.Sprintf("SendNativeFunds [from:%d, to:%d]", s.FromUser, s.ToUser)
+}
+
+func (s *SendNativeFunds) Run(ctx context.Context, _ networktest.NetworkConnector) (context.Context, error) {
+	user, err := FetchTestUser(ctx, s.FromUser)
+	if err != nil {
+		return ctx, err
+	}
+	target, err := FetchTestUser(ctx, s.ToUser)
+	if err != nil {
+		return ctx, err
+	}
+	txHash, err := user.SendFunds(ctx, target.Address(), s.Amount)
+	if err != nil {
+		return nil, err
+	}
+	s.user = user
+	s.txHash = txHash
+	return ctx, nil
+}
+
+func (s *SendNativeFunds) Verify(ctx context.Context, _ networktest.NetworkConnector) error {
+	receipt, err := s.user.AwaitReceipt(ctx, s.txHash)
+	if err != nil {
+		return fmt.Errorf("failed to fetch receipt - %w", err)
+	}
+	if receipt.Status != types.ReceiptStatusSuccessful {
+		return fmt.Errorf("receipt status not successful, state=%v", receipt.Status)
+	}
+	return nil
+}
+
+type VerifyBalanceAfterTest struct {
+	UserID          int
+	ExpectedBalance *big.Int
+}
+
+func (c *VerifyBalanceAfterTest) String() string {
+	return fmt.Sprintf("**Verify Only** VerifyBalanceAfterTest [user:%d]", c.UserID)
+}
+
+func (c *VerifyBalanceAfterTest) Run(ctx context.Context, _ networktest.NetworkConnector) (context.Context, error) {
+	// this is a verifier action, nothing to do during run
+	return ctx, nil
+}
+
+func (c *VerifyBalanceAfterTest) Verify(ctx context.Context, network networktest.NetworkConnector) error {
+	user, err := FetchTestUser(ctx, c.UserID)
+	if err != nil {
+		return err
+	}
+	bal, err := user.NativeBalance(ctx)
+	if err != nil {
+		return err
+	}
+	if bal.Cmp(c.ExpectedBalance) != 0 {
+		return fmt.Errorf("unexpected balance, expected=%d, actual=%d", c.ExpectedBalance, bal)
+	}
+	return nil
+}

--- a/integration/networktest/actions/node_actions.go
+++ b/integration/networktest/actions/node_actions.go
@@ -1,0 +1,79 @@
+package actions
+
+import (
+	"context"
+	"time"
+
+	"github.com/obscuronet/go-obscuro/go/common/retry"
+	"github.com/obscuronet/go-obscuro/integration/networktest"
+)
+
+func StartValidatorEnclave(validatorIdx int) networktest.Action {
+	return &startValidatorEnclaveAction{validatorIdx: validatorIdx}
+}
+
+type startValidatorEnclaveAction struct {
+	validatorIdx int
+}
+
+func (s *startValidatorEnclaveAction) Run(ctx context.Context, network networktest.NetworkConnector) (context.Context, error) {
+	validator := network.GetValidatorNode(s.validatorIdx)
+	err := validator.StartEnclave()
+	if err != nil {
+		return nil, err
+	}
+	return ctx, nil
+}
+
+func (s *startValidatorEnclaveAction) Verify(_ context.Context, _ networktest.NetworkConnector) error {
+	return nil
+}
+
+func StopValidatorEnclave(validatorIdx int) networktest.Action {
+	return &stopValidatorEnclaveAction{validatorIdx: validatorIdx}
+}
+
+type stopValidatorEnclaveAction struct {
+	validatorIdx int
+}
+
+func (s *stopValidatorEnclaveAction) Run(ctx context.Context, network networktest.NetworkConnector) (context.Context, error) {
+	validator := network.GetValidatorNode(s.validatorIdx)
+	err := validator.StopEnclave()
+	if err != nil {
+		return nil, err
+	}
+	return ctx, nil
+}
+
+func (s *stopValidatorEnclaveAction) Verify(_ context.Context, _ networktest.NetworkConnector) error {
+	return nil
+}
+
+func WaitForValidatorHealthCheck(validatorIdx int, maxWait time.Duration) networktest.Action {
+	return &waitForValidatorHealthCheckAction{
+		validatorIdx: validatorIdx,
+		maxWait:      maxWait,
+	}
+}
+
+type waitForValidatorHealthCheckAction struct {
+	validatorIdx int
+	maxWait      time.Duration
+}
+
+func (w *waitForValidatorHealthCheckAction) Run(ctx context.Context, network networktest.NetworkConnector) (context.Context, error) {
+	validator := network.GetValidatorNode(w.validatorIdx)
+	// poll the health check until success or timeout
+	err := retry.Do(func() error {
+		return networktest.NodeHealthCheck(validator.HostRPCAddress())
+	}, retry.NewTimeoutStrategy(30*time.Second, 1*time.Second))
+	if err != nil {
+		return nil, err
+	}
+	return ctx, nil
+}
+
+func (w *waitForValidatorHealthCheckAction) Verify(_ context.Context, _ networktest.NetworkConnector) error {
+	return nil
+}

--- a/integration/networktest/actions/setup_actions.go
+++ b/integration/networktest/actions/setup_actions.go
@@ -1,0 +1,86 @@
+package actions
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/obscuronet/go-obscuro/integration"
+	"github.com/obscuronet/go-obscuro/integration/common/testlog"
+	"github.com/obscuronet/go-obscuro/integration/datagenerator"
+	"github.com/obscuronet/go-obscuro/integration/networktest"
+	"github.com/obscuronet/go-obscuro/integration/networktest/userwallet"
+)
+
+type CreateTestUser struct {
+	UserID int
+}
+
+func (c *CreateTestUser) String() string {
+	return fmt.Sprintf("CreateTestUser [id: %d]", c.UserID)
+}
+
+func (c *CreateTestUser) Run(ctx context.Context, network networktest.NetworkConnector) (context.Context, error) {
+	logger := testlog.Logger()
+	wal := datagenerator.RandomWallet(integration.ObscuroChainID)
+	// traffic sim users are round robin-ed onto the validators for now (todo: make that overridable)
+	user := userwallet.NewUserWallet(wal.PrivateKey(), network.ValidatorRPCAddress(c.UserID%network.NumValidators()), logger)
+	return storeTestUser(ctx, c.UserID, user), nil
+}
+
+func (c *CreateTestUser) Verify(_ context.Context, _ networktest.NetworkConnector) error {
+	return nil
+}
+
+type AllocateFaucetFunds struct {
+	UserID int
+}
+
+func (a *AllocateFaucetFunds) String() string {
+	return fmt.Sprintf("AllocateFaucetFunds [user: %d]", a.UserID)
+}
+
+func (a *AllocateFaucetFunds) Run(ctx context.Context, network networktest.NetworkConnector) (context.Context, error) {
+	user, err := FetchTestUser(ctx, a.UserID)
+	if err != nil {
+		return ctx, err
+	}
+	return ctx, network.AllocateFaucetFunds(ctx, user.Address())
+}
+
+func (a *AllocateFaucetFunds) Verify(_ context.Context, _ networktest.NetworkConnector) error {
+	return nil
+}
+
+// action generators (create series of actions for convenient test setups)
+
+func CreateAndFundTestUsers(numUsers int) *MultiAction {
+	var newUserActions []networktest.Action
+	for i := 0; i < numUsers; i++ {
+		newUserActions = append(newUserActions, &CreateTestUser{UserID: i}, &AllocateFaucetFunds{
+			UserID: i,
+		})
+	}
+	// set number of users on the context so downstream know how many test users to access if they want all of them
+	newUserActions = append(newUserActions, ContextValueAction(keyNumberOfTestUsers, numUsers))
+	return Series(newUserActions...)
+}
+
+func AuthenticateAllUsers() networktest.Action {
+	return NoStateNoVerifyAction(func(ctx context.Context, network networktest.NetworkConnector) (context.Context, error) {
+		numUsers, err := FetchNumberOfTestUsers(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("expected number of test users to be set on the context")
+		}
+		for i := 0; i < numUsers; i++ {
+			user, err := FetchTestUser(ctx, i)
+			if err != nil {
+				return nil, err
+			}
+			err = user.ResetClient(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("unable to (re)authenticate client %d - %w", i, err)
+			}
+		}
+		return ctx, nil
+	})
+}

--- a/integration/networktest/actions/setup_actions.go
+++ b/integration/networktest/actions/setup_actions.go
@@ -61,7 +61,8 @@ func CreateAndFundTestUsers(numUsers int) *MultiAction {
 		})
 	}
 	// set number of users on the context so downstream know how many test users to access if they want all of them
-	newUserActions = append(newUserActions, ContextValueAction(keyNumberOfTestUsers, numUsers))
+	newUserActions = append(newUserActions, SetContextValue(KeyNumberOfTestUsers, numUsers))
+	newUserActions = append(newUserActions, SnapshotUserBalances(SnapAfterAllocation))
 	return Series(newUserActions...)
 }
 

--- a/integration/networktest/actions/snapshot_actions.go
+++ b/integration/networktest/actions/snapshot_actions.go
@@ -1,0 +1,51 @@
+package actions
+
+import (
+	"context"
+	"fmt"
+	"github.com/obscuronet/go-obscuro/integration/networktest"
+	"math/big"
+)
+
+// standard snapshots to use as reference points across all tests
+var (
+	// SnapAfterAllocation used to record state after initialisation and faucet allocations to test users
+	SnapAfterAllocation = "after-allocation"
+)
+
+// Snapshots are used for recording data at a point in the test with a string label to describe that stage
+// (storing the data into the context or the snapshot struct for usage or verification later on)
+
+func BalanceSnapshotKey(userID int, snapshot string) ActionKey {
+	return ActionKey(fmt.Sprintf("bal-%s-%d", snapshot, userID))
+}
+func FetchBalanceAtSnapshot(ctx context.Context, userID int, snapshot string) (*big.Int, error) {
+	bal, err := FetchBigInt(ctx, BalanceSnapshotKey(userID, snapshot))
+	if err != nil {
+		return nil, err
+	}
+	return bal, nil
+}
+
+// SnapshotUserBalances requests and records the curr users native balances in the context
+// Note: when running this ensure that there are no transactions in flight if that will affect usage of this data
+func SnapshotUserBalances(snapshot string) networktest.Action {
+	return NoStateNoVerifyAction(func(ctx context.Context, network networktest.NetworkConnector) (context.Context, error) {
+		numUsers, err := FetchNumberOfTestUsers(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for i := 0; i < numUsers; i++ {
+			user, err := FetchTestUser(ctx, i)
+			if err != nil {
+				return nil, fmt.Errorf("failed to fetch user %d - %w", i, err)
+			}
+			bal, err := user.NativeBalance(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("failed to fetch balance for user %d - %w", i, err)
+			}
+			ctx = context.WithValue(ctx, BalanceSnapshotKey(i, snapshot), bal)
+		}
+		return ctx, nil
+	})
+}

--- a/integration/networktest/actions/snapshot_actions.go
+++ b/integration/networktest/actions/snapshot_actions.go
@@ -3,8 +3,9 @@ package actions
 import (
 	"context"
 	"fmt"
-	"github.com/obscuronet/go-obscuro/integration/networktest"
 	"math/big"
+
+	"github.com/obscuronet/go-obscuro/integration/networktest"
 )
 
 // standard snapshots to use as reference points across all tests
@@ -19,6 +20,7 @@ var (
 func BalanceSnapshotKey(userID int, snapshot string) ActionKey {
 	return ActionKey(fmt.Sprintf("bal-%s-%d", snapshot, userID))
 }
+
 func FetchBalanceAtSnapshot(ctx context.Context, userID int, snapshot string) (*big.Int, error) {
 	bal, err := FetchBigInt(ctx, BalanceSnapshotKey(userID, snapshot))
 	if err != nil {

--- a/integration/networktest/actions/traffic_actions.go
+++ b/integration/networktest/actions/traffic_actions.go
@@ -1,0 +1,77 @@
+package actions
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"math/rand"
+	"time"
+
+	"github.com/obscuronet/go-obscuro/integration/common"
+	"github.com/obscuronet/go-obscuro/integration/networktest"
+)
+
+const _minTransferAmt = 1_000_000
+
+// functions in here are used to generate actions to run in parallel or series which
+// simulate "random" user activity over a period of time
+
+type parallelUserActions struct {
+	txPerSec int
+	duration time.Duration
+
+	// parallelUserActions just wraps a ParallelAction, but it doesn't initialise that until Run() is called because it
+	// relies on data from the context
+	parallelAction networktest.Action
+}
+
+// Run builds the parallel action series to be run before delegating its call to the parallel runner
+func (p *parallelUserActions) Run(ctx context.Context, network networktest.NetworkConnector) (context.Context, error) {
+	// find number of test users available
+	numUsers, err := FetchNumberOfTestUsers(ctx)
+	if err != nil {
+		return nil, err
+	}
+	avgTimeBetweenUserTx := float32(numUsers) / float32(p.txPerSec)
+	txPerUser := int(float64(p.txPerSec) * p.duration.Seconds() / float64(numUsers))
+
+	// create a series of actions for each test user that can be run in parallel
+	var allUsersActionSeries []networktest.Action // series of actions per user
+	for i := 0; i < numUsers; i++ {
+		var userActionSeries []networktest.Action
+		for j := 0; j < txPerUser; j++ {
+			// sleep up to 2x avg time between tx (avgTimeBetweenUserTx is a float in seconds, important to multiply it up before casting it to duration)
+			maxWait := time.Duration(float32(2000)*avgTimeBetweenUserTx) * time.Millisecond
+			userActionSeries = append(userActionSeries, RandomSleepAction(time.Millisecond, maxWait),
+				&SendNativeFunds{
+					FromUser: i,
+					ToUser:   getRandomTargetUser(numUsers, i),
+					Amount:   big.NewInt(int64(common.RndBtw(_minTransferAmt, 50*_minTransferAmt))),
+				})
+		}
+		allUsersActionSeries = append(allUsersActionSeries, NamedSeries(fmt.Sprintf("native transfers - user %d", i), userActionSeries...))
+	}
+	// create a parallel action for the user serieses and then delegate running to that action
+	p.parallelAction = NamedParallel(p.String(), allUsersActionSeries...)
+	return p.parallelAction.Run(ctx, network)
+}
+
+func (p *parallelUserActions) String() string {
+	return fmt.Sprintf("user actions - %d TPS", p.txPerSec)
+}
+
+func getRandomTargetUser(numUsers int, fromUser int) int {
+	rndIdx := rand.Intn(numUsers) //nolint:gosec
+	for rndIdx == fromUser {
+		rndIdx = rand.Intn(numUsers) //nolint:gosec
+	}
+	return rndIdx
+}
+
+func (p *parallelUserActions) Verify(ctx context.Context, network networktest.NetworkConnector) error {
+	return p.parallelAction.Verify(ctx, network)
+}
+
+func GenerateUsersRandomisedTransferActionsInParallel(txPerSec int, duration time.Duration) networktest.Action {
+	return &parallelUserActions{txPerSec: txPerSec, duration: duration}
+}

--- a/integration/networktest/actions/traffic_actions.go
+++ b/integration/networktest/actions/traffic_actions.go
@@ -16,17 +16,17 @@ const _minTransferAmt = 1_000_000
 // functions in here are used to generate actions to run in parallel or series which
 // simulate "random" user activity over a period of time
 
-type parallelUserActions struct {
+type parallelFundsTransferTraffic struct {
 	txPerSec int
 	duration time.Duration
 
-	// parallelUserActions just wraps a ParallelAction, but it doesn't initialise that until Run() is called because it
+	// parallelFundsTransferTraffic just wraps a ParallelAction, but it doesn't initialise that until Run() is called because it
 	// relies on data from the context
 	parallelAction networktest.Action
 }
 
 // Run builds the parallel action series to be run before delegating its call to the parallel runner
-func (p *parallelUserActions) Run(ctx context.Context, network networktest.NetworkConnector) (context.Context, error) {
+func (p *parallelFundsTransferTraffic) Run(ctx context.Context, network networktest.NetworkConnector) (context.Context, error) {
 	// find number of test users available
 	numUsers, err := FetchNumberOfTestUsers(ctx)
 	if err != nil {
@@ -56,7 +56,7 @@ func (p *parallelUserActions) Run(ctx context.Context, network networktest.Netwo
 	return p.parallelAction.Run(ctx, network)
 }
 
-func (p *parallelUserActions) String() string {
+func (p *parallelFundsTransferTraffic) String() string {
 	return fmt.Sprintf("user actions - %d TPS", p.txPerSec)
 }
 
@@ -68,10 +68,10 @@ func getRandomTargetUser(numUsers int, fromUser int) int {
 	return rndIdx
 }
 
-func (p *parallelUserActions) Verify(ctx context.Context, network networktest.NetworkConnector) error {
+func (p *parallelFundsTransferTraffic) Verify(ctx context.Context, network networktest.NetworkConnector) error {
 	return p.parallelAction.Verify(ctx, network)
 }
 
 func GenerateUsersRandomisedTransferActionsInParallel(txPerSec int, duration time.Duration) networktest.Action {
-	return &parallelUserActions{txPerSec: txPerSec, duration: duration}
+	return &parallelFundsTransferTraffic{txPerSec: txPerSec, duration: duration}
 }

--- a/integration/networktest/actions/util_actions.go
+++ b/integration/networktest/actions/util_actions.go
@@ -1,0 +1,79 @@
+package actions
+
+import (
+	"context"
+	"time"
+
+	"github.com/obscuronet/go-obscuro/integration/common"
+	"github.com/obscuronet/go-obscuro/integration/networktest"
+)
+
+// ContextValueAction is a simple action step that just sets a value on the context
+func ContextValueAction(key ActionKey, value interface{}) networktest.Action {
+	return &contextValueAction{key: key, value: value}
+}
+
+type contextValueAction struct {
+	key   ActionKey
+	value interface{}
+}
+
+func (c *contextValueAction) Run(ctx context.Context, network networktest.NetworkConnector) (context.Context, error) {
+	return context.WithValue(ctx, c.key, c.value), nil
+}
+
+func (c *contextValueAction) Verify(ctx context.Context, network networktest.NetworkConnector) error {
+	// nothing to verify
+	return nil
+}
+
+func RandomSleepAction(minSleep time.Duration, maxSleep time.Duration) networktest.Action {
+	return SleepAction(common.RndBtwTime(minSleep, maxSleep))
+}
+
+func SleepAction(duration time.Duration) networktest.Action {
+	return &sleepAction{sleepDuration: duration}
+}
+
+type sleepAction struct {
+	sleepDuration time.Duration
+}
+
+func (s *sleepAction) Run(ctx context.Context, network networktest.NetworkConnector) (context.Context, error) {
+	time.Sleep(s.sleepDuration)
+	return ctx, nil
+}
+
+func (s *sleepAction) Verify(ctx context.Context, network networktest.NetworkConnector) error {
+	// nothing to verify
+	return nil
+}
+
+type (
+	RunFunc    func(ctx context.Context, network networktest.NetworkConnector) (context.Context, error)
+	VerifyFunc func(ctx context.Context, network networktest.NetworkConnector) error
+)
+
+// NoStateNoVerifyAction allows you to create an action quickly with an in-line function when it doesn't need state or a verify method
+func NoStateNoVerifyAction(run RunFunc) networktest.Action {
+	return &basicAction{run: run}
+}
+
+type basicAction struct {
+	run    RunFunc
+	verify VerifyFunc
+}
+
+func (b *basicAction) Run(ctx context.Context, network networktest.NetworkConnector) (context.Context, error) {
+	if b.run == nil {
+		return ctx, nil
+	}
+	return b.run(ctx, network)
+}
+
+func (b *basicAction) Verify(ctx context.Context, network networktest.NetworkConnector) error {
+	if b.verify == nil {
+		return nil
+	}
+	return b.verify(ctx, network)
+}

--- a/integration/networktest/actions/util_actions.go
+++ b/integration/networktest/actions/util_actions.go
@@ -8,8 +8,8 @@ import (
 	"github.com/obscuronet/go-obscuro/integration/networktest"
 )
 
-// ContextValueAction is a simple action step that just sets a value on the context
-func ContextValueAction(key ActionKey, value interface{}) networktest.Action {
+// SetContextValue is a simple action step that just sets a value on the context
+func SetContextValue(key ActionKey, value interface{}) networktest.Action {
 	return &contextValueAction{key: key, value: value}
 }
 
@@ -57,6 +57,11 @@ type (
 // NoStateNoVerifyAction allows you to create an action quickly with an in-line function when it doesn't need state or a verify method
 func NoStateNoVerifyAction(run RunFunc) networktest.Action {
 	return &basicAction{run: run}
+}
+
+// VerifyOnlyAction allows you to create an action quickly with an in-line function when it doesn't need state or a verify method
+func VerifyOnlyAction(verify VerifyFunc) networktest.Action {
+	return &basicAction{verify: verify}
 }
 
 type basicAction struct {

--- a/integration/networktest/env/dev_network.go
+++ b/integration/networktest/env/dev_network.go
@@ -1,0 +1,34 @@
+package env
+
+import (
+	"time"
+
+	"github.com/obscuronet/go-obscuro/integration/networktest"
+	"github.com/obscuronet/go-obscuro/integration/simulation/devnetwork"
+)
+
+type devNetworkEnv struct{}
+
+func (d *devNetworkEnv) Prepare() (networktest.NetworkConnector, func(), error) {
+	devNet := devnetwork.DefaultDevNetwork()
+	devNet.Start()
+
+	err := awaitNodesAvailable(devNet)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return devNet, devNet.CleanUp, nil
+}
+
+func awaitNodesAvailable(_ networktest.NetworkConnector) error { //nolint:unparam
+	// todo: create RPC clients for all the nodes and wait until their health checks pass
+
+	// for now we just sleep
+	time.Sleep(15 * time.Second)
+	return nil
+}
+
+func LocalDevNetwork() networktest.Environment {
+	return &devNetworkEnv{}
+}

--- a/integration/networktest/env/network_setup.go
+++ b/integration/networktest/env/network_setup.go
@@ -1,0 +1,32 @@
+package env
+
+import (
+	"github.com/obscuronet/go-obscuro/integration/networktest"
+)
+
+func Testnet() networktest.Environment {
+	connector := NewTestnetConnector(
+		"http://testnet.obscu.ro:13000",
+		[]string{"http://testnet.obscu.ro:13000"}, // for now we'll just use sequencer as validator node... (todo)
+		"http://testnet-faucet.uksouth.azurecontainer.io/fund/obx",
+	)
+	return &testnetEnv{connector}
+}
+
+func DevTestnet() networktest.Environment {
+	connector := NewTestnetConnector(
+		"http://dev-testnet.obscu.ro:13000",
+		[]string{"http://dev-testnet.obscu.ro:13000"}, // for now we'll just use sequencer as validator node... (todo)
+		"http://dev-testnet-faucet.uksouth.azurecontainer.io/fund/obx",
+	)
+	return &testnetEnv{connector}
+}
+
+type testnetEnv struct {
+	testnetConnector networktest.NetworkConnector
+}
+
+func (t *testnetEnv) Prepare() (networktest.NetworkConnector, func(), error) {
+	// no cleanup or setup required for the testnet connector (unlike dev network which has teardown and startup to handle)
+	return t.testnetConnector, func() {}, nil
+}

--- a/integration/networktest/env/testnet.go
+++ b/integration/networktest/env/testnet.go
@@ -1,0 +1,71 @@
+package env
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/obscuronet/go-obscuro/integration"
+
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/obscuronet/go-obscuro/integration/networktest"
+)
+
+type testnetConnector struct {
+	seqRPCAddress         string
+	validatorRPCAddresses []string
+	faucetHTTPAddress     string
+}
+
+func NewTestnetConnector(seqRPCAddr string, validatorRPCAddressses []string, faucetHTTPAddress string) networktest.NetworkConnector {
+	return &testnetConnector{
+		seqRPCAddress:         seqRPCAddr,
+		validatorRPCAddresses: validatorRPCAddressses,
+		faucetHTTPAddress:     faucetHTTPAddress,
+	}
+}
+
+func (t *testnetConnector) ChainID() int64 {
+	return integration.ObscuroChainID
+}
+
+func (t *testnetConnector) AllocateFaucetFunds(ctx context.Context, account gethcommon.Address) error {
+	payload := map[string]string{"address": account.Hex()}
+	jsonPayload, _ := json.Marshal(payload)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, t.faucetHTTPAddress, bytes.NewBuffer(jsonPayload))
+	if err != nil {
+		return fmt.Errorf("unable to make http faucet request - %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("error executing http faucet request - %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("unexpected status of http faucet request, code=%d status=%s", resp.StatusCode, resp.Status)
+	}
+	return nil
+}
+
+func (t *testnetConnector) SequencerRPCAddress() string {
+	return t.seqRPCAddress
+}
+
+func (t *testnetConnector) ValidatorRPCAddress(idx int) string {
+	return t.validatorRPCAddresses[idx]
+}
+
+func (t *testnetConnector) NumValidators() int {
+	return len(t.validatorRPCAddresses)
+}
+
+func (t *testnetConnector) GetSequencerNode() networktest.NodeOperator {
+	panic("node operators cannot be accessed for testnets")
+}
+
+func (t *testnetConnector) GetValidatorNode(_ int) networktest.NodeOperator {
+	panic("node operators cannot be accessed for testnets")
+}

--- a/integration/networktest/interfaces.go
+++ b/integration/networktest/interfaces.go
@@ -1,0 +1,59 @@
+package networktest
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// NetworkConnector represents the network being tested against, e.g. testnet, dev-testnet, dev-sim
+//
+// It provides network details (standard contract addresses) and easy client setup for sim users
+type NetworkConnector interface {
+	ChainID() int64
+	// AllocateFaucetFunds uses the networks default faucet mechanism for allocating funds to a test account
+	AllocateFaucetFunds(ctx context.Context, account common.Address) error
+	SequencerRPCAddress() string
+	ValidatorRPCAddress(idx int) string
+	NumValidators() int
+	GetSequencerNode() NodeOperator
+	GetValidatorNode(idx int) NodeOperator
+}
+
+// Action is any step in a test, they will typically be either minimally small steps in the test or they will be containers
+// that coordinate the running of multiple sub-actions (e.g. SeriesAction/ParallelAction)
+//
+// With these action containers a tree of actions is built to form a test.
+//
+// A test will call Run on an action (triggering the run of the tree of subactions),
+// and then Verify (orchestrating the verification step on all sub actions)
+//
+// Conventions:
+//   - if an action name begins with `Verify` then its `Run` method will be a no-op, these should be at the end of a test run (since they only test the post-test state)
+type Action interface {
+	Run(ctx context.Context, network NetworkConnector) (context.Context, error)
+	Verify(ctx context.Context, network NetworkConnector) error
+}
+
+// Environment abstraction allows the test runner to prepare the network connector with optional config and steps
+// and to handle the clean-up so that different types of NetworkConnector can be configured in the same style (see runner.go)
+// (local network requires setup and teardown for example, whereas a connector to a Testnet is ready to go)
+type Environment interface {
+	Prepare() (NetworkConnector, func(), error)
+}
+
+// NodeOperator is used by the DevNetwork for orchestrating different scenarios
+//
+// It attempts to encapsulate the data, monitoring and possible actions that would be available to a real NodeOperator
+// in a live permissionless Obscuro network
+type NodeOperator interface {
+	Start() error
+	Stop() error
+
+	StartEnclave() error
+	StopEnclave() error
+	StartHost() error
+	StopHost() error
+
+	HostRPCAddress() string
+}

--- a/integration/networktest/log.go
+++ b/integration/networktest/log.go
@@ -1,0 +1,24 @@
+package networktest
+
+import (
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/obscuronet/go-obscuro/integration/common/testlog"
+)
+
+// EnsureTestLogsSetUp calls Setup iff it hasn't already been called (some tests run tests within themselves, we don't want
+// the log folder flipping around for every subtest, so we assume this is called for the top level test that is running
+// and ignore subsequent calls
+func EnsureTestLogsSetUp(testName string) {
+	logger := testlog.Logger()
+	if logger != nil {
+		return // already setup, do not reconfigure
+	}
+	testlog.Setup(&testlog.Cfg{
+		// todo: walk up the dir tree to find /integration/.build or find best practice solution
+		// bit of a hack - tests need to be in a package nested within /tests to get logs in the right place
+		LogDir:      "../../../.build/networktest/",
+		TestType:    "net",
+		TestSubtype: testName,
+		LogLevel:    log.LvlInfo,
+	})
+}

--- a/integration/networktest/runner.go
+++ b/integration/networktest/runner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 )
 
 // Run provides a standardised way to run tests and provides a single place for changing logging/output styles, etc.
@@ -32,6 +33,7 @@ func Run(testName string, t *testing.T, env Environment, action Action) {
 		t.Fatal(err)
 	}
 	fmt.Println("Verifying test:", testName)
+	time.Sleep(2 * time.Second) // allow time for latest test transactions to propagate todo: consider how to configure this sleep
 	err = action.Verify(ctx, network)
 	if err != nil {
 		t.Fatal(err)

--- a/integration/networktest/runner.go
+++ b/integration/networktest/runner.go
@@ -1,0 +1,39 @@
+package networktest
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+// Run provides a standardised way to run tests and provides a single place for changing logging/output styles, etc.
+//
+// The tests in `/tests` should typically only contain a single line, executing this method.
+// The Environment and NetworkTest implementations and how they're configured define the test to be run.
+//
+// Example usage:
+//
+//	networktest.Run(t, env.DevTestnet(), tests.smokeTest())
+//	networktest.Run(t, env.LocalDevNetwork(WithNumValidators(8)), traffic.RunnerTest(traffic.NativeFundsTransfers(), 30*time.Second)
+func Run(testName string, t *testing.T, env Environment, action Action) {
+	EnsureTestLogsSetUp(testName)
+	network, envCleanup, err := env.Prepare()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	defer func() {
+		envCleanup()
+		cancelCtx()
+	}()
+	fmt.Println("Started test:", testName)
+	ctx, err = action.Run(ctx, network)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fmt.Println("Verifying test:", testName)
+	err = action.Verify(ctx, network)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/integration/networktest/tests/helpful/smoke_test.go
+++ b/integration/networktest/tests/helpful/smoke_test.go
@@ -1,9 +1,10 @@
 package helpful
 
 import (
-	"github.com/obscuronet/go-obscuro/integration/networktest/actions"
 	"math/big"
 	"testing"
+
+	"github.com/obscuronet/go-obscuro/integration/networktest/actions"
 
 	"github.com/obscuronet/go-obscuro/integration/networktest"
 	"github.com/obscuronet/go-obscuro/integration/networktest/env"

--- a/integration/networktest/tests/helpful/smoke_test.go
+++ b/integration/networktest/tests/helpful/smoke_test.go
@@ -1,10 +1,9 @@
 package helpful
 
 import (
+	"github.com/obscuronet/go-obscuro/integration/networktest/actions"
 	"math/big"
 	"testing"
-
-	"github.com/obscuronet/go-obscuro/integration/networktest/actions"
 
 	"github.com/obscuronet/go-obscuro/integration/networktest"
 	"github.com/obscuronet/go-obscuro/integration/networktest/env"
@@ -23,10 +22,15 @@ func TestExecuteNativeFundsTransfer(t *testing.T) {
 		actions.Series(
 			&actions.CreateTestUser{UserID: 0},
 			&actions.CreateTestUser{UserID: 1},
+			actions.SetContextValue(actions.KeyNumberOfTestUsers, 2),
+
 			&actions.AllocateFaucetFunds{UserID: 0},
+			actions.SnapshotUserBalances(actions.SnapAfterAllocation), // record user balances (we have no guarantee on how much the network faucet allocates)
+
 			&actions.SendNativeFunds{FromUser: 0, ToUser: 1, Amount: _transferAmount},
 
 			&actions.VerifyBalanceAfterTest{UserID: 1, ExpectedBalance: _transferAmount},
+			&actions.VerifyBalanceDiffAfterTest{UserID: 0, Snapshot: actions.SnapAfterAllocation, ExpectedDiff: big.NewInt(0).Neg(_transferAmount)},
 		),
 	)
 }

--- a/integration/networktest/tests/helpful/smoke_test.go
+++ b/integration/networktest/tests/helpful/smoke_test.go
@@ -1,0 +1,32 @@
+package helpful
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/obscuronet/go-obscuro/integration/networktest/actions"
+
+	"github.com/obscuronet/go-obscuro/integration/networktest"
+	"github.com/obscuronet/go-obscuro/integration/networktest/env"
+)
+
+// Smoke tests are useful for checking a network is live or checking basic functionality is not broken
+
+var _transferAmount = big.NewInt(100_000_000)
+
+func TestExecuteNativeFundsTransfer(t *testing.T) {
+	networktest.TestOnlyRunsInIDE(t)
+	networktest.Run(
+		"native-funds-smoketest",
+		t,
+		env.LocalDevNetwork(),
+		actions.Series(
+			&actions.CreateTestUser{UserID: 0},
+			&actions.CreateTestUser{UserID: 1},
+			&actions.AllocateFaucetFunds{UserID: 0},
+			&actions.SendNativeFunds{FromUser: 0, ToUser: 1, Amount: _transferAmount},
+
+			&actions.VerifyBalanceAfterTest{UserID: 1, ExpectedBalance: _transferAmount},
+		),
+	)
+}

--- a/integration/networktest/tests/helpful/spin_up_local_network_test.go
+++ b/integration/networktest/tests/helpful/spin_up_local_network_test.go
@@ -1,0 +1,33 @@
+package helpful
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"testing"
+
+	"github.com/obscuronet/go-obscuro/integration/networktest"
+	"github.com/obscuronet/go-obscuro/integration/networktest/env"
+)
+
+func TestRunLocalNetwork(t *testing.T) {
+	networktest.TestOnlyRunsInIDE(t)
+	networktest.EnsureTestLogsSetUp("run-local-network")
+	networkConnector, cleanUp, err := env.LocalDevNetwork().Prepare()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanUp()
+
+	fmt.Println("----")
+	fmt.Println("Sequencer RPC", networkConnector.SequencerRPCAddress())
+	for i := 0; i < networkConnector.NumValidators(); i++ {
+		fmt.Println("Validator  ", i, networkConnector.ValidatorRPCAddress(i))
+	}
+	fmt.Println("----")
+	done := make(chan os.Signal, 1)
+	signal.Notify(done, syscall.SIGINT, syscall.SIGTERM)
+	fmt.Println("Network running until test is stopped...")
+	<-done // Will block here until user hits ctrl+c
+}

--- a/integration/networktest/tests/load/load_test.go
+++ b/integration/networktest/tests/load/load_test.go
@@ -18,6 +18,8 @@ func TestNativeTransfers(t *testing.T) {
 		actions.Series(
 			actions.CreateAndFundTestUsers(2),
 			actions.GenerateUsersRandomisedTransferActionsInParallel(2, 10*time.Second),
+
+			actions.VerifyUserBalancesSanity(),
 		),
 	)
 }

--- a/integration/networktest/tests/load/load_test.go
+++ b/integration/networktest/tests/load/load_test.go
@@ -1,0 +1,28 @@
+package load
+
+import (
+	"testing"
+	"time"
+
+	"github.com/obscuronet/go-obscuro/integration/networktest"
+	"github.com/obscuronet/go-obscuro/integration/networktest/actions"
+	"github.com/obscuronet/go-obscuro/integration/networktest/env"
+)
+
+func TestNativeTransfers(t *testing.T) {
+	networktest.TestOnlyRunsInIDE(t)
+	networktest.Run(
+		"native-transfers-load-test",
+		t,
+		env.LocalDevNetwork(),
+		actions.Series(
+			actions.CreateAndFundTestUsers(2),
+			actions.GenerateUsersRandomisedTransferActionsInParallel(2, 10*time.Second),
+		),
+	)
+}
+
+//func TestERC20Transfers(t *testing.T) {
+//	networktest.TestOnlyRunsInIDE(t)
+//	networktest.Run(t, env.LocalDevNetwork(), traffic.DurationTest(traffic.ERC20Transfers(), 30*time.Second))
+//}

--- a/integration/networktest/tests/nodescenario/restart_validator_enclave_test.go
+++ b/integration/networktest/tests/nodescenario/restart_validator_enclave_test.go
@@ -1,0 +1,43 @@
+package nodescenario
+
+import (
+	"testing"
+	"time"
+
+	"github.com/obscuronet/go-obscuro/integration/networktest/actions"
+
+	"github.com/obscuronet/go-obscuro/integration/networktest"
+	"github.com/obscuronet/go-obscuro/integration/networktest/env"
+)
+
+func TestRestartValidatorEnclave(t *testing.T) {
+	networktest.TestOnlyRunsInIDE(t)
+	networktest.Run(
+		"restart-enclave",
+		t,
+		env.LocalDevNetwork(),
+		actions.Series(
+			actions.CreateAndFundTestUsers(5),
+
+			// short load test, build up some state
+			actions.GenerateUsersRandomisedTransferActionsInParallel(4, 10*time.Second),
+
+			// restart enclave on a validator
+			actions.StopValidatorEnclave(1),
+			actions.SleepAction(10*time.Second), // allow time for shutdown
+			actions.StartValidatorEnclave(1),
+			actions.WaitForValidatorHealthCheck(1, 30*time.Second),
+
+			// todo: we often see 1 transaction getting lost without this sleep after the node restarts.
+			// 	This needs investigating but it suggests to me that the health check is succeeding prematurely
+			actions.SleepAction(5*time.Second), // allow time for re-sync
+
+			// resubmit user viewing keys (any users attached to the restarted node will have lost their "session")
+			// todo: would we like enclave to remember user keys on restart? Probably not I guess...
+			actions.AuthenticateAllUsers(),
+
+			// another load test (important that at least one of the users will be using the validator with restarted enclave)
+			actions.GenerateUsersRandomisedTransferActionsInParallel(4, 10*time.Second),
+		),
+	)
+}

--- a/integration/networktest/tests/nodescenario/restart_validator_enclave_test.go
+++ b/integration/networktest/tests/nodescenario/restart_validator_enclave_test.go
@@ -33,7 +33,7 @@ func TestRestartValidatorEnclave(t *testing.T) {
 			actions.SleepAction(5*time.Second), // allow time for re-sync
 
 			// resubmit user viewing keys (any users attached to the restarted node will have lost their "session")
-			// todo: would we like enclave to remember user keys on restart? Probably not I guess...
+			// todo: get rid of this once the enclave persists viewing keys correctly
 			actions.AuthenticateAllUsers(),
 
 			// another load test (important that at least one of the users will be using the validator with restarted enclave)

--- a/integration/networktest/userwallet/userwallet.go
+++ b/integration/networktest/userwallet/userwallet.go
@@ -1,0 +1,228 @@
+package userwallet
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"errors"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/obscuronet/go-obscuro/integration/common/testlog"
+	"github.com/obscuronet/go-obscuro/integration/datagenerator"
+	"github.com/obscuronet/go-obscuro/integration/networktest"
+
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	gethlog "github.com/ethereum/go-ethereum/log"
+	"github.com/obscuronet/go-obscuro/go/common/retry"
+	"github.com/obscuronet/go-obscuro/go/obsclient"
+	"github.com/obscuronet/go-obscuro/go/rpc"
+	"github.com/obscuronet/go-obscuro/integration"
+)
+
+const (
+	_maxReceiptWaitTime  = 30 * time.Second
+	_receiptPollInterval = 1 * time.Second
+)
+
+// UserWallet implements wallet.Wallet so it can be used with the original Wallet code.
+// But it aims to provide a wider range of functionality, akin to the software and hardware wallets that users interact with.
+// Note: UserWallet is **not** thread-safe for a single wallet (creates nonce conflicts etc.)
+type UserWallet struct {
+	privateKey     *ecdsa.PrivateKey
+	publicKey      *ecdsa.PublicKey
+	accountAddress gethcommon.Address
+	chainID        *big.Int
+	rpcEndpoint    string
+
+	// state managed by the wallet
+	nonce uint64
+
+	client *obsclient.AuthObsClient // lazily initialised and authenticated on first usage
+	logger gethlog.Logger
+}
+
+// Option modifies a UserWallet. See below for options, in the form `WithXxx(xxx)` that can be chained into constructor
+type Option func(wallet *UserWallet)
+
+// GenerateRandomWallet will generate a random wallet with a UserWallet wrapper, connecting to a random validator node
+// Note: will use testlog.Logger() as the logger
+func GenerateRandomWallet(network networktest.NetworkConnector) *UserWallet {
+	wallet := datagenerator.RandomWallet(network.ChainID())
+	_, err := obsclient.DialWithAuth(network.SequencerRPCAddress(), wallet, testlog.Logger())
+	if err != nil {
+		panic(err)
+	}
+
+	rndValidatorIdx := int(datagenerator.RandomUInt64()) % network.NumValidators()
+	return NewUserWallet(wallet.PrivateKey(), network.ValidatorRPCAddress(rndValidatorIdx), testlog.Logger())
+}
+
+func NewUserWallet(pk *ecdsa.PrivateKey, rpcEndpoint string, logger gethlog.Logger, opts ...Option) *UserWallet {
+	publicKeyECDSA, ok := pk.Public().(*ecdsa.PublicKey)
+	if !ok {
+		// this shouldn't happen
+		logger.Crit("error casting public key to ECDSA")
+	}
+	wal := &UserWallet{
+		privateKey:     pk,
+		publicKey:      publicKeyECDSA,
+		accountAddress: crypto.PubkeyToAddress(*publicKeyECDSA),
+		chainID:        big.NewInt(integration.ObscuroChainID), // default, overridable using `WithChainID(...) opt`
+		rpcEndpoint:    rpcEndpoint,
+		logger:         logger,
+	}
+	// apply any optional config to the wallet
+	for _, opt := range opts {
+		opt(wal)
+	}
+	return wal
+}
+
+func (s *UserWallet) SendFunds(ctx context.Context, addr gethcommon.Address, value *big.Int) (*gethcommon.Hash, error) {
+	err := s.EnsureClientSetup(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("unable to prepare client to send funds - %w", err)
+	}
+
+	tx := &types.LegacyTx{
+		Nonce:    s.nonce,
+		Value:    value,
+		Gas:      uint64(1_000_000),
+		GasPrice: gethcommon.Big1,
+		To:       &addr,
+	}
+
+	txHash, err := s.SendTransaction(ctx, tx)
+	if err != nil {
+		return nil, fmt.Errorf("unable to send transaction - %w", err)
+	}
+
+	return txHash, nil
+}
+
+func (s *UserWallet) SendTransaction(ctx context.Context, tx *types.LegacyTx) (*gethcommon.Hash, error) {
+	signedTx, err := s.SignTransaction(tx)
+	if err != nil {
+		return nil, fmt.Errorf("unable to sign transaction - %w", err)
+	}
+	// fmt.Printf("waiting for receipt hash %s\n", signedTx.Hash())
+	err = s.client.SendTransaction(ctx, signedTx)
+	if err != nil {
+		return nil, fmt.Errorf("unable to send transaction - %w", err)
+	}
+
+	txHash := signedTx.Hash()
+	// transaction has been sent, we increment the nonce
+	s.nonce++
+	return &txHash, nil
+}
+
+func (s *UserWallet) AwaitReceipt(ctx context.Context, txHash *gethcommon.Hash) (*types.Receipt, error) {
+	var receipt *types.Receipt
+	var err error
+	err = retry.Do(func() error {
+		receipt, err = s.client.TransactionReceipt(ctx, *txHash)
+		if !errors.Is(err, rpc.ErrNilResponse) {
+			// nil response means not found. Any other error is unexpected, so we stop polling and fail immediately
+			return retry.FailFast(err)
+		}
+		return err
+	}, retry.NewTimeoutStrategy(_maxReceiptWaitTime, _receiptPollInterval))
+	return receipt, err
+}
+
+func (s *UserWallet) Address() gethcommon.Address {
+	return s.accountAddress
+}
+
+func (s *UserWallet) SignTransaction(tx types.TxData) (*types.Transaction, error) {
+	return types.SignNewTx(s.privateKey, types.NewLondonSigner(s.chainID), tx)
+}
+
+func (s *UserWallet) GetNonce() uint64 {
+	return s.nonce
+}
+
+func (s *UserWallet) PrivateKey() *ecdsa.PrivateKey {
+	return s.privateKey
+}
+
+func (s *UserWallet) SetNonce(_ uint64) {
+	panic("UserWallet is designed to manage its own nonce - this method exists to support legacy interface methods")
+}
+
+func (s *UserWallet) GetNonceAndIncrement() uint64 {
+	panic("UserWallet is designed to manage its own nonce - this method exists to support legacy interface methods")
+}
+
+// EnsureClientSetup creates an authenticated RPC client (with a viewing key generated, signed and registered) when first called
+// Also fetches current nonce value.
+func (s *UserWallet) EnsureClientSetup(ctx context.Context) error {
+	if s.client != nil {
+		// client already setup
+		return nil
+	}
+	authClient, err := obsclient.DialWithAuth(s.rpcEndpoint, s, s.logger)
+	if err != nil {
+		return err
+	}
+	s.client = authClient
+
+	// fetch current nonce for account
+	nonce, err := authClient.NonceAt(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("unable to fetch client nonce - %w", err)
+	}
+	s.nonce = nonce
+
+	return nil
+}
+
+// ResetClient creates an authenticated RPC client (with a viewing key generated, signed and registered)
+// Also fetches current nonce value. It closes previous client if it exists.
+func (s *UserWallet) ResetClient(ctx context.Context) error {
+	if s.client != nil {
+		// client already setup, close it before re-authenticating
+		s.client.Close()
+	}
+	authClient, err := obsclient.DialWithAuth(s.rpcEndpoint, s, s.logger)
+	if err != nil {
+		return err
+	}
+	s.client = authClient
+
+	// fetch current nonce for account
+	nonce, err := authClient.NonceAt(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("unable to fetch client nonce - %w", err)
+	}
+	s.nonce = nonce
+
+	return nil
+}
+
+func (s *UserWallet) NativeBalance(ctx context.Context) (*big.Int, error) {
+	err := s.EnsureClientSetup(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return s.client.BalanceAt(ctx, nil)
+}
+
+// Init forces VK setup: currently the faucet http server requires a viewing key for a wallet to even *receive* funds :(
+func (s *UserWallet) Init(ctx context.Context) (*UserWallet, error) {
+	return s, s.EnsureClientSetup(ctx)
+}
+
+// UserWalletOptions can be passed into the constructor to override default values
+// e.g. NewUserWallet(pk, rpcAddr, logger, WithChainId(123))
+// NewUserWallet(pk, rpcAddr, logger, WithChainId(123), WithRPCTimeout(20*time.Second)), )
+
+func WithChainID(chainID *big.Int) Option {
+	return func(wallet *UserWallet) {
+		wallet.chainID = chainID
+	}
+}

--- a/integration/networktest/util.go
+++ b/integration/networktest/util.go
@@ -1,0 +1,35 @@
+package networktest
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/obscuronet/go-obscuro/go/obsclient"
+)
+
+// IDEFlag is used as an environnment variable to allow tests to run that are designed not to run in CI
+// todo: come up with a better method, perhaps using directory-based ignore/include mechanism for `ci` dir only
+const IDEFlag = "IDE"
+
+func TestOnlyRunsInIDE(t *testing.T) {
+	// test is skipped by default to avoid breaking CI - set env flag in `Run Configurations` to run it in IDE
+	if os.Getenv(IDEFlag) == "" {
+		t.Skipf("set flag %s to run this test in the IDE", IDEFlag)
+	}
+}
+
+func NodeHealthCheck(rpcAddress string) error {
+	client, err := obsclient.Dial(rpcAddress)
+	if err != nil {
+		return err
+	}
+	health, err := client.Health()
+	if err != nil {
+		return err
+	}
+	if !health {
+		return errors.New("node health check failed")
+	}
+	return nil
+}

--- a/integration/simulation/devnetwork/config.go
+++ b/integration/simulation/devnetwork/config.go
@@ -1,0 +1,47 @@
+package devnetwork
+
+import (
+	"sync"
+	"time"
+
+	"github.com/obscuronet/go-obscuro/integration"
+	"github.com/obscuronet/go-obscuro/integration/common/testlog"
+	"github.com/obscuronet/go-obscuro/integration/simulation/params"
+)
+
+// L1Config tells network admin how to setup the L1 network
+type L1Config struct {
+	PortStart          int
+	WebsocketPortStart int
+	NumNodes           int
+	AvgBlockDuration   time.Duration
+}
+
+// ObscuroConfig tells the L2 node operators how to configure the nodes
+type ObscuroConfig struct {
+	PortStart         int
+	InitNumValidators int
+}
+
+// DefaultDevNetwork provides an off-the-shelf default config for a sim network
+func DefaultDevNetwork() *InMemDevNetwork {
+	numNodes := 4 // Default sim currently uses 4 L1 nodes. Obscuro nodes: 1 seq, 3 validators
+	networkWallets := params.NewSimWallets(0, numNodes, integration.EthereumChainID, integration.ObscuroChainID)
+	l1Config := &L1Config{
+		PortStart:        integration.StartPortSimulationFullNetwork,
+		NumNodes:         4,
+		AvgBlockDuration: 1 * time.Second,
+	}
+	l1Network := NewGethNetwork(networkWallets, l1Config)
+
+	return &InMemDevNetwork{
+		logger:         testlog.Logger(),
+		networkWallets: networkWallets,
+		l1Network:      l1Network,
+		obscuroConfig: ObscuroConfig{
+			PortStart:         integration.StartPortSimulationFullNetwork,
+			InitNumValidators: 3,
+		},
+		faucetLock: sync.Mutex{},
+	}
+}

--- a/integration/simulation/devnetwork/dev_network.go
+++ b/integration/simulation/devnetwork/dev_network.go
@@ -1,0 +1,152 @@
+package devnetwork
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/core/types"
+
+	"github.com/obscuronet/go-obscuro/integration/networktest/userwallet"
+
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	gethlog "github.com/ethereum/go-ethereum/log"
+	"github.com/obscuronet/go-obscuro/go/common"
+	"github.com/obscuronet/go-obscuro/go/wallet"
+	"github.com/obscuronet/go-obscuro/integration"
+	"github.com/obscuronet/go-obscuro/integration/networktest"
+	"github.com/obscuronet/go-obscuro/integration/simulation/params"
+)
+
+var _defaultFaucetAmount = big.NewInt(750_000_000_000_000)
+
+// InMemDevNetwork is a local dev network (L1 and L2) - the obscuro nodes are in-memory in a single go process, the L1 nodes are a docker geth network
+//
+// It can play the role of node operators and network admins to reproduce complex scenarios around nodes joining/leaving/failing.
+//
+// It also implements networktest.NetworkConnector to allow us to run the same NetworkTests against it that we can run against Testnets.
+type InMemDevNetwork struct {
+	logger gethlog.Logger
+
+	// todo: replace this with a struct for accs/contracts that are controlled by network admins
+	// 	(don't pollute with "user" wallets, they will be controlled by the individual network test runners)
+	networkWallets *params.SimWallets
+
+	l1Network L1Network
+
+	obscuroConfig     ObscuroConfig
+	obscuroSequencer  *InMemNodeOperator
+	obscuroValidators []*InMemNodeOperator
+
+	faucet     *userwallet.UserWallet
+	faucetLock sync.Mutex
+}
+
+func (s *InMemDevNetwork) ChainID() int64 {
+	return integration.ObscuroChainID
+}
+
+func (s *InMemDevNetwork) FaucetWallet() wallet.Wallet {
+	return s.networkWallets.L2FaucetWallet
+}
+
+func (s *InMemDevNetwork) AllocateFaucetFunds(ctx context.Context, account gethcommon.Address) error {
+	// ensure only one test account is getting faucet funds at a time, faucet client isn't thread-safe
+	s.faucetLock.Lock()
+	defer s.faucetLock.Unlock()
+
+	txHash, err := s.faucet.SendFunds(ctx, account, _defaultFaucetAmount)
+	if err != nil {
+		return err
+	}
+
+	receipt, err := s.faucet.AwaitReceipt(ctx, txHash)
+	if err != nil {
+		return err
+	}
+	if receipt.Status != types.ReceiptStatusSuccessful {
+		return fmt.Errorf("faucet transaction receipt status not successful - %v", receipt.Status)
+	}
+	return nil
+}
+
+func (s *InMemDevNetwork) SequencerRPCAddress() string {
+	seq := s.GetSequencerNode()
+	return seq.HostRPCAddress()
+}
+
+func (s *InMemDevNetwork) ValidatorRPCAddress(idx int) string {
+	val := s.GetValidatorNode(idx)
+	return val.HostRPCAddress()
+}
+
+func (s *InMemDevNetwork) GetSequencerNode() networktest.NodeOperator {
+	return s.obscuroSequencer
+}
+
+func (s *InMemDevNetwork) GetValidatorNode(i int) networktest.NodeOperator {
+	return s.obscuroValidators[i]
+}
+
+func (s *InMemDevNetwork) NumValidators() int {
+	return len(s.obscuroValidators)
+}
+
+func (s *InMemDevNetwork) Start() {
+	s.l1Network.Start()
+	s.startNodes()
+}
+
+func (s *InMemDevNetwork) DeployL1StandardContracts() {
+	// todo: separate out L1 contract deployment from the geth network setup to give better sim control
+}
+
+func (s *InMemDevNetwork) startNodes() {
+	if s.obscuroSequencer == nil {
+		// initialise node operators
+		s.obscuroSequencer = NewInMemNodeOperator(0, s.obscuroConfig, common.Sequencer, s.l1Network.ObscuroSetupData(), s.l1Network.GetClient(0), s.networkWallets.NodeWallets[0], s.logger)
+		for i := 1; i <= s.obscuroConfig.InitNumValidators; i++ {
+			l1Client := s.l1Network.GetClient(i % s.l1Network.NumNodes())
+			s.obscuroValidators = append(s.obscuroValidators, NewInMemNodeOperator(i, s.obscuroConfig, common.Validator, s.l1Network.ObscuroSetupData(), l1Client, s.networkWallets.NodeWallets[i], s.logger))
+		}
+	}
+
+	go func() {
+		err := s.obscuroSequencer.Start()
+		if err != nil {
+			panic(err)
+		}
+	}()
+	for _, v := range s.obscuroValidators {
+		go func(v networktest.NodeOperator) {
+			err := v.Start()
+			if err != nil {
+				panic(err)
+			}
+		}(v)
+	}
+	s.faucet = userwallet.NewUserWallet(s.networkWallets.L2FaucetWallet.PrivateKey(), s.SequencerRPCAddress(), s.logger)
+}
+
+func (s *InMemDevNetwork) CleanUp() {
+	for _, v := range s.obscuroValidators {
+		go func(v networktest.NodeOperator) {
+			err := v.Stop()
+			if err != nil {
+				fmt.Println("failed to stop validator", err.Error())
+			}
+		}(v)
+	}
+	go func() {
+		err := s.obscuroSequencer.Stop()
+		if err != nil {
+			panic(err)
+		}
+	}()
+	go s.l1Network.Stop()
+
+	s.logger.Info("Waiting for servers to stop.")
+	time.Sleep(3 * time.Second)
+}

--- a/integration/simulation/devnetwork/geth_l1.go
+++ b/integration/simulation/devnetwork/geth_l1.go
@@ -1,0 +1,51 @@
+package devnetwork
+
+import (
+	"fmt"
+
+	"github.com/obscuronet/go-obscuro/go/ethadapter"
+	"github.com/obscuronet/go-obscuro/integration/eth2network"
+	"github.com/obscuronet/go-obscuro/integration/simulation/network"
+	"github.com/obscuronet/go-obscuro/integration/simulation/params"
+)
+
+type gethDockerNetwork struct {
+	networkWallets *params.SimWallets
+	l1Config       *L1Config
+	l1SetupData    *params.L1SetupData
+	l1Clients      []ethadapter.EthClient
+	ethNetwork     eth2network.Eth2Network
+}
+
+func NewGethNetwork(networkWallets *params.SimWallets, l1Config *L1Config) L1Network {
+	return &gethDockerNetwork{
+		networkWallets: networkWallets,
+		l1Config:       l1Config,
+	}
+}
+
+func (g *gethDockerNetwork) Start() {
+	l1SetupData, l1Clients, gethNetwork := network.SetUpGethNetwork(g.networkWallets, g.l1Config.PortStart, g.l1Config.NumNodes, int(g.l1Config.AvgBlockDuration.Seconds()))
+	g.l1SetupData = l1SetupData
+	g.l1Clients = l1Clients
+	g.ethNetwork = gethNetwork
+}
+
+func (g *gethDockerNetwork) Stop() {
+	err := g.ethNetwork.Stop()
+	if err != nil {
+		fmt.Println("eth network failed to stop", err)
+	}
+}
+
+func (g *gethDockerNetwork) NumNodes() int {
+	return len(g.l1Clients)
+}
+
+func (g *gethDockerNetwork) GetClient(idx int) ethadapter.EthClient {
+	return g.l1Clients[idx]
+}
+
+func (g *gethDockerNetwork) ObscuroSetupData() *params.L1SetupData {
+	return g.l1SetupData
+}

--- a/integration/simulation/devnetwork/l1_network.go
+++ b/integration/simulation/devnetwork/l1_network.go
@@ -1,0 +1,17 @@
+package devnetwork
+
+import (
+	"github.com/obscuronet/go-obscuro/go/ethadapter"
+	"github.com/obscuronet/go-obscuro/integration/simulation/params"
+)
+
+// L1Network represents the L1Network being used for the devnetwork
+// (it could be a local geth docker network, a local in-memory network or even a live public L1)
+// todo: refactor to use the same NodeOperator approach as the L2?
+type L1Network interface {
+	Start()
+	Stop()
+	NumNodes() int
+	GetClient(i int) ethadapter.EthClient
+	ObscuroSetupData() *params.L1SetupData
+}

--- a/integration/simulation/devnetwork/node.go
+++ b/integration/simulation/devnetwork/node.go
@@ -1,0 +1,214 @@
+package devnetwork
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/obscuronet/go-obscuro/go/ethadapter/mgmtcontractlib"
+
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	gethlog "github.com/ethereum/go-ethereum/log"
+	"github.com/obscuronet/go-obscuro/go/common"
+	"github.com/obscuronet/go-obscuro/go/common/log"
+	"github.com/obscuronet/go-obscuro/go/common/metrics"
+	"github.com/obscuronet/go-obscuro/go/config"
+	enclavecontainer "github.com/obscuronet/go-obscuro/go/enclave/container"
+	"github.com/obscuronet/go-obscuro/go/enclave/db/sql"
+	"github.com/obscuronet/go-obscuro/go/ethadapter"
+	hostcontainer "github.com/obscuronet/go-obscuro/go/host/container"
+	"github.com/obscuronet/go-obscuro/go/host/p2p"
+	"github.com/obscuronet/go-obscuro/go/host/rpc/clientrpc"
+	"github.com/obscuronet/go-obscuro/go/host/rpc/enclaverpc"
+	"github.com/obscuronet/go-obscuro/go/wallet"
+	"github.com/obscuronet/go-obscuro/integration"
+	"github.com/obscuronet/go-obscuro/integration/common/testlog"
+	"github.com/obscuronet/go-obscuro/integration/simulation/network"
+	"github.com/obscuronet/go-obscuro/integration/simulation/params"
+)
+
+// InMemNodeOperator represents an Obscuro node playing a role in a DevSimulation
+//
+// Anything a node operator could do, that we need to simulate belongs here, for example:
+// * start/stop/reset the host/enclave components of the node
+// * provide convenient access to RPC clients for the node
+// * it might even provide access to things like the database files for the node if needed
+//
+// Note: InMemNodeOperator will panic when things go wrong, we want to fail fast in sims and avoid verbose error handling in usage
+type InMemNodeOperator struct {
+	operatorIdx int
+	config      ObscuroConfig
+	nodeType    common.NodeType
+	l1Data      *params.L1SetupData
+	l1Client    ethadapter.EthClient
+	logger      gethlog.Logger
+
+	host         *hostcontainer.HostContainer
+	enclave      *enclavecontainer.EnclaveContainer
+	l1Wallet     wallet.Wallet
+	sqliteDBPath string
+}
+
+func (n *InMemNodeOperator) StopHost() error {
+	err := n.host.Stop()
+	if err != nil {
+		return fmt.Errorf("unable to stop host - %w", err)
+	}
+	return nil
+}
+
+func (n *InMemNodeOperator) Start() error {
+	err := n.StartEnclave()
+	if err != nil {
+		return fmt.Errorf("failed to start enclave - %w", err)
+	}
+	err = n.StartHost()
+	if err != nil {
+		return fmt.Errorf("failed to start host - %w", err)
+	}
+	return nil
+}
+
+// StartHost starts the host process in a new thread
+func (n *InMemNodeOperator) StartHost() error {
+	// even if host was running previously we recreate the container to ensure state is like a new process
+	// todo: check if host is still running, stop or error?
+	n.host = n.createHostContainer()
+	go func() {
+		err := n.host.Start()
+		if err != nil {
+			// todo: rework this to return error but able to start all hosts simultaneously
+			panic(err)
+		}
+	}()
+	return nil
+}
+
+// StartEnclave starts the enclave process in
+func (n *InMemNodeOperator) StartEnclave() error {
+	// even if enclave was running previously we recreate the container to ensure state is like a new process
+	// todo: check if enclave is still running?
+	n.enclave = n.createEnclaveContainer()
+	return n.enclave.Start()
+}
+
+func (n *InMemNodeOperator) createHostContainer() *hostcontainer.HostContainer {
+	enclavePort := n.config.PortStart + integration.DefaultEnclaveOffset + n.operatorIdx
+	enclaveAddr := fmt.Sprintf("%s:%d", network.Localhost, enclavePort)
+
+	p2pPort := n.config.PortStart + integration.DefaultHostP2pOffset + n.operatorIdx
+	p2pAddr := fmt.Sprintf("%s:%d", network.Localhost, p2pPort)
+
+	hostConfig := &config.HostConfig{
+		ID:                        getHostID(n.operatorIdx),
+		IsGenesis:                 n.nodeType == common.Sequencer,
+		NodeType:                  n.nodeType,
+		HasClientRPCHTTP:          true,
+		ClientRPCPortHTTP:         uint64(n.config.PortStart + integration.DefaultHostRPCHTTPOffset + n.operatorIdx),
+		HasClientRPCWebsockets:    true,
+		ClientRPCPortWS:           uint64(n.config.PortStart + integration.DefaultHostRPCWSOffset + n.operatorIdx),
+		ClientRPCHost:             network.Localhost,
+		EnclaveRPCAddress:         enclaveAddr,
+		P2PBindAddress:            p2pAddr,
+		P2PPublicAddress:          p2pAddr,
+		EnclaveRPCTimeout:         network.EnclaveClientRPCTimeout,
+		L1RPCTimeout:              network.DefaultL1RPCTimeout,
+		ManagementContractAddress: n.l1Data.MgmtContractAddress,
+		L1ChainID:                 integration.EthereumChainID,
+		ObscuroChainID:            integration.ObscuroChainID,
+		L1StartHash:               n.l1Data.ObscuroStartBlock,
+	}
+
+	hostLogger := testlog.Logger().New(log.NodeIDKey, n.operatorIdx, log.CmpKey, log.HostCmp)
+
+	// create a socket P2P layer
+	p2pLogger := hostLogger.New(log.CmpKey, log.P2PCmp)
+	nodeP2p := p2p.NewSocketP2PLayer(hostConfig, p2pLogger, nil)
+	// create an enclave client
+
+	enclaveClient := enclaverpc.NewClient(hostConfig, testlog.Logger().New(log.NodeIDKey, n.operatorIdx))
+	rpcServer := clientrpc.NewServer(hostConfig, n.logger)
+	mgmtContractLib := mgmtcontractlib.NewMgmtContractLib(&hostConfig.ManagementContractAddress, n.logger)
+	return hostcontainer.NewHostContainer(hostConfig, nodeP2p, n.l1Client, enclaveClient, mgmtContractLib, n.l1Wallet, rpcServer, hostLogger, metrics.New(false, 0, n.logger))
+}
+
+func (n *InMemNodeOperator) createEnclaveContainer() *enclavecontainer.EnclaveContainer {
+	enclaveLogger := testlog.Logger().New(log.NodeIDKey, n.operatorIdx, log.CmpKey, log.EnclaveCmp)
+	enclavePort := n.config.PortStart + integration.DefaultEnclaveOffset + n.operatorIdx
+	enclaveAddr := fmt.Sprintf("%s:%d", network.Localhost, enclavePort)
+
+	hostPort := n.config.PortStart + integration.DefaultHostP2pOffset + n.operatorIdx
+	hostAddr := fmt.Sprintf("%s:%d", network.Localhost, hostPort)
+
+	enclaveConfig := config.EnclaveConfig{
+		HostID:                    getHostID(n.operatorIdx),
+		SequencerID:               getHostID(0),
+		HostAddress:               hostAddr,
+		Address:                   enclaveAddr,
+		NodeType:                  n.nodeType,
+		L1ChainID:                 integration.EthereumChainID,
+		ObscuroChainID:            integration.ObscuroChainID,
+		ValidateL1Blocks:          false,
+		WillAttest:                false,
+		GenesisJSON:               nil,
+		UseInMemoryDB:             false,
+		ManagementContractAddress: n.l1Data.MgmtContractAddress,
+		MinGasPrice:               big.NewInt(1),
+		MessageBusAddress:         *n.l1Data.MessageBusAddr,
+		SqliteDBPath:              n.sqliteDBPath,
+	}
+	return enclavecontainer.NewEnclaveContainerWithLogger(enclaveConfig, enclaveLogger)
+}
+
+func (n *InMemNodeOperator) Stop() error {
+	err := n.host.Stop()
+	if err != nil {
+		return fmt.Errorf("failed to stop host - %w", err)
+	}
+	err = n.enclave.Stop()
+	if err != nil {
+		return fmt.Errorf("failed to stop enclave - %w", err)
+	}
+	return nil
+}
+
+func (n *InMemNodeOperator) HostRPCAddress() string {
+	hostPort := n.config.PortStart + integration.DefaultHostRPCWSOffset + n.operatorIdx
+	return fmt.Sprintf("ws://%s:%d", network.Localhost, hostPort)
+}
+
+func (n *InMemNodeOperator) StopEnclave() error {
+	err := n.enclave.Stop()
+	if err != nil {
+		n.logger.Error("failed to stop enclave - %w", err)
+
+		// try again
+		err := n.enclave.Stop()
+		if err != nil {
+			return fmt.Errorf("failed to stop enclave after second attempt - %w", err)
+		}
+	}
+	return nil
+}
+
+func NewInMemNodeOperator(operatorIdx int, config ObscuroConfig, nodeType common.NodeType, l1Data *params.L1SetupData,
+	l1Client ethadapter.EthClient, l1Wallet wallet.Wallet, logger gethlog.Logger,
+) *InMemNodeOperator {
+	dbFile, err := sql.CreateTempDBFile()
+	if err != nil {
+		panic("failed to create temp db path")
+	}
+	return &InMemNodeOperator{
+		operatorIdx:  operatorIdx,
+		config:       config,
+		nodeType:     nodeType,
+		l1Data:       l1Data,
+		l1Client:     l1Client,
+		l1Wallet:     l1Wallet,
+		logger:       logger,
+		sqliteDBPath: dbFile,
+	}
+}
+
+func getHostID(nodeIdx int) gethcommon.Address {
+	return gethcommon.BigToAddress(big.NewInt(int64(nodeIdx)))
+}


### PR DESCRIPTION
Note: this is a continuation of this PR: https://github.com/obscuronet/go-obscuro/pull/1039 . Fresh branch for the refactor because there was a lot of old comments on there.

The main difference is just swapping out the NetworkTest interface for the more flexible Action interface that Tudor suggested in a comment. So now the tests read more like a series of steps which I think is perhaps what Stefan had in mind too.

I haven't attempted to make this integrate with hardhat stuff or with Pedro's docker-based local network stuff yet but hopefully this is flexible enough that we can use it with that stuff without too much hassle.

### Why this change is needed

- Adds a tool that can be used for testing network situations against a local dev network in-memory or one of our existing testnets
- Adds a test for restarting the enclave of a node and the means to add other similar style tests

### What changes were made as part of this PR

It adds a few new tools to play with and iterate on. The abstractions probably need improving but hopefully a useful first step.

/devnetwork **(a package for running a test network and orchestrating situations with its nodes)**
- DevNetwork interface represents a network that can be manipulated by tests
    * inherits the NetworkConnector interface so it can be used in network-tests
    * exposes `Start()`, `Stop()`, Getters for specific NodeOperators, etc.
- DefaultDevNetwork implements it with a bunch of configurable options
	
/networktest **(a package for creating tests that can run against a network - either local dev network or a testnet)**
- NetworkConnector interface represents a network that can be connected to by tests
    * exposes rpc address getters for nodes, exposes a faucet allocation function so tests can fund their sim accounts
    * DevNetworks are implementations of NetworkConnector, but we also have a TestnetConnector implementation using http faucet to allow tests to run against diff environments
- Action interface represents a step in a test that requires a NetworkConnector to run against. Actions typically run other Actions within them in series or in parallel and then once they've finished running each step has an optional Verify step that it can use to do additional checks.

/userwallet
- this integration test helper bundles a user's private keys with an a client and provides high level functionality (similar to metamask or other user-facing software/hardware wallet)

Note: this PR also touches the db code to make the sqlite temp DB setup public for re-use from the dev network code.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


