### PR TITLE
Expose underlying sql database

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/go-sql-driver/mysql v1.4.1
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/websocket v1.4.2
-	github.com/mattn/go-sqlite3 v1.14.13
+	github.com/mattn/go-sqlite3 v1.14.16
 	github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416
 	github.com/status-im/keycard-go v0.0.0-20190316090335-8537d3370df4
 	github.com/stretchr/testify v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -435,8 +435,8 @@ github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzp
 github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-sqlite3 v1.11.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
-github.com/mattn/go-sqlite3 v1.14.13 h1:1tj15ngiFfcZzii7yd82foL+ks+ouQcj8j/TPq3fk1I=
-github.com/mattn/go-sqlite3 v1.14.13/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
+github.com/mattn/go-sqlite3 v1.14.16 h1:yOQRA0RpS5PFz/oikGwBEqvAWhWg5ufRz4ETLjwpU1Y=
+github.com/mattn/go-sqlite3 v1.14.16/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
 github.com/mattn/go-tty v0.0.0-20180907095812-13ff1204f104/go.mod h1:XPvLUNfbS4fJH25nqRHfWLMa1ONC8Amw+mIA639KxkE=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=

--- a/go/enclave/db/db.go
+++ b/go/enclave/db/db.go
@@ -17,7 +17,7 @@ func CreateDBFromConfig(cfg config.EnclaveConfig, logger gethlog.Logger) (sql.En
 	}
 	if cfg.UseInMemoryDB {
 		logger.Info("UseInMemoryDB flag is true, data will not be persisted. Creating in-memory database...")
-		// this creates an in memory sqllite db
+		// this creates a temporary sqlite db
 		return sql.CreateTemporarySQLiteDB("", logger)
 	}
 

