### PR TITLE
Retry L1 reconnect indefinitely

### DIFF
--- a/go/common/retry/retry_strategy.go
+++ b/go/common/retry/retry_strategy.go
@@ -93,6 +93,7 @@ func (b *backoffStrategy) Reset() {
 
 // NewBackoffAndRetryForeverStrategy will keep retrying until there is a success. For the first retries it will wait the
 // durations specified by the `backoffIntervals` slice, after which it will use the `retryInterval` indefinitely
+// Note: caller can still use retry.FailFast(err) to wrap an error if it wants to break out of the retry
 func NewBackoffAndRetryForeverStrategy(backoffIntervals []time.Duration, retryInterval time.Duration) Strategy {
 	return &infiniteRetryStrategy{
 		backoffIntervals: backoffIntervals,

--- a/go/ethadapter/blockprovider.go
+++ b/go/ethadapter/blockprovider.go
@@ -7,6 +7,8 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/obscuronet/go-obscuro/go/common/retry"
+
 	"github.com/obscuronet/go-obscuro/go/common/host"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
@@ -19,7 +21,10 @@ const (
 	waitingForBlockTimeout = 30 * time.Second
 )
 
-var one = big.NewInt(1)
+var (
+	one                   = big.NewInt(1)
+	backoffRetryIntervals = []time.Duration{10 * time.Millisecond, 100 * time.Millisecond, 1 * time.Second, 10 * time.Second}
+)
 
 func NewEthBlockProvider(ethClient EthClient, logger gethlog.Logger) *EthBlockProvider {
 	return &EthBlockProvider{
@@ -84,14 +89,20 @@ func (e *EthBlockProvider) streamBlocks(ctx context.Context, fromHeight *big.Int
 		case <-ctx.Done():
 			return
 		default:
-			// this will block if we're up-to-date with live blocks
-			block, err := e.fetchNextCanonicalBlock(ctx, fromHeight, latestSent)
-			if err != nil {
-				e.logger.Warn("unexpected error while preparing block to stream, will retry in 1 sec", log.ErrKey, err)
-				// todo: consider possible scenarios and what an appropriate wait time is here. Perhaps use a back-off strategy?
-				time.Sleep(10 * time.Millisecond)
-				continue
-			}
+			var block *types.Block
+			var err error
+			// this will retry forever with a back-off, if L1 client is unavailable we should still recover eventually
+			err = retry.Do(func() error {
+				// this will block if we're up-to-date with live blocks
+				block, err = e.fetchNextCanonicalBlock(ctx, fromHeight, latestSent)
+				if err != nil {
+					// this shouldn't happen often, it's important that node operator has visibility on it, and that host can
+					// eventually recover when L1 client issue is resolved
+					e.logger.Warn("unexpected error while preparing block to stream, will retry periodically", log.ErrKey, err)
+					return err
+				}
+				return nil
+			}, retry.NewBackoffAndRetryForeverStrategy(backoffRetryIntervals, 30*time.Second))
 			e.logger.Trace("blockProvider streaming block", "height", block.Number(), "hash", block.Hash())
 			streamCh <- block // we block here until consumer takes it
 			// update stream state

--- a/go/ethadapter/geth_rpc_client.go
+++ b/go/ethadapter/geth_rpc_client.go
@@ -55,11 +55,7 @@ func (e *gethRPCClient) FetchHeadBlock() (*types.Block, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), e.timeout)
 	defer cancel()
 
-	blk, err := e.client.BlockByNumber(ctx, nil)
-	if err != nil {
-		e.logger.Crit("could not fetch head block.", log.ErrKey, err)
-	}
-	return blk, nil
+	return e.client.BlockByNumber(ctx, nil)
 }
 
 func (e *gethRPCClient) Info() Info {


### PR DESCRIPTION
### Why this change is needed

Sometimes we get an unexpected error from the L1 client and the host falls over so the node operator can deal with it.

But the host should self recover when the L1 client becomes available again (this will help us understand more clearly what the L1 issues are on testnets, blips or falling over).

### What changes were made as part of this PR

Add a new retry strategy that keeps trying forever, use it for L1 connection from host.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [x] PR checks reviewed and performed 


