### PR TITLE
Wipe and re-clone obscuro code on testnet node upgrade

### DIFF
--- a/.github/workflows/manual-upgrade-testnet-l2.yml
+++ b/.github/workflows/manual-upgrade-testnet-l2.yml
@@ -141,7 +141,8 @@ jobs:
             az vm run-command invoke -g Testnet -n "${{needs.build.outputs.RESOURCE_STARTING_NAME}}-${{ matrix.host_id }}-${{ github.event.inputs.github_deploy_number }}"  \
             --command-id RunShellScript \
             --scripts '
-              git clone --depth 1 -b ${{ steps.extract_branch.outputs.branch }} https://github.com/obscuronet/go-obscuro.git /home/obscuro/go-obscuro \
+              rm -rf /home/obscuro/go-obscuro \
+            && git clone --depth 1 -b ${{ steps.extract_branch.outputs.branch }} https://github.com/obscuronet/go-obscuro.git /home/obscuro/go-obscuro \
             && cd /home/obscuro/go-obscuro/ \
             && sudo go run /home/obscuro/go-obscuro/go/node/cmd  \
               -is_genesis=${{ matrix.is_genesis }} \

--- a/go/node/network_config.go
+++ b/go/node/network_config.go
@@ -5,8 +5,8 @@ import (
 	"os"
 )
 
-// This is the location where the metadata will be stored on all testnet VMs
-const _networkCfgFilePath = "./network.json"
+// This is the location where the metadata will be stored (currently only used on testnet VMs, may need to be made configurable eventually)
+const _defaultNetworkCfgFilePath = "/home/obscuro/network.json"
 
 // NetworkConfig is key network information required to start a node connecting to that network.
 // We persist it as a json file on our testnet hosts so that they can read it off when restart/upgrading
@@ -27,7 +27,7 @@ func WriteNetworkConfigToDisk(cfg *Config) error {
 		return err
 	}
 	// create the file as read-only, expect it to be immutable data for the lifetime of the obscuro network for the node
-	err = os.WriteFile(_networkCfgFilePath, jsonStr, 0o644) //nolint:gosec
+	err = os.WriteFile(_defaultNetworkCfgFilePath, jsonStr, 0o644) //nolint:gosec
 	if err != nil {
 		return err
 	}
@@ -35,7 +35,7 @@ func WriteNetworkConfigToDisk(cfg *Config) error {
 }
 
 func ReadNetworkConfigFromDisk() (*NetworkConfig, error) {
-	bytes, err := os.ReadFile(_networkCfgFilePath)
+	bytes, err := os.ReadFile(_defaultNetworkCfgFilePath)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Why this change is needed

Upgrade needs to update the code to the specified branch so it should delete and reclone the code (could pull and potentially switch branch but this seems simpler given we've got depth 1 clone.

### What changes were made as part of this PR

Delete obscuro code from VM before cloning on upgrade script.

Move the network config file to not be in the same dir as the checked out code by default.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


