### PR TITLE
fix names of types aliases

### DIFF
--- a/go/common/batches.go
+++ b/go/common/batches.go
@@ -18,9 +18,9 @@ type ExtBatch struct {
 
 // Hash returns the keccak256 hash of the batch's header.
 // The hash is computed on the first call and cached thereafter.
-func (b *ExtBatch) Hash() L2RootHash {
+func (b *ExtBatch) Hash() L2BatchHash {
 	if hash := b.hash.Load(); hash != nil {
-		return hash.(L2RootHash)
+		return hash.(L2BatchHash)
 	}
 	v := b.Header.Hash()
 	b.hash.Store(v)

--- a/go/common/headers.go
+++ b/go/common/headers.go
@@ -22,7 +22,7 @@ var hasherPool = sync.Pool{
 // Making changes to this struct will require GRPC + GRPC Converters regen
 type BatchHeader struct {
 	// The fields present in Geth's `types/Header` struct.
-	ParentHash  L2RootHash
+	ParentHash  L2BatchHash
 	UncleHash   common.Hash    `json:"sha3Uncles"`
 	Coinbase    common.Address `json:"miner"`
 	Root        StateRoot      `json:"stateRoot"`
@@ -41,7 +41,7 @@ type BatchHeader struct {
 
 	// The custom Obscuro fields.
 	Agg                common.Address                        // todo - can this be removed and replaced with the `Coinbase` field?
-	L1Proof            L1RootHash                            // the L1 block used by the enclave to generate the current batch
+	L1Proof            L1BlockHash                           // the L1 block used by the enclave to generate the current batch
 	R, S               *big.Int                              // signature values
 	CrossChainMessages []MessageBus.StructsCrossChainMessage `json:"crossChainMessages"`
 
@@ -56,7 +56,7 @@ type BatchHeader struct {
 // Making changes to this struct will require GRPC + GRPC Converters regen
 type RollupHeader struct {
 	// The fields present in Geth's `types/Header` struct.
-	ParentHash  L2RootHash
+	ParentHash  L2BatchHash
 	UncleHash   common.Hash    `json:"sha3Uncles"`
 	Coinbase    common.Address `json:"miner"`
 	Root        StateRoot      `json:"stateRoot"`
@@ -74,7 +74,7 @@ type RollupHeader struct {
 
 	// The custom Obscuro fields.
 	Agg                common.Address                        // todo - can this be removed and replaced with the `Coinbase` field?
-	L1Proof            L1RootHash                            // the L1 block used by the enclave to generate the current rollup
+	L1Proof            L1BlockHash                           // the L1 block used by the enclave to generate the current rollup
 	R, S               *big.Int                              // signature values
 	CrossChainMessages []MessageBus.StructsCrossChainMessage `json:"crossChainMessages"`
 	HeadBatchHash      common.Hash                           // The latest batch included in this rollup.
@@ -88,7 +88,7 @@ type RollupHeader struct {
 
 // Hash returns the block hash of the header, which is simply the keccak256 hash of its
 // RLP encoding excluding the signature.
-func (b *BatchHeader) Hash() L2RootHash {
+func (b *BatchHeader) Hash() L2BatchHash {
 	cp := *b
 	cp.R = nil
 	cp.S = nil
@@ -129,7 +129,7 @@ func (b *BatchHeader) ToRollupHeader() *RollupHeader {
 
 // Hash returns the block hash of the header, which is simply the keccak256 hash of its
 // RLP encoding excluding the signature.
-func (r *RollupHeader) Hash() L2RootHash {
+func (r *RollupHeader) Hash() L2BatchHash {
 	cp := *r
 	cp.R = nil
 	cp.S = nil

--- a/go/common/rollups.go
+++ b/go/common/rollups.go
@@ -15,9 +15,9 @@ type ExtRollup struct {
 
 // Hash returns the keccak256 hash of the rollup's header.
 // The hash is computed on the first call and cached thereafter.
-func (r *ExtRollup) Hash() L2RootHash {
+func (r *ExtRollup) Hash() L2BatchHash {
 	if hash := r.hash.Load(); hash != nil {
-		return hash.(L2RootHash)
+		return hash.(L2BatchHash)
 	}
 	v := r.Header.Hash()
 	r.hash.Store(v)

--- a/go/common/types.go
+++ b/go/common/types.go
@@ -16,14 +16,14 @@ type (
 
 	// MainNet aliases
 	L1Address     = common.Address
-	L1RootHash    = common.Hash
+	L1BlockHash   = common.Hash
 	L1Block       = types.Block
 	L1Transaction = types.Transaction
 	L1Receipt     = types.Receipt
 	L1Receipts    = types.Receipts
 
 	// Local Obscuro aliases
-	L2RootHash     = common.Hash // todo this is not a state root hash. This is the hash of the batch. Rename to L2Hash
+	L2BatchHash    = common.Hash
 	L2TxHash       = common.Hash
 	L2Tx           = types.Transaction
 	L2Transactions = types.Transactions

--- a/go/config/host_config.go
+++ b/go/config/host_config.go
@@ -201,7 +201,7 @@ func DefaultHostParsedConfig() *HostInputConfig {
 		L1ChainID:                 1337,
 		ObscuroChainID:            777,
 		ProfilerEnabled:           false,
-		L1StartHash:               common.L1RootHash{}, // this hash will not be found, host will log a warning and then stream from L1 genesis
+		L1StartHash:               common.L1BlockHash{}, // this hash will not be found, host will log a warning and then stream from L1 genesis
 		MetricsEnabled:            true,
 		MetricsHTTPPort:           14000,
 		UseInMemoryDB:             true,

--- a/go/enclave/core/batch.go
+++ b/go/enclave/core/batch.go
@@ -25,12 +25,12 @@ type Batch struct {
 
 // Hash returns the keccak256 hash of b's header.
 // The hash is computed on the first call and cached thereafter.
-func (b *Batch) Hash() *common.L2RootHash {
+func (b *Batch) Hash() *common.L2BatchHash {
 	// Temporarily disabling the caching of the hash because it's causing bugs.
 	// Transforming a Batch to an ExtBatch and then back to a Batch will generate a different hash if caching is enabled.
 	// todo (#1547) - re-enable
 	//if hash := b.hash.Load(); hash != nil {
-	//	return hash.(common.L2RootHash)
+	//	return hash.(common.L2BatchHash)
 	//}
 	v := b.Header.Hash()
 	b.hash.Store(v)

--- a/go/enclave/core/rollup.go
+++ b/go/enclave/core/rollup.go
@@ -17,12 +17,12 @@ type Rollup struct {
 
 // Hash returns the keccak256 hash of b's header.
 // The hash is computed on the first call and cached thereafter.
-func (r *Rollup) Hash() *common.L2RootHash {
+func (r *Rollup) Hash() *common.L2BatchHash {
 	// Temporarily disabling the caching of the hash because it's causing bugs.
 	// Transforming a Rollup to an ExtRollup and then back to a Rollup will generate a different hash if caching is enabled.
 	// todo (#1547) - re-enable
 	//if hash := r.hash.Load(); hash != nil {
-	//	return hash.(common.L2RootHash)
+	//	return hash.(common.L2BatchHash)
 	//}
 	v := r.Header.Hash()
 	r.hash.Store(v)

--- a/go/enclave/db/interfaces.go
+++ b/go/enclave/db/interfaces.go
@@ -17,7 +17,7 @@ import (
 // BlockResolver stores new blocks and returns information on existing blocks
 type BlockResolver interface {
 	// FetchBlock returns the L1 Block with the given hash.
-	FetchBlock(blockHash common.L1RootHash) (*types.Block, error)
+	FetchBlock(blockHash common.L1BlockHash) (*types.Block, error)
 	// FetchHeadBlock - returns the head of the current chain.
 	FetchHeadBlock() (*types.Block, error)
 	// StoreBlock persists the L1 Block
@@ -27,12 +27,12 @@ type BlockResolver interface {
 	// IsBlockAncestor returns true if maybeAncestor is an ancestor of the L1 Block, and false otherwise
 	// Takes into consideration that the Block to verify might be on a branch we haven't received yet
 	// todo (low priority) - this is super confusing, analyze the usage
-	IsBlockAncestor(block *types.Block, maybeAncestor common.L1RootHash) bool
+	IsBlockAncestor(block *types.Block, maybeAncestor common.L1BlockHash) bool
 }
 
 type BatchResolver interface {
 	// FetchBatch returns the batch with the given hash.
-	FetchBatch(hash common.L2RootHash) (*core.Batch, error)
+	FetchBatch(hash common.L2BatchHash) (*core.Batch, error)
 	// FetchBatchByHeight returns the batch on the canonical chain with the given height.
 	FetchBatchByHeight(height uint64) (*core.Batch, error)
 	// FetchHeadBatch returns the current head batch of the canonical chain.
@@ -48,20 +48,20 @@ type RollupResolver interface {
 
 type HeadsAfterL1BlockStorage interface {
 	// FetchHeadBatchForBlock returns the hash of the head batch at a given L1 block.
-	FetchHeadBatchForBlock(blockHash common.L1RootHash) (*core.Batch, error)
+	FetchHeadBatchForBlock(blockHash common.L1BlockHash) (*core.Batch, error)
 	// FetchHeadRollupForBlock returns the hash of the latest (i.e. highest-numbered) rollup in the given L1 block, or
 	// nil if the block contains no rollups.
-	FetchHeadRollupForBlock(blockHash *common.L1RootHash) (*core.Rollup, error)
+	FetchHeadRollupForBlock(blockHash *common.L1BlockHash) (*core.Rollup, error)
 	// UpdateL1Head updates the L1 head.
-	UpdateL1Head(l1Head common.L1RootHash) error
+	UpdateL1Head(l1Head common.L1BlockHash) error
 	// UpdateHeadBatch updates the canonical L2 head batch for a given L1 block.
-	UpdateHeadBatch(l1Head common.L1RootHash, l2Head *core.Batch, receipts []*types.Receipt) error
+	UpdateHeadBatch(l1Head common.L1BlockHash, l2Head *core.Batch, receipts []*types.Receipt) error
 	// SetHeadBatchPointer updates the canonical L2 head batch for a given L1 block.
 	SetHeadBatchPointer(l2Head *core.Batch) error
 	// UpdateHeadRollup just updates the canonical L2 head batch, leaving data untouched (used to rewind after L1 fork or data corruption)
-	UpdateHeadRollup(l1Head *common.L1RootHash, l2Head *common.L2RootHash) error
+	UpdateHeadRollup(l1Head *common.L1BlockHash, l2Head *common.L2BatchHash) error
 	// CreateStateDB creates a database that can be used to execute transactions
-	CreateStateDB(hash common.L2RootHash) (*state.StateDB, error)
+	CreateStateDB(hash common.L2BatchHash) (*state.StateDB, error)
 	// EmptyStateDB creates the original empty StateDB
 	EmptyStateDB() (*state.StateDB, error)
 }
@@ -79,7 +79,7 @@ type TransactionStorage interface {
 	// GetTransactionReceipt - returns the receipt of a tx by tx hash
 	GetTransactionReceipt(txHash common.L2TxHash) (*types.Receipt, error)
 	// GetReceiptsByHash retrieves the receipts for all transactions in a given rollup.
-	GetReceiptsByHash(hash common.L2RootHash) (types.Receipts, error)
+	GetReceiptsByHash(hash common.L2BatchHash) (types.Receipts, error)
 	// GetSender returns the sender of the tx by hash
 	GetSender(txHash common.L2TxHash) (gethcommon.Address, error)
 	// GetContractCreationTx returns the hash of the tx that created a contract
@@ -94,8 +94,8 @@ type AttestationStorage interface {
 }
 
 type CrossChainMessagesStorage interface {
-	StoreL1Messages(blockHash common.L1RootHash, messages common.CrossChainMessages) error
-	GetL1Messages(blockHash common.L1RootHash) (common.CrossChainMessages, error)
+	StoreL1Messages(blockHash common.L1BlockHash, messages common.CrossChainMessages) error
+	GetL1Messages(blockHash common.L1BlockHash) (common.CrossChainMessages, error)
 }
 
 // Storage is the enclave's interface for interacting with the enclave's datastore
@@ -114,5 +114,5 @@ type Storage interface {
 	HealthCheck() (bool, error)
 	// FilterLogs - applies the properties the relevancy checks for the requestingAccount to all the stored log events
 	// nil values will be ignored. Make sure to set all fields to the right values before calling this function
-	FilterLogs(requestingAccount *gethcommon.Address, fromBlock, toBlock *big.Int, blockHash *common.L2RootHash, addresses []gethcommon.Address, topics [][]gethcommon.Hash) ([]*types.Log, error)
+	FilterLogs(requestingAccount *gethcommon.Address, fromBlock, toBlock *big.Int, blockHash *common.L2BatchHash, addresses []gethcommon.Address, topics [][]gethcommon.Hash) ([]*types.Log, error)
 }

--- a/go/enclave/db/rawdb/accessors_receipts.go
+++ b/go/enclave/db/rawdb/accessors_receipts.go
@@ -68,7 +68,7 @@ func ReadReceipts(db ethdb.Reader, hash common.Hash, number uint64, config *para
 }
 
 // WriteReceipts stores all the transaction receipts belonging to a batch.
-func WriteReceipts(db ethdb.KeyValueWriter, hash common2.L2RootHash, receipts types.Receipts) error {
+func WriteReceipts(db ethdb.KeyValueWriter, hash common2.L2BatchHash, receipts types.Receipts) error {
 	// Convert the receipts into their storage form and serialize them
 	storageReceipts := make([]*types.ReceiptForStorage, len(receipts))
 	for i, receipt := range receipts {

--- a/go/enclave/db/rawdb/schema.go
+++ b/go/enclave/db/rawdb/schema.go
@@ -36,22 +36,22 @@ func encodeNumber(number uint64) []byte {
 }
 
 // For storing and fetching a batch header by batch hash.
-func batchHeaderKey(hash common.L2RootHash) []byte {
+func batchHeaderKey(hash common.L2BatchHash) []byte {
 	return append(batchHeaderPrefix, hash.Bytes()...)
 }
 
 // For storing and fetching a batch body by batch hash.
-func batchBodyKey(hash common.L2RootHash) []byte {
+func batchBodyKey(hash common.L2BatchHash) []byte {
 	return append(batchBodyPrefix, hash.Bytes()...)
 }
 
 // For storing and fetching a batch number by batch hash.
-func batchNumberKey(hash common.L2RootHash) []byte {
+func batchNumberKey(hash common.L2BatchHash) []byte {
 	return append(batchNumberPrefix, hash.Bytes()...)
 }
 
 // For storing and fetching the L2 head batch hash by L1 block hash.
-func headBatchAfterL1BlockKey(hash common.L1RootHash) []byte {
+func headBatchAfterL1BlockKey(hash common.L1BlockHash) []byte {
 	return append(headBatchAfterL1BlockPrefix, hash.Bytes()...)
 }
 
@@ -61,12 +61,12 @@ func batchHeaderHashKey(number uint64) []byte {
 }
 
 // For storing and fetching a batch's receipts by batch hash.
-func batchReceiptsKey(hash common.L2RootHash) []byte {
+func batchReceiptsKey(hash common.L2BatchHash) []byte {
 	return append(batchReceiptsPrefix, hash.Bytes()...)
 }
 
 // For storing and fetching the L2 head rollup hash by L1 block hash.
-func headRollupAfterL1BlockKey(hash *common.L1RootHash) []byte {
+func headRollupAfterL1BlockKey(hash *common.L1BlockHash) []byte {
 	return append(headRollupAfterL1BlockPrefix, hash.Bytes()...)
 }
 
@@ -83,21 +83,21 @@ func attestationPkKey(aggregator gethcommon.Address) []byte {
 	return append(attestationKeyPrefix, aggregator.Bytes()...)
 }
 
-func crossChainMessagesKey(blockHash common.L1RootHash) []byte {
+func crossChainMessagesKey(blockHash common.L1BlockHash) []byte {
 	return append(syntheticTransactionsKeyPrefix, blockHash.Bytes()...)
 }
 
 // For storing and fetching a rollup header by batch hash.
-func rollupHeaderKey(hash common.L2RootHash) []byte {
+func rollupHeaderKey(hash common.L2BatchHash) []byte {
 	return append(rollupHeaderPrefix, hash.Bytes()...)
 }
 
 // For storing and fetching a rollup body by batch hash.
-func rollupBodyKey(hash common.L2RootHash) []byte {
+func rollupBodyKey(hash common.L2BatchHash) []byte {
 	return append(rollupBodyPrefix, hash.Bytes()...)
 }
 
 // For storing and fetching a rollup number by batch hash.
-func rollupNumberKey(hash common.L2RootHash) []byte {
+func rollupNumberKey(hash common.L2BatchHash) []byte {
 	return append(rollupNumberPrefix, hash.Bytes()...)
 }

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -739,7 +739,7 @@ func (e *enclaveImpl) GetBalance(encryptedParams common.EncryptedParamsGetBalanc
 	return encryptedBalance, nil
 }
 
-func (e *enclaveImpl) GetCode(address gethcommon.Address, batchHash *common.L2RootHash) ([]byte, error) {
+func (e *enclaveImpl) GetCode(address gethcommon.Address, batchHash *common.L2BatchHash) ([]byte, error) {
 	if atomic.LoadInt32(e.stopInterrupt) == 1 {
 		return nil, nil
 	}
@@ -1199,7 +1199,7 @@ func (e *enclaveImpl) removeOldMempoolTxs(batchHeader *common.BatchHeader) error
 	return nil
 }
 
-func (e *enclaveImpl) produceBlockSubmissionResponse(l2Head *common.L2RootHash, producedBatch *core.Batch) *common.BlockSubmissionResponse {
+func (e *enclaveImpl) produceBlockSubmissionResponse(l2Head *common.L2BatchHash, producedBatch *core.Batch) *common.BlockSubmissionResponse {
 	if l2Head == nil {
 		// not an error state, we ingested a block but no rollup head found
 		return &common.BlockSubmissionResponse{}
@@ -1262,7 +1262,7 @@ func (e *enclaveImpl) subscriptionLogs(upToBatchNr *big.Int) (map[gethrpc.ID][]b
 }
 
 func (e *enclaveImpl) rejectBlockErr(cause error) *common.BlockRejectError {
-	var hash common.L1RootHash
+	var hash common.L1BlockHash
 	l1Head, err := e.storage.FetchHeadBlock()
 	// TODO - Handle error.
 	if err == nil {

--- a/go/enclave/enclave_test.go
+++ b/go/enclave/enclave_test.go
@@ -619,7 +619,7 @@ func checkExpectedBalance(enclave common.Enclave, blkNumber gethrpc.BlockNumber,
 func dummyBatch(blkHash gethcommon.Hash, height uint64, state *state.StateDB) *core.Batch {
 	h := common.BatchHeader{
 		Agg:         gethcommon.HexToAddress("0x0"),
-		ParentHash:  common.L1RootHash{},
+		ParentHash:  common.L1BlockHash{},
 		L1Proof:     blkHash,
 		Root:        state.IntermediateRoot(true),
 		Number:      big.NewInt(int64(height)),

--- a/go/enclave/events/subscription_manager.go
+++ b/go/enclave/events/subscription_manager.go
@@ -110,7 +110,7 @@ func (s *SubscriptionManager) RemoveSubscription(id gethrpc.ID) {
 
 // FilterLogs takes a list of logs and the hash of the rollup to use to create the state DB. It returns the logs
 // filtered based on the provided account and filter.
-func (s *SubscriptionManager) FilterLogs(logs []*types.Log, rollupHash common.L2RootHash, account *gethcommon.Address, filter *filters.FilterCriteria) ([]*types.Log, error) {
+func (s *SubscriptionManager) FilterLogs(logs []*types.Log, rollupHash common.L2BatchHash, account *gethcommon.Address, filter *filters.FilterCriteria) ([]*types.Log, error) {
 	filteredLogs := []*types.Log{}
 	stateDB, err := s.storage.CreateStateDB(rollupHash)
 	if err != nil {

--- a/go/ethadapter/blockprovider_test.go
+++ b/go/ethadapter/blockprovider_test.go
@@ -209,7 +209,7 @@ func (e *ethClientMock) BlocksBetween(block *types.Block, head *types.Block) []*
 	panic("implement me")
 }
 
-func (e *ethClientMock) IsBlockAncestor(block *types.Block, proof common.L1RootHash) bool {
+func (e *ethClientMock) IsBlockAncestor(block *types.Block, proof common.L1BlockHash) bool {
 	// TODO implement me
 	panic("implement me")
 }

--- a/go/ethadapter/geth_rpc_client.go
+++ b/go/ethadapter/geth_rpc_client.go
@@ -80,8 +80,8 @@ func (e *gethRPCClient) BlocksBetween(startingBlock *types.Block, lastBlock *typ
 	return blocksBetween
 }
 
-func (e *gethRPCClient) IsBlockAncestor(block *types.Block, maybeAncestor common.L1RootHash) bool {
-	if bytes.Equal(maybeAncestor.Bytes(), block.Hash().Bytes()) || bytes.Equal(maybeAncestor.Bytes(), (common.L1RootHash{}).Bytes()) {
+func (e *gethRPCClient) IsBlockAncestor(block *types.Block, maybeAncestor common.L1BlockHash) bool {
+	if bytes.Equal(maybeAncestor.Bytes(), block.Hash().Bytes()) || bytes.Equal(maybeAncestor.Bytes(), (common.L1BlockHash{}).Bytes()) {
 		return true
 	}
 

--- a/go/ethadapter/interface.go
+++ b/go/ethadapter/interface.go
@@ -30,7 +30,7 @@ type EthClient interface {
 	Info() Info                                                         // retrieves the node Info
 	FetchHeadBlock() (*types.Block, error)                              // retrieves the block at head height
 	BlocksBetween(block *types.Block, head *types.Block) []*types.Block // returns the blocks between two blocks
-	IsBlockAncestor(block *types.Block, proof common.L1RootHash) bool   // returns if the node considers a block the ancestor
+	IsBlockAncestor(block *types.Block, proof common.L1BlockHash) bool  // returns if the node considers a block the ancestor
 	BlockListener() (chan *types.Header, ethereum.Subscription)         // subscribes to new blocks and returns a listener with the blocks heads and the subscription handler
 
 	CallContract(msg ethereum.CallMsg) ([]byte, error) // Runs the provided call message on the latest block.

--- a/go/host/db/batches.go
+++ b/go/host/db/batches.go
@@ -216,7 +216,7 @@ func (db *DB) readBatchHash(number *big.Int) (*gethcommon.Hash, error) {
 }
 
 // Returns the transaction hashes in the batch with the given hash.
-func (db *DB) readBatchTxHashes(batchHash common.L2RootHash) ([]gethcommon.Hash, error) {
+func (db *DB) readBatchTxHashes(batchHash common.L2BatchHash) ([]gethcommon.Hash, error) {
 	data, err := db.kvStore.Get(batchTxHashesKey(batchHash))
 	if err != nil {
 		return nil, err
@@ -243,7 +243,7 @@ func (db *DB) writeBatchNumber(w ethdb.KeyValueWriter, header *common.BatchHeade
 }
 
 // Writes the transaction hashes against the batch containing them.
-func (db *DB) writeBatchTxHashes(w ethdb.KeyValueWriter, batchHash common.L2RootHash, txHashes []gethcommon.Hash) error {
+func (db *DB) writeBatchTxHashes(w ethdb.KeyValueWriter, batchHash common.L2BatchHash, txHashes []gethcommon.Hash) error {
 	data, err := rlp.EncodeToBytes(txHashes)
 	if err != nil {
 		return err

--- a/integration/ethereummock/db.go
+++ b/integration/ethereummock/db.go
@@ -18,7 +18,7 @@ import (
 
 // Received blocks ar stored here
 type blockResolverInMem struct {
-	blockCache map[common.L1RootHash]*types.Block
+	blockCache map[common.L1BlockHash]*types.Block
 	m          sync.RWMutex
 }
 
@@ -28,7 +28,7 @@ func (n *blockResolverInMem) Proof(_ *core.Rollup) (*types.Block, error) {
 
 func NewResolver() db.BlockResolver {
 	return &blockResolverInMem{
-		blockCache: map[common.L1RootHash]*types.Block{},
+		blockCache: map[common.L1BlockHash]*types.Block{},
 		m:          sync.RWMutex{},
 	}
 }
@@ -39,7 +39,7 @@ func (n *blockResolverInMem) StoreBlock(block *types.Block) {
 	n.blockCache[block.Hash()] = block
 }
 
-func (n *blockResolverInMem) FetchBlock(hash common.L1RootHash) (*types.Block, error) {
+func (n *blockResolverInMem) FetchBlock(hash common.L1BlockHash) (*types.Block, error) {
 	n.m.RLock()
 	defer n.m.RUnlock()
 	block, f := n.blockCache[hash]
@@ -87,7 +87,7 @@ func (n *blockResolverInMem) IsAncestor(block *types.Block, maybeAncestor *types
 	return n.IsAncestor(p, maybeAncestor)
 }
 
-func (n *blockResolverInMem) IsBlockAncestor(block *types.Block, maybeAncestor common.L1RootHash) bool {
+func (n *blockResolverInMem) IsBlockAncestor(block *types.Block, maybeAncestor common.L1BlockHash) bool {
 	if bytes.Equal(maybeAncestor.Bytes(), block.Hash().Bytes()) {
 		return true
 	}
@@ -118,13 +118,13 @@ func (n *blockResolverInMem) IsBlockAncestor(block *types.Block, maybeAncestor c
 
 // The cache of included transactions
 type txDBInMem struct {
-	transactionsPerBlockCache map[common.L1RootHash]map[common.TxHash]*types.Transaction
+	transactionsPerBlockCache map[common.L1BlockHash]map[common.TxHash]*types.Transaction
 	rpbcM                     *sync.RWMutex
 }
 
 func NewTxDB() TxDB {
 	return &txDBInMem{
-		transactionsPerBlockCache: make(map[common.L1RootHash]map[common.TxHash]*types.Transaction),
+		transactionsPerBlockCache: make(map[common.L1BlockHash]map[common.TxHash]*types.Transaction),
 		rpbcM:                     &sync.RWMutex{},
 	}
 }

--- a/integration/ethereummock/node.go
+++ b/integration/ethereummock/node.go
@@ -140,7 +140,7 @@ func (m *Node) BlockByNumber(n *big.Int) (*types.Block, error) {
 		}
 		return nil, fmt.Errorf("could not retrieve head block. Cause: %w", err)
 	}
-	for !bytes.Equal(blk.ParentHash().Bytes(), (common.L1RootHash{}).Bytes()) {
+	for !bytes.Equal(blk.ParentHash().Bytes(), (common.L1BlockHash{}).Bytes()) {
 		if blk.NumberU64() == n.Uint64() {
 			return blk, nil
 		}
@@ -175,7 +175,7 @@ func (m *Node) Info() ethadapter.Info {
 	}
 }
 
-func (m *Node) IsBlockAncestor(block *types.Block, proof common.L1RootHash) bool {
+func (m *Node) IsBlockAncestor(block *types.Block, proof common.L1BlockHash) bool {
 	return m.Resolver.IsBlockAncestor(block, proof)
 }
 

--- a/integration/simulation/output_stats.go
+++ b/integration/simulation/output_stats.go
@@ -59,7 +59,7 @@ func (o *OutputStats) countBlockChain() {
 	header := getHeadRollupHeader(obscuroClient, 0)
 	var err error
 	for {
-		if header != nil && !bytes.Equal(header.Hash().Bytes(), (common.L1RootHash{}).Bytes()) {
+		if header != nil && !bytes.Equal(header.Hash().Bytes(), (common.L1BlockHash{}).Bytes()) {
 			break
 		}
 
@@ -72,7 +72,7 @@ func (o *OutputStats) countBlockChain() {
 	}
 
 	// iterate the L1 Blocks and get the rollups
-	for block, _ := l1Node.FetchHeadBlock(); block != nil && !bytes.Equal(block.Hash().Bytes(), (common.L1RootHash{}).Bytes()); block, _ = l1Node.BlockByHash(block.ParentHash()) {
+	for block, _ := l1Node.FetchHeadBlock(); block != nil && !bytes.Equal(block.Hash().Bytes(), (common.L1BlockHash{}).Bytes()); block, _ = l1Node.BlockByHash(block.ParentHash()) {
 		o.incrementStats(block, l1Node)
 	}
 }

--- a/integration/simulation/utils.go
+++ b/integration/simulation/utils.go
@@ -103,8 +103,8 @@ func findHashDups(list []gethcommon.Hash) map[gethcommon.Hash]int {
 }
 
 // FindRollupDups - returns a map of all L2 root hashes that appear multiple times, and how many times
-func findRollupDups(list []*common.ExtRollup) map[common.L2RootHash]int {
-	elementCount := make(map[common.L2RootHash]int)
+func findRollupDups(list []*common.ExtRollup) map[common.L2BatchHash]int {
+	elementCount := make(map[common.L2BatchHash]int)
 
 	for _, item := range list {
 		// check if the item/element exist in the duplicate_frequency map
@@ -115,7 +115,7 @@ func findRollupDups(list []*common.ExtRollup) map[common.L2RootHash]int {
 			elementCount[item.Hash()] = 1 // else start counting from 1
 		}
 	}
-	dups := make(map[common.L2RootHash]int)
+	dups := make(map[common.L2BatchHash]int)
 	for u, i := range elementCount {
 		if i > 1 {
 			dups[u] = i


### PR DESCRIPTION
### Why this change is needed

The aliases were not state roots, but hashes of the actual headers

### What changes were made as part of this PR

rename

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


