### PR TITLE
Host to retry forever waiting for the enclave to come up

### DIFF
--- a/go/host/rpc/enclaverpc/enclave_client.go
+++ b/go/host/rpc/enclaverpc/enclave_client.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/obscuronet/go-obscuro/go/common/retry"
 	"time"
 
 	"github.com/ethereum/go-ethereum/core/types"
@@ -41,22 +42,25 @@ func NewClient(config *config.HostConfig, logger gethlog.Logger) *Client {
 	if err != nil {
 		logger.Crit("Failed to connect to enclave RPC service.", log.ErrKey, err)
 	}
+	connection.Connect()
+	// perform an initial sleep because that Connect() method is not blocking and the retry immediately checks the status
+	time.Sleep(500 * time.Millisecond)
 
 	// We wait for the RPC connection to be ready.
-	currentTime := time.Now()
-	deadline := currentTime.Add(60 * time.Second)
-	currentState := connection.GetState()
-	for currentState == connectivity.Idle || currentState == connectivity.Connecting || currentState == connectivity.TransientFailure {
-		connection.Connect()
-		if time.Now().After(deadline) {
-			break
+	err = retry.Do(func() error {
+		currState := connection.GetState()
+		if currState != connectivity.Ready {
+			logger.Info("retrying connection until enclave is available", "status", currState.String())
+			connection.Connect()
+			return fmt.Errorf("connection is not ready, status=%s", currState)
 		}
-		time.Sleep(500 * time.Millisecond)
-		currentState = connection.GetState()
-	}
+		// connection is ready, break out of the loop
+		return nil
+	}, retry.NewBackoffAndRetryForeverStrategy([]time.Duration{500 * time.Millisecond, 1 * time.Second, 5 * time.Second}, 10*time.Second))
 
-	if currentState != connectivity.Ready {
-		logger.Crit(fmt.Sprintf("RPC connection failed to establish. Current state is %s", currentState))
+	if err != nil {
+		// this should not happen as we retry forever...
+		logger.Crit("failed to connect to enclave", log.ErrKey, err)
 	}
 
 	return &Client{


### PR DESCRIPTION
### Why this change is needed

After upgrade the host sometimes gives up too soon while the enclave is rebuilding its stateDB data. Similar to the L1 connection I see no reason why the host shouldn't wait forever (it settles to a 10second interval with info level log message).

### What changes were made as part of this PR

Use infinite retry for initial enclave connection

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


