### PR TITLE
decrease rollup time

### DIFF
--- a/go/node/docker_node.go
+++ b/go/node/docker_node.go
@@ -113,6 +113,8 @@ func (d *DockerNode) startHost() error {
 		// host persistence hardcoded to use /data dir within the container, this needs to be mounted
 		fmt.Sprintf("-useInMemoryDB=%t", d.cfg.hostInMemDB),
 		fmt.Sprintf("-debugNamespaceEnabled=%t", d.cfg.debugNamespaceEnabled),
+		// todo (@stefan): once the limiter is in, increase it back to 5 or 10s
+		"-rollupInterval=2s",
 	}
 	if !d.cfg.hostInMemDB {
 		cmd = append(cmd, "-levelDBPath", _hostDataDir)


### PR DESCRIPTION
### Why this change is needed

currently, testnet dies because rollups get too big.
This issue will be fixed properly with the introduction of the limiter.
Until then, we're reducing the rollup interval

### What changes were made as part of this PR

- reduce rollup interval to 2s



