### PR TITLE
Set host and enclave loggers to INFO by default

### DIFF
--- a/go/node/docker.go
+++ b/go/node/docker.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"fmt"
+	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/obscuronet/go-obscuro/go/common/docker"
 )
@@ -48,7 +49,7 @@ func (d *DockerNode) startHost() error {
 		"-privateKey", d.cfg.privateKey,
 		"-clientRPCHost", "0.0.0.0",
 		"-logPath", "sys_out",
-		"-logLevel", "4",
+		"-logLevel", fmt.Sprint(log.LvlInfo),
 		fmt.Sprintf("-isGenesis=%t", d.cfg.isGenesis), // boolean are a special case where the = is required
 		"-nodeType", d.cfg.nodeType,
 		"-profilerEnabled=false",
@@ -108,7 +109,7 @@ func (d *DockerNode) startEnclave() error {
 		"-profilerEnabled=false",
 		"-useInMemoryDB=false",
 		"-logPath", "sys_out",
-		"-logLevel", "2",
+		"-logLevel", fmt.Sprint(log.LvlInfo),
 	)
 
 	if d.cfg.sgxEnabled {

--- a/go/node/docker.go
+++ b/go/node/docker.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"fmt"
+
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/obscuronet/go-obscuro/go/common/docker"


### PR DESCRIPTION
### Why this change is needed

At some point the enclave logs on testnet were set above INFO and we started losing visibility of the goings on.

We should continue to reduce logs where possible by selectively downgrading and removing log messages. If we still feel there are too many logs then perhaps we set testnet to WARN but keep dev testnet at INFO level.

### What changes were made as part of this PR

Change default log levels to be human readable and set to INFO in the testnet docker launch script.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


