### PR TITLE
Add config to enable host persistence

### DIFF
--- a/go/config/host_config.go
+++ b/go/config/host_config.go
@@ -69,6 +69,12 @@ type HostInputConfig struct {
 
 	// MetricsHTTPPort sets the port where the http server is available
 	MetricsHTTPPort uint
+
+	// UseInMemoryDB sets whether the enclave should use in-memory or persistent storage
+	UseInMemoryDB bool
+
+	// LevelDBPath path for the levelDB persistence dir (can be empty if a throwaway file in /tmp/ is acceptable, or if using InMemory DB)
+	LevelDBPath string
 }
 
 // ToHostConfig returns a HostConfig given a HostInputConfig
@@ -100,6 +106,8 @@ func (p HostInputConfig) ToHostConfig() *HostConfig {
 		ID:                        gethcommon.Address{},
 		MetricsEnabled:            p.MetricsEnabled,
 		MetricsHTTPPort:           p.MetricsHTTPPort,
+		UseInMemoryDB:             p.UseInMemoryDB,
+		LevelDBPath:               p.LevelDBPath,
 	}
 }
 
@@ -160,6 +168,12 @@ type HostConfig struct {
 
 	// MetricsHTTPPort sets the port where the http server is available
 	MetricsHTTPPort uint
+
+	// Whether the host should use in-memory or persistent storage
+	UseInMemoryDB bool
+
+	// filepath for the levelDB persistence dir (can be empty if a throwaway file in /tmp/ is acceptable, or if using InMemory DB)
+	LevelDBPath string
 }
 
 // DefaultHostParsedConfig returns a HostConfig with default values.
@@ -190,5 +204,6 @@ func DefaultHostParsedConfig() *HostInputConfig {
 		L1StartHash:               common.L1RootHash{}, // this hash will not be found, host will log a warning and then stream from L1 genesis
 		MetricsEnabled:            true,
 		MetricsHTTPPort:           14000,
+		UseInMemoryDB:             true,
 	}
 }

--- a/go/host/container/cli.go
+++ b/go/host/container/cli.go
@@ -42,6 +42,8 @@ type HostConfigToml struct {
 	L1StartHash               string
 	MetricsEnabled            bool
 	MetricsHTTPPort           uint
+	UseInMemoryDB             bool
+	LevelDBPath               string
 }
 
 // ParseConfig returns a config.HostInputConfig based on either the file identified by the `config` flag, or the flags with
@@ -74,6 +76,8 @@ func ParseConfig() (*config.HostInputConfig, error) {
 	l1StartHash := flag.String(l1StartHashName, cfg.L1StartHash.Hex(), flagUsageMap[l1StartHashName])
 	metricsEnabled := flag.Bool(metricsEnabledName, cfg.MetricsEnabled, flagUsageMap[metricsEnabledName])
 	metricsHTPPPort := flag.Uint(metricsHTTPPortName, cfg.MetricsHTTPPort, flagUsageMap[metricsHTTPPortName])
+	useInMemoryDB := flag.Bool(useInMemoryDBName, cfg.UseInMemoryDB, flagUsageMap[useInMemoryDBName])
+	levelDBPath := flag.String(levelDBPathName, cfg.LevelDBPath, flagUsageMap[levelDBPathName])
 
 	flag.Parse()
 
@@ -111,6 +115,8 @@ func ParseConfig() (*config.HostInputConfig, error) {
 	cfg.L1StartHash = gethcommon.HexToHash(*l1StartHash)
 	cfg.MetricsEnabled = *metricsEnabled
 	cfg.MetricsHTTPPort = *metricsHTPPPort
+	cfg.UseInMemoryDB = *useInMemoryDB
+	cfg.LevelDBPath = *levelDBPath
 
 	return cfg, nil
 }
@@ -159,5 +165,7 @@ func fileBasedConfig(configPath string) (*config.HostInputConfig, error) {
 		L1StartHash:               gethcommon.HexToHash(tomlConfig.L1StartHash),
 		MetricsEnabled:            tomlConfig.MetricsEnabled,
 		MetricsHTTPPort:           tomlConfig.MetricsHTTPPort,
+		UseInMemoryDB:             tomlConfig.UseInMemoryDB,
+		LevelDBPath:               tomlConfig.LevelDBPath,
 	}, nil
 }

