### PR TITLE
Use docker mount for enclave persistence

### DIFF
--- a/dockerfiles/enclave.Dockerfile
+++ b/dockerfiles/enclave.Dockerfile
@@ -41,7 +41,6 @@ COPY --from=build-enclave \
     /home/obscuro/go-obscuro/go/enclave/main home/obscuro/go-obscuro/go/enclave/main
     
 WORKDIR /home/obscuro/go-obscuro/go/enclave/main
-RUN mkdir -p /home/obscuro/data
 
 # simulation mode is ACTIVE by default
 ENV OE_SIMULATION=1

--- a/dockerfiles/enclave.debug.Dockerfile
+++ b/dockerfiles/enclave.debug.Dockerfile
@@ -13,7 +13,7 @@ RUN go install github.com/go-delve/delve/cmd/dlv@v1.9.1
 
 FROM system as get-dependencies
 # setup container data structure
-RUN mkdir -p /data && mkdir -p /home/obscuro/go-obscuro
+RUN mkdir -p /enclavedata && mkdir -p /home/obscuro/go-obscuro
 
 # Ensures container layer caching when dependencies are not changed
 WORKDIR /home/obscuro/go-obscuro

--- a/go/enclave/main/enclave.json
+++ b/go/enclave/main/enclave.json
@@ -8,7 +8,7 @@
   "securityVersion": 1,
   "mounts": [
     {
-      "source": "/home/obscuro/data",
+      "source": "/enclavedata",
       "target": "/data",
       "type": "hostfs",
       "readOnly": false

--- a/go/node/docker.go
+++ b/go/node/docker.go
@@ -9,8 +9,12 @@ import (
 )
 
 var (
-	_hostDataDir      = "/data"
-	_defaultHostMount = map[string]string{"host-persistence": _hostDataDir}
+	_hostDataDir    = "/data"        // this is how the directory is referenced within the host container
+	_enclaveDataDir = "/enclavedata" // this is how the directory is references within the enclave container
+
+	// these mounts are created if they don't exist by the `StartNewContainer` function
+	_defaultHostMount    = map[string]string{"host-persistence": _hostDataDir}       // used for host database
+	_defaultEnclaveMount = map[string]string{"enclave-persistence": _enclaveDataDir} // used to store data encrypted by the enclave (e.g. EDB credentials)
 )
 
 type DockerNode struct {
@@ -169,7 +173,7 @@ func (d *DockerNode) startEnclave() error {
 		)
 	}
 
-	_, err := docker.StartNewContainer(d.cfg.nodeName+"-enclave", d.cfg.enclaveImage, cmd, exposedPorts, envs, devices, nil)
+	_, err := docker.StartNewContainer(d.cfg.nodeName+"-enclave", d.cfg.enclaveImage, cmd, exposedPorts, envs, devices, _defaultEnclaveMount)
 	return err
 }
 


### PR DESCRIPTION
### Why this change is needed

After upgrading the enclave couldn't find the persisted EDB credentials and was trying to reinitialise the database (which fails).

Eventually realised this is because the creds are just persisted into the enclave container which is discarded on upgrade.

This change mirrors the host persistence, a persistent docker mount on the VM that is made available into the enclave docker container.

### What changes were made as part of this PR

Add enclave persistence mount and configure it into the enclave docker container and the SGX enclave within that.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


