### PR TITLE
performance fixes

### DIFF
--- a/go/common/compression/data_compression_service.go
+++ b/go/common/compression/data_compression_service.go
@@ -8,7 +8,8 @@ import (
 )
 
 type DataCompressionService interface {
-	Compress(blob []byte) ([]byte, error)
+	CompressRollup(blob []byte) ([]byte, error)
+	CompressBatch(blob []byte) ([]byte, error)
 	Decompress(blob []byte) ([]byte, error)
 }
 
@@ -18,14 +19,12 @@ func NewBrotliDataCompressionService() DataCompressionService {
 
 type brotliDataCompressionService struct{}
 
-func (cs *brotliDataCompressionService) Compress(in []byte) ([]byte, error) {
-	var buf bytes.Buffer
-	writer := brotli.NewWriterLevel(&buf, brotli.BestCompression)
-	_, err := writer.Write(in)
-	if closeErr := writer.Close(); err == nil {
-		err = closeErr
-	}
-	return buf.Bytes(), err
+func (cs *brotliDataCompressionService) CompressRollup(blob []byte) ([]byte, error) {
+	return cs.compress(blob, brotli.BestCompression)
+}
+
+func (cs *brotliDataCompressionService) CompressBatch(blob []byte) ([]byte, error) {
+	return cs.compress(blob, brotli.DefaultCompression)
 }
 
 func (cs *brotliDataCompressionService) Decompress(in []byte) ([]byte, error) {
@@ -33,11 +32,21 @@ func (cs *brotliDataCompressionService) Decompress(in []byte) ([]byte, error) {
 	return io.ReadAll(r)
 }
 
+func (cs *brotliDataCompressionService) compress(in []byte, level int) ([]byte, error) {
+	var buf bytes.Buffer
+	writer := brotli.NewWriterLevel(&buf, level)
+	_, err := writer.Write(in)
+	if closeErr := writer.Close(); err == nil {
+		err = closeErr
+	}
+	return buf.Bytes(), err
+}
+
 /*
 // commented for now,  and to remove once we run some comparative testing
 type gzipDataCompressionService struct{}
 
-func (cs *gzipDataCompressionService) Compress(in []byte) ([]byte, error) {
+func (cs *gzipDataCompressionService) CompressRollup(in []byte) ([]byte, error) {
 	var b bytes.Buffer
 	gz := gzip.NewWriter(&b)
 	if _, err := gz.Write(in); err != nil {

--- a/go/common/compression/data_compression_service.go
+++ b/go/common/compression/data_compression_service.go
@@ -8,7 +8,9 @@ import (
 )
 
 type DataCompressionService interface {
+	// CompressRollup - uses the maximum compression level, because the final size matters when publishing to Ethereum
 	CompressRollup(blob []byte) ([]byte, error)
+	// CompressBatch - uses the default compression level, because the compression is for the efficiency of the p2p transfer
 	CompressBatch(blob []byte) ([]byte, error)
 	Decompress(blob []byte) ([]byte, error)
 }

--- a/go/enclave/components/batch_registry.go
+++ b/go/enclave/components/batch_registry.go
@@ -60,7 +60,7 @@ func (br *batchRegistryImpl) UnsubscribeFromEvents() {
 // stored head pointers
 func (br *batchRegistryImpl) StoreBatch(batch *core.Batch, receipts types.Receipts) error {
 	// Check if this batch is already stored.
-	if _, err := br.GetBatch(*batch.Hash()); err == nil {
+	if _, err := br.storage.FetchBatchHeader(*batch.Hash()); err == nil {
 		br.logger.Warn("Attempted to store batch twice! This indicates issues with the batch processing loop")
 		return nil
 	}

--- a/go/enclave/core/batch.go
+++ b/go/enclave/core/batch.go
@@ -67,7 +67,7 @@ func (b *Batch) ToExtBatch(transactionBlobCrypto crypto.DataEncryptionService, c
 	if err != nil {
 		return nil, err
 	}
-	compressed, err := compression.Compress(bytes)
+	compressed, err := compression.CompressBatch(bytes)
 	if err != nil {
 		return nil, err
 	}

--- a/go/enclave/core/rollup.go
+++ b/go/enclave/core/rollup.go
@@ -61,12 +61,12 @@ func (r *Rollup) ToExtRollup(dataEncryptionService crypto.DataEncryptionService,
 		return nil, err
 	}
 
-	compressedTransactionsBlob, err := compression.Compress(plaintextTransactionsBlob)
+	compressedTransactionsBlob, err := compression.CompressRollup(plaintextTransactionsBlob)
 	if err != nil {
 		return nil, err
 	}
 
-	compressedHeadersBlob, err := compression.Compress(headersBlob)
+	compressedHeadersBlob, err := compression.CompressRollup(headersBlob)
 	if err != nil {
 		return nil, err
 	}

--- a/go/enclave/db/interfaces.go
+++ b/go/enclave/db/interfaces.go
@@ -35,6 +35,8 @@ type BlockResolver interface {
 type BatchResolver interface {
 	// FetchBatch returns the batch with the given hash.
 	FetchBatch(hash common.L2BatchHash) (*core.Batch, error)
+	// FetchBatchHeader returns the batch header with the given hash.
+	FetchBatchHeader(hash common.L2BatchHash) (*common.BatchHeader, error)
 	// FetchBatchByHeight returns the batch on the canonical chain with the given height.
 	FetchBatchByHeight(height uint64) (*core.Batch, error)
 	// FetchHeadBatch returns the current head batch of the canonical chain.

--- a/go/enclave/db/rawdb/accessors_chain.go
+++ b/go/enclave/db/rawdb/accessors_chain.go
@@ -15,7 +15,7 @@ import (
 )
 
 func ReadBatch(db ethdb.KeyValueReader, hash common.L2BatchHash) (*core.Batch, error) {
-	header, err := readBatchHeader(db, hash)
+	header, err := ReadBatchHeader(db, hash)
 	if err != nil {
 		return nil, fmt.Errorf("could not read header. Cause: %w", err)
 	}
@@ -111,8 +111,8 @@ func writeBatchHeaderNumber(db ethdb.KeyValueWriter, hash gethcommon.Hash, numbe
 	return nil
 }
 
-// Retrieves the batch header corresponding to the hash.
-func readBatchHeader(db ethdb.KeyValueReader, hash common.L2BatchHash) (*common.BatchHeader, error) {
+// ReadBatchHeader Retrieves the batch header corresponding to the hash.
+func ReadBatchHeader(db ethdb.KeyValueReader, hash common.L2BatchHash) (*common.BatchHeader, error) {
 	data, err := readBatchHeaderRLP(db, hash)
 	if err != nil {
 		return nil, fmt.Errorf("could not read header. Cause: %w", err)

--- a/go/enclave/db/storage.go
+++ b/go/enclave/db/storage.go
@@ -83,6 +83,15 @@ func (s *storageImpl) FetchBatch(hash common.L2BatchHash) (*core.Batch, error) {
 	return batch, nil
 }
 
+func (s *storageImpl) FetchBatchHeader(hash common.L2BatchHash) (*common.BatchHeader, error) {
+	s.assertSecretAvailable()
+	batchHeader, err := obscurorawdb.ReadBatchHeader(s.db, hash)
+	if err != nil {
+		return nil, err
+	}
+	return batchHeader, nil
+}
+
 func (s *storageImpl) FetchBatchByHeight(height uint64) (*core.Batch, error) {
 	hash, err := obscurorawdb.ReadCanonicalBatchHash(s.db, height)
 	if err != nil {

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -1038,11 +1038,11 @@ func (e *enclaveImpl) GetLogs(encryptedParams common.EncryptedParamsGetLogs) (*r
 
 	// Set from to the height of the block hash
 	if from == nil && filter.BlockHash != nil {
-		batch, err := e.storage.FetchBatch(*filter.BlockHash)
+		batch, err := e.storage.FetchBatchHeader(*filter.BlockHash)
 		if err != nil {
 			return nil, responses.ToInternalError(err)
 		}
-		from = batch.Number()
+		from = batch.Number
 	}
 
 	to := filter.ToBlock
@@ -1418,12 +1418,12 @@ func (e *enclaveImpl) produceBlockSubmissionResponse(l2Head *common.L2BatchHash,
 		return nil
 	}
 
-	batch, err := e.storage.FetchBatch(*l2Head)
+	batch, err := e.storage.FetchBatchHeader(*l2Head)
 	if err != nil {
 		e.logger.Crit("Failed to retrieve batch. Should not happen", log.ErrKey, err)
 		return nil
 	}
-	logs, err := e.subscriptionLogs(batch.Number())
+	logs, err := e.subscriptionLogs(batch.Number)
 	if err != nil {
 		e.logger.Error("Could not fetch logs", log.ErrKey, err)
 		return nil

--- a/go/enclave/evm/chain_context.go
+++ b/go/enclave/evm/chain_context.go
@@ -33,7 +33,7 @@ func (occ *ObscuroChainContext) Engine() consensus.Engine {
 }
 
 func (occ *ObscuroChainContext) GetHeader(hash common.Hash, height uint64) *types.Header {
-	batch, err := occ.storage.FetchBatch(hash)
+	batch, err := occ.storage.FetchBatchHeader(hash)
 	if err != nil {
 		if errors.Is(err, errutil.ErrNotFound) {
 			return nil
@@ -41,7 +41,7 @@ func (occ *ObscuroChainContext) GetHeader(hash common.Hash, height uint64) *type
 		occ.logger.Crit("Could not retrieve rollup", log.ErrKey, err)
 	}
 
-	h, err := gethencoding.ConvertToEthHeader(batch.Header, secret(occ.storage))
+	h, err := gethencoding.ConvertToEthHeader(batch, secret(occ.storage))
 	if err != nil {
 		occ.logger.Crit("Could not convert to eth header", log.ErrKey, err)
 		return nil


### PR DESCRIPTION
### Why this change is needed
to remove some bottlenecks

### What changes were made as part of this PR
1. no longer read the entire batch when only the header is needed
2. use faster default brotli compression when compressing batches

