### PR TITLE
Add test that restarts the host as well as the enclave

### DIFF
--- a/integration/networktest/actions/node_actions.go
+++ b/integration/networktest/actions/node_actions.go
@@ -2,6 +2,7 @@ package actions
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/obscuronet/go-obscuro/go/common/retry"
@@ -17,6 +18,7 @@ type startValidatorEnclaveAction struct {
 }
 
 func (s *startValidatorEnclaveAction) Run(ctx context.Context, network networktest.NetworkConnector) (context.Context, error) {
+	fmt.Printf("Validator %d: starting enclave\n", s.validatorIdx)
 	validator := network.GetValidatorNode(s.validatorIdx)
 	err := validator.StartEnclave()
 	if err != nil {
@@ -38,6 +40,7 @@ type stopValidatorEnclaveAction struct {
 }
 
 func (s *stopValidatorEnclaveAction) Run(ctx context.Context, network networktest.NetworkConnector) (context.Context, error) {
+	fmt.Printf("Validator %d: stopping enclave\n", s.validatorIdx)
 	validator := network.GetValidatorNode(s.validatorIdx)
 	err := validator.StopEnclave()
 	if err != nil {
@@ -48,6 +51,30 @@ func (s *stopValidatorEnclaveAction) Run(ctx context.Context, network networktes
 
 func (s *stopValidatorEnclaveAction) Verify(_ context.Context, _ networktest.NetworkConnector) error {
 	return nil
+}
+
+func StopValidatorHost(validatorIdx int) networktest.Action {
+	return NoStateNoVerifyAction(func(ctx context.Context, network networktest.NetworkConnector) (context.Context, error) {
+		fmt.Printf("Validator %d: stopping host\n", validatorIdx)
+		validator := network.GetValidatorNode(validatorIdx)
+		err := validator.StopHost()
+		if err != nil {
+			return nil, err
+		}
+		return ctx, nil
+	})
+}
+
+func StartValidatorHost(validatorIdx int) networktest.Action {
+	return NoStateNoVerifyAction(func(ctx context.Context, network networktest.NetworkConnector) (context.Context, error) {
+		fmt.Printf("Validator %d: starting host\n", validatorIdx)
+		validator := network.GetValidatorNode(validatorIdx)
+		err := validator.StartHost()
+		if err != nil {
+			return nil, err
+		}
+		return ctx, nil
+	})
 }
 
 func WaitForValidatorHealthCheck(validatorIdx int, maxWait time.Duration) networktest.Action {

--- a/integration/networktest/tests/nodescenario/restart_validator_test.go
+++ b/integration/networktest/tests/nodescenario/restart_validator_test.go
@@ -10,10 +10,11 @@ import (
 	"github.com/obscuronet/go-obscuro/integration/networktest/env"
 )
 
-func TestRestartValidatorEnclave(t *testing.T) {
+// restart both the host and the enclave for a validator
+func TestRestartValidatorNode(t *testing.T) {
 	networktest.TestOnlyRunsInIDE(t)
 	networktest.Run(
-		"restart-enclave",
+		"restart-node",
 		t,
 		env.LocalDevNetwork(),
 		actions.Series(
@@ -22,10 +23,14 @@ func TestRestartValidatorEnclave(t *testing.T) {
 			// short load test, build up some state
 			actions.GenerateUsersRandomisedTransferActionsInParallel(4, 10*time.Second),
 
-			// restart enclave on a validator
+			actions.SleepAction(10*time.Second), // allow time for in-flight transactions
+
+			// restart host and enclave on a validator
 			actions.StopValidatorEnclave(1),
+			actions.StopValidatorHost(1),
 			actions.SleepAction(5*time.Second), // allow time for shutdown
 			actions.StartValidatorEnclave(1),
+			actions.StartValidatorHost(1),
 			actions.WaitForValidatorHealthCheck(1, 30*time.Second),
 
 			// todo: we often see 1 transaction getting lost without this sleep after the node restarts.


### PR DESCRIPTION
### Why this change is needed

We had no demonstration that a host could be restarted and reconnect.

### What changes were made as part of this PR

Add test that restarts a whole validator node locally and then is able to resync and serve clients

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


