### PR TITLE
Only perform the L2 deployment on a scheduled basis

### DIFF
--- a/.github/workflows/manual-deploy-testnet-l1.yml
+++ b/.github/workflows/manual-deploy-testnet-l1.yml
@@ -16,8 +16,6 @@
 name: '[M] Deploy Testnet L1'
 
 on:
-  schedule:
-    - cron: '05 3 * * 2-6'
   workflow_dispatch:
     inputs:
       testnet_type:
@@ -46,7 +44,7 @@ jobs:
           echo "L1_CONTAINER_NAME=testnet-eth2network" >> $GITHUB_ENV
 
       - name: 'Sets env vars for dev-testnet'
-        if: ${{ github.event.inputs.testnet_type == 'dev-testnet' || (github.event_name == 'schedule') }}
+        if: ${{ github.event.inputs.testnet_type == 'dev-testnet' }}
         run: |
           echo "ETH2NETWORK_BUILD_TAG=testnetobscuronet.azurecr.io/obscuronet/dev_eth2network:latest" >> $GITHUB_ENV
           echo "L1_DOCKER_BUILD_TAG=testnetobscuronet.azurecr.io/obscuronet/dev_testnet_l1network:latest" >> $GITHUB_ENV
@@ -103,8 +101,3 @@ jobs:
           ports: '8025 8026 9000 9001'
           cpu: 2
           memory: 8
-
-      - name: 'Dispatch trigger'
-        if: ${{ github.event_name == 'schedule' }}
-        run: |
-          curl -XPOST -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" -H "Accept:application/vnd.github" -H "Content-Type:application/json" https://api.github.com/repos/obscuronet/go-obscuro/dispatches --data '{ "event_type": "l1_dev_deployment", "client_payload": { "ref": "main", "env": "dev-testnet" }'

--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -1,16 +1,18 @@
 # Deploys an Obscuro network on Azure for Testnet and Dev Testnet
 #
 # The Obscuro network is composed of 2 obscuro nodes running on individual vms with SGX. At the moment the workflow
-# can either be triggered manually as a workflow dispatch, or as a repository dispatch task. When manually triggered the
-# testnet type (dev-testnet or testnet) can be supplied as an input argument. When triggered as a repository dispatch task,
-# we always default to a dev-testnet deployment. A repository dispatch deployment of dev-testnet will additionally kick off
-# the E2E tests via a repository dispatch.
+# can either be triggered manually as a workflow dispatch, or as a scheduled task. When manually triggered the
+# testnet type (dev-testnet or testnet) can be supplied as an input argument. When triggered as a scheduled task,
+# we always default to a dev-testnet deployment. A scheduled deployment of dev-testnet will additionally kick
+# off the E2E tests via a repository dispatch.
+
+# The scheduled deployment runs at 03:05 on every day-of-week from Tuesday through Saturday, for dev-testnet only.
 #
 
 name: '[M] Deploy Testnet L2'
 on:
-  repository_dispatch:
-    types: [l1_dev_deployment]
+  schedule:
+    - cron: '05 3 * * 2-6'
   workflow_dispatch:
     inputs:
       testnet_type:
@@ -66,7 +68,7 @@ jobs:
           echo "L1_HOST=testnet-eth2network.uksouth.azurecontainer.io" >> $GITHUB_ENV
 
       - name: 'Sets env vars for dev-testnet'
-        if: ${{ (github.event.inputs.testnet_type == 'dev-testnet') || (github.event_name == 'repository_dispatch') }}
+        if: ${{ (github.event.inputs.testnet_type == 'dev-testnet') || (github.event_name == 'schedule') }}
         run: |
           echo "L2_ENCLAVE_DOCKER_BUILD_TAG=testnetobscuronet.azurecr.io/obscuronet/dev_enclave:latest" >> $GITHUB_ENV
           echo "L2_HOST_DOCKER_BUILD_TAG=testnetobscuronet.azurecr.io/obscuronet/dev_host:latest" >> $GITHUB_ENV
@@ -358,7 +360,7 @@ jobs:
         run: |
           curl -XPOST -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" -H "Accept:application/vnd.github" -H "Content-Type:application/json" https://api.github.com/repos/obscuronet/faucet/actions/workflows/manual-deploy-${{ github.event.inputs.testnet_type }}-faucet.yml/dispatches --data '{"ref": "main" }'
 
-      - name: 'Trigger Faucet deployment on repository_dispatch'
-        if: ${{ github.event_name == 'repository_dispatch' }}
+      - name: 'Trigger Faucet deployment on schedule'
+        if: ${{ github.event_name == 'schedule' }}
         run: |
           curl -XPOST -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" -H "Accept:application/vnd.github" -H "Content-Type:application/json" https://api.github.com/repos/obscuronet/faucet/dispatches --data '{ "event_type": "l2_dev_deployment", "client_payload": { "ref": "main", "env": "dev-testnet" }'


### PR DESCRIPTION
### Why this change is needed

In the scheduled nightly dev-testnet deployments, just redeploy the L2
