### PR TITLE
fix the block hash of log messages and receipts

### DIFF
--- a/go/common/batches.go
+++ b/go/common/batches.go
@@ -19,9 +19,9 @@ type ExtBatch struct {
 // Hash returns the keccak256 hash of the batch's header.
 // The hash is computed on the first call and cached thereafter.
 func (b *ExtBatch) Hash() L2BatchHash {
-	if hash := b.hash.Load(); hash != nil {
-		return hash.(L2BatchHash)
-	}
+	//if hash := b.hash.Load(); hash != nil {
+	//	return hash.(L2BatchHash)
+	//}
 	v := b.Header.Hash()
 	b.hash.Store(v)
 	return v

--- a/go/common/rollups.go
+++ b/go/common/rollups.go
@@ -16,9 +16,9 @@ type ExtRollup struct {
 // Hash returns the keccak256 hash of the rollup's header.
 // The hash is computed on the first call and cached thereafter.
 func (r *ExtRollup) Hash() L2BatchHash {
-	if hash := r.hash.Load(); hash != nil {
-		return hash.(L2BatchHash)
-	}
+	//if hash := r.hash.Load(); hash != nil {
+	//	return hash.(L2BatchHash)
+	//}
 	v := r.Header.Hash()
 	r.hash.Store(v)
 	return v

--- a/go/enclave/evm/evm_facade.go
+++ b/go/enclave/evm/evm_facade.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"math"
 
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/obscuronet/go-obscuro/go/enclave/crypto"
+
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/state"
@@ -13,10 +16,8 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/obscuronet/go-obscuro/go/common"
 	"github.com/obscuronet/go-obscuro/go/common/log"
-	"github.com/obscuronet/go-obscuro/go/enclave/crypto"
 	"github.com/obscuronet/go-obscuro/go/enclave/db"
 
-	gethcommon "github.com/ethereum/go-ethereum/common"
 	gethcore "github.com/ethereum/go-ethereum/core"
 	gethlog "github.com/ethereum/go-ethereum/log"
 	gethrpc "github.com/ethereum/go-ethereum/rpc"
@@ -38,7 +39,7 @@ func ExecuteTransactions(txs []*common.L2Tx, s *state.StateDB, header *common.Ba
 	}
 
 	for i, t := range txs {
-		r, err := executeTransaction(s, chainConfig, chain, gp, ethHeader, t, usedGas, vmCfg, fromTxIndex+i)
+		r, err := executeTransaction(s, chainConfig, chain, gp, ethHeader, t, usedGas, vmCfg, fromTxIndex+i, header.Hash())
 		if err != nil {
 			result[t.Hash()] = err
 			logger.Info("Failed to execute tx:", log.TxKey, t.Hash().Hex(), log.CtrErrKey, err)
@@ -51,7 +52,7 @@ func ExecuteTransactions(txs []*common.L2Tx, s *state.StateDB, header *common.Ba
 	return result
 }
 
-func executeTransaction(s *state.StateDB, cc *params.ChainConfig, chain *ObscuroChainContext, gp *gethcore.GasPool, header *types.Header, t *common.L2Tx, usedGas *uint64, vmCfg vm.Config, tCount int) (*types.Receipt, error) {
+func executeTransaction(s *state.StateDB, cc *params.ChainConfig, chain *ObscuroChainContext, gp *gethcore.GasPool, header *types.Header, t *common.L2Tx, usedGas *uint64, vmCfg vm.Config, tCount int, batchHash common.L2BatchHash) (*types.Receipt, error) {
 	s.Prepare(t.Hash(), tCount)
 	snap := s.Snapshot()
 
@@ -59,6 +60,13 @@ func executeTransaction(s *state.StateDB, cc *params.ChainConfig, chain *Obscuro
 	// calculate a random value per transaction
 	header.MixDigest = gethcommon.BytesToHash(crypto.PerTransactionRnd(before.Bytes(), tCount))
 	receipt, err := gethcore.ApplyTransaction(cc, chain, nil, gp, s, header, t, usedGas, vmCfg)
+
+	// adjust the receipt to point to the right batch hash
+	if receipt != nil {
+		receipt.Logs = s.GetLogs(t.Hash(), batchHash)
+		receipt.BlockHash = batchHash
+	}
+
 	header.MixDigest = before
 	if err != nil {
 		s.RevertToSnapshot(snap)

--- a/go/enclave/evm/utils.go
+++ b/go/enclave/evm/utils.go
@@ -3,11 +3,12 @@ package evm
 import (
 	"math/big"
 
+	"github.com/obscuronet/go-obscuro/go/enclave/crypto"
+
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/obscuronet/go-obscuro/go/common"
-	"github.com/obscuronet/go-obscuro/go/enclave/crypto"
 )
 
 // Perform the conversion between an Obscuro header and an Ethereum header that the EVM understands

--- a/go/enclave/rollupmanager/rollupmanager.go
+++ b/go/enclave/rollupmanager/rollupmanager.go
@@ -169,7 +169,12 @@ func (re *rollupManager) extractRollups(br *common.BlockAndReceipts, blockResolv
 		// In case of L1 reorgs, rollups may end published on a fork
 		if blockResolver.IsBlockAncestor(b, r.Header.L1Proof) {
 			rollups = append(rollups, core.ToRollup(r, re.TransactionBlobCrypto))
-			re.logger.Trace(fmt.Sprintf("Extracted Rollup r_%d from block b_%d",
+			re.logger.Info(fmt.Sprintf("Extracted Rollup r_%d from block b_%d",
+				common.ShortHash(r.Hash()),
+				common.ShortHash(b.Hash()),
+			))
+		} else {
+			re.logger.Warn(fmt.Sprintf("Ignored rollup r_%d from block b_%d, because it was produced on a fork",
 				common.ShortHash(r.Hash()),
 				common.ShortHash(b.Hash()),
 			))

--- a/integration/simulation/validate_chain.go
+++ b/integration/simulation/validate_chain.go
@@ -567,8 +567,8 @@ func extractWithdrawals(t *testing.T, obscuroClient *obsclient.ObsClient, nodeId
 // Terminates all subscriptions and validates the received events.
 func checkReceivedLogs(t *testing.T, s *Simulation) {
 	logsFromSnapshots := 0
-	// at least one event per transfer tx
-	nrLogs := len(s.TxInjector.TxTracker.TransferL2Transactions) * len(s.RPCHandles.AuthObsClients)
+	// at least one event per transfer tx for half the transactions
+	nrLogs := len(s.TxInjector.TxTracker.TransferL2Transactions) * len(s.RPCHandles.AuthObsClients) / 2
 	for _, clients := range s.RPCHandles.AuthObsClients {
 		for _, client := range clients {
 			logsFromSnapshots += checkSnapshotLogs(t, client)
@@ -681,10 +681,7 @@ func assertNoDupeLogs(t *testing.T, logs []*types.Log) {
 	logCount := make(map[string]int)
 
 	for _, item := range logs {
-		l := *item
-		// todo - uncomment this to catch events saved multiple times in different batches
-		// l.BlockHash = gethcommon.Hash{}
-		logJSON, err := l.MarshalJSON()
+		logJSON, err := item.MarshalJSON()
 		if err != nil {
 			t.Errorf("could not marshal log to JSON to check for duplicate logs")
 			continue


### PR DESCRIPTION
### Why this change is needed

The batch->block header conversion logic was changing the "block hash" property of receipts and logs



### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


