### PR TITLE
Add l1 up-to-date flag to host health check

### DIFF
--- a/go/common/host/host_healthcheck.go
+++ b/go/common/host/host_healthcheck.go
@@ -16,6 +16,7 @@ type HealthCheckEnclave struct {
 type HealthCheckHost struct {
 	P2PStatus       *P2PStatus
 	L1BlockProvider *L1BlockProviderStatus
+	L1Synced        bool
 }
 
 // P2PStatus is the representation of the Status of the P2P layer

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -345,14 +345,16 @@ func (h *host) HealthCheck() (*hostcommon.HealthCheck, error) {
 	}
 
 	l1BlockProviderStatus := h.l1BlockProvider.HealthStatus()
+	isL1Synced := h.l1UpToDate.Load()
 
 	// Overall health is achieved when all parts are healthy
-	obscuroNodeHealth := h.p2p.HealthCheck() && l1BlockProviderStatus.Healthy && enclaveHealthy
+	obscuroNodeHealth := h.p2p.HealthCheck() && l1BlockProviderStatus.Healthy && enclaveHealthy && isL1Synced
 
 	return &hostcommon.HealthCheck{
 		HealthCheckHost: &hostcommon.HealthCheckHost{
 			P2PStatus:       h.p2p.Status(),
 			L1BlockProvider: &l1BlockProviderStatus,
+			L1Synced:        isL1Synced,
 		},
 		HealthCheckEnclave: &hostcommon.HealthCheckEnclave{
 			EnclaveHealthy: enclaveHealthy,


### PR DESCRIPTION
### Why this change is needed

When we are behind the L1 we don't produce batches and we probably don't have current L2 state. So we should fail the health check so external tests etc. are aware.

### What changes were made as part of this PR

Add L1 synced flag to the host health check

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


