### PR TITLE
New batch log msg getting overwritten

### DIFF
--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -269,7 +269,7 @@ func describeBSR(response *common.BlockSubmissionResponse) string {
 	}
 	producedRollup := "no rollup produced"
 	if response.ProducedRollup != nil {
-		producedBatch = fmt.Sprintf("newRollup{num=%d, numBatches=%d, hash=%s}",
+		producedRollup = fmt.Sprintf("newRollup{num=%d, numBatches=%d, hash=%s}",
 			response.ProducedRollup.Header.Number, len(response.ProducedRollup.Batches), response.ProducedRollup.Hash())
 	}
 	return fmt.Sprintf("%s, %s", producedBatch, producedRollup)


### PR DESCRIPTION
### Why this change is needed

Spammy log is missing one of the most helpful parts (the new batch details) because it's getting overwritten by the rollup msg)

### What changes were made as part of this PR

fix the log msg

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


