### PR TITLE
Wallet extension verbose logging

### DIFF
--- a/tools/walletextension/main/cli.go
+++ b/tools/walletextension/main/cli.go
@@ -39,6 +39,10 @@ const (
 	persistencePathName    = "persistencePath"
 	persistencePathDefault = ""
 	persistencePathUsage   = "The path for the wallet extension's persistence file. Default: ~/.obscuro/wallet_extension_persistence"
+
+	verboseFlagName    = "verbose"
+	verboseFlagDefault = false
+	verboseFlagUsage   = "Flag to enable verbose logging of wallet extension traffic"
 )
 
 func parseCLIArgs() walletextension.Config {
@@ -50,6 +54,7 @@ func parseCLIArgs() walletextension.Config {
 	nodeWebsocketPort := flag.Int(nodeWebsocketPortName, nodeWebsocketPortDefault, nodeWebsocketPortUsage)
 	logPath := flag.String(logPathName, logPathDefault, logPathUsage)
 	persistencePath := flag.String(persistencePathName, persistencePathDefault, persistencePathUsage)
+	verboseFlag := flag.Bool(verboseFlagName, verboseFlagDefault, verboseFlagUsage)
 	flag.Parse()
 
 	return walletextension.Config{
@@ -60,5 +65,6 @@ func parseCLIArgs() walletextension.Config {
 		NodeRPCWebsocketAddress: fmt.Sprintf("%s:%d", *nodeHost, *nodeWebsocketPort),
 		LogPath:                 *logPath,
 		PersistencePathOverride: *persistencePath,
+		VerboseFlag:             *verboseFlag,
 	}
 }

--- a/tools/walletextension/main/main.go
+++ b/tools/walletextension/main/main.go
@@ -53,7 +53,11 @@ func main() {
 		}
 	}
 
-	logger := log.New(log.WalletExtCmp, int(gethlog.LvlError), config.LogPath)
+	logLvl := gethlog.LvlError
+	if config.VerboseFlag {
+		logLvl = gethlog.LvlDebug
+	}
+	logger := log.New(log.WalletExtCmp, int(logLvl), config.LogPath)
 
 	walletExtension := walletextension.NewWalletExtension(config, logger)
 	defer walletExtension.Shutdown()

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -230,6 +230,7 @@ func (we *WalletExtension) handleEthJSON(userConn userconn.UserConn) {
 		userConn.HandleError(err.Error())
 		return
 	}
+	we.logger.Debug("REQUEST", "method", rpcReq.Method, "body", string(body))
 
 	if rpcReq.Method == rpc.Subscribe && !userConn.SupportsSubscriptions() {
 		userConn.HandleError(ErrSubscribeFailHTTP)
@@ -429,4 +430,5 @@ type Config struct {
 	NodeRPCWebsocketAddress string
 	LogPath                 string
 	PersistencePathOverride string // Overrides the persistence file location. Used in tests.
+	VerboseFlag             bool
 }


### PR DESCRIPTION
### Why this change is needed

Want to understand metamask traffic behaviour for debugging purposes

### What changes were made as part of this PR

- add `--verbose` boolean flag
- set logger to debug if true
- add debug log message on receiving each request.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


