### PR TITLE
Testnet upgrade - lookup env build number from azure VMs

### DIFF
--- a/.github/workflows/manual-upgrade-testnet-l2.yml
+++ b/.github/workflows/manual-upgrade-testnet-l2.yml
@@ -135,7 +135,7 @@ jobs:
         run: |
           TAG_NAME="${{needs.build.outputs.RESOURCE_TAG_NAME}}"
           VM_HOSTNAME=$(az vm list --query "[?tags.$TAG_NAME=='true'].{Name:name}[0]" -o tsv)
-          VM_BUILD_NUMBER=$(echo $VM_HOSTNAME | perl -ne 'if (/(-[0-9]{1,2}-)(\d+)/) { print $2 }') # Extract build number from VM hostname, e.g. D-0-321 -> 321
+          VM_BUILD_NUMBER=$(echo $VM_HOSTNAME | perl -ne 'if (/(-[0-9]{1}-)(\d+)/) { print $2 }') # Extract build number from VM hostname, e.g. D-0-321 -> 321
           echo "VM_BUILD_NUMBER=VM_BUILD_NUMBER" >> $GITHUB_ENV
           if ! [[ $BUILD_NUMBER =~ ^[0-9]+$ ]]; then # fail if build number is not a number
             echo "Error: Hostname lookup or regex extraction of build number failed."

--- a/.github/workflows/manual-upgrade-testnet-l2.yml
+++ b/.github/workflows/manual-upgrade-testnet-l2.yml
@@ -137,10 +137,10 @@ jobs:
           VM_HOSTNAME=$(az vm list --query "[?tags.$TAG_NAME=='true'].{Name:name}[0]" -g Testnet -o tsv)
           VM_BUILD_NUMBER=$(echo $VM_HOSTNAME | perl -ne 'if (/(-[0-9]{1}-)(\d+)/) { print $2 }') # Extract build number from VM hostname, e.g. D-0-321 -> 321
           echo "VM_BUILD_NUMBER=VM_BUILD_NUMBER" >> $GITHUB_ENV
+          echo "VM_HOSTNAME: ${VM_HOSTNAME}"
+          echo "VM_BUILD_NUMBER: ${VM_BUILD_NUMBER}"
           if ! [[ $BUILD_NUMBER =~ ^[0-9]+$ ]]; then # fail if build number is not a number
             echo "Error: Hostname lookup or regex extraction of build number failed."
-            echo "VM_HOSTNAME: ${VM_HOSTNAME}"
-            echo "VM_BUILD_NUMBER: ${VM_BUILD_NUMBER}"
             exit 1
           fi
 

--- a/.github/workflows/manual-upgrade-testnet-l2.yml
+++ b/.github/workflows/manual-upgrade-testnet-l2.yml
@@ -75,8 +75,7 @@ jobs:
       - name: 'Fetch latest VM hostnames by env tag and extract build number'
         id: fetch_hostnames
         run: |
-          TAG_NAME="${{needs.build.outputs.RESOURCE_TAG_NAME}}"
-          VM_HOSTNAME=$(az vm list --query "[?tags.$TAG_NAME=='true'].{Name:name}[0]" -g Testnet -o tsv)
+          VM_HOSTNAME=$(az vm list --query "[?tags.${{env.RESOURCE_TAG_NAME}}=='true'].{Name:name}[0]" -g Testnet -o tsv)
           VM_BUILD_NUMBER=$(echo $VM_HOSTNAME | perl -ne 'if (/(-[0-9]{1}-)(\d+)/) { print $2 }') # Extract build number from VM hostname, e.g. D-0-321 -> 321
           echo "VM_BUILD_NUMBER=${VM_BUILD_NUMBER}" >> $GITHUB_ENV
           echo "VM_HOSTNAME: ${VM_HOSTNAME}"

--- a/.github/workflows/manual-upgrade-testnet-l2.yml
+++ b/.github/workflows/manual-upgrade-testnet-l2.yml
@@ -72,6 +72,20 @@ jobs:
           echo "RESOURCE_TESTNET_NAME=${{env.RESOURCE_TESTNET_NAME}}" >> $GITHUB_OUTPUT
           echo "L1_HOST=${{env.L1_HOST}}" >> $GITHUB_OUTPUT
 
