### PR TITLE
Add upgrade option to node script

### DIFF
--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -261,7 +261,8 @@ jobs:
                -host_public_p2p_addr=obscuronode-${{ matrix.host_id }}-${{needs.build.outputs.RESOURCE_TESTNET_NAME}}-${{ GITHUB.RUN_NUMBER }}.uksouth.cloudapp.azure.com:10000 \
                -host_p2p_port=10000 \
                -enclave_docker_image=${{needs.build.outputs.L2_ENCLAVE_DOCKER_BUILD_TAG}} \
-               -host_docker_image=${{needs.build.outputs.L2_HOST_DOCKER_BUILD_TAG}}'
+               -host_docker_image=${{needs.build.outputs.L2_HOST_DOCKER_BUILD_TAG}}
+               start'
 
 
   update-loadbalancer:

--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -261,7 +261,7 @@ jobs:
                -host_public_p2p_addr=obscuronode-${{ matrix.host_id }}-${{needs.build.outputs.RESOURCE_TESTNET_NAME}}-${{ GITHUB.RUN_NUMBER }}.uksouth.cloudapp.azure.com:10000 \
                -host_p2p_port=10000 \
                -enclave_docker_image=${{needs.build.outputs.L2_ENCLAVE_DOCKER_BUILD_TAG}} \
-               -host_docker_image=${{needs.build.outputs.L2_HOST_DOCKER_BUILD_TAG}}
+               -host_docker_image=${{needs.build.outputs.L2_HOST_DOCKER_BUILD_TAG}} \
                start'
 
 

--- a/.github/workflows/manual-upgrade-testnet-l2.yml
+++ b/.github/workflows/manual-upgrade-testnet-l2.yml
@@ -154,7 +154,7 @@ jobs:
               -host_public_p2p_addr=obscuronode-${{ matrix.host_id }}-${{needs.build.outputs.RESOURCE_TESTNET_NAME}}-${{ github.event.inputs.github_deploy_number }}.uksouth.cloudapp.azure.com:10000 \
               -host_p2p_port=10000 \
               -enclave_docker_image=${{needs.build.outputs.L2_ENCLAVE_DOCKER_BUILD_TAG}} \
-              -host_docker_image=${{needs.build.outputs.L2_HOST_DOCKER_BUILD_TAG}}
+              -host_docker_image=${{needs.build.outputs.L2_HOST_DOCKER_BUILD_TAG}} \
               upgrade'
 
   check-obscuro-is-healthy:

--- a/.github/workflows/manual-upgrade-testnet-l2.yml
+++ b/.github/workflows/manual-upgrade-testnet-l2.yml
@@ -33,9 +33,14 @@ jobs:
       RESOURCE_TAG_NAME: ${{ steps.outputVars.outputs.RESOURCE_TAG_NAME }}
       RESOURCE_STARTING_NAME: ${{ steps.outputVars.outputs.RESOURCE_STARTING_NAME }}
       RESOURCE_TESTNET_NAME: ${{ steps.outputVars.outputs.RESOURCE_TESTNET_NAME }}
+      L1_HOST: ${{ steps.outputVars.outputs.L1_HOST }}
 
     steps:
       - uses: actions/checkout@v2
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
 
       - name: 'Login via Azure CLI'
         uses: azure/login@v1
@@ -50,6 +55,7 @@ jobs:
           echo "RESOURCE_TAG_NAME=testnetlatest" >> $GITHUB_ENV
           echo "RESOURCE_STARTING_NAME=T" >> $GITHUB_ENV
           echo "RESOURCE_TESTNET_NAME=testnet" >> $GITHUB_ENV
+          echo "L1_HOST=testnet-eth2network.uksouth.azurecontainer.io" >> $GITHUB_ENV
           
       - name: 'Sets env vars for dev-tesnet'
         if: ${{ github.event.inputs.testnet_type == 'dev-testnet' }}
@@ -59,6 +65,7 @@ jobs:
           echo "RESOURCE_TAG_NAME=devtestnetlatest" >> $GITHUB_ENV
           echo "RESOURCE_STARTING_NAME=D" >> $GITHUB_ENV
           echo "RESOURCE_TESTNET_NAME=devtestnet" >> $GITHUB_ENV
+          echo "L1_HOST=dev-testnet-eth2network.uksouth.azurecontainer.io" >> $GITHUB_ENV
 
       - name: 'Output env vars'
         id: outputVars
