### PR TITLE
L1_HOST not output properly in GH upgrade action

### DIFF
--- a/.github/workflows/manual-upgrade-testnet-l2.yml
+++ b/.github/workflows/manual-upgrade-testnet-l2.yml
@@ -57,7 +57,7 @@ jobs:
           echo "RESOURCE_TESTNET_NAME=testnet" >> $GITHUB_ENV
           echo "L1_HOST=testnet-eth2network.uksouth.azurecontainer.io" >> $GITHUB_ENV
           
-      - name: 'Sets env vars for dev-tesnet'
+      - name: 'Sets env vars for dev-testnet'
         if: ${{ github.event.inputs.testnet_type == 'dev-testnet' }}
         run: |
           echo "L2_ENCLAVE_DOCKER_BUILD_TAG=testnetobscuronet.azurecr.io/obscuronet/dev_enclave:latest" >> $GITHUB_ENV
@@ -75,6 +75,7 @@ jobs:
           echo "RESOURCE_TAG_NAME=${{env.RESOURCE_TAG_NAME}}" >> $GITHUB_OUTPUT
           echo "RESOURCE_STARTING_NAME=${{env.RESOURCE_STARTING_NAME}}" >> $GITHUB_OUTPUT
           echo "RESOURCE_TESTNET_NAME=${{env.RESOURCE_TESTNET_NAME}}" >> $GITHUB_OUTPUT
+          echo "L1_HOST=${{env.L1_HOST}}" >> $GITHUB_OUTPUT
 
       - name: 'Login to Azure docker registry'
         uses: azure/docker-login@v1


### PR DESCRIPTION
### Why this change is needed

When running the L2 upgrade GitHub action the hosts fail to come up with the following error:

`CRIT [03-27|09:04:07.345] could not create Ethereum client.        node_id=0x0000000000000000000000000000000000000000 component=host err="unable to connect to the eth node - dial tcp :9000: connect: connection refused"`

It failed to connect because it's got the empty string as the L1 host name. I did a diff with the L2 Deploy script and this line was missing to output the L1_HOST variable.

### What changes were made as part of this PR

Make sure L1_HOST var is exported in GH upgrade script.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


