### PR TITLE
Bump prysm version to 3.2.2

### DIFF
--- a/integration/eth2network/eth2_binaries.go
+++ b/integration/eth2network/eth2_binaries.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	_gethVersion  = "1.10.26"
-	_prysmVersion = "v3.2.0"
+	_prysmVersion = "v3.2.2"
 )
 
 var (


### PR DESCRIPTION
### Why this change is needed

Upgrade prysm version to include stability fix proposed by Pedro

