### PR TITLE
Enable persistence on testnet hosts

### DIFF
--- a/go/common/docker/docker.go
+++ b/go/common/docker/docker.go
@@ -3,11 +3,12 @@ package docker
 import (
 	"context"
 	"fmt"
-	"github.com/docker/docker/api/types/mount"
-	volumetypes "github.com/docker/docker/api/types/volume"
 	"io"
 	"os"
 	"time"
+
+	"github.com/docker/docker/api/types/mount"
+	volumetypes "github.com/docker/docker/api/types/volume"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
@@ -61,7 +62,7 @@ func StartNewContainer(containerName, image string, cmds []string, ports []int, 
 		})
 	}
 
-	var mountVolumes []mount.Mount
+	mountVolumes := make([]mount.Mount, 0, len(volumes))
 	for v, mntTarget := range volumes {
 		vol, err := ensureVolumeExists(cli, v)
 		if err != nil {

--- a/testnet/launcher/eth2network/docker.go
+++ b/testnet/launcher/eth2network/docker.go
@@ -44,7 +44,7 @@ func (n *Eth2Network) Start() error {
 		exposedPorts = append(exposedPorts, n.cfg.gethWSPort)
 	}
 
-	_, err := docker.StartNewContainer("eth2network", "testnetobscuronet.azurecr.io/obscuronet/eth2network:latest", cmds, exposedPorts, nil, nil)
+	_, err := docker.StartNewContainer("eth2network", "testnetobscuronet.azurecr.io/obscuronet/eth2network:latest", cmds, exposedPorts, nil, nil, nil)
 	return err
 }
 

--- a/testnet/launcher/l1contractdeployer/docker.go
+++ b/testnet/launcher/l1contractdeployer/docker.go
@@ -49,7 +49,7 @@ func (n *ContractDeployer) Start() error {
 `, n.cfg.l1Host, n.cfg.l1Port, n.cfg.privateKey),
 	}
 
-	containerID, err := docker.StartNewContainer("hh-l1-deployer", n.cfg.dockerImage, cmds, nil, envs, nil)
+	containerID, err := docker.StartNewContainer("hh-l1-deployer", n.cfg.dockerImage, cmds, nil, envs, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/testnet/launcher/l2contractdeployer/docker.go
+++ b/testnet/launcher/l2contractdeployer/docker.go
@@ -65,7 +65,7 @@ func (n *ContractDeployer) Start() error {
 `, n.cfg.l1Host, n.cfg.l1Port, n.cfg.l1privateKey, n.cfg.l2Host, n.cfg.l2Port, n.cfg.l2PrivateKey, n.cfg.hocPKString, n.cfg.pocPKString),
 	}
 
-	containerID, err := docker.StartNewContainer("hh-l2-deployer", n.cfg.dockerImage, cmds, nil, envs, nil)
+	containerID, err := docker.StartNewContainer("hh-l2-deployer", n.cfg.dockerImage, cmds, nil, envs, nil, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Why this change is needed

Currently testnet hosts use in-memory state but it'd be better for upgrades if they use a local db

### What changes were made as part of this PR

- Change the docker launcher script to support docker volumes
- make sure the host-persistence volume is there for testnet hosts

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


