### PR TITLE
Storage updates atomicity

### DIFF
--- a/go/enclave/db/batch.go
+++ b/go/enclave/db/batch.go
@@ -1,0 +1,78 @@
+package db
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/obscuronet/go-obscuro/go/common"
+	"github.com/obscuronet/go-obscuro/go/enclave/core"
+	obscurorawdb "github.com/obscuronet/go-obscuro/go/enclave/db/rawdb"
+	"github.com/obscuronet/go-obscuro/go/enclave/db/sql"
+)
+
+type storageUpdaterImpl struct {
+	sqlBatch *sql.Batch
+	storage  *storageImpl
+}
+
+func NewStorageUpdater(batch *sql.Batch, storage *storageImpl) StorageUpdater {
+	return &storageUpdaterImpl{
+		sqlBatch: batch,
+		storage:  storage,
+	}
+}
+
+func (s *storageUpdaterImpl) Commit() error {
+	if err := s.sqlBatch.Write(); err != nil {
+		return fmt.Errorf("could not write batch to storage. Cause: %w", err)
+	}
+	return nil
+}
+
+func (s *storageUpdaterImpl) StoreBatch(batch *core.Batch, receipts []*types.Receipt) error {
+	if err := obscurorawdb.WriteBatch(s.sqlBatch, batch); err != nil {
+		return fmt.Errorf("could not write batch. Cause: %w", err)
+	}
+	if err := obscurorawdb.WriteTxLookupEntriesByBatch(s.sqlBatch, batch); err != nil {
+		return fmt.Errorf("could not write transaction lookup entries by batch. Cause: %w", err)
+	}
+	if err := obscurorawdb.WriteReceipts(s.sqlBatch, *batch.Hash(), receipts); err != nil {
+		return fmt.Errorf("could not write transaction receipts. Cause: %w", err)
+	}
+	if err := obscurorawdb.WriteContractCreationTxs(s.sqlBatch, receipts); err != nil {
+		return fmt.Errorf("could not save contract creation transaction. Cause: %w", err)
+	}
+	return nil
+}
+
+// UpdateHeadBatch updates the canonical L2 head batch for a given L1 block.
+func (s *storageUpdaterImpl) UpdateHeadBatch(l1Head common.L1BlockHash, l2Head *core.Batch, receipts []*types.Receipt) error {
+	if err := obscurorawdb.SetL2HeadBatch(s.sqlBatch, *l2Head.Hash()); err != nil {
+		return fmt.Errorf("could not write block state. Cause: %w", err)
+	}
+	if err := obscurorawdb.WriteL1ToL2BatchMapping(s.sqlBatch, l1Head, *l2Head.Hash()); err != nil {
+		return fmt.Errorf("could not write block state. Cause: %w", err)
+	}
+
+	// We update the canonical hash of the batch at this height.
+	if err := obscurorawdb.WriteCanonicalHash(s.sqlBatch, l2Head); err != nil {
+		return fmt.Errorf("could not write canonical hash. Cause: %w", err)
+	}
+
+	if l2Head.Number().Int64() > 1 {
+		err2 := s.storage.writeLogs(l2Head.Header.ParentHash, receipts, s.sqlBatch)
+		if err2 != nil {
+			return fmt.Errorf("could not save logs %w", err2)
+		}
+	}
+	return nil
+}
+
+// SetHeadBatchPointer updates the canonical L2 head batch for a given L1 block.
+func (s *storageUpdaterImpl) SetHeadBatchPointer(l2Head *core.Batch) error {
+	// We update the canonical hash of the batch at this height.
+	if err := obscurorawdb.SetL2HeadBatch(s.sqlBatch, *l2Head.Hash()); err != nil {
+		return fmt.Errorf("could not write canonical hash. Cause: %w", err)
+	}
+	return nil
+}

--- a/go/enclave/db/interfaces.go
+++ b/go/enclave/db/interfaces.go
@@ -137,5 +137,5 @@ type Storage interface {
 	// DebugGetLogs returns logs for a given tx hash without any constraints - should only be used for debug purposes
 	DebugGetLogs(txHash common.TxHash) ([]*tracers.DebugLogs, error)
 
-	NewTransaction() StorageUpdater
+	ModifyStorage(func(StorageUpdater) error) error
 }

--- a/go/enclave/nodetype/sequencer.go
+++ b/go/enclave/nodetype/sequencer.go
@@ -285,14 +285,16 @@ func (s *sequencer) handleFork(block *common.L1Block, ancestralBatch *core.Batch
 
 		// i equals 0 at the highest batch number
 		if i == 0 {
-			dbTransaction := s.storage.NewTransaction()
-			if err = dbTransaction.SetHeadBatchPointer(cb.Batch); err != nil {
-				return fmt.Errorf("failed setting head batch ptr. Cause: %w", err)
-			}
-			if err = dbTransaction.UpdateHeadBatch(block.Hash(), cb.Batch, cb.Receipts); err != nil {
-				return fmt.Errorf("failed updating head batch. Cause: %w", err)
-			}
-			return dbTransaction.Commit()
+			err := s.storage.ModifyStorage(func(su db.StorageUpdater) error {
+				if err = su.SetHeadBatchPointer(cb.Batch); err != nil {
+					return fmt.Errorf("failed setting head batch ptr. Cause: %w", err)
+				}
+				if err = su.UpdateHeadBatch(block.Hash(), cb.Batch, cb.Receipts); err != nil {
+					return fmt.Errorf("failed updating head batch. Cause: %w", err)
+				}
+				return nil
+			})
+			return err
 		}
 	}
 

--- a/go/enclave/nodetype/sequencer.go
+++ b/go/enclave/nodetype/sequencer.go
@@ -285,10 +285,14 @@ func (s *sequencer) handleFork(block *common.L1Block, ancestralBatch *core.Batch
 
 		// i equals 0 at the highest batch number
 		if i == 0 {
-			if err := s.storage.SetHeadBatchPointer(cb.Batch); err != nil {
+			dbTransaction := s.storage.NewTransaction()
+			if err = dbTransaction.SetHeadBatchPointer(cb.Batch); err != nil {
 				return fmt.Errorf("failed setting head batch ptr. Cause: %w", err)
 			}
-			return s.storage.UpdateHeadBatch(block.Hash(), cb.Batch, cb.Receipts)
+			if err = dbTransaction.UpdateHeadBatch(block.Hash(), cb.Batch, cb.Receipts); err != nil {
+				return fmt.Errorf("failed updating head batch. Cause: %w", err)
+			}
+			return dbTransaction.Commit()
 		}
 	}
 


### PR DESCRIPTION
### Why this change is needed

Storage operations that should be atomic are not, which is causing failures due to race conditions.

### What changes were made as part of this PR

Moved the responsibility for who controls the database batch.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