+      - name: 'Fetch latest VM hostnames by env tag and extract build number'
+        id: fetch_hostnames
+        run: |
+          TAG_NAME="${{needs.build.outputs.RESOURCE_TAG_NAME}}"
+          VM_HOSTNAME=$(az vm list --query "[?tags.$TAG_NAME=='true'].{Name:name}[0]" -g Testnet -o tsv)
+          VM_BUILD_NUMBER=$(echo $VM_HOSTNAME | perl -ne 'if (/(-[0-9]{1}-)(\d+)/) { print $2 }') # Extract build number from VM hostname, e.g. D-0-321 -> 321
+          echo "VM_BUILD_NUMBER=${VM_BUILD_NUMBER}" >> $GITHUB_ENV
+          echo "VM_HOSTNAME: ${VM_HOSTNAME}"
+          echo "VM_BUILD_NUMBER: ${VM_BUILD_NUMBER}"
+          if ! [[ $VM_BUILD_NUMBER =~ ^[0-9]+$ ]]; then # fail if build number is not a number
+            echo "Error: Hostname lookup or regex extraction of build number failed."
+            exit 1
+          fi
+
       - name: 'Login to Azure docker registry'
         uses: azure/docker-login@v1
         with:
@@ -130,20 +144,6 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
-      - name: 'Fetch latest VM hostnames by env tag and extract build number'
-        id: fetch_hostnames
-        run: |
-          TAG_NAME="${{needs.build.outputs.RESOURCE_TAG_NAME}}"
-          VM_HOSTNAME=$(az vm list --query "[?tags.$TAG_NAME=='true'].{Name:name}[0]" -g Testnet -o tsv)
-          VM_BUILD_NUMBER=$(echo $VM_HOSTNAME | perl -ne 'if (/(-[0-9]{1}-)(\d+)/) { print $2 }') # Extract build number from VM hostname, e.g. D-0-321 -> 321
-          echo "VM_BUILD_NUMBER=${VM_BUILD_NUMBER}" >> $GITHUB_ENV
-          echo "VM_HOSTNAME: ${VM_HOSTNAME}"
-          echo "VM_BUILD_NUMBER: ${VM_BUILD_NUMBER}"
-          if ! [[ $VM_BUILD_NUMBER =~ ^[0-9]+$ ]]; then # fail if build number is not a number
-            echo "Error: Hostname lookup or regex extraction of build number failed."
-            exit 1
-          fi
-
       - name: 'Update Obscuro node-${{ matrix.host_id }} on Azure'
         uses: azure/CLI@v1
         with:
@@ -182,3 +182,4 @@ jobs:
         shell: bash
         run: |
           ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-0-${{needs.build.outputs.RESOURCE_TESTNET_NAME}}-${{ env.VM_BUILD_NUMBER }}.uksouth.cloudapp.azure.com
+          ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-1-${{needs.build.outputs.RESOURCE_TESTNET_NAME}}-${{ env.VM_BUILD_NUMBER }}.uksouth.cloudapp.azure.com --timeout=60

--- a/.github/workflows/manual-upgrade-testnet-l2.yml
+++ b/.github/workflows/manual-upgrade-testnet-l2.yml
@@ -134,7 +134,7 @@ jobs:
         id: fetch_hostnames
         run: |
           TAG_NAME="${{needs.build.outputs.RESOURCE_TAG_NAME}}"
-          VM_HOSTNAME=$(az vm list --query "[?tags.$TAG_NAME=='true'].{Name:name}[0]" -o tsv)
+          VM_HOSTNAME=$(az vm list --query "[?tags.$TAG_NAME=='true'].{Name:name}[0]" -g Testnet -o tsv)
           VM_BUILD_NUMBER=$(echo $VM_HOSTNAME | perl -ne 'if (/(-[0-9]{1}-)(\d+)/) { print $2 }') # Extract build number from VM hostname, e.g. D-0-321 -> 321
           echo "VM_BUILD_NUMBER=VM_BUILD_NUMBER" >> $GITHUB_ENV
           if ! [[ $BUILD_NUMBER =~ ^[0-9]+$ ]]; then # fail if build number is not a number

