### PR TITLE
Set sequencer host to use in-mem db as well

### DIFF
--- a/testnet/launcher/docker.go
+++ b/testnet/launcher/docker.go
@@ -59,6 +59,7 @@ func (t *Testnet) Start() error {
 		node.WithSequencerID("0x0654D8B60033144D567f25bF41baC1FB0D60F23B"),
 		node.WithManagementContractAddress(managementContractAddr),
 		node.WithMessageBusContractAddress(messageBusContractAddr),
+		node.WithInMemoryDB(true),
 	)
 
 	sequencerNode, err := node.NewDockerNode(sequencerNodeConfig)


### PR DESCRIPTION
### Why this change is needed

Missed that the launcher script creates the validator host config separately from the seq.

Set seq host to use in-mem db as well.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


