### PR TITLE
Wrap levelDB so its error types don't leak into our codebase

### DIFF
--- a/go/host/db/batches.go
+++ b/go/host/db/batches.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/syndtr/goleveldb/leveldb"
-
 	"github.com/ethereum/go-ethereum/ethdb"
 
 	"github.com/obscuronet/go-obscuro/go/common/errutil"
@@ -23,9 +21,6 @@ import (
 func (db *DB) GetHeadBatchHeader() (*common.BatchHeader, error) {
 	headBatchHash, err := db.readHeadBatchHash()
 	if err != nil {
-		if errors.Is(err, leveldb.ErrNotFound) { // todo: checking for impl specific error at this level feels like the abstractions are wrong
-			return nil, errutil.ErrNotFound
-		}
 		return nil, err
 	}
 	return db.readBatchHeader(*headBatchHash)
@@ -153,9 +148,6 @@ func batchNumberKey(txHash gethcommon.Hash) []byte {
 func (db *DB) readBatchHeader(hash gethcommon.Hash) (*common.BatchHeader, error) {
 	data, err := db.kvStore.Get(batchHeaderKey(hash))
 	if err != nil {
-		if errors.Is(err, leveldb.ErrNotFound) {
-			return nil, errutil.ErrNotFound
-		}
 		return nil, err
 	}
 	if len(data) == 0 {
@@ -172,9 +164,6 @@ func (db *DB) readBatchHeader(hash gethcommon.Hash) (*common.BatchHeader, error)
 func (db *DB) readHeadBatchHash() (*gethcommon.Hash, error) {
 	value, err := db.kvStore.Get(headBatch)
 	if err != nil {
-		if errors.Is(err, leveldb.ErrNotFound) {
-			return nil, errutil.ErrNotFound
-		}
 		return nil, err
 	}
 	h := gethcommon.BytesToHash(value)
@@ -217,9 +206,6 @@ func (db *DB) writeBatchHash(w ethdb.KeyValueWriter, header *common.BatchHeader)
 func (db *DB) readBatchHash(number *big.Int) (*gethcommon.Hash, error) {
 	data, err := db.kvStore.Get(batchHashKey(number))
 	if err != nil {
-		if errors.Is(err, leveldb.ErrNotFound) {
-			return nil, errutil.ErrNotFound
-		}
 		return nil, err
 	}
 	if len(data) == 0 {
@@ -233,9 +219,6 @@ func (db *DB) readBatchHash(number *big.Int) (*gethcommon.Hash, error) {
 func (db *DB) readBatchTxHashes(batchHash common.L2RootHash) ([]gethcommon.Hash, error) {
 	data, err := db.kvStore.Get(batchTxHashesKey(batchHash))
 	if err != nil {
-		if errors.Is(err, leveldb.ErrNotFound) {
-			return nil, errutil.ErrNotFound
-		}
 		return nil, err
 	}
 	if len(data) == 0 {
@@ -276,9 +259,6 @@ func (db *DB) writeBatchTxHashes(w ethdb.KeyValueWriter, batchHash common.L2Root
 func (db *DB) readBatchNumber(txHash gethcommon.Hash) (*big.Int, error) {
 	data, err := db.kvStore.Get(batchNumberKey(txHash))
 	if err != nil {
-		if errors.Is(err, leveldb.ErrNotFound) {
-			return nil, errutil.ErrNotFound
-		}
 		return nil, err
 	}
 	if len(data) == 0 {
@@ -291,7 +271,7 @@ func (db *DB) readBatchNumber(txHash gethcommon.Hash) (*big.Int, error) {
 func (db *DB) readTotalTransactions() (*big.Int, error) {
 	data, err := db.kvStore.Get(totalTransactionsKey)
 	if err != nil {
-		if errors.Is(err, errutil.ErrNotFound) || errors.Is(err, leveldb.ErrNotFound) {
+		if errors.Is(err, errutil.ErrNotFound) {
 			return big.NewInt(0), nil
 		}
 		return nil, err
@@ -330,9 +310,6 @@ func (db *DB) writeBatch(batch *common.ExtBatch) error {
 func (db *DB) readBatch(hash gethcommon.Hash) (*common.ExtBatch, error) {
 	data, err := db.kvStore.Get(batchKey(hash))
 	if err != nil {
-		if errors.Is(err, leveldb.ErrNotFound) {
-			return nil, errutil.ErrNotFound
-		}
 		return nil, err
 	}
 	if len(data) == 0 {

--- a/go/host/db/blocks.go
+++ b/go/host/db/blocks.go
@@ -2,10 +2,7 @@ package db
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
-
-	"github.com/syndtr/goleveldb/leveldb"
 
 	"github.com/obscuronet/go-obscuro/go/common/errutil"
 
@@ -61,9 +58,6 @@ func (db *DB) writeBlockHeader(header *types.Header) error {
 func (db *DB) readBlockHeader(r ethdb.KeyValueReader, hash gethcommon.Hash) (*types.Header, error) {
 	data, err := r.Get(blockHeaderKey(hash))
 	if err != nil {
-		if errors.Is(err, leveldb.ErrNotFound) {
-			return nil, errutil.ErrNotFound
-		}
 		return nil, err
 	}
 	if len(data) == 0 {

--- a/go/host/db/hostdb.go
+++ b/go/host/db/hostdb.go
@@ -93,7 +93,7 @@ func NewLevelDBBackedDB(dbPath string, regMetrics gethmetrics.Registry, logger g
 		return nil, fmt.Errorf("could not create leveldb - %w", err)
 	}
 	logger.Info(fmt.Sprintf("Opened %s level db dir at %s", dbDesc, dbPath))
-	return newDB(db, regMetrics, logger), nil
+	return newDB(&ObscuroLevelDB{db: db}, regMetrics, logger), nil
 }
 
 func newDB(kvStore ethdb.KeyValueStore, regMetrics gethmetrics.Registry, logger gethlog.Logger) *DB {

--- a/go/host/db/leveldb.go
+++ b/go/host/db/leveldb.go
@@ -1,0 +1,60 @@
+package db
+
+import (
+	"errors"
+
+	"github.com/ethereum/go-ethereum/ethdb"
+	ethldb "github.com/ethereum/go-ethereum/ethdb/leveldb"
+	"github.com/obscuronet/go-obscuro/go/common/errutil"
+	"github.com/syndtr/goleveldb/leveldb"
+)
+
+// ObscuroLevelDB is a very thin wrapper around a level DB database for compatibility with our internal interfaces
+// In particular, it overrides the Get method to return the obscuro ErrNotFound
+type ObscuroLevelDB struct {
+	db *ethldb.Database
+}
+
+func (o *ObscuroLevelDB) Has(key []byte) (bool, error) {
+	return o.db.Has(key)
+}
+
+// Get is overridden here to return our internal NotFound error
+func (o *ObscuroLevelDB) Get(key []byte) ([]byte, error) {
+	d, err := o.db.Get(key)
+	if err != nil {
+		if errors.Is(err, leveldb.ErrNotFound) {
+			return nil, errutil.ErrNotFound
+		}
+		return nil, err
+	}
+	return d, nil
+}
+
+func (o *ObscuroLevelDB) Put(key []byte, value []byte) error {
+	return o.db.Put(key, value)
+}
+
+func (o *ObscuroLevelDB) Delete(key []byte) error {
+	return o.db.Delete(key)
+}
+
+func (o *ObscuroLevelDB) NewBatch() ethdb.Batch {
+	return o.db.NewBatch()
+}
+
+func (o *ObscuroLevelDB) NewIterator(prefix []byte, start []byte) ethdb.Iterator {
+	return o.db.NewIterator(prefix, start)
+}
+
+func (o *ObscuroLevelDB) Stat(property string) (string, error) {
+	return o.db.Stat(property)
+}
+
+func (o *ObscuroLevelDB) Compact(start []byte, limit []byte) error {
+	return o.db.Compact(start, limit)
+}
+
+func (o *ObscuroLevelDB) Close() error {
+	return o.db.Close()
+}


### PR DESCRIPTION
### Why this change is needed

Follow-up to yesterday's PR adding persistence to host

### What changes were made as part of this PR

Wrap levelDB with thin wrapper that returns our own errNotFound

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [x] PR checks reviewed and performed 