--- a/go/enclave/db/db.go
+++ b/go/enclave/db/db.go
@@ -18,7 +18,7 @@ func CreateDBFromConfig(cfg config.EnclaveConfig, logger gethlog.Logger) (sql.En
 	if cfg.UseInMemoryDB {
 		logger.Info("UseInMemoryDB flag is true, data will not be persisted. Creating in-memory database...")
 		// this creates an in memory sqllite db
-		return sql.CreateTemporarySQLiteDB("file:"+cfg.HostID.Hex()+"?mode=memory&cache=shared", true, logger)
+		return sql.CreateTemporarySQLiteDB("", logger)
 	}
 
 	if !cfg.WillAttest {
@@ -26,7 +26,7 @@ func CreateDBFromConfig(cfg config.EnclaveConfig, logger gethlog.Logger) (sql.En
 		logger.Warn("Attestation is disabled, using a basic sqlite DB for persistence")
 		// when we want to test persistence after node restart the SqliteDBPath should be set
 		// (if empty string then a temp db file will be created for the lifetime of the enclave)
-		return sql.CreateTemporarySQLiteDB(cfg.SqliteDBPath, false, logger)
+		return sql.CreateTemporarySQLiteDB(cfg.SqliteDBPath, logger)
 	}
 
 	// persistent and with attestation means connecting to edgeless DB in a trusted enclave from a secure enclave

--- a/go/enclave/db/db.go
+++ b/go/enclave/db/db.go
@@ -18,7 +18,7 @@ func CreateDBFromConfig(cfg config.EnclaveConfig, logger gethlog.Logger) (sql.En
 	if cfg.UseInMemoryDB {
 		logger.Info("UseInMemoryDB flag is true, data will not be persisted. Creating in-memory database...")
 		// this creates a temporary sqlite db
-		return sql.CreateTemporarySQLiteDB("", logger)
+		return sql.CreateTemporarySQLiteDB("file:"+cfg.HostID.String()+"?mode=memory&cache=shared", logger)
 	}
 
 	if !cfg.WillAttest {

--- a/go/enclave/db/rawdb/README.md
+++ b/go/enclave/db/rawdb/README.md
@@ -1,4 +1,4 @@
-This package dubplicates the geth "rawdb" package.
+This package duplicates the geth "rawdb" package.
 It contains logic to wrap access to the key value store.
 The only changes are around the used prefixes, and the removal of the "ancients" which we don't use for now. 
 

--- a/go/enclave/db/sql/batch.go
+++ b/go/enclave/db/sql/batch.go
@@ -17,7 +17,7 @@ type keyvalue struct {
 }
 
 type sqlBatch struct {
-	db     *sqlEthDatabase
+	db     *sqlDBImpl
 	writes []keyvalue
 	size   int
 }

--- a/go/enclave/db/sql/edgelessdb.go
+++ b/go/enclave/db/sql/edgelessdb.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/obscuronet/go-obscuro/go/enclave/core/egoutils"
 
-	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/go-sql-driver/mysql"
 )
 
@@ -124,7 +123,7 @@ type EdgelessDBCredentials struct {
 	UserKeyPEM   string // db user private key, generated in our enclave
 }
 
-func EdgelessDBConnector(edbCfg *EdgelessDBConfig, logger gethlog.Logger) (ethdb.Database, error) {
+func EdgelessDBConnector(edbCfg *EdgelessDBConfig, logger gethlog.Logger) (EnclaveDB, error) {
 	// rather than fail immediately if EdgelessDB is not available yet we wait up for `edgelessDBStartTimeout` for it to be available
 	err := waitForEdgelessDBToStart(edbCfg.Host, logger)
 	if err != nil {

--- a/go/enclave/db/sql/sql.go
+++ b/go/enclave/db/sql/sql.go
@@ -5,9 +5,8 @@ import (
 	"errors"
 	"fmt"
 
-	gethlog "github.com/ethereum/go-ethereum/log"
-
 	"github.com/ethereum/go-ethereum/ethdb"
+	gethlog "github.com/ethereum/go-ethereum/log"
 	"github.com/obscuronet/go-obscuro/go/common/errutil"
 )
 
@@ -19,18 +18,33 @@ const (
 	searchQry = `select * from keyvalue where substring(keyvalue.ky, 1, ?) = ? and keyvalue.ky >= ? order by keyvalue.ky asc`
 )
 
-// sqlEthDatabase implements ethdb.Database
-type sqlEthDatabase struct {
+// EnclaveSQLDB - exposes the underlying sql database
+type EnclaveSQLDB interface {
+	GetSQLDB() *sql.DB
+}
+
+// EnclaveDB - the type returned by the database connectors. Extends the ethdb and exposes an SQL db.
+type EnclaveDB interface {
+	ethdb.Database
+	EnclaveSQLDB
+}
+
+// sqlDBImpl implements db.EnclaveDB which implements ethdb.Database
+type sqlDBImpl struct {
 	db     *sql.DB
 	logger gethlog.Logger
 }
 
-func CreateSQLEthDatabase(db *sql.DB, logger gethlog.Logger) (ethdb.Database, error) {
-	return &sqlEthDatabase{db: db, logger: logger}, nil
+func CreateSQLEthDatabase(db *sql.DB, logger gethlog.Logger) (EnclaveDB, error) {
+	return &sqlDBImpl{db: db, logger: logger}, nil
 }
 
-func (m *sqlEthDatabase) Has(key []byte) (bool, error) {
-	err := m.db.QueryRow(getQry, key).Scan()
+func (sqlDB *sqlDBImpl) GetSQLDB() *sql.DB {
+	return sqlDB.db
+}
+
+func (sqlDB *sqlDBImpl) Has(key []byte) (bool, error) {
+	err := sqlDB.db.QueryRow(getQry, key).Scan()
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return false, nil
@@ -40,10 +54,10 @@ func (m *sqlEthDatabase) Has(key []byte) (bool, error) {
 	return true, nil
 }
 
-func (m *sqlEthDatabase) Get(key []byte) ([]byte, error) {
+func (sqlDB *sqlDBImpl) Get(key []byte) ([]byte, error) {
 	var res []byte
 
-	err := m.db.QueryRow(getQry, key).Scan(&res)
+	err := sqlDB.db.QueryRow(getQry, key).Scan(&res)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			// make sure the error is converted to obscuro-wide not found error
@@ -54,34 +68,34 @@ func (m *sqlEthDatabase) Get(key []byte) ([]byte, error) {
 	return res, nil
 }
 
-func (m *sqlEthDatabase) Put(key []byte, value []byte) error {
-	_, err := m.db.Exec(putQry, key, value)
+func (sqlDB *sqlDBImpl) Put(key []byte, value []byte) error {
+	_, err := sqlDB.db.Exec(putQry, key, value)
 	return err
 }
 
-func (m *sqlEthDatabase) Delete(key []byte) error {
-	_, err := m.db.Exec(delQry, key)
+func (sqlDB *sqlDBImpl) Delete(key []byte) error {
+	_, err := sqlDB.db.Exec(delQry, key)
 	return err
 }
 
-func (m *sqlEthDatabase) Close() error {
-	if err := m.db.Close(); err != nil {
+func (sqlDB *sqlDBImpl) Close() error {
+	if err := sqlDB.db.Close(); err != nil {
 		return fmt.Errorf("failed to close sql db - %w", err)
 	}
 	return nil
 }
 
-func (m *sqlEthDatabase) NewBatch() ethdb.Batch {
+func (sqlDB *sqlDBImpl) NewBatch() ethdb.Batch {
 	return &sqlBatch{
-		db: m,
+		db: sqlDB,
 	}
 }
 
-func (m *sqlEthDatabase) NewIterator(prefix []byte, start []byte) ethdb.Iterator {
+func (sqlDB *sqlDBImpl) NewIterator(prefix []byte, start []byte) ethdb.Iterator {
 	pr := prefix
 	st := append(prefix, start...)
 	// iterator clean-up handles closing this rows iterator
-	rows, err := m.db.Query(searchQry, len(pr), pr, st)
+	rows, err := sqlDB.db.Query(searchQry, len(pr), pr, st)
 	if err != nil {
 		return &iterator{
 			err: fmt.Errorf("failed to get rows, iter will be empty, %w", err),
@@ -97,15 +111,15 @@ func (m *sqlEthDatabase) NewIterator(prefix []byte, start []byte) ethdb.Iterator
 	}
 }
 
-func (m *sqlEthDatabase) Stat(property string) (string, error) {
+func (sqlDB *sqlDBImpl) Stat(property string) (string, error) {
 	// TODO implement me
-	m.logger.Crit("implement me")
+	sqlDB.logger.Crit("implement me")
 	return "", nil
 }
 
-func (m *sqlEthDatabase) Compact(start []byte, limit []byte) error {
+func (sqlDB *sqlDBImpl) Compact(start []byte, limit []byte) error {
 	// TODO implement me
-	m.logger.Crit("implement me")
+	sqlDB.logger.Crit("implement me")
 	return nil
 }
 
@@ -115,46 +129,46 @@ func (m *sqlEthDatabase) Compact(start []byte, limit []byte) error {
 var errNotSupported = errors.New("this operation is not supported")
 
 // HasAncient returns an error as we don't have a backing chain freezer.
-func (m *sqlEthDatabase) HasAncient(kind string, number uint64) (bool, error) {
+func (sqlDB *sqlDBImpl) HasAncient(kind string, number uint64) (bool, error) {
 	return false, errNotSupported
 }
 
 // Ancient returns an error as we don't have a backing chain freezer.
-func (m *sqlEthDatabase) Ancient(kind string, number uint64) ([]byte, error) {
+func (sqlDB *sqlDBImpl) Ancient(kind string, number uint64) ([]byte, error) {
 	return nil, errNotSupported
 }
 
 // AncientRange returns an error as we don't have a backing chain freezer.
-func (m *sqlEthDatabase) AncientRange(kind string, start, max, maxByteSize uint64) ([][]byte, error) {
+func (sqlDB *sqlDBImpl) AncientRange(kind string, start, max, maxByteSize uint64) ([][]byte, error) {
 	return nil, errNotSupported
 }
 
 // Ancients returns an error as we don't have a backing chain freezer.
-func (m *sqlEthDatabase) Ancients() (uint64, error) {
+func (sqlDB *sqlDBImpl) Ancients() (uint64, error) {
 	return 0, errNotSupported
 }
 
 // AncientSize returns an error as we don't have a backing chain freezer.
-func (m *sqlEthDatabase) AncientSize(kind string) (uint64, error) {
+func (sqlDB *sqlDBImpl) AncientSize(kind string) (uint64, error) {
 	return 0, errNotSupported
 }
 
 // ModifyAncients is not supported.
-func (m *sqlEthDatabase) ModifyAncients(func(ethdb.AncientWriteOp) error) (int64, error) {
+func (sqlDB *sqlDBImpl) ModifyAncients(func(ethdb.AncientWriteOp) error) (int64, error) {
 	return 0, errNotSupported
 }
 
 // TruncateAncients returns an error as we don't have a backing chain freezer.
-func (m *sqlEthDatabase) TruncateAncients(items uint64) error {
+func (sqlDB *sqlDBImpl) TruncateAncients(items uint64) error {
 	return errNotSupported
 }
 
 // Sync returns an error as we don't have a backing chain freezer.
-func (m *sqlEthDatabase) Sync() error {
+func (sqlDB *sqlDBImpl) Sync() error {
 	return errNotSupported
 }
 
-func (m *sqlEthDatabase) ReadAncients(fn func(reader ethdb.AncientReader) error) (err error) {
+func (sqlDB *sqlDBImpl) ReadAncients(fn func(reader ethdb.AncientReader) error) (err error) {
 	// Unlike other ancient-related methods, this method does not return
 	// errNotSupported when invoked.
 	// The reason for this is that the caller might want to do several things:
@@ -167,5 +181,5 @@ func (m *sqlEthDatabase) ReadAncients(fn func(reader ethdb.AncientReader) error)
 	// If we instead were to return errNotSupported here, then the caller would
 	// have to explicitly check for that, having an extra clause to do the
 	// non-ancient operations.
-	return fn(m)
+	return fn(sqlDB)
 }

--- a/go/enclave/db/sql/sqlite.go
+++ b/go/enclave/db/sql/sqlite.go
@@ -20,7 +20,7 @@ const (
 
 // CreateTemporarySQLiteDB if dbPath is empty will use a random throwaway temp file,
 // otherwise dbPath is a filepath for the db file, allows for tests that care about persistence between restarts
-func CreateTemporarySQLiteDB(dbPath string, inMem bool, logger gethlog.Logger) (EnclaveDB, error) {
+func CreateTemporarySQLiteDB(dbPath string, logger gethlog.Logger) (EnclaveDB, error) {
 	if dbPath == "" {
 		tempPath, err := CreateTempDBFile()
 		if err != nil {
@@ -28,13 +28,10 @@ func CreateTemporarySQLiteDB(dbPath string, inMem bool, logger gethlog.Logger) (
 		}
 		dbPath = tempPath
 	}
-	// for in memory databases set up every time
-	existingDB := false
-	if !inMem {
-		// determine if a db file already exists, we don't want to overwrite it
-		_, err := os.Stat(dbPath)
-		existingDB = err == nil
-	}
+
+	// determine if a db file already exists, we don't want to overwrite it
+	_, err := os.Stat(dbPath)
+	existingDB := err == nil
 
 	db, err := sql.Open("sqlite3", dbPath)
 	if err != nil {

--- a/go/enclave/db/storage.go
+++ b/go/enclave/db/storage.go
@@ -7,10 +7,11 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/obscuronet/go-obscuro/go/enclave/db/sql"
+
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/obscuronet/go-obscuro/go/common"
 	"github.com/obscuronet/go-obscuro/go/common/errutil"
@@ -30,13 +31,13 @@ var ErrNoRollups = errors.New("no rollups have been published")
 // TODO - Consistency around whether we assert the secret is available or not.
 
 type storageImpl struct {
-	db          ethdb.Database
+	db          sql.EnclaveDB
 	stateDB     state.Database
 	chainConfig *params.ChainConfig
 	logger      gethlog.Logger
 }
 
-func NewStorage(backingDB ethdb.Database, chainConfig *params.ChainConfig, logger gethlog.Logger) Storage {
+func NewStorage(backingDB sql.EnclaveDB, chainConfig *params.ChainConfig, logger gethlog.Logger) Storage {
 	return &storageImpl{
 		db:          backingDB,
 		stateDB:     state.NewDatabase(backingDB),

--- a/go/enclave/genesis/genesis_test.go
+++ b/go/enclave/genesis/genesis_test.go
@@ -24,9 +24,9 @@ func TestDefaultGenesis(t *testing.T) {
 		t.Fatal("unexpected number of accounts")
 	}
 
-	backingDB, err := sql.CreateTemporarySQLiteDB("", false, testlog.Logger())
+	backingDB, err := sql.CreateTemporarySQLiteDB("", testlog.Logger())
 	if err != nil {
-		t.Fatalf("unable to apply genesis allocations")
+		t.Fatalf("unable to create temp db: %s", err)
 	}
 	storageDB := db.NewStorage(backingDB, nil, gethlog.New())
 	stateDB, err := gen.applyAllocations(storageDB)
@@ -60,9 +60,9 @@ func TestCustomGenesis(t *testing.T) {
 		t.Fatal("unexpected number of accounts")
 	}
 
-	backingDB, err := sql.CreateTemporarySQLiteDB("", false, testlog.Logger())
+	backingDB, err := sql.CreateTemporarySQLiteDB("", testlog.Logger())
 	if err != nil {
-		t.Fatalf("unable to apply genesis allocations")
+		t.Fatalf("unable to create temp db: %s", err)
 	}
 	storageDB := db.NewStorage(backingDB, nil, gethlog.New())
 	stateDB, err := gen.applyAllocations(storageDB)

--- a/go/enclave/genesis/genesis_test.go
+++ b/go/enclave/genesis/genesis_test.go
@@ -5,7 +5,9 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/obscuronet/go-obscuro/go/enclave/db/sql"
+	"github.com/obscuronet/go-obscuro/integration/common/testlog"
+
 	"github.com/obscuronet/go-obscuro/go/enclave/db"
 	"github.com/obscuronet/go-obscuro/integration/datagenerator"
 
@@ -22,7 +24,10 @@ func TestDefaultGenesis(t *testing.T) {
 		t.Fatal("unexpected number of accounts")
 	}
 
-	backingDB := rawdb.NewMemoryDatabase()
+	backingDB, err := sql.CreateTemporarySQLiteDB("", false, testlog.Logger())
+	if err != nil {
+		t.Fatalf("unable to apply genesis allocations")
+	}
 	storageDB := db.NewStorage(backingDB, nil, gethlog.New())
 	stateDB, err := gen.applyAllocations(storageDB)
 	if err != nil {
@@ -55,7 +60,10 @@ func TestCustomGenesis(t *testing.T) {
 		t.Fatal("unexpected number of accounts")
 	}
 
-	backingDB := rawdb.NewMemoryDatabase()
+	backingDB, err := sql.CreateTemporarySQLiteDB("", false, testlog.Logger())
+	if err != nil {
+		t.Fatalf("unable to apply genesis allocations")
+	}
 	storageDB := db.NewStorage(backingDB, nil, gethlog.New())
 	stateDB, err := gen.applyAllocations(storageDB)
 	if err != nil {

--- a/go/enclave/genesis/genesis_test.go
+++ b/go/enclave/genesis/genesis_test.go
@@ -14,7 +14,16 @@ import (
 	gethlog "github.com/ethereum/go-ethereum/log"
 )
 
+const testLogs = "../.build/tests/"
+
 func TestDefaultGenesis(t *testing.T) {
+	testlog.Setup(&testlog.Cfg{
+		LogDir:      testLogs,
+		TestType:    "unit",
+		TestSubtype: "genesis",
+		LogLevel:    gethlog.LvlInfo,
+	})
+
 	gen, err := New("")
 	if err != nil {
 		t.Fatalf("unexpected error %s", err)
@@ -40,6 +49,13 @@ func TestDefaultGenesis(t *testing.T) {
 }
 
 func TestCustomGenesis(t *testing.T) {
+	testlog.Setup(&testlog.Cfg{
+		LogDir:      testLogs,
+		TestType:    "unit",
+		TestSubtype: "genesis",
+		LogLevel:    gethlog.LvlInfo,
+	})
+
 	addr1 := datagenerator.RandomAddress()
 	amt1 := datagenerator.RandomUInt64()
 	addr2 := datagenerator.RandomAddress()


### PR DESCRIPTION
### Why this change is needed

This is a prerequisite to the performance improvements required for event storage.

### What changes were made as part of this PR

1. Instead of using the `ethdb.Database` as the main database, we use a wrapper `EnclaveDB`, which also exposes an `sql` object which will be used to run queries directly against other tables.
2. There was some minor complexity during testing as we were using an "inMemory" database provided by geth. This is now replaced with an in-memory sqlite.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


