### PR TITLE
Skip rollup production when out of sync with L1

### DIFF
--- a/go/host/host.go
+++ b/go/host/host.go
@@ -928,6 +928,7 @@ func (h *host) startBatchProduction() {
 		case <-batchProdTicker.C:
 			if !h.l1UpToDate.Load() {
 				// if we're behind the L1, we don't want to produce batches
+				h.logger.Debug("skipping batch production because L1 is not up to date")
 				continue
 			}
 			h.logger.Info("create batch")
@@ -1010,6 +1011,11 @@ func (h *host) startRollupProduction() {
 	for {
 		select {
 		case <-rollupTicker.C:
+			if !h.l1UpToDate.Load() {
+				// if we're behind the L1, we don't want to produce rollups
+				h.logger.Debug("skipping rollup production because L1 is not up to date")
+				continue
+			}
 			producedRollup, err := h.enclaveClient.CreateRollup()
 			if err != nil {
 				h.logger.Error("unable to produce rollup", log.ErrKey, err)


### PR DESCRIPTION
### Why this change is needed

Producing rollups when out of sync with L1 is not a good idea (no batches are being produced and the enclave won't see them for a long time, causing issues with spamming out rollups at the same height).

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