@@ -90,6 +97,31 @@ jobs:
     strategy:
       matrix:
         host_id: [ 0,1 ]
+        include:
+          # Hardcoded host addresses
+          - host_addr: 0x0000000000000000000000000000000000000000
+            host_id: 0
+          - host_addr: 0x0000000000000000000000000000000000000001
+            host_id: 1
+          # Hardcoded host prefunded keys
+          - node_pk_str: GETHNETWORK_PREFUNDED_PKSTR_0
+            host_id: 0
+          - node_pk_str: GETHNETWORK_PREFUNDED_PKSTR_1
+            host_id: 1
+          - node_pk_addr: GETHNETWORK_PREFUNDED_ADDR_0
+            host_id: 0
+          - node_pk_addr: GETHNETWORK_PREFUNDED_ADDR_1
+            host_id: 1
+          # Ensure there is a single genesis node
+          - is_genesis: true
+            host_id: 0
+          - is_genesis: false
+            host_id: 1
+          # Ensure there is a single sequencer
+          - node_type: sequencer
+            host_id: 0
+          - node_type: validator
+            host_id: 1
 
     steps:
       - name: 'Extract branch name'
@@ -109,11 +141,21 @@ jobs:
             az vm run-command invoke -g Testnet -n "${{needs.build.outputs.RESOURCE_STARTING_NAME}}-${{ matrix.host_id }}-${{ github.event.inputs.github_deploy_number }}"  \
             --command-id RunShellScript \
             --scripts '
-              cd /home/obscuro/go-obscuro/testnet/ \
-              docker compose down host enclave && \
-              docker compose pull && \
-              docker compose up host enclave
-            '
+              git clone --depth 1 -b ${{ steps.extract_branch.outputs.branch }} https://github.com/obscuronet/go-obscuro.git /home/obscuro/go-obscuro \
+            && cd /home/obscuro/go-obscuro/ \
+            && sudo go run /home/obscuro/go-obscuro/go/node/cmd  \
+              -is_genesis=${{ matrix.is_genesis }} \
+              -node_type=${{ matrix.node_type }} \
+              -is_sgx_enabled=true \
+              -host_id=${{ secrets[matrix.node_pk_addr] }} \
+              -l1_host=${{needs.build.outputs.L1_HOST}} \
+              -private_key=${{ secrets[matrix.node_pk_str] }} \
+              -sequencer_id=${{ secrets.GETHNETWORK_PREFUNDED_ADDR_0 }} \
+              -host_public_p2p_addr=obscuronode-${{ matrix.host_id }}-${{needs.build.outputs.RESOURCE_TESTNET_NAME}}-${{ github.event.inputs.github_deploy_number }}.uksouth.cloudapp.azure.com:10000 \
+              -host_p2p_port=10000 \
+              -enclave_docker_image=${{needs.build.outputs.L2_ENCLAVE_DOCKER_BUILD_TAG}} \
+              -host_docker_image=${{needs.build.outputs.L2_HOST_DOCKER_BUILD_TAG}}
+              upgrade'
 
   check-obscuro-is-healthy:
     needs:

--- a/docs/_docs/testnet/starting-a-node.md
+++ b/docs/_docs/testnet/starting-a-node.md
@@ -46,7 +46,8 @@ go run /home/obscuro/go-obscuro/go/node/cmd \
   -management_contract_addr=0xeDa66Cc53bd2f26896f6Ba6b736B1Ca325DE04eF \
   -message_bus_contract_addr=0xFD03804faCA2538F4633B3EBdfEfc38adafa259B \
   -private_key="PrivateKeyString" \
