### PR TITLE
normalise data field to fix event dups bug

### DIFF
--- a/go/enclave/db/storage.go
+++ b/go/enclave/db/storage.go
@@ -265,9 +265,15 @@ func (s *storageImpl) writeLog(l *types.Log, stateDB *state.StateDB, dbBatch *sq
 		isLifecycle = isLifecycle && !isUserAccount
 	}
 
+	// normalise the data field to nil to avoid duplicates
+	data := l.Data
+	if len(data) == 0 {
+		data = nil
+	}
+
 	dbBatch.ExecuteSQL("insert into events values (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
 		t0, t1, t2, t3, t4,
-		l.Data, l.BlockHash, l.BlockNumber, l.TxHash, l.TxIndex, l.Index, l.Address,
+		data, l.BlockHash, l.BlockNumber, l.TxHash, l.TxIndex, l.Index, l.Address,
 		isLifecycle, addr1, addr2, addr3, addr4,
 	)
 }
@@ -468,13 +474,13 @@ func (s *storageImpl) StoreRollup(rollup *core.Rollup) error {
 }
 
 // utility function that knows how to load relevant logs from the database
-// todo always pass in the actual batch hashes because of reorgs
+// todo always pass in the actual batch hashes because of reorgs, or make sure to clean up log entries from discarded batches
 func (s *storageImpl) loadLogs(requestingAccount *gethcommon.Address, whereCondition string, whereParams []any) ([]*types.Log, error) {
 	if requestingAccount == nil {
 		return nil, fmt.Errorf("logs can only be requested for an account")
 	}
 
-	result := []*types.Log{}
+	var result []*types.Log
 	// todo - remove the "distinct" once the fast-finality work is completed
 	// currently the events seem to be stored twice because of some weird logic in the rollup/batch processing.
 	query := "select distinct topic0, topic1, topic2, topic3, topic4, datablob, blockHash, blockNumber, txHash, txIdx, logIdx, address from events where 1=1 "
@@ -492,6 +498,7 @@ func (s *storageImpl) loadLogs(requestingAccount *gethcommon.Address, whereCondi
 	query += whereCondition
 	queryParams = append(queryParams, whereParams...)
 
+	// indexes := map[uint]uint{}
 	rows, err := s.db.GetSQLDB().Query(query, queryParams...)
 	if err != nil {
 		return nil, err
@@ -521,6 +528,11 @@ func (s *storageImpl) loadLogs(requestingAccount *gethcommon.Address, whereCondi
 			l.Topics = append(l.Topics, hash(t4))
 		}
 
+		//_, f := indexes[l.Index]
+		//if f {
+		//	fmt.Printf("duplicate log: %v\n", l)
+		//}
+		//indexes[l.Index] = l.Index
 		result = append(result, &l)
 	}
 	err = rows.Close()

--- a/go/enclave/db/storage.go
+++ b/go/enclave/db/storage.go
@@ -498,7 +498,6 @@ func (s *storageImpl) loadLogs(requestingAccount *gethcommon.Address, whereCondi
 	query += whereCondition
 	queryParams = append(queryParams, whereParams...)
 
-	// indexes := map[uint]uint{}
 	rows, err := s.db.GetSQLDB().Query(query, queryParams...)
 	if err != nil {
 		return nil, err
@@ -528,11 +527,6 @@ func (s *storageImpl) loadLogs(requestingAccount *gethcommon.Address, whereCondi
 			l.Topics = append(l.Topics, hash(t4))
 		}
 
-		//_, f := indexes[l.Index]
-		//if f {
-		//	fmt.Printf("duplicate log: %v\n", l)
-		//}
-		//indexes[l.Index] = l.Index
 		result = append(result, &l)
 	}
 	err = rows.Close()


### PR DESCRIPTION
### Why this change is needed

normalise the "data field" of logs to nil, to prevent "select distinct" from returning multiple rows

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


