### PR TITLE
Fix: node launcher was ignoring the L1 start param

### DIFF
--- a/go/node/cmd/main.go
+++ b/go/node/cmd/main.go
@@ -28,6 +28,7 @@ func main() {
 		node.WithSequencerID(cliConfig.sequencerID),                          // "0x0654D8B60033144D567f25bF41baC1FB0D60F23B"),
 		node.WithManagementContractAddress(cliConfig.managementContractAddr), // "0xeDa66Cc53bd2f26896f6Ba6b736B1Ca325DE04eF"),
 		node.WithMessageBusContractAddress(cliConfig.messageBusContractAddr), // "0xFD03804faCA2538F4633B3EBdfEfc38adafa259B"),
+		node.WithL1Start(cliConfig.l1Start),
 		node.WithPCCSAddr(cliConfig.pccsAddr),
 		node.WithEdgelessDBImage(cliConfig.edgelessDBImage),
 	)


### PR DESCRIPTION
### Why this change is needed
 
Added CLI flag for L1 start param to node launcher but missed a step in wiring it through to the node config. Found that it was not getting set in testnet startups despite contract deployer outputting a value for it.

### What changes were made as part of this PR

Set the L1 start in node conf


### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


