### PR TITLE
Tell prysm node not to look for peers

### DIFF
--- a/integration/eth2network/eth2_network.go
+++ b/integration/eth2network/eth2_network.go
@@ -408,9 +408,12 @@ func (n *Impl) prysmStartBeaconNode(gethAuthRPCPort, rpcPort, p2pPort int, nodeD
 		"--datadir", path.Join(nodeDataDir, "prysm", "beacondata"),
 		"--interop-eth1data-votes",
 		"--accept-terms-of-use",
+		"--no-discovery",
 		"--rpc-port", fmt.Sprintf("%d", rpcPort),
 		"--p2p-udp-port", fmt.Sprintf("%d", p2pPort),
 		"--min-sync-peers", fmt.Sprintf("%d", len(n.dataDirs)-1),
+		// if nodes have zero or one peers then that's the min-peers, if more than that then say 2 peers is the min
+		"--minimum-peers-per-subnet", fmt.Sprintf("%d", min(len(n.dataDirs)-1, 2)),
 		"--interop-num-validators", fmt.Sprintf("%d", len(n.dataDirs)),
 		"--genesis-state", n.prysmGenesisPath,
 		"--chain-config-file", n.prysmConfigPath,
@@ -555,4 +558,11 @@ func (n *Impl) gethImportEnodes(enodes []string) error {
 		time.Sleep(time.Second)
 	}
 	return nil
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
 }


### PR DESCRIPTION
### Why this change is needed

We want to reduce the amount of errors noise we see in the prysm logs. It is often complaining about not being able to find peers, these flags should help with that (unclear whether that will help with our L1 stability but should make it easier to see what's going on hopefully).

### What changes were made as part of this PR

Use `--no-discover` flag and `--minimum-peers-per-subnet 0` for our single node network.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