--- a/.github/workflows/manual-upgrade-testnet-l2.yml
+++ b/.github/workflows/manual-upgrade-testnet-l2.yml
@@ -29,6 +29,7 @@ jobs:
       RESOURCE_STARTING_NAME: ${{ steps.outputVars.outputs.RESOURCE_STARTING_NAME }}
       RESOURCE_TESTNET_NAME: ${{ steps.outputVars.outputs.RESOURCE_TESTNET_NAME }}
       L1_HOST: ${{ steps.outputVars.outputs.L1_HOST }}
+      VM_BUILD_NUMBER: ${{ steps.outputVars.outputs.VM_BUILD_NUMBER }}
 
     steps:
       - uses: actions/checkout@v2
@@ -62,16 +63,6 @@ jobs:
           echo "RESOURCE_TESTNET_NAME=devtestnet" >> $GITHUB_ENV
           echo "L1_HOST=dev-testnet-eth2network.uksouth.azurecontainer.io" >> $GITHUB_ENV
 
-      - name: 'Output env vars'
-        id: outputVars
-        run: |
-          echo "L2_ENCLAVE_DOCKER_BUILD_TAG=${{env.L2_ENCLAVE_DOCKER_BUILD_TAG}}" >> $GITHUB_OUTPUT
-          echo "L2_HOST_DOCKER_BUILD_TAG=${{env.L2_HOST_DOCKER_BUILD_TAG}}" >> $GITHUB_OUTPUT
-          echo "RESOURCE_TAG_NAME=${{env.RESOURCE_TAG_NAME}}" >> $GITHUB_OUTPUT
-          echo "RESOURCE_STARTING_NAME=${{env.RESOURCE_STARTING_NAME}}" >> $GITHUB_OUTPUT
-          echo "RESOURCE_TESTNET_NAME=${{env.RESOURCE_TESTNET_NAME}}" >> $GITHUB_OUTPUT
-          echo "L1_HOST=${{env.L1_HOST}}" >> $GITHUB_OUTPUT
-
       - name: 'Fetch latest VM hostnames by env tag and extract build number'
         id: fetch_hostnames
         run: |
@@ -84,6 +75,17 @@ jobs:
             echo "Error: Hostname lookup or regex extraction of build number failed."
             exit 1
           fi
+
+      - name: 'Output env vars'
+        id: outputVars
+        run: |
+          echo "L2_ENCLAVE_DOCKER_BUILD_TAG=${{env.L2_ENCLAVE_DOCKER_BUILD_TAG}}" >> $GITHUB_OUTPUT
+          echo "L2_HOST_DOCKER_BUILD_TAG=${{env.L2_HOST_DOCKER_BUILD_TAG}}" >> $GITHUB_OUTPUT
+          echo "RESOURCE_TAG_NAME=${{env.RESOURCE_TAG_NAME}}" >> $GITHUB_OUTPUT
+          echo "RESOURCE_STARTING_NAME=${{env.RESOURCE_STARTING_NAME}}" >> $GITHUB_OUTPUT
+          echo "RESOURCE_TESTNET_NAME=${{env.RESOURCE_TESTNET_NAME}}" >> $GITHUB_OUTPUT
+          echo "L1_HOST=${{env.L1_HOST}}" >> $GITHUB_OUTPUT
+          echo "VM_BUILD_NUMBER=${{env.VM_BUILD_NUMBER}}" >> $GITHUB_OUTPUT
 
       - name: 'Login to Azure docker registry'
         uses: azure/docker-login@v1
@@ -147,7 +149,7 @@ jobs:
         uses: azure/CLI@v1
         with:
           inlineScript: |
-            az vm run-command invoke -g Testnet -n "${{needs.build.outputs.RESOURCE_STARTING_NAME}}-${{ matrix.host_id }}-${{ env.VM_BUILD_NUMBER }}"  \
+            az vm run-command invoke -g Testnet -n "${{needs.build.outputs.RESOURCE_STARTING_NAME}}-${{ matrix.host_id }}-${{needs.build.outputs.VM_BUILD_NUMBER}}"  \
             --command-id RunShellScript \
             --scripts '
                docker pull ${{needs.build.outputs.L2_HOST_DOCKER_BUILD_TAG}} \
