### PR TITLE
Removing the External API Calls section

### DIFF
--- a/docs/_docs/testnet/obscuroscan.md
+++ b/docs/_docs/testnet/obscuroscan.md
@@ -19,7 +19,3 @@ Notice the _Decrypted transaction blob_ section for each rollup. This allows you
 transactions in unencrypted plain text. This is a feature of Testnet aimed at helping you understand how Obscuro works, 
 and is only possible because Testnet uses a rollup encryption key that is long-lived and well-known. On Mainnet, 
 rollups will be encrypted with rotating keys that are not known to anyone, or anything, other than the Obscuro enclaves.
-
-## External API Calls
-
-The URL path [/rollup/](http://testnet.obscuroscan.io/rollup/) may be requested from external clients using a HTTP POST request with either a rollup number (integer) or transaction hash (string beginning with "0x"). A JSON object representing the rollup will be returned. Further API development of ObscuroScan with RESTful documentation will follow.


### PR DESCRIPTION
### Why this change is needed

The APIs for fetching rollup & transaction details are not accessible & ready to be used by users.

### What changes were made as part of this PR

Removed the 'External API Calls' section.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [x] PR checks reviewed and performed 


