### PR TITLE
Enclave: always update L1 head on submit block

### DIFF
--- a/go/enclave/components/block_processor.go
+++ b/go/enclave/components/block_processor.go
@@ -96,10 +96,8 @@ func (bp *l1BlockProcessor) ingestBlock(block *common.L1Block, isLatest bool) (*
 			return nil, errutil.ErrBlockAncestorNotFound
 		}
 
-		if lcaBlock.NumberU64() < prevL1Head.NumberU64() {
-			// fork - least common ancestor for this block and l1 head is before the l1 head.
-			isFork = true
-		}
+		// fork - least common ancestor for this block and l1 head is before the l1 head.
+		isFork = lcaBlock.NumberU64() < prevL1Head.NumberU64()
 	}
 	return &BlockIngestionType{IsLatest: isLatest, Fork: isFork, PreGenesis: false}, nil
 }


### PR DESCRIPTION
### Why this change is needed

The enclave should always be operating from the tip of the L1 that it knows about. So we should treat every submitted L1 block as the new head.

### What changes were made as part of this PR

- Remove the isLatest gate on updating L1 head
- Minor refactor of the block ingest method

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