@@ -163,7 +165,7 @@ jobs:
               -l1_host=${{needs.build.outputs.L1_HOST}} \
               -private_key=${{ secrets[matrix.node_pk_str] }} \
               -sequencer_id=${{ secrets.GETHNETWORK_PREFUNDED_ADDR_0 }} \
-              -host_public_p2p_addr=obscuronode-${{ matrix.host_id }}-${{needs.build.outputs.RESOURCE_TESTNET_NAME}}-${{ env.VM_BUILD_NUMBER }}.uksouth.cloudapp.azure.com:10000 \
+              -host_public_p2p_addr=obscuronode-${{ matrix.host_id }}-${{needs.build.outputs.RESOURCE_TESTNET_NAME}}-${{needs.build.outputs.VM_BUILD_NUMBER}}.uksouth.cloudapp.azure.com:10000 \
               -host_p2p_port=10000 \
               -enclave_docker_image=${{needs.build.outputs.L2_ENCLAVE_DOCKER_BUILD_TAG}} \
               -host_docker_image=${{needs.build.outputs.L2_HOST_DOCKER_BUILD_TAG}} \
@@ -180,5 +182,5 @@ jobs:
       - name: "Wait until obscuro node is healthy"
         shell: bash
         run: |
-          ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-0-${{needs.build.outputs.RESOURCE_TESTNET_NAME}}-${{ env.VM_BUILD_NUMBER }}.uksouth.cloudapp.azure.com
-          ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-1-${{needs.build.outputs.RESOURCE_TESTNET_NAME}}-${{ env.VM_BUILD_NUMBER }}.uksouth.cloudapp.azure.com --timeout=60
+          ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-0-${{needs.build.outputs.RESOURCE_TESTNET_NAME}}-${{needs.build.outputs.VM_BUILD_NUMBER}}.uksouth.cloudapp.azure.com
+          ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-1-${{needs.build.outputs.RESOURCE_TESTNET_NAME}}-${{needs.build.outputs.VM_BUILD_NUMBER}}.uksouth.cloudapp.azure.com --timeout=60

--- a/.github/workflows/manual-upgrade-testnet-l2.yml
+++ b/.github/workflows/manual-upgrade-testnet-l2.yml
@@ -139,7 +139,7 @@ jobs:
           echo "VM_BUILD_NUMBER=VM_BUILD_NUMBER" >> $GITHUB_ENV
           echo "VM_HOSTNAME: ${VM_HOSTNAME}"
           echo "VM_BUILD_NUMBER: ${VM_BUILD_NUMBER}"
-          if ! [[ $BUILD_NUMBER =~ ^[0-9]+$ ]]; then # fail if build number is not a number
+          if ! [[ $VM_BUILD_NUMBER =~ ^[0-9]+$ ]]; then # fail if build number is not a number
             echo "Error: Hostname lookup or regex extraction of build number failed."
             exit 1
           fi

--- a/.github/workflows/manual-upgrade-testnet-l2.yml
+++ b/.github/workflows/manual-upgrade-testnet-l2.yml
@@ -16,11 +16,6 @@ on:
         options:
           - 'dev-testnet'
           - 'testnet'
-      github_deploy_number:
-        description: 'Github Deployment Number'
-        type: number
-        default: 0
-        required: true
 
 
 jobs:
@@ -135,11 +130,25 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
+      - name: 'Fetch latest VM hostnames by env tag and extract build number'
+        id: fetch_hostnames
+        run: |
+          TAG_NAME="${{needs.build.outputs.RESOURCE_TAG_NAME}}"
+          VM_HOSTNAME=$(az vm list --query "[?tags.$TAG_NAME=='true'].{Name:name}[0]" -o tsv)
+          VM_BUILD_NUMBER=$(echo $VM_HOSTNAME | perl -ne 'if (/(-[0-9]{1,2}-)(\d+)/) { print $2 }') # Extract build number from VM hostname, e.g. D-0-321 -> 321
+          echo "VM_BUILD_NUMBER=VM_BUILD_NUMBER" >> $GITHUB_ENV
+          if ! [[ $BUILD_NUMBER =~ ^[0-9]+$ ]]; then # fail if build number is not a number
+            echo "Error: Hostname lookup or regex extraction of build number failed."
+            echo "VM_HOSTNAME: ${VM_HOSTNAME}"
+            echo "VM_BUILD_NUMBER: ${VM_BUILD_NUMBER}"
+            exit 1
+          fi
+
       - name: 'Update Obscuro node-${{ matrix.host_id }} on Azure'
         uses: azure/CLI@v1
         with:
           inlineScript: |
