### PR TITLE
Docker testnet launcher to use in-mem db for host

### DIFF
--- a/go/node/config.go
+++ b/go/node/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	edgelessDBImage           string
 	enclaveDebug              bool
 	nodeName                  string
+	hostInMemDB               bool
 }
 
 func NewNodeConfig(opts ...Option) *Config {
@@ -168,5 +169,11 @@ func WithEdgelessDBImage(s string) Option {
 func WithPCCSAddr(s string) Option {
 	return func(c *Config) {
 		c.pccsAddr = s
+	}
+}
+
+func WithInMemoryDB(b bool) Option {
+	return func(c *Config) {
+		c.hostInMemDB = b
 	}
 }

--- a/go/node/docker.go
+++ b/go/node/docker.go
@@ -106,8 +106,10 @@ func (d *DockerNode) startHost() error {
 		"-clientRPCPortHttp", fmt.Sprintf("%d", d.cfg.hostHTTPPort),
 		"-clientRPCPortWs", fmt.Sprintf("%d", d.cfg.hostWSPort),
 		// host persistence hardcoded to use /data dir within the container, this needs to be mounted
-		"-useInMemoryDB=false",
-		"-levelDBPath", _hostDataDir,
+		fmt.Sprintf("-useInMemoryDB=%t", d.cfg.hostInMemDB),
+	}
+	if !d.cfg.hostInMemDB {
+		cmd = append(cmd, "-levelDBPath", _hostDataDir)
 	}
 
 	exposedPorts := []int{

--- a/testnet/launcher/docker.go
+++ b/testnet/launcher/docker.go
@@ -98,6 +98,7 @@ func (t *Testnet) Start() error {
 		node.WithSequencerID("0x0654D8B60033144D567f25bF41baC1FB0D60F23B"),
 		node.WithManagementContractAddress(managementContractAddr),
 		node.WithMessageBusContractAddress(messageBusContractAddr),
+		node.WithInMemoryDB(true),
 	)
 
 	validatorNode, err := node.NewDockerNode(validatorNodeConfig)


### PR DESCRIPTION
### Why this change is needed

Spinning up local networks was failing because we haven't catered for setting up difference persistence files for the different nodes. For now this adds the option to use in-memory db for docker host.

### What changes were made as part of this PR

- add option to use in-mem DB for docker host.
- use that when launching local testnet

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [x] PR checks reviewed and performed 


