### PR TITLE
Enclave should not be automatically stopped when host stopping

### DIFF
--- a/go/enclave/container/enclave_container.go
+++ b/go/enclave/container/enclave_container.go
@@ -37,6 +37,11 @@ func (e *EnclaveContainer) Start() error {
 func (e *EnclaveContainer) Stop() error {
 	_, err := e.RPCServer.Stop(context.Background(), nil)
 	if err != nil {
+		e.Logger.Warn("unable to cleanly stop enclave RPC server", log.ErrKey, err)
+		return err
+	}
+	err = e.Enclave.Stop()
+	if err != nil {
 		e.Logger.Warn("unable to cleanly stop enclave", log.ErrKey, err)
 		return err
 	}

--- a/go/enclave/rpc_server.go
+++ b/go/enclave/rpc_server.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net"
-
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/obscuronet/go-obscuro/go/common"
@@ -15,6 +13,7 @@ import (
 	"github.com/obscuronet/go-obscuro/go/common/rpc/generated"
 	"github.com/obscuronet/go-obscuro/go/enclave/evm"
 	"google.golang.org/grpc"
+	"net"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	gethlog "github.com/ethereum/go-ethereum/log"
@@ -154,7 +153,8 @@ func (s *RPCServer) GetTransactionCount(_ context.Context, request *generated.Ge
 }
 
 func (s *RPCServer) Stop(context.Context, *generated.StopRequest) (*generated.StopResponse, error) {
-	defer s.grpcServer.GracefulStop()
+	// if we want to use grpcServer.GracefulShutdown here we need to set a timeout and then call Stop() afterwards
+	s.grpcServer.Stop()
 	err := s.enclave.Stop()
 	return &generated.StopResponse{}, err
 }

--- a/go/enclave/rpc_server.go
+++ b/go/enclave/rpc_server.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
+
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/obscuronet/go-obscuro/go/common"
@@ -13,7 +15,6 @@ import (
 	"github.com/obscuronet/go-obscuro/go/common/rpc/generated"
 	"github.com/obscuronet/go-obscuro/go/enclave/evm"
 	"google.golang.org/grpc"
-	"net"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	gethlog "github.com/ethereum/go-ethereum/log"

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -279,9 +279,6 @@ func (h *host) Stop() {
 	if err := h.p2p.StopListening(); err != nil {
 		h.logger.Error("failed to close transaction P2P listener cleanly", log.ErrKey, err)
 	}
-	if err := h.enclaveClient.Stop(); err != nil {
-		h.logger.Error("could not stop enclave server", log.ErrKey, err)
-	}
 	if err := h.enclaveClient.StopClient(); err != nil {
 		h.logger.Error("failed to stop enclave RPC client", log.ErrKey, err)
 	}

--- a/integration/noderunner/noderunner_test.go
+++ b/integration/noderunner/noderunner_test.go
@@ -86,8 +86,9 @@ func TestCanStartStandaloneObscuroHostAndEnclave(t *testing.T) {
 		panic(err)
 	}
 
+	enclave := enclavecontainer.NewEnclaveContainerFromConfig(enclaveConfig)
 	go func() {
-		err := enclavecontainer.NewEnclaveContainerFromConfig(enclaveConfig).Start()
+		err := enclave.Start()
 		if err != nil {
 			panic(err)
 		}
@@ -114,9 +115,11 @@ func TestCanStartStandaloneObscuroHostAndEnclave(t *testing.T) {
 		wait--
 	}
 	defer func() {
-		// the container stops the enclave
 		if err = hostContainer.Stop(); err != nil {
-			t.Fatal("unable to properly stop the host container")
+			t.Fatal("unable to properly stop the host container", err)
+		}
+		if err = enclave.Stop(); err != nil {
+			t.Fatal("unable to properly stop the enclave", err)
 		}
 	}()
 


### PR DESCRIPTION
### Why this change is needed

I don't think the lifecycles of host and enclave are so tightly coupled that we should always attempt to shutdown the enclave when shutting down the host.

When node operator starts up they start the enclave then the host, it would be cleaner I think to be able to shutdown the host then the enclave cleanly.

### What changes were made as part of this PR

Remover enclave stop from host `Stop()`

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


