### PR TITLE
Fix testnet deploy sleep condition

### DIFF
--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -225,7 +225,7 @@ jobs:
 
       - name: 'Wait for Obscuro sequencer to start'
         shell: bash
-        run: if [ 0! = ${{ matrix.host_id }} ]; then sleep 60; fi
+        run: if [ 0 != ${{ matrix.host_id }} ]; then echo "Sleeping while sequencer starts" & sleep 60; fi
 
       - name: 'Start Obscuro node-${{ matrix.host_id }} on Azure'
         uses: azure/CLI@v1


### PR DESCRIPTION
### Why this change is needed

We can see in Deploy testnet batch jobs that the 60second sleep the validator has scheduled never happens, this seems to be because of a whitespace issue in the condition:
<img width="301" alt="image" src="https://github.com/obscuronet/go-obscuro/assets/98158711/f4b9fd48-bf3a-47f6-9756-57a406ab444e">

Not sure if this sleep helps really but if it's not working we should fix it or delete it.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


