### PR TITLE
Testnet deploy: validator health check to 5mins

### DIFF
--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -306,7 +306,7 @@ jobs:
         shell: bash
         run: |
           ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-0-${{needs.build.outputs.RESOURCE_TESTNET_NAME}}-${{ GITHUB.RUN_NUMBER }}.uksouth.cloudapp.azure.com
-          ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-1-${{needs.build.outputs.RESOURCE_TESTNET_NAME}}-${{ GITHUB.RUN_NUMBER }}.uksouth.cloudapp.azure.com --timeout=60
+          ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-1-${{needs.build.outputs.RESOURCE_TESTNET_NAME}}-${{ GITHUB.RUN_NUMBER }}.uksouth.cloudapp.azure.com
 
   deploy-l2-contracts:
     needs:

--- a/.github/workflows/manual-upgrade-testnet-l2.yml
+++ b/.github/workflows/manual-upgrade-testnet-l2.yml
@@ -189,7 +189,7 @@ jobs:
         shell: bash
         run: |
           ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-0-${{needs.build.outputs.RESOURCE_TESTNET_NAME}}-${{needs.build.outputs.VM_BUILD_NUMBER}}.uksouth.cloudapp.azure.com
-          ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-1-${{needs.build.outputs.RESOURCE_TESTNET_NAME}}-${{needs.build.outputs.VM_BUILD_NUMBER}}.uksouth.cloudapp.azure.com --timeout=60
+          ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-1-${{needs.build.outputs.RESOURCE_TESTNET_NAME}}-${{needs.build.outputs.VM_BUILD_NUMBER}}.uksouth.cloudapp.azure.com
 
   deploy-faucet:
     runs-on: ubuntu-latest

--- a/.github/workflows/runner-scripts/wait-node-healthy.sh
+++ b/.github/workflows/runner-scripts/wait-node-healthy.sh
@@ -54,6 +54,8 @@ fi
 net_status=""
 time=0
 
+echo "Running health check against http://${host}:${port}"
+
 while ! [[ $net_status = *\"OverallHealth\":true* ]]
 do
     net_status=$(curl --request POST "http://${host}:${port}" \
@@ -61,8 +63,8 @@ do
                  --data-raw '{ "method":"obscuro_health", "params":null, "id":1, "jsonrpc":"2.0" }') || true
     echo $net_status
 
-    sleep 1
-    ((time=time+1))
+    sleep 2
+    ((time=time+2))
 
     if [[ $time == $timeout ]] ;
     then


### PR DESCRIPTION
### Why this change is needed

Validator starts 1min after sequencer, so giving it just 1min of timeout after seq success is fragile (and regularly failing). 

### What changes were made as part of this PR

Removed the 60s timeout so it defaults to 5min.
Also changed the interval to 2sec to reduce the noise.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


