### PR TITLE
Run scheduled dev-testnet deployment at 3:05am Tues to Sat

### DIFF
--- a/.github/workflows/manual-deploy-testnet-l1.yml
+++ b/.github/workflows/manual-deploy-testnet-l1.yml
@@ -10,12 +10,14 @@
 #  testnet-eth2network-DEPLOYNUMBER.uksouth.azurecontainer.io
 # or
 #  dev-testnet-eth2network-DEPLOYNUMBER.uksouth.azurecontainer.io
+#
+# The scheduled deployment runs tt 03:05 on every day-of-week from Tuesday through Saturday, for dev-testnet only.
 
 name: '[M] Deploy Testnet L1'
 
 on:
   schedule:
-    - cron: '05 3 * * *'
+    - cron: '05 3 * * 2-6'
   workflow_dispatch:
     inputs:
       testnet_type:

--- a/.github/workflows/manual-deploy-testnet-l1.yml
+++ b/.github/workflows/manual-deploy-testnet-l1.yml
@@ -11,7 +11,7 @@
 # or
 #  dev-testnet-eth2network-DEPLOYNUMBER.uksouth.azurecontainer.io
 #
-# The scheduled deployment runs tt 03:05 on every day-of-week from Tuesday through Saturday, for dev-testnet only.
+# The scheduled deployment runs at 03:05 on every day-of-week from Tuesday through Saturday, for dev-testnet only.
 
 name: '[M] Deploy Testnet L1'
 


### PR DESCRIPTION
Allows us to run longer E2E tests over the weekend. 