--- a/go/host/container/cli_flags.go
+++ b/go/host/container/cli_flags.go
@@ -27,6 +27,8 @@ const (
 	l1StartHashName              = "l1Start"
 	metricsEnabledName           = "metricsEnabled"
 	metricsHTTPPortName          = "metricsHTTPPort"
+	useInMemoryDBName            = "useInMemoryDB"
+	levelDBPathName              = "levelDBPath"
 )
 
 // Returns a map of the flag usages.
@@ -57,5 +59,7 @@ func getFlagUsageMap() map[string]string {
 		profilerEnabledName:          "Runs a profiler instance (Defaults to false)",
 		metricsEnabledName:           "Whether the metrics are enabled (Defaults to true)",
 		metricsHTTPPortName:          "The port on which the metrics are served (Defaults to 0.0.0.0:14000)",
+		useInMemoryDBName:            "Whether the host will use an in-memory DB rather than persist data",
+		levelDBPathName:              "Filepath for the levelDB persistence dir (can be empty if a throwaway file in /tmp/ is acceptable or if using InMemory DB)",
 	}
 }

--- a/go/host/db/batches_test.go
+++ b/go/host/db/batches_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestCanStoreAndRetrieveBatchHeader(t *testing.T) {
-	db := NewInMemoryDB(nil)
+	db := NewInMemoryDB(nil, nil)
 	header := common.BatchHeader{
 		Number: big.NewInt(batchNumber),
 	}
@@ -36,7 +36,7 @@ func TestCanStoreAndRetrieveBatchHeader(t *testing.T) {
 }
 
 func TestUnknownBatchHeaderReturnsNotFound(t *testing.T) {
-	db := NewInMemoryDB(nil)
+	db := NewInMemoryDB(nil, nil)
 	header := types.Header{}
 
 	_, err := db.GetBatchHeader(header.Hash())
@@ -46,7 +46,7 @@ func TestUnknownBatchHeaderReturnsNotFound(t *testing.T) {
 }
 
 func TestHigherNumberBatchBecomesBatchHeader(t *testing.T) { //nolint:dupl
-	db := NewInMemoryDB(nil)
+	db := NewInMemoryDB(nil, nil)
 	headerOne := common.BatchHeader{
 		Number: big.NewInt(batchNumber),
 	}
@@ -82,7 +82,7 @@ func TestHigherNumberBatchBecomesBatchHeader(t *testing.T) { //nolint:dupl
 }
 
 func TestLowerNumberBatchDoesNotBecomeBatchHeader(t *testing.T) { //nolint:dupl
-	db := NewInMemoryDB(nil)
+	db := NewInMemoryDB(nil, nil)
 	headerOne := common.BatchHeader{
 		Number: big.NewInt(batchNumber),
 	}
@@ -118,7 +118,7 @@ func TestLowerNumberBatchDoesNotBecomeBatchHeader(t *testing.T) { //nolint:dupl
 }
 
 func TestHeadBatchHeaderIsNotSetInitially(t *testing.T) {
-	db := NewInMemoryDB(nil)
+	db := NewInMemoryDB(nil, nil)
 
 	_, err := db.GetHeadBatchHeader()
 	if !errors.Is(err, errutil.ErrNotFound) {
@@ -127,7 +127,7 @@ func TestHeadBatchHeaderIsNotSetInitially(t *testing.T) {
 }
 
 func TestCanRetrieveBatchHashByNumber(t *testing.T) {
-	db := NewInMemoryDB(nil)
+	db := NewInMemoryDB(nil, nil)
 	header := common.BatchHeader{
 		Number: big.NewInt(batchNumber),
 	}
@@ -150,7 +150,7 @@ func TestCanRetrieveBatchHashByNumber(t *testing.T) {
 }
 
 func TestUnknownBatchNumberReturnsNotFound(t *testing.T) {
-	db := NewInMemoryDB(nil)
+	db := NewInMemoryDB(nil, nil)
 	header := types.Header{}
 
 	_, err := db.GetBatchHash(header.Number)
@@ -160,7 +160,7 @@ func TestUnknownBatchNumberReturnsNotFound(t *testing.T) {
 }
 
 func TestCanRetrieveBatchNumberByTxHash(t *testing.T) {
-	db := NewInMemoryDB(nil)
+	db := NewInMemoryDB(nil, nil)
 	header := common.BatchHeader{
 		Number: big.NewInt(batchNumber),
 	}
@@ -185,7 +185,7 @@ func TestCanRetrieveBatchNumberByTxHash(t *testing.T) {
 }
 
 func TestUnknownBatchTxHashReturnsNotFound(t *testing.T) {
-	db := NewInMemoryDB(nil)
+	db := NewInMemoryDB(nil, nil)
 
 	_, err := db.GetBatchNumber(gethcommon.BytesToHash([]byte("magicString")))
 	if !errors.Is(err, errutil.ErrNotFound) {
@@ -194,7 +194,7 @@ func TestUnknownBatchTxHashReturnsNotFound(t *testing.T) {
 }
 
 func TestCanRetrieveBatchTransactions(t *testing.T) {
-	db := NewInMemoryDB(nil)
+	db := NewInMemoryDB(nil, nil)
 	header := common.BatchHeader{
 		Number: big.NewInt(batchNumber),
 	}
@@ -224,7 +224,7 @@ func TestCanRetrieveBatchTransactions(t *testing.T) {
 }
 
 func TestTransactionsForUnknownBatchReturnsNotFound(t *testing.T) {
-	db := NewInMemoryDB(nil)
+	db := NewInMemoryDB(nil, nil)
 
 	_, err := db.GetBatchNumber(gethcommon.BytesToHash([]byte("magicString")))
 	if !errors.Is(err, errutil.ErrNotFound) {
@@ -233,7 +233,7 @@ func TestTransactionsForUnknownBatchReturnsNotFound(t *testing.T) {
 }
 
 func TestCanRetrieveTotalNumberOfTransactions(t *testing.T) {
-	db := NewInMemoryDB(nil)
+	db := NewInMemoryDB(nil, nil)
 	headerOne := common.BatchHeader{
 		Number: big.NewInt(batchNumber),
 	}

--- a/go/host/db/blocks.go
+++ b/go/host/db/blocks.go
@@ -2,7 +2,10 @@ package db
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
+
+	"github.com/syndtr/goleveldb/leveldb"
 
 	"github.com/obscuronet/go-obscuro/go/common/errutil"
 
@@ -58,6 +61,9 @@ func (db *DB) writeBlockHeader(header *types.Header) error {
 func (db *DB) readBlockHeader(r ethdb.KeyValueReader, hash gethcommon.Hash) (*types.Header, error) {
 	data, err := r.Get(blockHeaderKey(hash))
 	if err != nil {
+		if errors.Is(err, leveldb.ErrNotFound) {
+			return nil, errutil.ErrNotFound
+		}
 		return nil, err
 	}
 	if len(data) == 0 {

--- a/go/host/db/blocks_test.go
+++ b/go/host/db/blocks_test.go
@@ -14,7 +14,7 @@ import (
 const batchNumber = 777
 
 func TestCanStoreAndRetrieveBlockHeader(t *testing.T) {
-	db := NewInMemoryDB(nil)
+	db := NewInMemoryDB(nil, nil)
 	header := types.Header{
 		Number: big.NewInt(batchNumber),
 	}
@@ -33,7 +33,7 @@ func TestCanStoreAndRetrieveBlockHeader(t *testing.T) {
 }
 
 func TestUnknownBlockHeaderReturnsNotFound(t *testing.T) {
-	db := NewInMemoryDB(nil)
+	db := NewInMemoryDB(nil, nil)
 	header := types.Header{}
 
 	_, err := db.GetBlockHeader(header.Hash())

--- a/go/host/db/hostdb.go
+++ b/go/host/db/hostdb.go
@@ -1,15 +1,16 @@
 package db
 
 import (
+	"fmt"
 	"os"
+
+	"github.com/obscuronet/go-obscuro/go/config"
 
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/ethdb/leveldb"
-	"github.com/obscuronet/go-obscuro/go/common/gethdb"
-	"github.com/obscuronet/go-obscuro/go/common/log"
-
 	gethlog "github.com/ethereum/go-ethereum/log"
 	gethmetrics "github.com/ethereum/go-ethereum/metrics"
+	"github.com/obscuronet/go-obscuro/go/common/gethdb"
 )
 
 // Schema keys, in alphabetical order.
@@ -34,32 +35,74 @@ type DB struct {
 	blockReads  gethmetrics.Gauge
 }
 
+// Stop is especially important for graceful shutdown of LevelDB as it may flush data to disk that is currently in cache
+func (db *DB) Stop() error {
+	err := db.kvStore.Close()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func CreateDBFromConfig(cfg *config.HostConfig, regMetrics gethmetrics.Registry, logger gethlog.Logger) (*DB, error) {
+	if err := validateDBConf(cfg); err != nil {
+		return nil, err
+	}
+	if cfg.UseInMemoryDB {
+		logger.Info("UseInMemoryDB flag is true, data will not be persisted. Creating in-memory database...")
+		return NewInMemoryDB(regMetrics, logger), nil
+	}
+	return NewLevelDBBackedDB(cfg.LevelDBPath, regMetrics, logger)
+}
+
+func validateDBConf(cfg *config.HostConfig) error {
+	if cfg.UseInMemoryDB && cfg.LevelDBPath != "" {
+		return fmt.Errorf("useInMemoryDB=true so levelDB will not be used and no path is needed, but levelDBPath=%s", cfg.LevelDBPath)
+	}
+	return nil
+}
+
 // NewInMemoryDB returns a new instance of the Node DB
-func NewInMemoryDB(regMetrics gethmetrics.Registry) *DB {
+func NewInMemoryDB(regMetrics gethmetrics.Registry, logger gethlog.Logger) *DB {
+	return newDB(gethdb.NewMemDB(), regMetrics, logger)
+}
+
+// NewLevelDBBackedDB creates a persistent DB for the host, if dbPath == "" it will generate a temp file
+func NewLevelDBBackedDB(dbPath string, regMetrics gethmetrics.Registry, logger gethlog.Logger) (*DB, error) {
+	var err error
+	if dbPath == "" {
+		// todo: remove this option before prod
+		dbPath, err = os.MkdirTemp("", "leveldb_*")
+		if err != nil {
+			return nil, fmt.Errorf("could not create temp leveldb directory - %w", err)
+		}
+		logger.Warn("dbPath was empty, created temp dir for persistence", "dbPath", dbPath)
+	}
+	// determine if a db file already exists, we don't want to overwrite it
+	_, err = os.Stat(dbPath)
+	dbDesc := "new"
+	if err == nil {
+		dbDesc = "existing"
+	}
+
+	// todo these should be configs
+	cache := 128
+	handles := 128
+	db, err := leveldb.New(dbPath, cache, handles, "host", false)
+	if err != nil {
+		return nil, fmt.Errorf("could not create leveldb - %w", err)
+	}
+	logger.Info(fmt.Sprintf("Opened %s level db dir at %s", dbDesc, dbPath))
+	return newDB(db, regMetrics, nil), nil
+}
+
+func newDB(kvStore ethdb.KeyValueStore, regMetrics gethmetrics.Registry, logger gethlog.Logger) *DB {
 	return &DB{
-		kvStore:     gethdb.NewMemDB(),
+		kvStore:     kvStore,
+		logger:      logger,
 		batchWrites: gethmetrics.NewRegisteredGauge("host/db/batch/writes", regMetrics),
 		batchReads:  gethmetrics.NewRegisteredGauge("host/db/batch/reads", regMetrics),
 		blockWrites: gethmetrics.NewRegisteredGauge("host/db/block/writes", regMetrics),
 		blockReads:  gethmetrics.NewRegisteredGauge("host/db/block/reads", regMetrics),
-	}
-}
-
-func NewLevelDBBackedDB(logger gethlog.Logger) *DB {
-	// todo, all these should be configs
-	f, err := os.MkdirTemp("", "leveldb_*")
-	if err != nil {
-		logger.Crit("Could not creat temp leveldb directory.", log.ErrKey, err)
-	}
-	cache := 128
-	handles := 128
-	db, err := leveldb.New(f, cache, handles, "host", false)
-	if err != nil {
-		logger.Crit("Could not create leveldb.", log.ErrKey, err)
-	}
-
-	return &DB{
-		kvStore: db,
-		logger:  logger,
 	}
 }

--- a/go/node/docker.go
+++ b/go/node/docker.go
@@ -56,6 +56,8 @@ func (d *DockerNode) startHost() error {
 		"-p2pBindAddress", fmt.Sprintf("0.0.0.0:%d", d.cfg.hostP2PPort),
 		"-clientRPCPortHttp", fmt.Sprintf("%d", d.cfg.hostHTTPPort),
 		"-clientRPCPortWs", fmt.Sprintf("%d", d.cfg.hostWSPort),
+		// for now this is hard-coded to true todo: default to false once we're confident
+		"-useInMemoryDB=true",
 	}
 
 	exposedPorts := []int{

--- a/integration/simulation/devnetwork/node.go
+++ b/integration/simulation/devnetwork/node.go
@@ -3,6 +3,7 @@ package devnetwork
 import (
 	"fmt"
 	"math/big"
+	"os"
 
 	"github.com/obscuronet/go-obscuro/go/ethadapter/mgmtcontractlib"
 
@@ -46,6 +47,7 @@ type InMemNodeOperator struct {
 	enclave      *enclavecontainer.EnclaveContainer
 	l1Wallet     wallet.Wallet
 	sqliteDBPath string
+	levelDBPath  string
 }
 
 func (n *InMemNodeOperator) StopHost() error {
@@ -116,6 +118,8 @@ func (n *InMemNodeOperator) createHostContainer() *hostcontainer.HostContainer {
 		L1ChainID:                 integration.EthereumChainID,
 		ObscuroChainID:            integration.ObscuroChainID,
 		L1StartHash:               n.l1Data.ObscuroStartBlock,
+		UseInMemoryDB:             false,
+		LevelDBPath:               n.levelDBPath,
 	}
 
 	hostLogger := testlog.Logger().New(log.NodeIDKey, n.operatorIdx, log.CmpKey, log.HostCmp)
@@ -193,9 +197,14 @@ func (n *InMemNodeOperator) StopEnclave() error {
 func NewInMemNodeOperator(operatorIdx int, config ObscuroConfig, nodeType common.NodeType, l1Data *params.L1SetupData,
 	l1Client ethadapter.EthClient, l1Wallet wallet.Wallet, logger gethlog.Logger,
 ) *InMemNodeOperator {
-	dbFile, err := sql.CreateTempDBFile()
+	// todo: put sqlite and levelDB storage in the same temp dir
+	sqliteDBPath, err := sql.CreateTempDBFile()
 	if err != nil {
-		panic("failed to create temp db path")
+		panic("failed to create temp sqlite db path")
+	}
+	levelDBPath, err := os.MkdirTemp("", "levelDB_*")
+	if err != nil {
+		panic("failed to create temp levelDBPath")
 	}
 	return &InMemNodeOperator{
 		operatorIdx:  operatorIdx,
@@ -205,7 +214,8 @@ func NewInMemNodeOperator(operatorIdx int, config ObscuroConfig, nodeType common
 		l1Client:     l1Client,
 		l1Wallet:     l1Wallet,
 		logger:       logger,
-		sqliteDBPath: dbFile,
+		sqliteDBPath: sqliteDBPath,
+		levelDBPath:  levelDBPath,
 	}
 }
 

--- a/integration/simulation/network/network_utils.go
+++ b/integration/simulation/network/network_utils.go
@@ -127,6 +127,7 @@ func createSocketObscuroHostContainer(
 		ObscuroChainID:            integration.ObscuroChainID,
 		L1StartHash:               l1StartBlk,
 		ManagementContractAddress: *mgmtContractLib.GetContractAddr(),
+		UseInMemoryDB:             true,
 	}
 
 	// TODO change this to use the NewHostContainerFromConfig - depends on https://github.com/obscuronet/obscuro-internal/issues/1303


### PR DESCRIPTION
### Why this change is needed

No persistence means restarted host doesn't remember the L1 blocks etc. that it's already seen. (Although we do need to be resilient to that too).

### What changes were made as part of this PR

- add config to allow persistence to be turned on and a file dir configured for levelDB
- fix compatibility issue in usage, which differs from the in-mem db because it errors when not found instead of returning empty

The config for testnets etc. is still set to use in-memory. I have tested the persistence using the `networktests` enclave restart test.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


