### PR TITLE
Mempool is now using a simpler mechanism to pick transactions and wait for ones that are not ready to go in yet.

### DIFF
--- a/go/enclave/components/batch_registry.go
+++ b/go/enclave/components/batch_registry.go
@@ -72,7 +72,6 @@ func (br *batchRegistryImpl) StoreBatch(batch *core.Batch, receipts types.Receip
 		return fmt.Errorf("failed to store batch. Cause: %w", err)
 	}
 
-	// TODO - we probably dont want to spawn a goroutine everytime
 	br.notifySubscriber(batch, isHeadBatch)
 
 	return nil

--- a/go/enclave/components/batch_registry.go
+++ b/go/enclave/components/batch_registry.go
@@ -222,9 +222,10 @@ func (br *batchRegistryImpl) FindAncestralBatchFor(block *common.L1Block) (*core
 			return nil, fmt.Errorf("unable to get latest ancestral batch. Cause: %w", err)
 		}
 
-		currentBlock, err = br.storage.FetchBlock(currentBlock.ParentHash())
+		parentBlockHash := currentBlock.ParentHash()
+		currentBlock, err = br.storage.FetchBlock(parentBlockHash)
 		if err != nil {
-			return nil, fmt.Errorf("unable to find parent for block in ancestral chain. Cause: %w", err)
+			return nil, fmt.Errorf("unable to find parent for block %s in ancestral chain. Cause: %w", parentBlockHash.Hex(), err)
 		}
 	}
 

--- a/go/enclave/core/utils.go
+++ b/go/enclave/core/utils.go
@@ -45,3 +45,13 @@ func VerifySignature(chainID int64, tx *types.Transaction) error {
 	_, err := types.Sender(signer, tx)
 	return err
 }
+
+// ExtractOrderingInfo - Get sender and tx nonce from transaction
+func ExtractOrderingInfo(chainID int64, tx *types.Transaction) (*gethcommon.Address, uint64, error) {
+	signer := types.NewLondonSigner(big.NewInt(chainID))
+	sender, err := types.Sender(signer, tx)
+	if err != nil {
+		return nil, 0, err
+	}
+	return &sender, tx.Nonce(), nil
+}

--- a/go/enclave/core/utils.go
+++ b/go/enclave/core/utils.go
@@ -46,12 +46,12 @@ func VerifySignature(chainID int64, tx *types.Transaction) error {
 	return err
 }
 
