### PR TITLE
Resolve image paths for faucet docs

### DIFF
--- a/docs/_docs/testnet/faucet.md
+++ b/docs/_docs/testnet/faucet.md
@@ -12,11 +12,11 @@ Using the steps below you will request testnet OBX from the faucet available on 
 1. Make a note of your wallet address or copy it to your clipboard.
 2. Open the [_faucet-requests_ channel](https://discord.gg/5qyj3qraaH) on Obscuro Discord.
 3. Request OBX using the `/faucet` command. The faucet will credit 100,000 OBX by default:
-   ![faucet command](../assets/images/faucet-cmd.png)
+   ![faucet command](../../assets/images/faucet-cmd.png)
 4. Provide your wallet address and hit Enter. The faucet will acknowledge your request:
-   ![faucet ack](../assets/images/faucet-ack.png)
+   ![faucet ack](../../assets/images/faucet-ack.png)
 5. After a short period of time the faucet will confirm the Testnet OBX have been credited to your wallet:
-   ![faucet complete](../assets/images/faucet-done.png)
+   ![faucet complete](../../assets/images/faucet-done.png)
 
 ## Viewing Your Wallet Balance
 To view the balance of your wallet you will need to establish a connection from your wallet to the Obscuro Testnet. An essential part of how Obscuro provides full privacy is the encryption of communication between an Obscuro application and Obscuro nodes on the network. As a result, you will need to use the wallet extension to allow your wallet to communication with the Obscuro Testnet.


### PR DESCRIPTION
Resolving images seems to be different on the built pages to that relative in the source
