### PR TITLE
add logging details when catching up missing batches

### DIFF
--- a/go/host/batchmanager/batch_manager.go
+++ b/go/host/batchmanager/batch_manager.go
@@ -78,7 +78,7 @@ func (b *BatchManager) GetBatches(batchRequest *common.BatchRequest) ([]*common.
 		lastBatchNumber := big.NewInt(0).Add(firstBatch.Header.Number, big.NewInt(maxBatchesPerRequest))
 		batchHash, err := b.db.GetBatchHash(lastBatchNumber)
 		if err != nil {
-			return nil, fmt.Errorf("could not retrieve batch hash. Cause: %w", err)
+			return nil, fmt.Errorf("could not retrieve batch hash for batchHeight=%d. Cause: %w", lastBatchNumber, err)
 		}
 		lastBatch, err = b.db.GetBatchHeader(*batchHash)
 		if err != nil {

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -886,7 +886,7 @@ func (h *host) handleBatches(encodedBatchMsg *common.EncodedBatchMsg) error {
 
 		// We have encountered a missing parent batch. We abort the storage operation and request the missing batches.
 		if !isParentStored {
-			h.logger.Info("Parent batch not found. Requesting missing batches.", "fromBatch", batchRequest.CurrentHeadBatch)
+			h.logger.Info("Parent batch not found. Requesting missing batches.", "fromBatch", batchRequest.CurrentHeadBatch, "isCatchUp", batchMsg.IsCatchUp)
 			// We only request the missing batches if the batches did not themselves arrive as part of catch-up, to
 			// avoid excessive P2P pressure.
 			if !batchMsg.IsCatchUp {

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -886,6 +886,7 @@ func (h *host) handleBatches(encodedBatchMsg *common.EncodedBatchMsg) error {
 
 		// We have encountered a missing parent batch. We abort the storage operation and request the missing batches.
 		if !isParentStored {
+			h.logger.Info("Parent batch not found. Requesting missing batches.", "fromHeight", batchRequest.CurrentHeadBatch)
 			// We only request the missing batches if the batches did not themselves arrive as part of catch-up, to
 			// avoid excessive P2P pressure.
 			if !batchMsg.IsCatchUp {

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -886,7 +886,7 @@ func (h *host) handleBatches(encodedBatchMsg *common.EncodedBatchMsg) error {
 
 		// We have encountered a missing parent batch. We abort the storage operation and request the missing batches.
 		if !isParentStored {
-			h.logger.Info("Parent batch not found. Requesting missing batches.", "fromHeight", batchRequest.CurrentHeadBatch)
+			h.logger.Info("Parent batch not found. Requesting missing batches.", "fromBatch", batchRequest.CurrentHeadBatch)
 			// We only request the missing batches if the batches did not themselves arrive as part of catch-up, to
 			// avoid excessive P2P pressure.
 			if !batchMsg.IsCatchUp {


### PR DESCRIPTION
### Why this change is needed

Hard to see what's going on when batch requests failing.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