-// ExtractOrderingInfo - Get sender and tx nonce from transaction
-func ExtractOrderingInfo(chainID int64, tx *types.Transaction) (*gethcommon.Address, uint64, error) {
+// GetAuthenticatedSender - Get sender and tx nonce from transaction
+func GetAuthenticatedSender(chainID int64, tx *types.Transaction) (*gethcommon.Address, error) {
 	signer := types.NewLondonSigner(big.NewInt(chainID))
 	sender, err := types.Sender(signer, tx)
 	if err != nil {
-		return nil, 0, err
+		return nil, err
 	}
-	return &sender, tx.Nonce(), nil
+	return &sender, nil
 }

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -180,7 +180,7 @@ func NewEnclave(
 
 	transactionBlobCrypto := crypto.NewTransactionBlobCryptoImpl(logger)
 
-	memp := mempool.New(config.ObscuroChainID)
+	memp := mempool.New(config.ObscuroChainID, logger)
 
 	crossChainProcessors := crosschain.New(&config.MessageBusAddress, storage, big.NewInt(config.ObscuroChainID), logger)
 
@@ -968,7 +968,7 @@ func (e *enclaveImpl) EstimateGas(encryptedParams common.EncryptedParamsEstimate
 	return responses.AsEncryptedResponse(&gasEstimate, encryptor), nil
 }
 
-//nolint
+// nolint
 func (e *enclaveImpl) GetLogs(encryptedParams common.EncryptedParamsGetLogs) (*responses.Logs, common.SystemError) {
 	if e.stopControl.IsStopping() {
 		return nil, responses.ToInternalError(fmt.Errorf("requested GetLogs with the enclave stopping"))

--- a/go/enclave/mempool/interface.go
+++ b/go/enclave/mempool/interface.go
@@ -1,10 +1,9 @@
 package mempool
 
 import (
+	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/obscuronet/go-obscuro/go/common"
-	"github.com/obscuronet/go-obscuro/go/enclave/core"
-	"github.com/obscuronet/go-obscuro/go/enclave/db"
 )
 
 type Manager interface {
@@ -15,6 +14,6 @@ type Manager interface {
 	// RemoveTxs removes transactions that are considered immune to re-orgs (i.e. over X batches deep).
 	RemoveTxs(transactions types.Transactions) error
 
-	// CurrentTxs Returns the transactions that should be included in the current batch
-	CurrentTxs(head *core.Batch, resolver db.Storage) ([]*common.L2Tx, error)
+	// SelectTransactions Returns the transactions that should be included in the current batch
+	SelectTransactions(stateDB *state.StateDB) ([]*common.L2Tx, error)
 }

--- a/go/enclave/mempool/interface.go
+++ b/go/enclave/mempool/interface.go
@@ -1,6 +1,7 @@
 package mempool
 
 import (
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/obscuronet/go-obscuro/go/common"
 	"github.com/obscuronet/go-obscuro/go/enclave/core"
 	"github.com/obscuronet/go-obscuro/go/enclave/db"
@@ -11,8 +12,9 @@ type Manager interface {
 	FetchMempoolTxs() []*common.L2Tx
 	// AddMempoolTx adds a transaction to the mempool
 	AddMempoolTx(tx *common.L2Tx) error
-	// RemoveMempoolTxs removes transactions that are considered immune to re-orgs (i.e. over X batches deep).
-	RemoveMempoolTxs(batch *core.Batch, resolver db.BatchResolver) error
+	// RemoveTxs removes transactions that are considered immune to re-orgs (i.e. over X batches deep).
+	RemoveTxs(transactions types.Transactions) error
+
 	// CurrentTxs Returns the transactions that should be included in the current batch
 	CurrentTxs(head *core.Batch, resolver db.BatchResolver) ([]*common.L2Tx, error)
 }

--- a/go/enclave/mempool/interface.go
+++ b/go/enclave/mempool/interface.go
@@ -16,5 +16,5 @@ type Manager interface {
 	RemoveTxs(transactions types.Transactions) error
 
 	// CurrentTxs Returns the transactions that should be included in the current batch
-	CurrentTxs(head *core.Batch, resolver db.BatchResolver) ([]*common.L2Tx, error)
+	CurrentTxs(head *core.Batch, resolver db.Storage) ([]*common.L2Tx, error)
 }

--- a/go/enclave/mempool/interface.go
+++ b/go/enclave/mempool/interface.go
@@ -14,6 +14,6 @@ type Manager interface {
 	// RemoveTxs removes transactions that are considered immune to re-orgs (i.e. over X batches deep).
 	RemoveTxs(transactions types.Transactions) error
 
-	// SelectTransactions Returns the transactions that should be included in the current batch
-	SelectTransactions(stateDB *state.StateDB) ([]*common.L2Tx, error)
+	// CurrentTxs Returns the transactions that should be included in the current batch
+	CurrentTxs(stateDB *state.StateDB) ([]*common.L2Tx, error)
 }

--- a/go/enclave/mempool/manager.go
+++ b/go/enclave/mempool/manager.go
@@ -83,10 +83,20 @@ func (db *mempoolManager) CurrentTxs(head *core.Batch, resolver db.Storage) ([]*
 
 	applicableTransactions := make(common.L2Transactions, 0)
 
-	for _, tx := range txes {
+	addressNonces := make(map[gethcommon.Address]uint64)
+	NonceFor := func(address gethcommon.Address) uint64 {
+		nonce, found := addressNonces[address]
+		if !found {
+			nonce = stateDB.GetNonce(address)
+			addressNonces[address] = nonce
+		}
 
+		return nonce
+	}
+
+	for _, tx := range txes {
 		sender, txNonce, _ := core.ExtractOrderingInfo(db.obscuroChainID, tx)
-		addressNonce := stateDB.GetNonce(*sender)
+		addressNonce := NonceFor(*sender)
 		if txNonce == addressNonce {
 			applicableTransactions = append(applicableTransactions, tx)
 		}

--- a/go/enclave/mempool/manager.go
+++ b/go/enclave/mempool/manager.go
@@ -92,9 +92,11 @@ func (db *mempoolManager) CurrentTxs(head *core.Batch, resolver db.Storage) ([]*
 		nonce, found := addressNonces[address]
 		if !found {
 			nonce = stateDB.GetNonce(address)
-			addressNonces[address] = nonce
+		} else {
+			nonce = nonce + 1
 		}
 
+		addressNonces[address] = nonce
 		return nonce
 	}
 

--- a/go/enclave/mempool/manager.go
+++ b/go/enclave/mempool/manager.go
@@ -1,11 +1,8 @@
 package mempool
 
 import (
-	"errors"
 	"sort"
 	"sync"
-
-	"github.com/obscuronet/go-obscuro/go/common/errutil"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -74,65 +71,7 @@ func (db *mempoolManager) RemoveTxs(transactions types.Transactions) error {
 
 // CurrentTxs - Calculate transactions to be included in the current batch
 func (db *mempoolManager) CurrentTxs(head *core.Batch, resolver db.BatchResolver) ([]*common.L2Tx, error) {
-	txs, err := findTxsNotIncluded(head, db.FetchMempoolTxs(), resolver)
-	if err != nil {
-		return nil, err
-	}
-	sort.Sort(sortByNonce(txs))
-	return txs, nil
-}
-
-// findTxsNotIncluded - given a list of transactions, it keeps only the ones that were not included in the block
-// todo (#1491) - inefficient
-func findTxsNotIncluded(head *core.Batch, txs []*common.L2Tx, s db.BatchResolver) ([]*common.L2Tx, error) {
-	// go back only HeightCommittedBlocks blocks to accumulate transactions to be diffed against the mempool
-	startAt := uint64(0)
-	if head.NumberU64() > common.HeightCommittedBlocks {
-		startAt = head.NumberU64() - common.HeightCommittedBlocks
-	}
-	included, err := allIncludedTransactions(head, s, startAt)
-	if err != nil {
-		return nil, err
-	}
-	return filterOutTransactions(txs, included), nil
-}
-
-// Recursively finds all transactions included in the past stopAtHeight batches.
-func allIncludedTransactions(batch *core.Batch, s db.BatchResolver, stopAtHeight uint64) (map[gethcommon.Hash]*common.L2Tx, error) {
-	if batch.Header.Number.Uint64() == stopAtHeight {
-		return core.MakeMap(batch.Transactions), nil
-	}
-
-	// We add this batch's transactions to the included transactions.
-	newMap := make(map[gethcommon.Hash]*common.L2Tx)
-	for _, tx := range batch.Transactions {
-		newMap[tx.Hash()] = tx
-	}
-
-	// If the batch has a parent (i.e. it is not the genesis block), we recurse.
-	parentBatch, err := s.FetchBatch(batch.Header.ParentHash)
-	if err != nil && !errors.Is(err, errutil.ErrNotFound) {
-		return nil, err
-	}
-	if err == nil {
-		txsMap, err := allIncludedTransactions(parentBatch, s, stopAtHeight)
-		if err != nil {
-			return nil, err
-		}
-		for hash, tx := range txsMap {
-			newMap[hash] = tx
-		}
-	}
-
-	return newMap, nil
-}
-
-func filterOutTransactions(txs []*common.L2Tx, txsToRemove map[gethcommon.Hash]*common.L2Tx) (r []*common.L2Tx) {
-	for _, tx := range txs {
-		_, f := txsToRemove[tx.Hash()]
-		if !f {
-			r = append(r, tx)
-		}
-	}
-	return
+	txes := db.FetchMempoolTxs()
+	sort.Sort(sortByNonce(txes))
+	return txes, nil
 }

--- a/go/enclave/mempool/manager.go
+++ b/go/enclave/mempool/manager.go
@@ -59,9 +59,11 @@ func (db *mempoolManager) FetchMempoolTxs() []*common.L2Tx {
 	db.mpMutex.RLock()
 	defer db.mpMutex.RUnlock()
 
-	mpCopy := make([]*common.L2Tx, 0)
+	mpCopy := make([]*common.L2Tx, len(db.mempool))
+	i := 0
 	for _, tx := range db.mempool {
-		mpCopy = append(mpCopy, tx)
+		mpCopy[i] = tx
+		i++
 	}
 	return mpCopy
 }

--- a/go/enclave/mempool/manager.go
+++ b/go/enclave/mempool/manager.go
@@ -30,7 +30,6 @@ type mempoolManager struct {
 	obscuroChainID int64
 	logger         gethlog.Logger
 	mempool        map[gethcommon.Hash]*common.L2Tx
-	pendingAccTxs  map[gethcommon.Address]common.L2Transactions
 }
 
 func New(chainID int64, logger gethlog.Logger) Manager {

--- a/go/enclave/mempool/nonce_tracker.go
+++ b/go/enclave/mempool/nonce_tracker.go
@@ -5,6 +5,10 @@ import (
 	"github.com/ethereum/go-ethereum/core/state"
 )
 
+// NonceTracker - a struct that helps us maintain the nonces for each account.
+// If it gets asked for an account it does not know the nonce for, it will pull it
+// from stateDB. Used when selecting transactions in order to ensure transactions get
+// applied at correct nonces and correct order without any gaps.
 type NonceTracker struct {
 	accountNonces map[gethcommon.Address]uint64
 	stateDB       *state.StateDB

--- a/go/enclave/mempool/nonce_tracker.go
+++ b/go/enclave/mempool/nonce_tracker.go
@@ -32,5 +32,5 @@ func (nt *NonceTracker) nonceFromState(address gethcommon.Address) uint64 {
 }
 
 func (nt *NonceTracker) IncrementNonce(address gethcommon.Address) {
-	nt.accountNonces[address] += 1
+	nt.accountNonces[address]++
 }

--- a/go/enclave/mempool/nonce_tracker.go
+++ b/go/enclave/mempool/nonce_tracker.go
@@ -1,0 +1,36 @@
+package mempool
+
+import (
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state"
+)
+
+type NonceTracker struct {
+	accountNonces map[gethcommon.Address]uint64
+	stateDB       *state.StateDB
+}
+
+func NewNonceTracker(stateDB *state.StateDB) *NonceTracker {
+	return &NonceTracker{
+		stateDB:       stateDB,
+		accountNonces: make(map[gethcommon.Address]uint64),
+	}
+}
+
+func (nt *NonceTracker) GetNonce(address gethcommon.Address) uint64 {
+	if nonce, ok := nt.accountNonces[address]; ok {
+		return nonce
+	}
+
+	nonce := nt.nonceFromState(address)
+	nt.accountNonces[address] = nonce
+	return nonce
+}
+
+func (nt *NonceTracker) nonceFromState(address gethcommon.Address) uint64 {
+	return nt.stateDB.GetNonce(address)
+}
+
+func (nt *NonceTracker) IncrementNonce(address gethcommon.Address) {
+	nt.accountNonces[address] += 1
+}

--- a/go/enclave/nodetype/sequencer.go
+++ b/go/enclave/nodetype/sequencer.go
@@ -189,7 +189,7 @@ func (s *sequencer) createNewHeadBatch(l1HeadBlock *common.L1Block) error {
 		return fmt.Errorf("failed storing batch. Cause: %w", err)
 	}
 
-	if err := s.mempool.RemoveMempoolTxs(cb.Batch, s.storage); err != nil {
+	if err := s.mempool.RemoveTxs(transactions); err != nil {
 		return fmt.Errorf("could not remove transactions from mempool. Cause: %w", err)
 	}
 

--- a/go/enclave/nodetype/sequencer.go
+++ b/go/enclave/nodetype/sequencer.go
@@ -152,7 +152,12 @@ func (s *sequencer) createNewHeadBatch(l1HeadBlock *common.L1Block) error {
 	// to be in our chain.
 	headBatch = ancestralBatch
 
-	transactions, err := s.mempool.CurrentTxs(headBatch, s.storage)
+	stateDB, err := s.storage.CreateStateDB(*headBatch.Hash())
+	if err != nil {
+		return fmt.Errorf("unable to create stateDB for selecting transactions. Cause: %w", err)
+	}
+
+	transactions, err := s.mempool.CurrentTxs(stateDB)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Why this change is needed

Sequencer needs to remove failing transactions from mempool.

### What changes were made as part of this PR

Modified the logic by which the mempool determines what current transactions to give. Furthermore changed what transactions are removed from it. We no longer use the successful transactions that can be found in the batch. 

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


