### PR TITLE
Extract the mgmt contract deployment block for node starts

### DIFF
--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -29,6 +29,7 @@ jobs:
     outputs:
       MGMT_CONTRACT_ADDR: ${{ steps.deployContracts.outputs.MGMT_CONTRACT_ADDR }}
       MSG_BUS_CONTRACT_ADDR: ${{ steps.deployContracts.outputs.MSG_BUS_CONTRACT_ADDR }}
+      L1_START_HASH: ${{ steps.deployContracts.outputs.L1_START_HASH }}
       HOC_ERC20_ADDR: ${{ steps.deployContracts.outputs.HOC_ERC20_ADDR }}
       POC_ERC20_ADDR: ${{ steps.deployContracts.outputs.POC_ERC20_ADDR }}
       L2_ENCLAVE_DOCKER_BUILD_TAG: ${{ steps.outputVars.outputs.L2_ENCLAVE_DOCKER_BUILD_TAG }}
@@ -121,6 +122,8 @@ jobs:
           echo "MGMT_CONTRACT_ADDR=$MGMTCONTRACTADDR" >> $GITHUB_OUTPUT
           echo "MSG_BUS_CONTRACT_ADDR=$MSGBUSCONTRACTADDR" >> $GITHUB_ENV
           echo "MSG_BUS_CONTRACT_ADDR=$MSGBUSCONTRACTADDR" >> $GITHUB_OUTPUT
+          echo "L1_START_HASH=$L1START" >> $GITHUB_ENV
+          echo "L1_START_HASH=$L1START" >> $GITHUB_OUTPUT
 
       - name: 'Save container logs on failure'
         if: failure()
@@ -256,6 +259,7 @@ jobs:
                -l1_host=${{needs.build.outputs.L1_HOST}} \
                -management_contract_addr=${{needs.build.outputs.MGMT_CONTRACT_ADDR}} \
                -message_bus_contract_addr=${{needs.build.outputs.MSG_BUS_CONTRACT_ADDR}} \
+               -l1_start=${{needs.build.outputs.}} \
                -private_key=${{ secrets[matrix.node_pk_str] }} \
                -sequencer_id=${{ secrets.GETHNETWORK_PREFUNDED_ADDR_0 }} \
                -host_public_p2p_addr=obscuronode-${{ matrix.host_id }}-${{needs.build.outputs.RESOURCE_TESTNET_NAME}}-${{ GITHUB.RUN_NUMBER }}.uksouth.cloudapp.azure.com:10000 \

--- a/contracts/deployment_scripts/core/001_deploy_management_contract.ts
+++ b/contracts/deployment_scripts/core/001_deploy_management_contract.ts
@@ -18,7 +18,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     const contractArtifact = await hre.artifacts.readArtifact("ManagementContract");
 
     // Deploying the management contract
