### PR TITLE
increase ego heapSize to 2GB

### DIFF
--- a/go/enclave/main/enclave.json
+++ b/go/enclave/main/enclave.json
@@ -2,7 +2,7 @@
   "exe": "main",
   "key": "testnet.pem",
   "debug": true,
-  "heapSize": 1024,
+  "heapSize": 2048,
   "executableHeap": true,
   "productID": 1,
   "securityVersion": 1,


### PR DESCRIPTION
### Why this change is needed

dev testnet failing with OOM errors.

### What changes were made as part of this PR

increase heap size to 2G.
If the OOM still happens it means we have a leak

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


