### PR TITLE
restore configs

### DIFF
--- a/go/config/host_config.go
+++ b/go/config/host_config.go
@@ -227,7 +227,7 @@ func DefaultHostParsedConfig() *HostInputConfig {
 		MetricsHTTPPort:           14000,
 		UseInMemoryDB:             true,
 		DebugNamespaceEnabled:     false,
-		BatchInterval:             750 * time.Millisecond,
-		RollupInterval:            1500 * time.Millisecond,
+		BatchInterval:             1 * time.Second,
+		RollupInterval:            5 * time.Second,
 	}
 }

--- a/go/node/docker_node.go
+++ b/go/node/docker_node.go
@@ -114,8 +114,8 @@ func (d *DockerNode) startHost() error {
 		fmt.Sprintf("-useInMemoryDB=%t", d.cfg.hostInMemDB),
 		fmt.Sprintf("-debugNamespaceEnabled=%t", d.cfg.debugNamespaceEnabled),
 		// todo (@stefan): once the limiter is in, increase it back to 5 or 10s
-		"-batchInterval=750ms",
-		"-rollupInterval=1500ms",
+		"-batchInterval=1s",
+		"-rollupInterval=5s",
 	}
 	if !d.cfg.hostInMemDB {
 		cmd = append(cmd, "-levelDBPath", _hostDataDir)


### PR DESCRIPTION
### Why this change is needed

Restore configs after the rollup/batch limiter is introduced

