### PR TITLE
Add wait group Wait() timeout function to util

### DIFF
--- a/go/common/async/README.md
+++ b/go/common/async/README.md
@@ -1,0 +1,1 @@
+Utilities for asynchronous programming (go routines, wait groups, etc.)

--- a/go/common/async/async.go
+++ b/go/common/async/async.go
@@ -3,28 +3,12 @@ package async
 import (
 	"fmt"
 	"sync"
-	"sync/atomic"
 	"time"
 )
 
 type (
 	ScheduledFunc func()
 )
-
-// ScheduleInterrupt runs the function after the delay and can be interrupted
-func ScheduleInterrupt(delay time.Duration, interrupt *int32, fun ScheduledFunc) {
-	ticker := time.NewTicker(delay)
-
-	go func() {
-		<-ticker.C
-		if atomic.LoadInt32(interrupt) == 1 {
-			return
-		}
-
-		fun()
-		ticker.Stop()
-	}()
-}
 
 // Schedule runs the function after the delay
 func Schedule(delay time.Duration, fun ScheduledFunc) {

--- a/go/common/async/async.go
+++ b/go/common/async/async.go
@@ -37,7 +37,7 @@ func Schedule(delay time.Duration, fun ScheduledFunc) {
 }
 
 // WaitTimeout waits for the waitgroup for the specified max timeout.
-// Returns true if waiting timed out.
+// Returns the error if waiting timed out.
 func WaitTimeout(wg *sync.WaitGroup, timeout time.Duration) error {
 	c := make(chan struct{})
 	go func() {

--- a/go/common/async/async.go
+++ b/go/common/async/async.go
@@ -1,0 +1,53 @@
+package async
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+type (
+	ScheduledFunc func()
+)
+
+// ScheduleInterrupt runs the function after the delay and can be interrupted
+func ScheduleInterrupt(delay time.Duration, interrupt *int32, fun ScheduledFunc) {
+	ticker := time.NewTicker(delay)
+
+	go func() {
+		<-ticker.C
+		if atomic.LoadInt32(interrupt) == 1 {
+			return
+		}
+
+		fun()
+		ticker.Stop()
+	}()
+}
+
+// Schedule runs the function after the delay
+func Schedule(delay time.Duration, fun ScheduledFunc) {
+	ticker := time.NewTicker(delay)
+	go func() {
+		<-ticker.C
+		ticker.Stop()
+		fun()
+	}()
+}
+
+// WaitTimeout waits for the waitgroup for the specified max timeout.
+// Returns true if waiting timed out.
+func WaitTimeout(wg *sync.WaitGroup, timeout time.Duration) error {
+	c := make(chan struct{})
+	go func() {
+		defer close(c)
+		wg.Wait()
+	}()
+	select {
+	case <-c:
+		return nil // completed normally
+	case <-time.After(timeout):
+		return fmt.Errorf("WaitGroup timed out after %s", timeout) // timed out
+	}
+}

--- a/go/common/utils.go
+++ b/go/common/utils.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"math/big"
-	"sync/atomic"
 	"time"
 
 	"github.com/ethereum/go-ethereum/core/types"
@@ -11,34 +10,8 @@ import (
 )
 
 type (
-	Latency       func() time.Duration
-	ScheduledFunc func()
+	Latency func() time.Duration
 )
-
-// ScheduleInterrupt runs the function after the delay and can be interrupted
-func ScheduleInterrupt(delay time.Duration, interrupt *int32, fun ScheduledFunc) {
-	ticker := time.NewTicker(delay)
-
-	go func() {
-		<-ticker.C
-		if atomic.LoadInt32(interrupt) == 1 {
-			return
-		}
-
-		fun()
-		ticker.Stop()
-	}()
-}
-
-// Schedule runs the function after the delay
-func Schedule(delay time.Duration, fun ScheduledFunc) {
-	ticker := time.NewTicker(delay)
-	go func() {
-		<-ticker.C
-		ticker.Stop()
-		fun()
-	}()
-}
 
 func MaxInt(x, y uint32) uint32 {
 	if x < y {

--- a/integration/ethereummock/mock_l1_network.go
+++ b/integration/ethereummock/mock_l1_network.go
@@ -2,6 +2,7 @@ package ethereummock
 
 import (
 	"fmt"
+	"github.com/obscuronet/go-obscuro/go/common/async"
 	"time"
 
 	"github.com/obscuronet/go-obscuro/go/common/log"
@@ -48,7 +49,7 @@ func (n *MockEthNetwork) BroadcastBlock(b common.EncodedL1Block, p common.Encode
 	for _, m := range n.AllNodes {
 		if m.Info().L2ID != n.CurrentNode.Info().L2ID {
 			t := m
-			common.Schedule(n.delay(), func() { t.P2PReceiveBlock(b, p) })
+			async.Schedule(n.delay(), func() { t.P2PReceiveBlock(b, p) })
 		} else {
 			m.logger.Info(printBlock(bl, m))
 		}
@@ -65,7 +66,7 @@ func (n *MockEthNetwork) BroadcastTx(tx *types.Transaction) {
 			// the time to broadcast a tx is half that of a L1 block, because it is smaller.
 			// todo - find a better way to express this
 			d := n.delay() / 2
-			common.Schedule(d, func() { t.P2PGossipTx(tx) })
+			async.Schedule(d, func() { t.P2PGossipTx(tx) })
 		}
 	}
 }

--- a/integration/ethereummock/mock_l1_network.go
+++ b/integration/ethereummock/mock_l1_network.go
@@ -2,8 +2,9 @@ package ethereummock
 
 import (
 	"fmt"
-	"github.com/obscuronet/go-obscuro/go/common/async"
 	"time"
+
+	"github.com/obscuronet/go-obscuro/go/common/async"
 
 	"github.com/obscuronet/go-obscuro/go/common/log"
 

--- a/integration/ethereummock/node.go
+++ b/integration/ethereummock/node.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"github.com/obscuronet/go-obscuro/go/common/async"
 	"math/big"
 	"sync"
 	"sync/atomic"
@@ -351,7 +352,7 @@ func (m *Node) startMining() {
 
 			// Generate a random number, and wait for that number of ms. Equivalent to PoW
 			// Include all rollups received during this period.
-			common.ScheduleInterrupt(m.cfg.PowTime(), interrupt, func() {
+			async.ScheduleInterrupt(m.cfg.PowTime(), interrupt, func() {
 				toInclude := findNotIncludedTxs(canonicalBlock, mempool, m.Resolver, m.db)
 				// todo - iterate through the rollup transactions and include only the ones with the proof on the canonical chain
 				if atomic.LoadInt32(m.interrupt) == 1 {

--- a/integration/ethereummock/node.go
+++ b/integration/ethereummock/node.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/obscuronet/go-obscuro/go/common/async"
 	"math/big"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/obscuronet/go-obscuro/go/common/async"
 
 	"github.com/google/uuid"
 

--- a/integration/ethereummock/node.go
+++ b/integration/ethereummock/node.go
@@ -353,7 +353,7 @@ func (m *Node) startMining() {
 
 			// Generate a random number, and wait for that number of ms. Equivalent to PoW
 			// Include all rollups received during this period.
-			async.ScheduleInterrupt(m.cfg.PowTime(), interrupt, func() {
+			async.Schedule(m.cfg.PowTime(), func() {
 				toInclude := findNotIncludedTxs(canonicalBlock, mempool, m.Resolver, m.db)
 				// todo - iterate through the rollup transactions and include only the ones with the proof on the canonical chain
 				if atomic.LoadInt32(m.interrupt) == 1 {

--- a/integration/networktest/tests/load/load_test.go
+++ b/integration/networktest/tests/load/load_test.go
@@ -16,8 +16,8 @@ func TestNativeTransfers(t *testing.T) {
 		t,
 		env.LocalDevNetwork(),
 		actions.Series(
-			actions.CreateAndFundTestUsers(2),
-			actions.GenerateUsersRandomisedTransferActionsInParallel(2, 10*time.Second),
+			actions.CreateAndFundTestUsers(5),
+			actions.GenerateUsersRandomisedTransferActionsInParallel(10, 60*time.Second),
 
 			actions.VerifyUserBalancesSanity(),
 		),

--- a/integration/simulation/network/obscuro_node_utils.go
+++ b/integration/simulation/network/obscuro_node_utils.go
@@ -2,12 +2,13 @@ package network
 
 import (
 	"fmt"
-	"github.com/obscuronet/go-obscuro/go/common/async"
 	"math/big"
 	"net"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/obscuronet/go-obscuro/go/common/async"
 
 	"github.com/obscuronet/go-obscuro/go/common"
 	"github.com/obscuronet/go-obscuro/go/common/container"

--- a/integration/simulation/p2p/mock_l2_network.go
+++ b/integration/simulation/p2p/mock_l2_network.go
@@ -5,6 +5,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/obscuronet/go-obscuro/go/common/async"
+
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/obscuronet/go-obscuro/go/common"
 	"github.com/obscuronet/go-obscuro/go/common/host"
@@ -52,7 +54,7 @@ func (netw *MockP2P) SendTxToSequencer(tx common.EncryptedTx) error {
 	if atomic.LoadInt32(netw.listenerInterrupt) == 1 {
 		return nil
 	}
-	common.Schedule(netw.delay()/2, func() { netw.Nodes[0].ReceiveTx(tx) })
+	async.Schedule(netw.delay()/2, func() { netw.Nodes[0].ReceiveTx(tx) })
 	return nil
 }
 
@@ -69,7 +71,7 @@ func (netw *MockP2P) BroadcastBatch(batchMsg *host.BatchMsg) error {
 	for _, node := range netw.Nodes {
 		if node.Config().ID.Hex() != netw.CurrentNode.Config().ID.Hex() {
 			tempNode := node
-			common.Schedule(netw.delay()/2, func() { tempNode.ReceiveBatches(encodedBatchMsg) })
+			async.Schedule(netw.delay()/2, func() { tempNode.ReceiveBatches(encodedBatchMsg) })
 		}
 	}
 
@@ -85,7 +87,7 @@ func (netw *MockP2P) RequestBatchesFromSequencer(batchRequest *common.BatchReque
 	if err != nil {
 		return fmt.Errorf("could not encode batch request using RLP. Cause: %w", err)
 	}
-	common.Schedule(netw.delay()/2, func() { netw.Nodes[0].ReceiveBatchRequest(encodedBatchRequest) })
+	async.Schedule(netw.delay()/2, func() { netw.Nodes[0].ReceiveBatchRequest(encodedBatchRequest) })
 	return nil
 }
 
@@ -106,7 +108,7 @@ func (netw *MockP2P) SendBatches(batchMsg *host.BatchMsg, requesterAddress strin
 		return fmt.Errorf("could not encode batch using RLP. Cause: %w", err)
 	}
 
-	common.Schedule(netw.delay()/2, func() { requester.ReceiveBatches(encodedBatchMsg) })
+	async.Schedule(netw.delay()/2, func() { requester.ReceiveBatches(encodedBatchMsg) })
 	return nil
 }
 


### PR DESCRIPTION
### Why this change is needed

Host is using a waitgroup for shutdown in Stefan's big PR and things keep hanging on shutdown, this feels like it might help but I didn't want to further bloat the PR with this refactor.

I found another async-related function and pulled it into the new util package as well.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


