### PR TITLE
Add basic L1 sanity check to networktests tools

### DIFF
--- a/integration/networktest/actions/node_actions.go
+++ b/integration/networktest/actions/node_actions.go
@@ -54,7 +54,7 @@ func (s *stopValidatorEnclaveAction) Verify(_ context.Context, _ networktest.Net
 }
 
 func StopValidatorHost(validatorIdx int) networktest.Action {
-	return NoStateNoVerifyAction(func(ctx context.Context, network networktest.NetworkConnector) (context.Context, error) {
+	return RunOnlyAction(func(ctx context.Context, network networktest.NetworkConnector) (context.Context, error) {
 		fmt.Printf("Validator %d: stopping host\n", validatorIdx)
 		validator := network.GetValidatorNode(validatorIdx)
 		err := validator.StopHost()
@@ -66,7 +66,7 @@ func StopValidatorHost(validatorIdx int) networktest.Action {
 }
 
 func StartValidatorHost(validatorIdx int) networktest.Action {
-	return NoStateNoVerifyAction(func(ctx context.Context, network networktest.NetworkConnector) (context.Context, error) {
+	return RunOnlyAction(func(ctx context.Context, network networktest.NetworkConnector) (context.Context, error) {
 		fmt.Printf("Validator %d: starting host\n", validatorIdx)
 		validator := network.GetValidatorNode(validatorIdx)
 		err := validator.StartHost()

--- a/integration/networktest/actions/setup_actions.go
+++ b/integration/networktest/actions/setup_actions.go
@@ -67,7 +67,7 @@ func CreateAndFundTestUsers(numUsers int) *MultiAction {
 }
 
 func AuthenticateAllUsers() networktest.Action {
-	return NoStateNoVerifyAction(func(ctx context.Context, network networktest.NetworkConnector) (context.Context, error) {
+	return RunOnlyAction(func(ctx context.Context, network networktest.NetworkConnector) (context.Context, error) {
 		numUsers, err := FetchNumberOfTestUsers(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("expected number of test users to be set on the context")

--- a/integration/networktest/actions/snapshot_actions.go
+++ b/integration/networktest/actions/snapshot_actions.go
@@ -32,7 +32,7 @@ func FetchBalanceAtSnapshot(ctx context.Context, userID int, snapshot string) (*
 // SnapshotUserBalances requests and records the curr users native balances in the context
 // Note: when running this ensure that there are no transactions in flight if that will affect usage of this data
 func SnapshotUserBalances(snapshot string) networktest.Action {
-	return NoStateNoVerifyAction(func(ctx context.Context, network networktest.NetworkConnector) (context.Context, error) {
+	return RunOnlyAction(func(ctx context.Context, network networktest.NetworkConnector) (context.Context, error) {
 		numUsers, err := FetchNumberOfTestUsers(ctx)
 		if err != nil {
 			return nil, err

--- a/integration/networktest/actions/util_actions.go
+++ b/integration/networktest/actions/util_actions.go
@@ -54,12 +54,12 @@ type (
 	VerifyFunc func(ctx context.Context, network networktest.NetworkConnector) error
 )
 
-// NoStateNoVerifyAction allows you to create an action quickly with an in-line function when it doesn't need state or a verify method
-func NoStateNoVerifyAction(run RunFunc) networktest.Action {
+// RunOnlyAction allows you to create an action quickly with an in-line function when it doesn't need state or a verify method
+func RunOnlyAction(run RunFunc) networktest.Action {
 	return &basicAction{run: run}
 }
 
-// VerifyOnlyAction allows you to create an action quickly with an in-line function when it doesn't need state or a verify method
+// VerifyOnlyAction allows you to create a test verification quickly with an in-line function when it doesn't need state or a run method
 func VerifyOnlyAction(verify VerifyFunc) networktest.Action {
 	return &basicAction{verify: verify}
 }

--- a/integration/networktest/env/network_setup.go
+++ b/integration/networktest/env/network_setup.go
@@ -9,6 +9,8 @@ func Testnet() networktest.Environment {
 		"http://testnet.obscu.ro:13000",
 		[]string{"http://testnet.obscu.ro:13000"}, // for now we'll just use sequencer as validator node... (todo)
 		"http://testnet-faucet.uksouth.azurecontainer.io/fund/obx",
+		"testnet-eth2network.uksouth.azurecontainer.io",
+		9000,
 	)
 	return &testnetEnv{connector}
 }
@@ -18,6 +20,8 @@ func DevTestnet() networktest.Environment {
 		"http://dev-testnet.obscu.ro:13000",
 		[]string{"http://dev-testnet.obscu.ro:13000"}, // for now we'll just use sequencer as validator node... (todo)
 		"http://dev-testnet-faucet.uksouth.azurecontainer.io/fund/obx",
+		"dev-testnet-eth2network.uksouth.azurecontainer.io",
+		9000,
 	)
 	return &testnetEnv{connector}
 }

--- a/integration/networktest/env/testnet.go
+++ b/integration/networktest/env/testnet.go
@@ -6,6 +6,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
+
+	"github.com/obscuronet/go-obscuro/go/ethadapter"
+	"github.com/obscuronet/go-obscuro/integration/common/testlog"
 
 	"github.com/obscuronet/go-obscuro/integration"
 
@@ -17,13 +21,17 @@ type testnetConnector struct {
 	seqRPCAddress         string
 	validatorRPCAddresses []string
 	faucetHTTPAddress     string
+	l1Host                string
+	l1HttpPort            uint
 }
 
-func NewTestnetConnector(seqRPCAddr string, validatorRPCAddressses []string, faucetHTTPAddress string) networktest.NetworkConnector {
+func NewTestnetConnector(seqRPCAddr string, validatorRPCAddressses []string, faucetHTTPAddress string, l1Host string, l1Port uint) networktest.NetworkConnector {
 	return &testnetConnector{
 		seqRPCAddress:         seqRPCAddr,
 		validatorRPCAddresses: validatorRPCAddressses,
 		faucetHTTPAddress:     faucetHTTPAddress,
+		l1Host:                l1Host,
+		l1HttpPort:            l1Port,
 	}
 }
 
@@ -60,6 +68,14 @@ func (t *testnetConnector) ValidatorRPCAddress(idx int) string {
 
 func (t *testnetConnector) NumValidators() int {
 	return len(t.validatorRPCAddresses)
+}
+
+func (t *testnetConnector) GetL1Client() (ethadapter.EthClient, error) {
+	client, err := ethadapter.NewEthClient(t.l1Host, t.l1HttpPort, time.Minute, gethcommon.Address{}, testlog.Logger())
+	if err != nil {
+		return nil, err
+	}
+	return client, nil
 }
 
 func (t *testnetConnector) GetSequencerNode() networktest.NodeOperator {

--- a/integration/networktest/interfaces.go
+++ b/integration/networktest/interfaces.go
@@ -3,6 +3,8 @@ package networktest
 import (
 	"context"
 
+	"github.com/obscuronet/go-obscuro/go/ethadapter"
+
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -18,6 +20,7 @@ type NetworkConnector interface {
 	NumValidators() int
 	GetSequencerNode() NodeOperator
 	GetValidatorNode(idx int) NodeOperator
+	GetL1Client() (ethadapter.EthClient, error)
 }
 
 // Action is any step in a test, they will typically be either minimally small steps in the test or they will be containers

--- a/integration/networktest/tests/helpful/l1_test.go
+++ b/integration/networktest/tests/helpful/l1_test.go
@@ -1,0 +1,44 @@
+package helpful
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/obscuronet/go-obscuro/integration/networktest"
+	"github.com/obscuronet/go-obscuro/integration/networktest/actions"
+	"github.com/obscuronet/go-obscuro/integration/networktest/env"
+)
+
+// super basic test that verifies it can connect to the L1 client and sees block numbers increasing (useful to sanity check testnet issues etc.)
+func TestL1IsAvailableAndProducingBlocks(t *testing.T) {
+	networktest.TestOnlyRunsInIDE(t)
+	networktest.Run(
+		"l1-availability",
+		t,
+		env.DevTestnet(),
+		actions.RunOnlyAction(func(ctx context.Context, network networktest.NetworkConnector) (context.Context, error) {
+			client, err := network.GetL1Client()
+			if err != nil {
+				return nil, err
+			}
+			blockStart, err := client.BlockNumber()
+			if err != nil {
+				return nil, err
+			}
+			fmt.Println("current block", blockStart)
+			time.Sleep(20 * time.Second)
+
+			blockEnd, err := client.BlockNumber()
+			if err != nil {
+				return nil, err
+			}
+			fmt.Println("current block", blockEnd)
+			if blockEnd <= blockStart {
+				return nil, fmt.Errorf("expected blocks to be increasing but went from %d to %d after 20secs", blockStart, blockEnd)
+			}
+			return ctx, nil
+		}),
+	)
+}

--- a/integration/simulation/devnetwork/dev_network.go
+++ b/integration/simulation/devnetwork/dev_network.go
@@ -84,6 +84,9 @@ func (s *InMemDevNetwork) ValidatorRPCAddress(idx int) string {
 	return val.HostRPCAddress()
 }
 
+// GetL1Client returns the first client we have for our local L1 network
+// todo: this allows tests some basic L1 verification but in future this will need support more manipulation of L1 nodes,
+//  (to allow us to simulate various scenarios where L1 is unavailable, under attack, etc.)
 func (s *InMemDevNetwork) GetL1Client() (ethadapter.EthClient, error) {
 	return s.l1Network.GetClient(0), nil
 }

--- a/integration/simulation/devnetwork/dev_network.go
+++ b/integration/simulation/devnetwork/dev_network.go
@@ -7,6 +7,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/obscuronet/go-obscuro/go/ethadapter"
+
 	"github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/obscuronet/go-obscuro/integration/networktest/userwallet"
@@ -80,6 +82,10 @@ func (s *InMemDevNetwork) SequencerRPCAddress() string {
 func (s *InMemDevNetwork) ValidatorRPCAddress(idx int) string {
 	val := s.GetValidatorNode(idx)
 	return val.HostRPCAddress()
+}
+
+func (s *InMemDevNetwork) GetL1Client() (ethadapter.EthClient, error) {
+	return s.l1Network.GetClient(0), nil
 }
 
 func (s *InMemDevNetwork) GetSequencerNode() networktest.NodeOperator {

--- a/integration/simulation/devnetwork/dev_network.go
+++ b/integration/simulation/devnetwork/dev_network.go
@@ -86,7 +86,8 @@ func (s *InMemDevNetwork) ValidatorRPCAddress(idx int) string {
 
 // GetL1Client returns the first client we have for our local L1 network
 // todo: this allows tests some basic L1 verification but in future this will need support more manipulation of L1 nodes,
-//  (to allow us to simulate various scenarios where L1 is unavailable, under attack, etc.)
+//
+//	(to allow us to simulate various scenarios where L1 is unavailable, under attack, etc.)
 func (s *InMemDevNetwork) GetL1Client() (ethadapter.EthClient, error) {
 	return s.l1Network.GetClient(0), nil
 }


### PR DESCRIPTION
- add L1 client to network connector interface (we'll need that to test bridging etc. with L1 transactions)
- add basic liveness test for L1 so we can quickly verify when the L1 is up for testnets
- rename the 'RunOnly' test action so it's more obvious and consistent with the VerifyOnly

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [x] PR checks reviewed and performed 