-    await deployments.deploy('ManagementContract', {
+    const mgmtContractDeployment = await deployments.deploy('ManagementContract', {
         from: deployer,
         contract: contractArtifact,
         args: [],
@@ -29,6 +29,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     // This is required in CI/CD - look at testnet-deploy-contracts.sh for more information.
     // depends on grep -e MessageBusAddress and a positional cut of the address
     console.log(`MessageBusAddress= ${busAddress}`);
+    console.log(`L1Start=${mgmtContractDeployment.receipt.blockHash}`)
 };
 
 export default func;

--- a/go/host/container/cli_flags.go
+++ b/go/host/container/cli_flags.go
@@ -57,6 +57,7 @@ func getFlagUsageMap() map[string]string {
 		l1ChainIDName:                "An integer representing the unique chain id of the Ethereum chain used as an L1 (default 1337)",
 		obscuroChainIDName:           "An integer representing the unique chain id of the Obscuro chain (default 777)",
 		profilerEnabledName:          "Runs a profiler instance (Defaults to false)",
+		l1StartHashName:              "The L1 block hash where the management contract was deployed",
 		metricsEnabledName:           "Whether the metrics are enabled (Defaults to true)",
 		metricsHTTPPortName:          "The port on which the metrics are served (Defaults to 0.0.0.0:14000)",
 		useInMemoryDBName:            "Whether the host will use an in-memory DB rather than persist data",

--- a/go/node/cmd/cli.go
+++ b/go/node/cmd/cli.go
@@ -33,6 +33,7 @@ type NodeConfigCLI struct {
 	sequencerID            string
 	managementContractAddr string
 	messageBusContractAddr string
+	l1Start                string
 	pccsAddr               string
 	edgelessDBImage        string
 	hostHTTPPort           int
@@ -65,6 +66,7 @@ func ParseConfigCLI() *NodeConfigCLI {
 	sequencerID := flag.String(sequencerIDFlag, "", flagUsageMap[sequencerIDFlag])
 	managementContractAddr := flag.String(managementContractAddrFlag, "", flagUsageMap[managementContractAddrFlag])
 	messageBusContractAddr := flag.String(messageBusContractAddrFlag, "", flagUsageMap[messageBusContractAddrFlag])
+	l1Start := flag.String(l1StartBlockFlag, "", flagUsageMap[l1StartBlockFlag])
 	pccsAddr := flag.String(pccsAddrFlag, "", flagUsageMap[pccsAddrFlag])
 	edgelessDBImage := flag.String(edgelessDBImageFlag, "ghcr.io/edgelesssys/edgelessdb-sgx-4gb:v0.3.2", flagUsageMap[edgelessDBImageFlag])
 
@@ -87,6 +89,7 @@ func ParseConfigCLI() *NodeConfigCLI {
 	cfg.sequencerID = *sequencerID
 	cfg.managementContractAddr = *managementContractAddr
 	cfg.messageBusContractAddr = *messageBusContractAddr
+	cfg.l1Start = *l1Start
 	cfg.pccsAddr = *pccsAddr
 	cfg.edgelessDBImage = *edgelessDBImage
 	cfg.hostHTTPPort = *hostHTTPPort

--- a/go/node/cmd/cli_flags.go
+++ b/go/node/cmd/cli_flags.go
@@ -22,6 +22,7 @@ const (
 	sequencerIDFlag            = "sequencer_id"
 	managementContractAddrFlag = "management_contract_addr"
 	messageBusContractAddrFlag = "message_bus_contract_addr"
+	l1StartBlockFlag           = "l1_start"
 	pccsAddrFlag               = "pccs_addr"
 	edgelessDBImageFlag        = "edgeless_db_image"
 )
@@ -48,6 +49,7 @@ func getFlagUsageMap() map[string]string {
 		sequencerIDFlag:            "The 20 bytes of the address of the sequencer for this network",
 		managementContractAddrFlag: "The management contract address on the L1",
 		messageBusContractAddrFlag: "The address of the L1 message bus contract owned by the management contract.",
+		l1StartBlockFlag:           "The block hash on the L1 where the management contract was deployed",
 		pccsAddrFlag:               "Sets the PCCS address",
 		edgelessDBImageFlag:        "Sets the edgelessdb image",
 		hostHTTPPortFlag:           "Host HTTPs bound port",

--- a/go/node/config.go
+++ b/go/node/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	enclaveWSPort             int
 	messageBusContractAddress string
 	managementContractAddr    string
+	l1Start                   string
 	l1WSPort                  int
 	hostP2PHost               string
 	hostPublicP2PAddr         string
@@ -115,6 +116,12 @@ func WithPrivateKey(s string) Option {
 func WithEnclaveWSPort(i int) Option {
 	return func(c *Config) {
 		c.enclaveWSPort = i
+	}
+}
+
+func WithL1Start(blockHash string) Option {
+	return func(c *Config) {
+		c.l1Start = blockHash
 	}
 }
 

--- a/go/node/docker.go
+++ b/go/node/docker.go
@@ -81,6 +81,7 @@ func (d *DockerNode) startHost() error {
 		"-l1NodePort", fmt.Sprintf("%d", d.cfg.l1WSPort),
 		"-enclaveRPCAddress", fmt.Sprintf("%s:%d", d.cfg.nodeName+"-enclave", d.cfg.enclaveWSPort),
 		"-managementContractAddress", d.cfg.managementContractAddr,
+		"-l1Start", d.cfg.l1Start,
 		"-privateKey", d.cfg.privateKey,
 		"-clientRPCHost", "0.0.0.0",
 		"-logPath", "sys_out",
@@ -200,4 +201,5 @@ func (d *DockerNode) startEdgelessDB() error {
 func (d *DockerNode) SetNetworkConfig(networkCfg *NetworkConfig) {
 	d.cfg.managementContractAddr = networkCfg.ManagementContractAddress
 	d.cfg.messageBusContractAddress = networkCfg.MessageBusAddress
+	d.cfg.l1Start = networkCfg.L1StartHash
 }

--- a/go/node/network_config.go
+++ b/go/node/network_config.go
@@ -13,12 +13,14 @@ const _networkCfgFilePath = "./network.json"
 type NetworkConfig struct {
 	ManagementContractAddress string
 	MessageBusAddress         string
+	L1StartHash               string // L1 block hash from which to process for L2 data (mgmt contract deploy block)
 }
 
 func WriteNetworkConfigToDisk(cfg *Config) error {
 	n := NetworkConfig{
 		ManagementContractAddress: cfg.managementContractAddr,
 		MessageBusAddress:         cfg.messageBusContractAddress,
+		L1StartHash:               cfg.l1Start,
 	}
 	jsonStr, err := json.Marshal(n)
 	if err != nil {

--- a/integration/networktest/tests/helpful/smoke_test.go
+++ b/integration/networktest/tests/helpful/smoke_test.go
@@ -19,7 +19,7 @@ func TestExecuteNativeFundsTransfer(t *testing.T) {
 	networktest.Run(
 		"native-funds-smoketest",
 		t,
-		env.LocalDevNetwork(),
+		env.DevTestnet(),
 		actions.Series(
 			&actions.CreateTestUser{UserID: 0},
 			&actions.CreateTestUser{UserID: 1},

--- a/testnet/launcher/docker.go
+++ b/testnet/launcher/docker.go
@@ -34,7 +34,7 @@ func (t *Testnet) Start() error {
 		return fmt.Errorf("unable to start eth2network - %w", err)
 	}
 
-	managementContractAddr, messageBusContractAddr, err := deployL1Contracts()
+	networkConfig, err := deployL1Contracts()
 	if err != nil {
 		return fmt.Errorf("unable to deploy l1 contracts - %w", err)
 	}
@@ -57,8 +57,9 @@ func (t *Testnet) Start() error {
 		node.WithPrivateKey("8ead642ca80dadb0f346a66cd6aa13e08a8ac7b5c6f7578d4bac96f5db01ac99"),
 		node.WithHostID("0x0654D8B60033144D567f25bF41baC1FB0D60F23B"),
 		node.WithSequencerID("0x0654D8B60033144D567f25bF41baC1FB0D60F23B"),
-		node.WithManagementContractAddress(managementContractAddr),
-		node.WithMessageBusContractAddress(messageBusContractAddr),
+		node.WithManagementContractAddress(networkConfig.ManagementContractAddress),
+		node.WithMessageBusContractAddress(networkConfig.MessageBusAddress),
+		node.WithL1Start(networkConfig.L1StartHash),
 		node.WithInMemoryDB(true),
 	)
 
@@ -97,8 +98,9 @@ func (t *Testnet) Start() error {
 		node.WithPrivateKey("ebca545772d6438bbbe1a16afbed455733eccf96157b52384f1722ea65ccfa89"),
 		node.WithHostID("0x2f7fCaA34b38871560DaAD6Db4596860744e1e8A"),
 		node.WithSequencerID("0x0654D8B60033144D567f25bF41baC1FB0D60F23B"),
-		node.WithManagementContractAddress(managementContractAddr),
-		node.WithMessageBusContractAddress(messageBusContractAddr),
+		node.WithManagementContractAddress(networkConfig.ManagementContractAddress),
+		node.WithMessageBusContractAddress(networkConfig.MessageBusAddress),
+		node.WithL1Start(networkConfig.L1StartHash),
 		node.WithInMemoryDB(true),
 	)
 
@@ -183,7 +185,7 @@ func startEth2Network() error {
 	return nil
 }
 
-func deployL1Contracts() (string, string, error) {
+func deployL1Contracts() (*node.NetworkConfig, error) {
 	l1ContractDeployer, err := l1cd.NewDockerContractDeployer(
 		l1cd.NewContractDeployerConfig(
 			l1cd.WithL1Host("eth2network"),
@@ -193,20 +195,20 @@ func deployL1Contracts() (string, string, error) {
 		),
 	)
 	if err != nil {
-		return "", "", fmt.Errorf("unable to configure l1 contract deployer - %w", err)
+		return nil, fmt.Errorf("unable to configure l1 contract deployer - %w", err)
 	}
 
 	err = l1ContractDeployer.Start()
 	if err != nil {
-		return "", "", fmt.Errorf("unable to start l1 contract deployer - %w", err)
+		return nil, fmt.Errorf("unable to start l1 contract deployer - %w", err)
 	}
 
-	managementContractAddr, messageBusContractAddr, err := l1ContractDeployer.RetrieveL1ContractAddresses()
+	networkConfig, err := l1ContractDeployer.RetrieveL1ContractAddresses()
 	if err != nil {
-		return "", "", fmt.Errorf("unable to fetch l1 contract addresses - %w", err)
+		return nil, fmt.Errorf("unable to fetch l1 contract addresses - %w", err)
 	}
 	fmt.Println("L1 Contracts were successfully deployed...")
-	return managementContractAddr, messageBusContractAddr, nil
+	return networkConfig, nil
 }
 
 // waitForHealthyNode retries continuously for the node to respond to a healthcheck http request

--- a/testnet/launcher/l1contractdeployer/cmd/main.go
+++ b/testnet/launcher/l1contractdeployer/cmd/main.go
@@ -29,19 +29,21 @@ func main() {
 		os.Exit(1)
 	}
 
-	managementContractAddr, messageBusContractAddr, err := l1ContractDeployer.RetrieveL1ContractAddresses()
+	networkConfig, err := l1ContractDeployer.RetrieveL1ContractAddresses()
 	if err != nil {
 		fmt.Println("unable to fetch l1 contract addresses - %w", err)
 		os.Exit(1)
 	}
 	fmt.Println("L1 Contracts were successfully deployed...")
 
-	fmt.Printf("MGMTCONTRACTADDR=%s\n", managementContractAddr)
-	fmt.Printf("MSGBUSCONTRACTADDR=%s\n", messageBusContractAddr)
+	fmt.Printf("MGMTCONTRACTADDR=%s\n", networkConfig.ManagementContractAddress)
+	fmt.Printf("MSGBUSCONTRACTADDR=%s\n", networkConfig.MessageBusAddress)
+	fmt.Printf("L1START=%s\n", networkConfig.L1StartHash)
 
 	// the responsibility of writing to disk is outside the deployers domain
 	if cliConfig.contractsEnvFile != "" {
-		envFile := fmt.Sprintf("MGMTCONTRACTADDR=%s\nMSGBUSCONTRACTADDR=%s\n", managementContractAddr, messageBusContractAddr)
+		envFile := fmt.Sprintf("MGMTCONTRACTADDR=%s\nMSGBUSCONTRACTADDR=%s\nL1START=%s\n",
+			networkConfig.ManagementContractAddress, networkConfig.MessageBusAddress, networkConfig.L1StartHash)
 
 		// Write the content to a new file or override the existing file
 		err = os.WriteFile(cliConfig.contractsEnvFile, []byte(envFile), 0o644) //nolint:gosec

--- a/testnet/launcher/l1contractdeployer/docker.go
+++ b/testnet/launcher/l1contractdeployer/docker.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/obscuronet/go-obscuro/go/node"
+
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
 	"github.com/obscuronet/go-obscuro/go/common/docker"
@@ -57,29 +59,29 @@ func (n *ContractDeployer) Start() error {
 	return nil
 }
 
-func (n *ContractDeployer) RetrieveL1ContractAddresses() (string, string, error) {
+func (n *ContractDeployer) RetrieveL1ContractAddresses() (*node.NetworkConfig, error) {
 	cli, err := client.NewClientWithOpts(client.FromEnv)
 	if err != nil {
-		return "", "", err
+		return nil, err
 	}
 	defer cli.Close()
 
 	// make sure the container has finished execution
 	err = docker.WaitForContainerToFinish(n.containerID, time.Minute)
 	if err != nil {
-		return "", "", err
+		return nil, err
 	}
 
 	logsOptions := types.ContainerLogsOptions{
 		ShowStdout: true,
 		ShowStderr: true,
-		Tail:       "2",
+		Tail:       "3",
 	}
 
 	// Read the container logs
 	out, err := cli.ContainerLogs(context.Background(), n.containerID, logsOptions)
 	if err != nil {
-		return "", "", err
+		return nil, err
 	}
 	defer out.Close()
 
@@ -87,23 +89,28 @@ func (n *ContractDeployer) RetrieveL1ContractAddresses() (string, string, error)
 	var buf bytes.Buffer
 	_, err = io.Copy(&buf, out)
 	if err != nil {
-		return "", "", err
+		return nil, err
 	}
 
-	// Get the last two lines
+	// Get the last three lines
 	output := buf.String()
 	lines := strings.Split(output, "\n")
 
 	managementAddr, err := findAddress(lines[0])
 	if err != nil {
-		return "", "", err
+		return nil, err
 	}
 	messageBusAddr, err := findAddress(lines[1])
 	if err != nil {
-		return "", "", err
+		return nil, err
 	}
+	l1BlockHash := readValue("L1Start", lines[2])
 
-	return managementAddr, messageBusAddr, nil
+	return &node.NetworkConfig{
+		ManagementContractAddress: managementAddr,
+		MessageBusAddress:         messageBusAddr,
+		L1StartHash:               l1BlockHash,
+	}, nil
 }
 
 func findAddress(line string) (string, error) {
@@ -118,4 +125,10 @@ func findAddress(line string) (string, error) {
 	}
 	// Print the last
 	return matches[len(matches)-1], nil
+}
+
+func readValue(name string, line string) string {
+	parts := strings.Split(line, fmt.Sprintf("%s=", name))
+	val := strings.TrimSpace(parts[len(parts)-1])
+	return val
 }


### PR DESCRIPTION
### Why this change is needed

When starting nodes we don't want them to have to process the entire L1 at startup. There is a host flag to tell it what block to start streaming from (mgmt contract deployment) but it wasn't being used.

### What changes were made as part of this PR

Capture mgmt contract deployment block and wire it into node start args.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


