### PR TITLE
Fix local network launcher for enclave persistence

### DIFF
--- a/go/enclave/db/sql/sqlite.go
+++ b/go/enclave/db/sql/sqlite.go
@@ -62,6 +62,15 @@ func CreateTemporarySQLiteDB(dbPath string, logger gethlog.Logger) (*EnclaveDB, 
 		dbPath = tempPath
 	}
 	inMem := strings.Contains(dbPath, "mode=memory")
+	description := "in memory"
+	if !inMem {
+		_, err := os.Stat(dbPath)
+		if err == nil {
+			description = "existing"
+		} else {
+			description = "new"
+		}
+	}
 
 	db, err := sql.Open("sqlite3", dbPath)
 	if err != nil {
@@ -78,16 +87,7 @@ func CreateTemporarySQLiteDB(dbPath string, logger gethlog.Logger) (*EnclaveDB, 
 		return nil, err
 	}
 
-	desc := "in memory"
-	if !inMem {
-		_, err := os.Stat(dbPath)
-		if err == nil {
-			desc = "existing"
-		} else {
-			desc = "new"
-		}
-	}
-	logger.Info(fmt.Sprintf("Opened %s sqlite db file at %s", desc, dbPath))
+	logger.Info(fmt.Sprintf("Opened %s sqlite db file at %s", description, dbPath))
 
 	return CreateSQLEthDatabase(db, logger)
 }

--- a/testnet/launcher/docker.go
+++ b/testnet/launcher/docker.go
@@ -76,7 +76,7 @@ func (t *Testnet) Start() error {
 	}
 	fmt.Println("Obscuro node was successfully started...")
 
-	// wait until the node it healthy
+	// wait until the node is healthy
 	err = waitForHealthyNode(13000)
 	if err != nil {
 		return fmt.Errorf("sequencer obscuro node not healthy - %w", err)
@@ -219,10 +219,9 @@ func waitForHealthyNode(port int) error { // todo: hook the cfg
 	reqBody := `{"method": "obscuro_health", "id": 1}`
 
 	timeStart := time.Now()
-	defer func() { fmt.Printf("Node became healthy after %f seconds\n", time.Since(timeStart).Seconds()) }()
 
 	fmt.Println("Waiting for Obscuro node to be healthy...")
-	return retry.Do(
+	err := retry.Do(
 		func() error {
 			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, requestURL, bytes.NewBufferString(reqBody))
 			if err != nil {
@@ -260,4 +259,9 @@ func waitForHealthyNode(port int) error { // todo: hook the cfg
 			return fmt.Errorf("node OverallHealth is not good yet")
 		}, retry.NewTimeoutStrategy(2*time.Minute, 1*time.Second),
 	)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Node became healthy after %f seconds\n", time.Since(timeStart).Seconds())
+	return nil
 }


### PR DESCRIPTION
### Why this change is needed

If multiple nodes were being started on the same docker system then they were using the same persistent volume causing issues at startup.

### What changes were made as part of this PR

- create node-specific enclave persistence dir and mount it on the docker container for the enclave
- couple tidy ups spotted while testing

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


