### PR TITLE
Pull the updated docker images in testnet upgrade script

### DIFF
--- a/.github/workflows/manual-upgrade-testnet-l2.yml
+++ b/.github/workflows/manual-upgrade-testnet-l2.yml
@@ -142,7 +142,9 @@ jobs:
             az vm run-command invoke -g Testnet -n "${{needs.build.outputs.RESOURCE_STARTING_NAME}}-${{ matrix.host_id }}-${{ github.event.inputs.github_deploy_number }}"  \
             --command-id RunShellScript \
             --scripts '
-              rm -rf /home/obscuro/go-obscuro \
+               docker pull ${{needs.build.outputs.L2_HOST_DOCKER_BUILD_TAG}} \
+            && docker pull ${{needs.build.outputs.L2_ENCLAVE_DOCKER_BUILD_TAG}} \
+            && rm -rf /home/obscuro/go-obscuro \
             && git clone --depth 1 -b ${{ steps.extract_branch.outputs.branch }} https://github.com/obscuronet/go-obscuro.git /home/obscuro/go-obscuro \
             && cd /home/obscuro/go-obscuro/ \
             && sudo go run /home/obscuro/go-obscuro/go/node/cmd  \


### PR DESCRIPTION
### Why this change is needed

Code changes aren't getting pulled in because old docker image already exists on the VM.

### What changes were made as part of this PR

Pull docker image to the VM before running upgrade script.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


