### PR TITLE
Trigger a repository dispatch to the faucet

### DIFF
--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -351,14 +351,4 @@ jobs:
       - name: 'Trigger Faucet deployment on repository_dispatch'
         if: ${{ github.event_name == 'repository_dispatch' }}
         run: |
-          curl -XPOST -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" -H "Accept:application/vnd.github" -H "Content-Type:application/json" https://api.github.com/repos/obscuronet/faucet/actions/workflows/manual-deploy-dev-testnet-faucet.yml/dispatches --data '{"ref": "main" }'
-
-  run-e2e-tests:
-    runs-on: ubuntu-latest
-    needs:
-      - deploy-faucet
-    steps:
-      - name: 'Run E2E tests on repository_dispatch trigger after successful deployment of dev-testnet'
-        if: ${{ github.event_name == 'repository_dispatch' }}
-        run: |
-           curl -XPOST -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" -H "Accept:application/vnd.github" -H "Content-Type:application/json" https://api.github.com/repos/obscuronet/obscuro-test/dispatches --data '{ "event_type": "scheduled_deployment", "client_payload": { "ref": "main", "env": "dev-testnet" }'
+          curl -XPOST -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" -H "Accept:application/vnd.github" -H "Content-Type:application/json" https://api.github.com/repos/obscuronet/faucet/dispatches --data '{ "event_type": "l2_dev_deployment", "client_payload": { "ref": "main", "env": "dev-testnet" }'


### PR DESCRIPTION
### Why this change is needed

When a nightly deployment is complete we want the trigger to the faucet deployment to be a repository dispatch, so we can use the faucet to trigger the end to end tests