### PR TITLE
Fix logLvl arg format in testnet script

### DIFF
--- a/go/node/docker.go
+++ b/go/node/docker.go
@@ -50,7 +50,7 @@ func (d *DockerNode) startHost() error {
 		"-privateKey", d.cfg.privateKey,
 		"-clientRPCHost", "0.0.0.0",
 		"-logPath", "sys_out",
-		"-logLevel", fmt.Sprint(log.LvlInfo),
+		"-logLevel", fmt.Sprintf("%d", log.LvlInfo),
 		fmt.Sprintf("-isGenesis=%t", d.cfg.isGenesis), // boolean are a special case where the = is required
 		"-nodeType", d.cfg.nodeType,
 		"-profilerEnabled=false",
@@ -110,7 +110,7 @@ func (d *DockerNode) startEnclave() error {
 		"-profilerEnabled=false",
 		"-useInMemoryDB=false",
 		"-logPath", "sys_out",
-		"-logLevel", fmt.Sprint(log.LvlInfo),
+		"-logLevel", fmt.Sprintf("%d", log.LvlInfo),
 	)
 
 	if d.cfg.sgxEnabled {


### PR DESCRIPTION
https://github.com/obscuronet/go-obscuro/pull/1149 introduced a bug, because of Go magic it was outputting a human readable string instead of the int value for the log level.

So the node start script was failing with `-logLvl info` argument when it expected `-logLvl 4`

This fixes that (verified by starting the nodes on dev testnet).

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


