### PR TITLE
Fix a dead link.

### DIFF
--- a/docs/_docs/testnet/obscuroscan.md
+++ b/docs/_docs/testnet/obscuroscan.md
@@ -22,4 +22,4 @@ rollups will be encrypted with rotating keys that are not known to anyone, or an
 
 ## External API Calls
 
-The URL path [/rollup/](http://testnet.obscuroscan.io/rollup/) may be requested from external clients using a HTTP POST request with either a rollup number (integer) or transaction hash (string beginning with "0x"). A JSON object representing the rollup will be returned. Further API development of ObscuroScan with RESTful documentation will follow.
+The URL path /rollup/ may be requested from external clients using a HTTP POST request with either a rollup number (integer) or transaction hash (string beginning with "0x"). A JSON object representing the rollup will be returned. Further API development of ObscuroScan with RESTful documentation will follow.


### PR DESCRIPTION
### Why this change is needed

The link pointing to rollup was broken.

### What changes were made as part of this PR

Removed the dead link pointing to rollup:
Anchor Text: /rollup/
Broken Link: http://testnet.obscuroscan.io/rollup/

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [x] PR checks reviewed and performed 


