### PR TITLE
Process network secrets now iterates only over successful transactions.

### DIFF
--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -266,7 +266,7 @@ func (e *enclaveImpl) SubmitL1Block(block types.Block, receipts types.Receipts, 
 
 	e.logger.Info("produceBlockSubmissionResponse successful", log.BlockHeightKey, block.Number(), log.BlockHashKey, block.Hash(),
 		"newBatch", describeBSR(blockSubmissionResponse))
-	blockSubmissionResponse.ProducedSecretResponses = e.processNetworkSecretMsgs(block)
+	blockSubmissionResponse.ProducedSecretResponses = e.processNetworkSecretMsgs(br)
 
 	// We remove any transactions considered immune to re-orgs from the mempool.
 	if blockSubmissionResponse.ProducedBatch != nil {
@@ -965,9 +965,11 @@ func (e *enclaveImpl) checkGas(tx *types.Transaction) error {
 }
 
 // processNetworkSecretMsgs we watch for all messages that are requesting or receiving the secret and we store the nodes attested keys
-func (e *enclaveImpl) processNetworkSecretMsgs(block types.Block) []*common.ProducedSecretResponse {
+func (e *enclaveImpl) processNetworkSecretMsgs(br *common.BlockAndReceipts) []*common.ProducedSecretResponse {
 	var responses []*common.ProducedSecretResponse
-	for _, tx := range block.Transactions() {
+	transactions := br.SuccessfulTransactions()
+	block := br.Block
+	for _, tx := range *transactions {
 		t := e.mgmtContractLib.DecodeTx(tx)
 
 		// this transaction is for a node that has joined the network and needs to be sent the network secret


### PR DESCRIPTION
### Why this change is needed

Addresses #527

### What changes were made as part of this PR

Reusing the BlockAndReceipts struct in order to have the secret messages functionality only iterate over transactions that are considered successful.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


