### PR TITLE
Update wallet extension docs and include a link to OBX faucet

### DIFF
--- a/docs/_docs/wallet-extension/wallet-extension.md
+++ b/docs/_docs/wallet-extension/wallet-extension.md
@@ -74,6 +74,8 @@ tools.
    MetaMask. Responses to sensitive RPC requests will now be encrypted with the viewing key and decrypted
    automatically by the wallet extension. Your balance in MetaMask will be set to 0 at the beginning.
    You can get testnet OBX from [faucet](https://docs.obscu.ro/testnet/faucet/) (you may need to switch to another network and back again to force MetaMask to refresh balance).
+   
+   Once a viewing key is generated it will be persisted across restarts of the wallet extension, saved in the user home space under `~/.obscuro/wallet_extension_persistence`.
 
 # Auditing the source
 

--- a/docs/_docs/wallet-extension/wallet-extension.md
+++ b/docs/_docs/wallet-extension/wallet-extension.md
@@ -72,10 +72,8 @@ tools.
 
 5. Visit `http://localhost:3000/viewingkeys/` to generate a new viewing key, and sign the viewing key when prompted by
    MetaMask. Responses to sensitive RPC requests will now be encrypted with the viewing key and decrypted
-   automatically by the wallet extension. Your balance in MetaMask will now display a testnet balance of `1000000` (you 
-   may need to switch to another network and back again to force MetaMask to refresh the balance). Once a viewing key
-   is generated it will be persisted across restarts of the wallet extension, saved in the user home space under 
-   `~/.obscuro/wallet_extension_persistence`.
+   automatically by the wallet extension. Your balance in MetaMask will be set to 0 at the beginning.
+   You can get testnet OBX from [faucet](https://docs.obscu.ro/testnet/faucet/) (you may need to switch to another network and back again to force MetaMask to refresh balance).
 
 # Auditing the source
 


### PR DESCRIPTION
### Why this change is needed

The description was wrong before as new users will have 0 OBX at the beginning and faucet can be used to get funds to your account.

### What changes were made as part of this PR

Changed docs.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ X] PR checks reviewed and performed 


