### PR TITLE
Small logging improvements, loosen isLatest restriction

### DIFF
--- a/go/common/host/host.go
+++ b/go/common/host/host.go
@@ -78,7 +78,7 @@ type ReconnectingBlockProvider interface {
 	// StartStreamingFromHeight and StartStreamingFromHash return the streaming channel and a function to cancel/clean-up the stream with
 	StartStreamingFromHeight(height *big.Int) (*BlockStream, error)
 	StartStreamingFromHash(latestHash gethcommon.Hash) (*BlockStream, error)
-	IsLive(hash *types.Block) bool // returns true if hash is of the latest known L1 head block
+	IsLatest(hash *types.Block) bool // returns true if hash is of the latest known L1 head block
 }
 
 type BlockStream struct {

--- a/go/common/host/host.go
+++ b/go/common/host/host.go
@@ -78,7 +78,7 @@ type ReconnectingBlockProvider interface {
 	// StartStreamingFromHeight and StartStreamingFromHash return the streaming channel and a function to cancel/clean-up the stream with
 	StartStreamingFromHeight(height *big.Int) (*BlockStream, error)
 	StartStreamingFromHash(latestHash gethcommon.Hash) (*BlockStream, error)
-	IsLive(hash gethcommon.Hash) bool // returns true if hash is of the latest known L1 head block
+	IsLive(hash *types.Block) bool // returns true if hash is of the latest known L1 head block
 }
 
 type BlockStream struct {

--- a/go/enclave/l2chain/l2_chain.go
+++ b/go/enclave/l2chain/l2_chain.go
@@ -96,14 +96,14 @@ func (oc *ObscuroChain) ProcessL1Block(block types.Block, receipts types.Receipt
 	defer oc.blockProcessingMutex.Unlock()
 
 	// We update the L1 chain state.
-	oc.logger.Info("updateL1State (entered mutex)", log.BlockHeightKey, block.NumberU64(), log.BlockHashKey, block.Hash())
 	l1IngestionType, err := oc.updateL1State(block, receipts, isLatest)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	// We update the L1 and L2 chain heads.
-	oc.logger.Info("updateL1AndL2Heads", log.BlockHeightKey, block.NumberU64(), log.BlockHashKey, block.Hash())
+	oc.logger.Info("updateL1AndL2Heads", log.BlockHeightKey, block.NumberU64(), log.BlockHashKey, block.Hash(),
+		"l1Ingestion", l1IngestionType)
 	newL2Head, producedBatch, err := oc.updateL1AndL2Heads(&block, l1IngestionType)
 	if err != nil {
 		return nil, nil, err

--- a/go/ethadapter/blockprovider.go
+++ b/go/ethadapter/blockprovider.go
@@ -58,15 +58,17 @@ func (e *EthBlockProvider) StartStreamingFromHeight(height *big.Int) (*host.Bloc
 	return &host.BlockStream{Stream: streamCh, Stop: cancel}, nil
 }
 
-func (e *EthBlockProvider) IsLive(b *types.Block) bool {
+// IsLatest returns true iff the block has the same hash as the L1 head block (from the eth client)
+func (e *EthBlockProvider) IsLatest(b *types.Block) bool {
 	l1Head, err := e.ethClient.FetchHeadBlock()
 	if err != nil {
 		e.logger.Warn("unable to fetch head eth block - %w", err)
 		return false
 	}
+	isLatest := b.Hash() == l1Head.Hash()
 	// this log message is helpful for visibility on how far behind the block feeding is
-	e.logger.Info("L1 block provider live-monitoring", "currBlock", b.NumberU64(), "head", l1Head.NumberU64())
-	return b.NumberU64() >= l1Head.NumberU64()-1
+	e.logger.Info("L1 block provider live-monitoring", "currBlock", b.NumberU64(), "head", l1Head.NumberU64(), "isLatest", isLatest)
+	return isLatest
 }
 
 // streamBlocks is the main loop. It should be run in a separate go routine. It will stream catch-up blocks from requested height until it

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -367,7 +367,7 @@ func (h *host) startProcessing() {
 		select {
 		case b := <-blockStream.Stream:
 			roundInterrupt = triggerInterrupt(roundInterrupt)
-			isLive := h.l1BlockProvider.IsLive(b) // checks whether the block is the current head of the L1 (false if there is a newer block available)
+			isLive := h.l1BlockProvider.IsLatest(b) // checks whether the block is the current head of the L1 (false if there is a newer block available)
 			err := h.processL1Block(b, isLive)
 			if err != nil {
 				// handle the error, replace the blockStream if necessary (e.g. if stream needs resetting based on enclave's reported L1 head)

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -367,7 +367,7 @@ func (h *host) startProcessing() {
 		select {
 		case b := <-blockStream.Stream:
 			roundInterrupt = triggerInterrupt(roundInterrupt)
-			isLive := h.l1BlockProvider.IsLive(b.Hash()) // checks whether the block is the current head of the L1 (false if there is a newer block available)
+			isLive := h.l1BlockProvider.IsLive(b) // checks whether the block is the current head of the L1 (false if there is a newer block available)
 			err := h.processL1Block(b, isLive)
 			if err != nil {
 				// handle the error, replace the blockStream if necessary (e.g. if stream needs resetting based on enclave's reported L1 head)


### PR DESCRIPTION
- Make the enclave logging a bit clearer
- Provide visibility on how far behind of L1 head we are
- Loosen `isLatest` to be "within 1 block of current head" since it's just a best-effort measure anyway (validators have no idea if sequencer had received the latest L1 block they've seen yet) - this change probably makes no difference in practice, especially when we decouple batch production

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


