### PR TITLE
Remove unused host flow controls

### DIFF
--- a/go/host/host.go
+++ b/go/host/host.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"sync/atomic"
 	"time"
 
 	"github.com/ethereum/go-ethereum/core/types"
@@ -416,14 +415,6 @@ func (h *host) handleProcessBlockErr(processedBlock *types.Block, stream *hostco
 	}
 	stream.Stop() // cancel the previous stream and return the replacement
 	return replacementStream
-}
-
-// activates the given interrupt (atomically) and returns a new interrupt
-func triggerInterrupt(interrupt *int32) *int32 {
-	// Notify the previous round to stop work
-	atomic.StoreInt32(interrupt, 1)
-	i := int32(0)
-	return &i
 }
 
 func (h *host) processL1Block(block *types.Block, isLatestBlock bool) error {

--- a/integration/networktest/tests/helpful/smoke_test.go
+++ b/integration/networktest/tests/helpful/smoke_test.go
@@ -19,7 +19,7 @@ func TestExecuteNativeFundsTransfer(t *testing.T) {
 	networktest.Run(
 		"native-funds-smoketest",
 		t,
-		env.DevTestnet(),
+		env.LocalDevNetwork(),
 		actions.Series(
 			&actions.CreateTestUser{UserID: 0},
 			&actions.CreateTestUser{UserID: 1},


### PR DESCRIPTION
### Why this change is needed

There were flags used to manage the state/lifecycle of the host that aren't used anymore and make the code more confusing to read.

### What changes were made as part of this PR

Remove unused controls.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


