### PR TITLE
Add buildkit to docker update step

### DIFF
--- a/.github/workflows/manual-upgrade-testnet-l2.yml
+++ b/.github/workflows/manual-upgrade-testnet-l2.yml
@@ -78,9 +78,9 @@ jobs:
 
       - name: 'Build and push obscuro node images'
         run: |
-          docker build -t ${{env.L2_ENCLAVE_DOCKER_BUILD_TAG}} -f dockerfiles/enclave.Dockerfile  .
+          DOCKER_BUILDKIT=1 docker build -t ${{env.L2_ENCLAVE_DOCKER_BUILD_TAG}} -f dockerfiles/enclave.Dockerfile  .
           docker push ${{env.L2_ENCLAVE_DOCKER_BUILD_TAG}}
-          docker build -t ${{env.L2_HOST_DOCKER_BUILD_TAG}} -f dockerfiles/host.Dockerfile .
+          DOCKER_BUILDKIT=1 docker build -t ${{env.L2_HOST_DOCKER_BUILD_TAG}} -f dockerfiles/host.Dockerfile .
           docker push ${{env.L2_HOST_DOCKER_BUILD_TAG}}
 
   deploy:


### PR DESCRIPTION
### Why this change is needed

We changed the node start github action script to use DOCKER_BUILDKIT but the upgrade script wasn't updated and failed with a buildkit missing error.

It got further after this change (something else going wrong now).

### What changes were made as part of this PR

Copy the build kit script changes from the testnet deploy action script.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


