### PR TITLE
fix hash formatting in error msg

### DIFF
--- a/go/enclave/components/rollup_consumer.go
+++ b/go/enclave/components/rollup_consumer.go
@@ -145,7 +145,7 @@ func (rc *rollupConsumerImpl) processRollup(br *common.BlockAndReceipts) (*core.
 	}
 
 	if err = rc.checkRollupsCorrectlyChained(signedRollup, latestRollup); err != nil {
-		return nil, fmt.Errorf("rollup was not correctly chained. height=%d hash=%d Cause: %w",
+		return nil, fmt.Errorf("rollup was not correctly chained. height=%d hash=%s Cause: %w",
 			signedRollup.NumberU64(), signedRollup.Hash(), err)
 	}
 


### PR DESCRIPTION
### Why this change is needed

```
ERROR[05-30|03:37:56.803] Encountered error while processing l1 block node_id=0xc272459070A881BfA28aB3E810f9b19E4F468531 component=enclave     err="rollup was not correctly chained. height=3717 hash=[16 220 20 248 176 213 148 46 141 189 113 121 134 63 28 158 254 110 86 208 254 227 234 182 64 180 94 42 235 1 70 0] Cause: expected new rollup but rollup 3717 height was less than or equal to previous rollup 3717"
```

### What changes were made as part of this PR

fix hex formatting

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


