### PR TITLE
Save deployment container logs as build artifacts for fault finding

### DIFF
--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -87,7 +87,6 @@ jobs:
           echo "RESOURCE_STARTING_NAME=${{env.RESOURCE_STARTING_NAME}}" >> $GITHUB_OUTPUT
           echo "RESOURCE_TESTNET_NAME=${{env.RESOURCE_TESTNET_NAME}}" >> $GITHUB_OUTPUT
           echo "L1_HOST=${{env.L1_HOST}}" >> $GITHUB_OUTPUT
-          
 
       - name: 'Login to Azure docker registry'
         uses: azure/docker-login@v1
@@ -123,6 +122,12 @@ jobs:
           echo "MSG_BUS_CONTRACT_ADDR=$MSGBUSCONTRACTADDR" >> $GITHUB_ENV
           echo "MSG_BUS_CONTRACT_ADDR=$MSGBUSCONTRACTADDR" >> $GITHUB_OUTPUT
 
+      - name: 'Grab L1 deployer logs on failure'
+        id: hhL1ContainerLogs
+        if: failure()
+        run: |
+          docker logs `docker ps -aqf "name=hh-l1-deployer"` > build-hh-l1-deployer.out
+
       # This will fail some deletions due to resource dependencies ( ie. you must first delete the vm before deleting the disk)
       - name: 'Delete deployed VMs'
         uses: azure/CLI@v1
@@ -136,6 +141,15 @@ jobs:
         with:
           inlineScript: |
             $(az resource list --tag ${{env.RESOURCE_TAG_NAME}}=true --query '[]."id"' -o tsv | xargs -n1 az resource delete --verbose -g Testnet --ids) || true
+
+      - name: 'Upload build step container logs'
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: build-artifacts
+          path: |
+            build-*.out
+          retention-days: 2
 
   deploy:
     needs: build

--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -122,11 +122,10 @@ jobs:
           echo "MSG_BUS_CONTRACT_ADDR=$MSGBUSCONTRACTADDR" >> $GITHUB_ENV
           echo "MSG_BUS_CONTRACT_ADDR=$MSGBUSCONTRACTADDR" >> $GITHUB_OUTPUT
 
-      - name: 'Grab L1 deployer logs on failure'
-        id: hhL1ContainerLogs
+      - name: 'Save container logs on failure'
         if: failure()
         run: |
-          docker logs `docker ps -aqf "name=hh-l1-deployer"` > build-hh-l1-deployer.out
+          docker logs `docker ps -aqf "name=hh-l1-deployer"` > build-hh-l1-deployer.out 2>&1
 
       # This will fail some deletions due to resource dependencies ( ie. you must first delete the vm before deleting the disk)
       - name: 'Delete deployed VMs'
@@ -142,7 +141,7 @@ jobs:
           inlineScript: |
             $(az resource list --tag ${{env.RESOURCE_TAG_NAME}}=true --query '[]."id"' -o tsv | xargs -n1 az resource delete --verbose -g Testnet --ids) || true
 
-      - name: 'Upload build step container logs'
+      - name: 'Upload container logs on failure'
         uses: actions/upload-artifact@v3
         if: failure()
         with:

--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -125,7 +125,7 @@ jobs:
       - name: 'Save container logs on failure'
         if: failure()
         run: |
-          docker logs `docker ps -aqf "name=hh-l1-deployer"` > build-hh-l1-deployer.out 2>&1
+          docker logs `docker ps -aqf "name=hh-l1-deployer"` > deploy-l1-contracts.out 2>&1
 
       # This will fail some deletions due to resource dependencies ( ie. you must first delete the vm before deleting the disk)
       - name: 'Delete deployed VMs'
@@ -145,9 +145,9 @@ jobs:
         uses: actions/upload-artifact@v3
         if: failure()
         with:
-          name: build-artifacts
+          name: deploy-l1-artifacts
           path: |
-            build-*.out
+            deploy-l1-contracts.out
           retention-days: 2
 
   deploy:
@@ -322,6 +322,20 @@ jobs:
           -private_key=${{ secrets.GETHNETWORK_PREFUNDED_PKSTR_WORKER }} \
           -message_bus_contract_addr=${{ needs.build.outputs.MSG_BUS_CONTRACT_ADDR }} \
           -docker_image=${{needs.build.outputs.L2_HARDHATDEPLOYER_DOCKER_BUILD_TAG}}
+
+      - name: 'Save container logs on failure'
+        if: failure()
+        run: |
+          docker logs `docker ps -aqf "name=hh-l2-deployer"` > deploy-l2-contracts.out 2>&1
+
+      - name: 'Upload container logs on failure'
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: deploy-l2-artifacts
+          path: |
+            deploy-l2-contracts.out
+          retention-days: 2
 
   deploy-faucet:
     runs-on: ubuntu-latest

--- a/testnet/launcher/l1contractdeployer/docker.go
+++ b/testnet/launcher/l1contractdeployer/docker.go
@@ -65,7 +65,7 @@ func (n *ContractDeployer) RetrieveL1ContractAddresses() (string, string, error)
 	defer cli.Close()
 
 	// make sure the container has finished execution
-	err = docker.WaitForContainerToFinish(n.containerID, time.Minute)
+	err = docker.WaitForContainerToFinish(n.containerID, 2*time.Minute)
 	if err != nil {
 		return "", "", err
 	}

--- a/testnet/launcher/l1contractdeployer/docker.go
+++ b/testnet/launcher/l1contractdeployer/docker.go
@@ -65,7 +65,7 @@ func (n *ContractDeployer) RetrieveL1ContractAddresses() (string, string, error)
 	defer cli.Close()
 
 	// make sure the container has finished execution
-	err = docker.WaitForContainerToFinish(n.containerID, 2*time.Minute)
+	err = docker.WaitForContainerToFinish(n.containerID, time.Minute)
 	if err != nil {
 		return "", "", err
 	}


### PR DESCRIPTION
### Why this change is needed

On failure of the L1 or L2 contract deployment, extract and uploads the container logs as build artifacts so we can diagnose from the action UI. 

