### PR TITLE
Pedro/log tx rollup hash

### DIFF
--- a/go/host/host.go
+++ b/go/host/host.go
@@ -554,7 +554,7 @@ func (h *host) signAndBroadcastL1Tx(tx types.TxData, tries uint64, awaitReceipt 
 	if err != nil {
 		return fmt.Errorf("broadcasting L1 transaction failed after %d tries. Cause: %w", tries, err)
 	}
-	h.logger.Trace("L1 transaction sent successfully, watching for receipt.")
+	h.logger.Info("Successfully issued Rollup on L1", "txHash", signedTx.Hash())
 
 	if awaitReceipt {
 		// block until receipt is found and then return

--- a/integration/manualtests/client_test.go
+++ b/integration/manualtests/client_test.go
@@ -1,0 +1,31 @@
+package manualtests
+
+import (
+	"math/big"
+	"os"
+	"testing"
+
+	"github.com/obscuronet/go-obscuro/go/common"
+	"github.com/obscuronet/go-obscuro/go/obsclient"
+	"github.com/obscuronet/go-obscuro/go/rpc"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClientGetRollup(t *testing.T) {
+	// test is skipped by default to avoid breaking CI - set env flag in `Run Configurations` to run it in IDE
+	if os.Getenv(_IDEFlag) == "" {
+		t.Skipf("set flag %s to run this test in the IDE", _IDEFlag)
+	}
+	hostRPCAddress := "http://testnet.obscu.ro:13000"
+	client, err := rpc.NewNetworkClient(hostRPCAddress)
+	assert.Nil(t, err)
+
+	obsClient := obsclient.NewObsClient(client)
+
+	rollupHeader, err := obsClient.RollupHeaderByNumber(big.NewInt(4392))
+	assert.Nil(t, err)
+
+	var rollup *common.ExtRollup
+	err = client.Call(&rollup, rpc.GetBatch, rollupHeader.Hash())
+	assert.Nil(t, err)
+}

--- a/integration/manualtests/tx_test.go
+++ b/integration/manualtests/tx_test.go
@@ -27,6 +27,13 @@ const (
 	_IDEFlag = "IDE"
 )
 
+// Testnet values used for quick debugging:
+// l1 host: testnet-eth2network.uksouth.azurecontainer.io
+// l1 port: 9000
+// l2 host: testnet.obscu.ro
+// l2 port: 13001
+// l2wallet: 8dfb8083da6275ae3e4f41e3e8a8c19d028d32c9247e24530933782f2a05035b
+
 func TestL1IssueTxWaitReceipt(t *testing.T) {
 	// test is skipped by default to avoid breaking CI - set env flag in `Run Configurations` to run it in IDE
 	if os.Getenv(_IDEFlag) == "" {

--- a/testnet/start-obscuroscan.sh
+++ b/testnet/start-obscuroscan.sh
@@ -6,9 +6,9 @@
 
 help_and_exit() {
     echo ""
-    echo "Usage: $(basename "${0}") --rpcServerAddress=http://testnet-host-1:13000 --receivingPort=80"
+    echo "Usage: $(basename "${0}") --rpcServerAddress=http://validator-host:13010 --receivingPort=80"
     echo ""
-    echo "  rpcServerAddress        *Optional* Set the rpc server address (defaults to http://testnet-host-1:13000)"
+    echo "  rpcServerAddress        *Optional* Set the rpc server address (defaults to http://validator-host:13010)"
     echo ""
     echo "  receivingPort           *Optional* Set the ObscuroScan server receiving port (defaults to 80)"
     echo ""
@@ -25,7 +25,7 @@ testnet_path="${start_path}"
 
 # Define defaults
 receivingPort=80
-rpcServerAddress='http://testnet-host-1:13000'
+rpcServerAddress='http://validator-host:13010'
 docker_image="testnetobscuronet.azurecr.io/obscuronet/obscuroscan:latest"
 
 # Fetch options


### PR DESCRIPTION
### Why this change is needed

Logs the rollup tx hash in the l1.
In regards to https://github.com/obscuronet/obscuro-internal/issues/971

### What changes were made as part of this PR

Please provide a high level list of the changes made

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


