### PR TITLE
Run a schedule deploy on the L1, and trigger L2 if succesful

### DIFF
--- a/.github/workflows/manual-deploy-testnet-l1.yml
+++ b/.github/workflows/manual-deploy-testnet-l1.yml
@@ -14,6 +14,8 @@
 name: '[M] Deploy Testnet L1'
 
 on:
+  schedule:
+    - cron: '05 3 * * *'
   workflow_dispatch:
     inputs:
       testnet_type:
@@ -40,8 +42,8 @@ jobs:
           echo "L1_DOCKER_BUILD_TAG=testnetobscuronet.azurecr.io/obscuronet/testnet_l1network:latest" >> $GITHUB_ENV
           echo "L1_CONTAINER_NAME=testnet-eth2network" >> $GITHUB_ENV
 
-      - name: 'Sets env vars for dev-tesnet'
-        if: ${{ github.event.inputs.testnet_type == 'dev-testnet' }}
+      - name: 'Sets env vars for dev-testnet'
+        if: ${{ github.event.inputs.testnet_type == 'dev-testnet' || (github.event_name == 'schedule') }}
         run: |
           echo "L1_DOCKER_BUILD_TAG=testnetobscuronet.azurecr.io/obscuronet/dev_testnet_l1network:latest" >> $GITHUB_ENV
           echo "L1_CONTAINER_NAME=dev-testnet-eth2network" >> $GITHUB_ENV
@@ -96,3 +98,8 @@ jobs:
           ports: '8025 8026 9000 9001'
           cpu: 2
           memory: 8
+
+      - name: 'Dispatch trigger'
+        if: ${{ github.event_name == 'schedule' }}
+        run: |
+          curl -XPOST -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" -H "Accept:application/vnd.github" -H "Content-Type:application/json" https://api.github.com/repos/obscuronet/go-obscuro/dispatches --data '{ "event_type": "l1_dev_deployment", "client_payload": { "ref": "main", "env": : "dev-testnet" }'

--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -1,16 +1,16 @@
 # Deploys an Obscuro network on Azure for Testnet and Dev Testnet
 #
 # The Obscuro network is composed of 2 obscuro nodes running on individual vms with SGX. At the moment the workflow
-# can either be triggered manually as a workflow dispatch, or as a scheduled task. When manually triggered the
-# testnet type (dev-testnet or testnet) can be supplied as an input argument. When triggered as a scheduled task,
-# we always default to a dev-testnet deployment. A scheduled deployment of dev-testnet will additionally kick off
+# can either be triggered manually as a workflow dispatch, or as a repository dispatch task. When manually triggered the
+# testnet type (dev-testnet or testnet) can be supplied as an input argument. When triggered as a repository dispatch task,
+# we always default to a dev-testnet deployment. A repository dispatch deployment of dev-testnet will additionally kick off
 # the E2E tests via a repository dispatch.
 #
 
 name: '[M] Deploy Testnet L2'
 on:
-  schedule:
-    - cron: '05 4 * * *'
+  repository_dispatch:
+    types: [l1_dev_deployment]
   workflow_dispatch:
     inputs:
       testnet_type:
@@ -65,7 +65,7 @@ jobs:
           echo "L1_HOST=testnet-eth2network.uksouth.azurecontainer.io" >> $GITHUB_ENV
 
       - name: 'Sets env vars for dev-testnet'
-        if: ${{ (github.event.inputs.testnet_type == 'dev-testnet') || (github.event_name == 'schedule') }}
+        if: ${{ (github.event.inputs.testnet_type == 'dev-testnet') || (github.event_name == 'repository_dispatch') }}
         run: |
           echo "L2_ENCLAVE_DOCKER_BUILD_TAG=testnetobscuronet.azurecr.io/obscuronet/dev_enclave:latest" >> $GITHUB_ENV
           echo "L2_HOST_DOCKER_BUILD_TAG=testnetobscuronet.azurecr.io/obscuronet/dev_host:latest" >> $GITHUB_ENV
@@ -348,8 +348,8 @@ jobs:
         run: |
           curl -XPOST -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" -H "Accept:application/vnd.github" -H "Content-Type:application/json" https://api.github.com/repos/obscuronet/faucet/actions/workflows/manual-deploy-${{ github.event.inputs.testnet_type }}-faucet.yml/dispatches --data '{"ref": "main" }'
 
-      - name: 'Trigger Faucet deployment on schedule'
-        if: ${{ github.event_name == 'schedule' }}
+      - name: 'Trigger Faucet deployment on repository_dispatch'
+        if: ${{ github.event_name == 'repository_dispatch' }}
         run: |
           curl -XPOST -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" -H "Accept:application/vnd.github" -H "Content-Type:application/json" https://api.github.com/repos/obscuronet/faucet/actions/workflows/manual-deploy-dev-testnet-faucet.yml/dispatches --data '{"ref": "main" }'
 
@@ -358,7 +358,7 @@ jobs:
     needs:
       - deploy-faucet
     steps:
-      - name: 'Run E2E tests on schedule trigger after successful deployment of dev-testnet'
-        if: ${{ github.event_name == 'schedule' }}
+      - name: 'Run E2E tests on repository_dispatch trigger after successful deployment of dev-testnet'
+        if: ${{ github.event_name == 'repository_dispatch' }}
         run: |
            curl -XPOST -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" -H "Accept:application/vnd.github" -H "Content-Type:application/json" https://api.github.com/repos/obscuronet/obscuro-test/dispatches --data '{ "event_type": "scheduled_deployment", "client_payload": { "ref": "main", "env": : "dev-testnet" }'


### PR DESCRIPTION
### Why this change is needed

We need to schedule L1 deployment followed by L2, rather than just doing an L2 deployment nightly. This adds a schedule trigger to L1 to deploy into dev-testnet, and if successul it will send a repository dispatch to perform the L2 deployment. 