### PR TITLE
Testnet deploy: health check validator node too

### DIFF
--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -311,6 +311,7 @@ jobs:
         shell: bash
         run: |
           ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-0-${{needs.build.outputs.RESOURCE_TESTNET_NAME}}-${{ GITHUB.RUN_NUMBER }}.uksouth.cloudapp.azure.com
+          ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-1-${{needs.build.outputs.RESOURCE_TESTNET_NAME}}-${{ GITHUB.RUN_NUMBER }}.uksouth.cloudapp.azure.com --timeout=60
 
   deploy-l2-contracts:
     needs:


### PR DESCRIPTION
### Why this change is needed

The `check-obscuro-is-healthy` currently just waits for the sequencer (node 0) to be healthy.

We sometimes have failures where the validator hasn't come up at all but the action reports successful. But the validator is critical for network interactions.

### What changes were made as part of this PR

Add another health check wait after the seq check completes.

Set timeout on that wait to just 60secs since we already waited for sequencer and it shouldn't take too long after that.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


