### PR TITLE
Testnet upgrade: trigger faucet deployment

### DIFF
--- a/.github/workflows/manual-upgrade-testnet-l2.yml
+++ b/.github/workflows/manual-upgrade-testnet-l2.yml
@@ -184,3 +184,18 @@ jobs:
         run: |
           ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-0-${{needs.build.outputs.RESOURCE_TESTNET_NAME}}-${{needs.build.outputs.VM_BUILD_NUMBER}}.uksouth.cloudapp.azure.com
           ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-1-${{needs.build.outputs.RESOURCE_TESTNET_NAME}}-${{needs.build.outputs.VM_BUILD_NUMBER}}.uksouth.cloudapp.azure.com --timeout=60
+
+  deploy-faucet:
+    runs-on: ubuntu-latest
+    needs:
+      - check-obscuro-is-healthy
+    steps:
+      - name: 'Trigger Faucet deployment on workflow dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          curl -XPOST -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" -H "Accept:application/vnd.github" -H "Content-Type:application/json" https://api.github.com/repos/obscuronet/faucet/actions/workflows/manual-deploy-${{ github.event.inputs.testnet_type }}-faucet.yml/dispatches --data '{"ref": "main" }'
+
+      - name: 'Trigger Faucet deployment on schedule'
+        if: ${{ github.event_name == 'schedule' }}
+        run: |
+          curl -XPOST -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" -H "Accept:application/vnd.github" -H "Content-Type:application/json" https://api.github.com/repos/obscuronet/faucet/dispatches --data '{ "event_type": "l2_dev_deployment", "client_payload": { "ref": "main", "env": "dev-testnet" }'


### PR DESCRIPTION
### Why this change is needed

With current setup we need to restart faucet when testnet is restarted. (This should be fixed eventually, persisting viewing keys on enclave or sending viewing keys with every request).

For now we are having to manually restart the faucet which is a pain, this brings it inline with the deploy testnet script.

### What changes were made as part of this PR

Trigger faucet deploy after successful testnet upgrade

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


