### PR TITLE
Move network config persistence further down stack

### DIFF
--- a/go/node/cmd/main.go
+++ b/go/node/cmd/main.go
@@ -39,8 +39,21 @@ func main() {
 
 	switch cliConfig.nodeAction {
 	case startAction:
+		// write the network-level config to disk for future restarts
+		err = node.WriteNetworkConfigToDisk(nodeCfg)
+		if err != nil {
+			panic(err)
+		}
 		err = dockerNode.Start()
 	case upgradeAction:
+		// load network-specific details from the initial node setup from disk
+		var ntwCfg *node.NetworkConfig
+		ntwCfg, err = node.ReadNetworkConfigFromDisk()
+		if err != nil {
+			panic(err)
+		}
+		dockerNode.SetNetworkConfig(ntwCfg)
+
 		err = dockerNode.Upgrade()
 	default:
 		panic("unrecognized node action: " + cliConfig.nodeAction)

--- a/go/node/docker.go
+++ b/go/node/docker.go
@@ -17,7 +17,7 @@ type DockerNode struct {
 	cfg *Config
 }
 
-func NewDockerNode(cfg *Config) (Node, error) {
+func NewDockerNode(cfg *Config) (*DockerNode, error) {
 	return &DockerNode{
 		cfg: cfg,
 	}, nil // todo: add config validation
@@ -27,13 +27,7 @@ func (d *DockerNode) Start() error {
 	// TODO this should probably be removed in the future
 	fmt.Printf("Starting Node %s with config: %+v\n", d.cfg.nodeName, d.cfg)
 
-	// write the network-level config to disk for future restarts
-	err := WriteNetworkConfigToDisk(d.getNetworkConfig())
-	if err != nil {
-		return err
-	}
-
-	err = d.startEdgelessDB()
+	err := d.startEdgelessDB()
 	if err != nil {
 		return err
 	}
@@ -55,15 +49,8 @@ func (d *DockerNode) Upgrade() error {
 	// TODO this should probably be removed in the future
 	fmt.Printf("Upgrading node %s with config: %+v\n", d.cfg.nodeName, d.cfg)
 
-	// first we load network-specific details from the initial node setup from disk
-	networkCfg, err := ReadNetworkConfigFromDisk()
-	if err != nil {
-		return err
-	}
-	d.updateConfigWithNetworkConfig(networkCfg)
-
 	fmt.Println("Stopping existing host and enclave")
-	err = docker.StopAndRemove(d.cfg.nodeName + "-host")
+	err := docker.StopAndRemove(d.cfg.nodeName + "-host")
 	if err != nil {
 		return err
 	}
@@ -208,14 +195,7 @@ func (d *DockerNode) startEdgelessDB() error {
 	return err
 }
 
-func (d *DockerNode) getNetworkConfig() networkConfig {
-	return networkConfig{
-		ManagementContractAddress: d.cfg.managementContractAddr,
-		MessageBusAddress:         d.cfg.messageBusContractAddress,
-	}
-}
-
-func (d *DockerNode) updateConfigWithNetworkConfig(networkCfg *networkConfig) {
+func (d *DockerNode) SetNetworkConfig(networkCfg *NetworkConfig) {
 	d.cfg.managementContractAddr = networkCfg.ManagementContractAddress
 	d.cfg.messageBusContractAddress = networkCfg.MessageBusAddress
 }

--- a/go/node/network_config.go
+++ b/go/node/network_config.go
@@ -6,34 +6,38 @@ import (
 )
 
 // This is the location where the metadata will be stored on all testnet VMs
-const _networkCfgFilePath = "/home/obscuro/network.json"
+const _networkCfgFilePath = "./network.json"
 
-// networkConfig is key network information required to start a node connecting to that network.
+// NetworkConfig is key network information required to start a node connecting to that network.
 // We persist it as a json file on our testnet hosts so that they can read it off when restart/upgrading
-type networkConfig struct {
+type NetworkConfig struct {
 	ManagementContractAddress string
 	MessageBusAddress         string
 }
 
-func WriteNetworkConfigToDisk(cfg networkConfig) error {
-	jsonStr, err := json.Marshal(cfg)
+func WriteNetworkConfigToDisk(cfg *Config) error {
+	n := NetworkConfig{
+		ManagementContractAddress: cfg.managementContractAddr,
+		MessageBusAddress:         cfg.messageBusContractAddress,
+	}
+	jsonStr, err := json.Marshal(n)
 	if err != nil {
 		return err
 	}
 	// create the file as read-only, expect it to be immutable data for the lifetime of the obscuro network for the node
-	err = os.WriteFile(_networkCfgFilePath, jsonStr, 0o444)
+	err = os.WriteFile(_networkCfgFilePath, jsonStr, 0o644) //nolint:gosec
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-func ReadNetworkConfigFromDisk() (*networkConfig, error) {
+func ReadNetworkConfigFromDisk() (*NetworkConfig, error) {
 	bytes, err := os.ReadFile(_networkCfgFilePath)
 	if err != nil {
 		return nil, err
 	}
-	var cfg networkConfig
+	var cfg NetworkConfig
 	err = json.Unmarshal(bytes, &cfg)
 	if err != nil {
 		return nil, err

--- a/go/node/node.go
+++ b/go/node/node.go
@@ -1,6 +1,0 @@
-package node
-
-type Node interface {
-	Start() error
-	Upgrade() error
-}


### PR DESCRIPTION
### Why this change is needed

Spinning up local networks was failing because we haven't catered for setting up difference persistence files for the different nodes. For now this adds the option to use in-memory db for docker host.

### What changes were made as part of this PR

- add option to use in-mem DB for docker host.
- use that when launching local testnet

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