-            az vm run-command invoke -g Testnet -n "${{needs.build.outputs.RESOURCE_STARTING_NAME}}-${{ matrix.host_id }}-${{ github.event.inputs.github_deploy_number }}"  \
+            az vm run-command invoke -g Testnet -n "${{needs.build.outputs.RESOURCE_STARTING_NAME}}-${{ matrix.host_id }}-${{ env.VM_BUILD_NUMBER }}"  \
             --command-id RunShellScript \
             --scripts '
                docker pull ${{needs.build.outputs.L2_HOST_DOCKER_BUILD_TAG}} \
@@ -155,7 +164,7 @@ jobs:
               -l1_host=${{needs.build.outputs.L1_HOST}} \
               -private_key=${{ secrets[matrix.node_pk_str] }} \
               -sequencer_id=${{ secrets.GETHNETWORK_PREFUNDED_ADDR_0 }} \
-              -host_public_p2p_addr=obscuronode-${{ matrix.host_id }}-${{needs.build.outputs.RESOURCE_TESTNET_NAME}}-${{ github.event.inputs.github_deploy_number }}.uksouth.cloudapp.azure.com:10000 \
+              -host_public_p2p_addr=obscuronode-${{ matrix.host_id }}-${{needs.build.outputs.RESOURCE_TESTNET_NAME}}-${{ env.VM_BUILD_NUMBER }}.uksouth.cloudapp.azure.com:10000 \
               -host_p2p_port=10000 \
               -enclave_docker_image=${{needs.build.outputs.L2_ENCLAVE_DOCKER_BUILD_TAG}} \
               -host_docker_image=${{needs.build.outputs.L2_HOST_DOCKER_BUILD_TAG}} \
@@ -172,4 +181,4 @@ jobs:
       - name: "Wait until obscuro node is healthy"
         shell: bash
         run: |
-          ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-0-${{needs.build.outputs.RESOURCE_TESTNET_NAME}}-${{ github.event.inputs.github_deploy_number }}.uksouth.cloudapp.azure.com
+          ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-0-${{needs.build.outputs.RESOURCE_TESTNET_NAME}}-${{ env.VM_BUILD_NUMBER }}.uksouth.cloudapp.azure.com

--- a/.github/workflows/manual-upgrade-testnet-l2.yml
+++ b/.github/workflows/manual-upgrade-testnet-l2.yml
@@ -136,7 +136,7 @@ jobs:
           TAG_NAME="${{needs.build.outputs.RESOURCE_TAG_NAME}}"
           VM_HOSTNAME=$(az vm list --query "[?tags.$TAG_NAME=='true'].{Name:name}[0]" -g Testnet -o tsv)
           VM_BUILD_NUMBER=$(echo $VM_HOSTNAME | perl -ne 'if (/(-[0-9]{1}-)(\d+)/) { print $2 }') # Extract build number from VM hostname, e.g. D-0-321 -> 321
-          echo "VM_BUILD_NUMBER=VM_BUILD_NUMBER" >> $GITHUB_ENV
+          echo "VM_BUILD_NUMBER=${VM_BUILD_NUMBER}" >> $GITHUB_ENV
           echo "VM_HOSTNAME: ${VM_HOSTNAME}"
           echo "VM_BUILD_NUMBER: ${VM_BUILD_NUMBER}"
           if ! [[ $VM_BUILD_NUMBER =~ ^[0-9]+$ ]]; then # fail if build number is not a number


### PR DESCRIPTION
### Why this change is needed

Automate testnet upgrades

### What changes were made as part of this PR

Use tags to do lookup on VM name, extract build number with regex

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


