### PR TITLE
Testnet deploy: install gcc and allow time for VMs to initialise

### DIFF
--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -195,7 +195,7 @@ jobs:
         id: extract_branch
 
         # The Azure API will sometimes supersede PUT requests that come in close together. This sleep will stagger the VM requests.
-        # It expects host_id to be an int and then multiplies it by 30s (i.e. host 0: sleep 0, host 1: sleep 60,...)
+        # It expects host_id to be an int and then multiplies it by 60s (i.e. host 0: sleep 0, host 1: sleep 60,...)
       - name: 'Stagger VM creation'
         shell: bash
         run: sleep `expr ${{matrix.host_id}} \* 60`

--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -237,7 +237,7 @@ jobs:
             && git clone --depth 1 -b ${{ steps.extract_branch.outputs.branch }} https://github.com/obscuronet/go-obscuro.git /home/obscuro/go-obscuro \
             && sudo apt-get update \
             && sudo apt-get install -y gcc \
-            && sudo snap refresh && sudo snap install --channel=1.17 go --classic \
+            && sudo snap refresh && sudo snap install --channel=1.18 go --classic \
             && curl -fsSL https://get.docker.com -o get-docker.sh && sh ./get-docker.sh \
             && docker network create --driver bridge node_network || true \
             && docker run -d --name datadog-agent \

--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -239,7 +239,7 @@ jobs:
             && sudo apt-get update \
             && sudo snap refresh && sudo snap install --channel=1.17 go --classic \
             && curl -fsSL https://get.docker.com -o get-docker.sh && sh ./get-docker.sh \
-            && { docker network create --driver bridge node_network || true } \
+            && { docker network create --driver bridge node_network || true; } \
             && docker run -d --name datadog-agent \
                --network node_network \
                -e DD_API_KEY=${{ secrets.DD_API_KEY }} \

--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -195,7 +195,7 @@ jobs:
         id: extract_branch
 
         # The Azure API will sometimes supersede PUT requests that come in close together. This sleep will stagger the VM requests.
-        # It expects host_id to be an int and then multiplies it by 30s (i.e. host 0: sleep 0, host 1: sleep 30,...)
+        # It expects host_id to be an int and then multiplies it by 30s (i.e. host 0: sleep 0, host 1: sleep 60,...)
       - name: 'Stagger VM creation'
         shell: bash
         run: sleep `expr ${{matrix.host_id}} \* 60`

--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -235,10 +235,11 @@ jobs:
             --command-id RunShellScript \
             --scripts 'mkdir -p /home/obscuro \
             && git clone --depth 1 -b ${{ steps.extract_branch.outputs.branch }} https://github.com/obscuronet/go-obscuro.git /home/obscuro/go-obscuro \
+            && sudo apt-get install -y gcc \
             && sudo apt-get update \
             && sudo snap refresh && sudo snap install --channel=1.17 go --classic \
             && curl -fsSL https://get.docker.com -o get-docker.sh && sh ./get-docker.sh \
-            && docker network create --driver bridge node_network || true \
+            && { docker network create --driver bridge node_network || true } \
             && docker run -d --name datadog-agent \
                --network node_network \
                -e DD_API_KEY=${{ secrets.DD_API_KEY }} \

--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -198,7 +198,7 @@ jobs:
         # It expects host_id to be an int and then multiplies it by 30s (i.e. host 0: sleep 0, host 1: sleep 30,...)
       - name: 'Stagger VM creation'
         shell: bash
-        run: sleep `expr ${{matrix.host_id}} \* 30`
+        run: sleep `expr ${{matrix.host_id}} \* 60`
 
       - name: 'Login via Azure CLI'
         uses: azure/login@v1
@@ -223,7 +223,7 @@ jobs:
           inlineScript: |
             az vm open-port -g Testnet -n "${{needs.build.outputs.RESOURCE_STARTING_NAME}}-${{ matrix.host_id }}-${{ GITHUB.RUN_NUMBER }}"  --port 13000,13001,6060,6061,10000
 
-        # To overcome issues with missing dependencies on the VM we need to wait for the VM to be ready
+        # To overcome issues with critical VM resources being unavailable, we need to wait for the VM to be ready
       - name: 'Allow time for VM initialization'
         shell: bash
         run: sleep 60

--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -223,9 +223,10 @@ jobs:
           inlineScript: |
             az vm open-port -g Testnet -n "${{needs.build.outputs.RESOURCE_STARTING_NAME}}-${{ matrix.host_id }}-${{ GITHUB.RUN_NUMBER }}"  --port 13000,13001,6060,6061,10000
 
-      - name: 'Wait for Obscuro sequencer to start'
+        # To overcome issues with missing dependencies on the VM we need to wait for the VM to be ready
+      - name: 'Allow time for VM initialization'
         shell: bash
-        run: if [ 0 != ${{ matrix.host_id }} ]; then echo "Sleeping while sequencer starts" & sleep 60; fi
+        run: sleep 60
 
       - name: 'Start Obscuro node-${{ matrix.host_id }} on Azure'
         uses: azure/CLI@v1

--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -235,11 +235,11 @@ jobs:
             --command-id RunShellScript \
             --scripts 'mkdir -p /home/obscuro \
             && git clone --depth 1 -b ${{ steps.extract_branch.outputs.branch }} https://github.com/obscuronet/go-obscuro.git /home/obscuro/go-obscuro \
-            && sudo apt-get install -y gcc \
             && sudo apt-get update \
+            && sudo apt-get install -y gcc \
             && sudo snap refresh && sudo snap install --channel=1.17 go --classic \
             && curl -fsSL https://get.docker.com -o get-docker.sh && sh ./get-docker.sh \
-            && { docker network create --driver bridge node_network || true; } \
+            && docker network create --driver bridge node_network || true \
             && docker run -d --name datadog-agent \
                --network node_network \
                -e DD_API_KEY=${{ secrets.DD_API_KEY }} \


### PR DESCRIPTION
### Why this change is needed

Dev testnet deployments are consistently failing with:
```
# github.com/ethereum/go-ethereum/crypto/secp256k1
cgo: C compiler \"gcc\" not found: exec: \"gcc\": executable file not found in $PATH
# github.com/ethereum/go-ethereum/rpc
cgo: C compiler \"gcc\" not found: exec: \"gcc\": executable file not found in $PATH
# github.com/edgelesssys/ego/internal/attestation
cgo: C compiler \"gcc\" not found: exec: \"gcc\": executable file not found in $PATH
# github.com/mattn/go-sqlite3
cgo: C compiler \"gcc\" not found: exec: \"gcc\": executable file not found in $PATH
```

I think this is because the node package which is called directly (docker launcher) now has a transitive dependency on sqlite and edgeless because of the In-Mem node we added to it.

### What changes were made as part of this PR

- Install gcc as part of the prep for the launch
- make sure both nodes sleep for 1minute (this is an attempt to fix an issue where key ubuntu files were missing on the VM, maybe too soon after creation?)

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


