### PR TITLE
Node upgrade: Fix management contract config

### DIFF
--- a/go/node/docker_node.go
+++ b/go/node/docker_node.go
@@ -73,7 +73,7 @@ func (d *DockerNode) Upgrade(networkCfg *NetworkConfig) error {
 	// update network configs
 	d.cfg.UpdateNodeConfig(
 		WithManagementContractAddress(networkCfg.ManagementContractAddress),
-		WithManagementContractAddress(networkCfg.MessageBusAddress),
+		WithMessageBusContractAddress(networkCfg.MessageBusAddress),
 		WithL1Start(networkCfg.L1StartHash),
 	)
 


### PR DESCRIPTION
### Why this change is needed

Typo meant the management contract was getting set wrong, breaking the rollup publishing.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