-  -private_key="HOST:10000"
+  -private_key="HOST:10000" \
+  start
 ```
 
 ## - (Alternatively) Steps required to run a node on Alibaba SGX

--- a/go/common/docker/docker.go
+++ b/go/common/docker/docker.go
@@ -126,6 +126,22 @@ func StartNewContainer(containerName, image string, cmds []string, ports []int, 
 	return resp.ID, nil
 }
 
+func StopAndRemove(containerName string) error {
+	ctx := context.Background()
+	cli, err := client.NewClientWithOpts(client.FromEnv)
+	if err != nil {
+		return err
+	}
+	defer cli.Close()
+
+	err = cli.ContainerStop(ctx, containerName, nil)
+	if err != nil {
+		return err
+	}
+
+	return cli.ContainerRemove(ctx, containerName, types.ContainerRemoveOptions{Force: true})
+}
+
 func ensureVolumeExists(cli *client.Client, volumeName string) (*types.Volume, error) {
 	ctx := context.Background()
 	allVolumes, err := cli.VolumeList(ctx, filters.NewArgs())

--- a/go/node/cmd/cli.go
+++ b/go/node/cmd/cli.go
@@ -2,10 +2,20 @@ package main
 
 import (
 	"flag"
+	"fmt"
+	"os"
+	"strings"
+)
+
+var (
+	startAction      = "start"
+	upgradeAction    = "upgrade"
+	validNodeActions = []string{startAction, upgradeAction}
 )
 
 // NodeConfigCLI represents the configurations passed into the node over CLI
 type NodeConfigCLI struct {
+	nodeAction             string
 	nodeType               string
 	isGenesis              bool
 	isSGXEnabled           bool
@@ -82,5 +92,26 @@ func ParseConfigCLI() *NodeConfigCLI {
 	cfg.hostHTTPPort = *hostHTTPPort
 	cfg.hostWSPort = *hostWSPort
 
+	cfg.nodeAction = flag.Arg(0)
+	if !validateNodeAction(cfg.nodeAction) {
+		if cfg.nodeAction == "" {
+			fmt.Printf("expected a node action string (%s) as the only argument after the flags but no argument provided\n",
+				strings.Join(validNodeActions, ", "))
+		} else {
+			fmt.Printf("expected a node action string (%s) as the only argument after the flags but got %s\n",
+				strings.Join(validNodeActions, ", "), cfg.nodeAction)
+		}
+		os.Exit(1)
+	}
+
 	return cfg
+}
+
+func validateNodeAction(action string) bool {
+	for _, a := range validNodeActions {
+		if a == action {
+			return true
+		}
+	}
+	return false
 }

--- a/go/node/cmd/main.go
+++ b/go/node/cmd/main.go
@@ -37,7 +37,14 @@ func main() {
 		panic(err)
 	}
 
-	err = dockerNode.Start()
+	switch cliConfig.nodeAction {
+	case startAction:
+		err = dockerNode.Start()
+	case upgradeAction:
+		err = dockerNode.Upgrade()
+	default:
+		panic("unrecognized node action: " + cliConfig.nodeAction)
+	}
 	if err != nil {
 		panic(err)
 	}

--- a/go/node/docker.go
+++ b/go/node/docker.go
@@ -210,12 +210,12 @@ func (d *DockerNode) startEdgelessDB() error {
 
 func (d *DockerNode) getNetworkConfig() networkConfig {
 	return networkConfig{
-		managementContractAddress: d.cfg.managementContractAddr,
-		messageBusAddress:         d.cfg.messageBusContractAddress,
+		ManagementContractAddress: d.cfg.managementContractAddr,
+		MessageBusAddress:         d.cfg.messageBusContractAddress,
 	}
 }
 
 func (d *DockerNode) updateConfigWithNetworkConfig(networkCfg *networkConfig) {
-	d.cfg.managementContractAddr = networkCfg.managementContractAddress
-	d.cfg.messageBusContractAddress = networkCfg.messageBusAddress
+	d.cfg.managementContractAddr = networkCfg.ManagementContractAddress
+	d.cfg.messageBusContractAddress = networkCfg.MessageBusAddress
 }

--- a/go/node/docker.go
+++ b/go/node/docker.go
@@ -27,11 +27,53 @@ func (d *DockerNode) Start() error {
 	// TODO this should probably be removed in the future
 	fmt.Printf("Starting Node %s with config: %+v\n", d.cfg.nodeName, d.cfg)
 
-	err := d.startEdgelessDB()
+	// write the network-level config to disk for future restarts
+	err := WriteNetworkConfigToDisk(d.getNetworkConfig())
 	if err != nil {
 		return err
 	}
 
+	err = d.startEdgelessDB()
+	if err != nil {
+		return err
+	}
+
+	err = d.startEnclave()
+	if err != nil {
+		return err
+	}
+
+	err = d.startHost()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (d *DockerNode) Upgrade() error {
+	// TODO this should probably be removed in the future
+	fmt.Printf("Upgrading node %s with config: %+v\n", d.cfg.nodeName, d.cfg)
+
+	// first we load network-specific details from the initial node setup from disk
+	networkCfg, err := ReadNetworkConfigFromDisk()
+	if err != nil {
+		return err
+	}
+	d.updateConfigWithNetworkConfig(networkCfg)
+
+	fmt.Println("Stopping existing host and enclave")
+	err = docker.StopAndRemove(d.cfg.nodeName + "-host")
+	if err != nil {
+		return err
+	}
+
+	err = docker.StopAndRemove(d.cfg.nodeName + "-enclave")
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Starting upgraded host and enclave")
 	err = d.startEnclave()
 	if err != nil {
 		return err
@@ -164,4 +206,16 @@ func (d *DockerNode) startEdgelessDB() error {
 	_, err := docker.StartNewContainer(d.cfg.nodeName+"-edgelessdb", d.cfg.edgelessDBImage, nil, nil, envs, devices, nil)
 
 	return err
+}
+
+func (d *DockerNode) getNetworkConfig() networkConfig {
+	return networkConfig{
+		managementContractAddress: d.cfg.managementContractAddr,
+		messageBusAddress:         d.cfg.messageBusContractAddress,
+	}
+}
+
+func (d *DockerNode) updateConfigWithNetworkConfig(networkCfg *networkConfig) {
+	d.cfg.managementContractAddr = networkCfg.managementContractAddress
+	d.cfg.messageBusContractAddress = networkCfg.messageBusAddress
 }

--- a/go/node/network_config.go
+++ b/go/node/network_config.go
@@ -2,7 +2,7 @@ package node
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 )
 
 // This is the location where the metadata will be stored on all testnet VMs
@@ -11,8 +11,8 @@ const _networkCfgFilePath = "/home/obscuro/network.json"
 // networkConfig is key network information required to start a node connecting to that network.
 // We persist it as a json file on our testnet hosts so that they can read it off when restart/upgrading
 type networkConfig struct {
-	managementContractAddress string
-	messageBusAddress         string
+	ManagementContractAddress string
+	MessageBusAddress         string
 }
 
 func WriteNetworkConfigToDisk(cfg networkConfig) error {
@@ -20,7 +20,8 @@ func WriteNetworkConfigToDisk(cfg networkConfig) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(_networkCfgFilePath, jsonStr, 0644)
+	// create the file as read-only, expect it to be immutable data for the lifetime of the obscuro network for the node
+	err = os.WriteFile(_networkCfgFilePath, jsonStr, 0o444)
 	if err != nil {
 		return err
 	}
@@ -28,7 +29,7 @@ func WriteNetworkConfigToDisk(cfg networkConfig) error {
 }
 
 func ReadNetworkConfigFromDisk() (*networkConfig, error) {
-	bytes, err := ioutil.ReadFile(_networkCfgFilePath)
+	bytes, err := os.ReadFile(_networkCfgFilePath)
 	if err != nil {
 		return nil, err
 	}

--- a/go/node/network_config.go
+++ b/go/node/network_config.go
@@ -1,0 +1,41 @@
+package node
+
+import (
+	"encoding/json"
+	"io/ioutil"
+)
+
+// This is the location where the metadata will be stored on all testnet VMs
+const _networkCfgFilePath = "/home/obscuro/network.json"
+
+// networkConfig is key network information required to start a node connecting to that network.
+// We persist it as a json file on our testnet hosts so that they can read it off when restart/upgrading
+type networkConfig struct {
+	managementContractAddress string
+	messageBusAddress         string
+}
+
+func WriteNetworkConfigToDisk(cfg networkConfig) error {
+	jsonStr, err := json.Marshal(cfg)
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(_networkCfgFilePath, jsonStr, 0644)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func ReadNetworkConfigFromDisk() (*networkConfig, error) {
+	bytes, err := ioutil.ReadFile(_networkCfgFilePath)
+	if err != nil {
+		return nil, err
+	}
+	var cfg networkConfig
+	err = json.Unmarshal(bytes, &cfg)
+	if err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}

--- a/go/node/node.go
+++ b/go/node/node.go
@@ -2,4 +2,5 @@ package node
 
 type Node interface {
 	Start() error
+	Upgrade() error
 }


### PR DESCRIPTION
### Why this change is needed

We replaced docker compose with go scripts that manage the docker containers.

The main script just starts the containers but we need to be able to upgrade existing nodes as well.

It became obvious as well that some metadata about the network is required when restarting. So now we persist network config data in a json file on the node VMs to be read when restarting/upgrading.

### What changes were made as part of this PR

- add "nodeAction" argument to the main script so you can call "start" or "upgrade" (and in the future we may add things like "stop", "status")
- add network config json file to node VMs so relevant config is available for node arguments when upgrading them

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


