### PR TITLE
Persist enclave key

### DIFF
--- a/go/enclave/db/interfaces.go
+++ b/go/enclave/db/interfaces.go
@@ -98,6 +98,11 @@ type CrossChainMessagesStorage interface {
 	GetL1Messages(blockHash common.L1BlockHash) (common.CrossChainMessages, error)
 }
 
+type EnclaveKeyStorage interface {
+	StoreEnclaveKey(enclaveKey *ecdsa.PrivateKey) error
+	GetEnclaveKey() (*ecdsa.PrivateKey, error)
+}
+
 // Storage is the enclave's interface for interacting with the enclave's datastore
 type Storage interface {
 	BlockResolver
@@ -108,6 +113,7 @@ type Storage interface {
 	TransactionStorage
 	AttestationStorage
 	CrossChainMessagesStorage
+	EnclaveKeyStorage
 	io.Closer
 
 	// HealthCheck returns whether the storage is deemed healthy or not

--- a/go/enclave/db/rawdb/accessors_enclave_key.go
+++ b/go/enclave/db/rawdb/accessors_enclave_key.go
@@ -1,0 +1,33 @@
+package rawdb
+
+import (
+	"crypto/ecdsa"
+	"errors"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethdb"
+	gethlog "github.com/ethereum/go-ethereum/log"
+)
+
+var _enclaveKeyDBKey = []byte("ek")
+
+func StoreEnclaveKey(db ethdb.KeyValueWriter, enclaveKey *ecdsa.PrivateKey, _ gethlog.Logger) error {
+	if enclaveKey == nil {
+		return errors.New("enclaveKey cannot be nil")
+	}
+	keyBytes := crypto.FromECDSA(enclaveKey)
+	return db.Put(_enclaveKeyDBKey, keyBytes)
+}
+
+func GetEnclaveKey(db ethdb.KeyValueReader, _ gethlog.Logger) (*ecdsa.PrivateKey, error) {
+	keyBytes, err := db.Get(_enclaveKeyDBKey)
+	if err != nil {
+		return nil, err
+	}
+	enclaveKey, err := crypto.ToECDSA(keyBytes)
+	if err != nil {
+		return nil, fmt.Errorf("unable to construct ECDSA private key from enclave key bytes - %w", err)
+	}
+	return enclaveKey, nil
+}

--- a/go/enclave/db/storage.go
+++ b/go/enclave/db/storage.go
@@ -460,6 +460,14 @@ func (s *storageImpl) GetL1Messages(blockHash common.L1BlockHash) (common.CrossC
 	return obscurorawdb.GetL1Messages(s.db, blockHash, s.logger)
 }
 
+func (s *storageImpl) StoreEnclaveKey(enclaveKey *ecdsa.PrivateKey) error {
+	return obscurorawdb.StoreEnclaveKey(s.db, enclaveKey, s.logger)
+}
+
+func (s *storageImpl) GetEnclaveKey() (*ecdsa.PrivateKey, error) {
+	return obscurorawdb.GetEnclaveKey(s.db, s.logger)
+}
+
 func (s *storageImpl) StoreRollup(rollup *core.Rollup) error {
 	dbBatch := s.db.NewBatch()
 


### PR DESCRIPTION
### Why this change is needed

Some issues with the upgrade seem to be because the enclave key is getting regenerated every time (which makes sense). 

This change persists the enclave key and attempts to load it on startup.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


