### PR TITLE
Ziga/obscuto gatweay storage

### DIFF
--- a/tools/walletextension/common/types.go
+++ b/tools/walletextension/common/types.go
@@ -1,0 +1,6 @@
+package common
+
+type AccountDB struct {
+	AccountAddress []byte
+	Signature      []byte
+}

--- a/tools/walletextension/container/walletextension_container.go
+++ b/tools/walletextension/container/walletextension_container.go
@@ -60,7 +60,7 @@ func NewWalletExtensionContainerFromConfig(config config.Config, logger gethlog.
 	if err != nil {
 		logger.Crit("unable to create database to store viewing keys ", log.ErrKey, err)
 	}
-	
+
 	// We reload data from the database
 	// todo (@ziga) - change this code once we can handle multiple users
 	defaultPrivateKeyBytes, err := databaseStorage.GetUserPrivateKey([]byte(wecommon.DefaultUser))

--- a/tools/walletextension/storage/sqlite.go
+++ b/tools/walletextension/storage/sqlite.go
@@ -51,7 +51,7 @@ func NewSqliteDatabase(dbName string) (*SqliteDatabase, error) {
 }
 
 func (s *SqliteDatabase) AddUser(userID []byte, privateKey []byte) error {
-	stmt, err := s.db.Prepare("INSERT INTO users(user_id, private_key) VALUES (?, ?)")
+	stmt, err := s.db.Prepare("INSERT OR REPLACE INTO users(user_id, private_key) VALUES (?, ?)")
 	if err != nil {
 		return err
 	}

--- a/tools/walletextension/storage/storage.go
+++ b/tools/walletextension/storage/storage.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/ethereum/go-ethereum/common"
+	"github.com/obscuronet/go-obscuro/tools/walletextension/common"
+
 	obscurocommon "github.com/obscuronet/go-obscuro/go/common"
-	"github.com/obscuronet/go-obscuro/go/rpc"
 )
 
 type Storage struct {
@@ -42,18 +42,34 @@ func New(dbPath string) (*Storage, error) {
 	return &Storage{db: newDB}, nil
 }
 
-func (s *Storage) SaveUserVK(userID string, vk *rpc.ViewingKey) error {
-	err := s.db.SaveUserVK(userID, vk)
+func (s *Storage) AddUser(userID []byte, privateKey []byte) error {
+	err := s.db.AddUser(userID, privateKey)
 	if err != nil {
-		return fmt.Errorf("failed to save viewingkey to the storage, %w", err)
+		return err
 	}
 	return nil
 }
 
-func (s *Storage) GetUserVKs(userID string) (map[common.Address]*rpc.ViewingKey, error) {
-	userVKs, err := s.db.GetUserVKs(userID)
+func (s *Storage) GetUserPrivateKey(userID []byte) ([]byte, error) {
+	privateKey, err := s.db.GetUserPrivateKey(userID)
 	if err != nil {
 		return nil, err
 	}
-	return userVKs, nil
+	return privateKey, nil
+}
+
+func (s *Storage) AddAccount(userID []byte, accountAddress []byte, signature []byte) error {
+	err := s.db.AddAccount(userID, accountAddress, signature)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *Storage) GetAccounts(userID []byte) ([]common.AccountDB, error) {
+	accounts, err := s.db.GetAccounts(userID)
+	if err != nil {
+		return nil, err
+	}
+	return accounts, nil
 }

--- a/tools/walletextension/storage/storage_test.go
+++ b/tools/walletextension/storage/storage_test.go
@@ -1,159 +1,89 @@
 package storage
 
 import (
-	"reflect"
+	"bytes"
 	"testing"
-
-	gethlog "github.com/ethereum/go-ethereum/log"
-	"github.com/obscuronet/go-obscuro/go/rpc"
-	"github.com/obscuronet/go-obscuro/go/wallet"
 )
 
-func TestStoringMultipleKeysPerUser(t *testing.T) {
-	userID := "abc"
-	wallet1 := wallet.NewInMemoryWalletFromConfig(
-		"4bfe14725e685901c062ccd4e220c61cf9c189897b6c78bd18d7f51291b2b8f8",
-		777,
-		gethlog.New())
-	wallet2 := wallet.NewInMemoryWalletFromConfig(
-		"111114725e685901c062ccd4e220c61cf9c189897b6c78bd18d7f51291b21111",
-		777,
-		gethlog.New())
-
-	vk1, _ := rpc.GenerateAndSignViewingKey(wallet1)
-	vk2, _ := rpc.GenerateAndSignViewingKey(wallet2)
-
-	myStorage, err := New("")
+func TestAddAndGetUser(t *testing.T) {
+	storage, err := New("")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = myStorage.SaveUserVK(userID, vk1)
+	userID := []byte("userID")
+	privateKey := []byte("privateKey")
+
+	err = storage.AddUser(userID, privateKey)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = myStorage.SaveUserVK(userID, vk2)
+
+	returnedPrivateKey, err := storage.GetUserPrivateKey(userID)
 	if err != nil {
 		t.Fatal(err)
 	}
-	result, err := myStorage.GetUserVKs(userID)
-	if err != nil {
-		t.Errorf("error getting user VKs")
-	}
 
-	// Check if vk1 is in the result
-	foundVK1 := false
-	for _, vk := range result {
-		if reflect.DeepEqual(vk, vk1) {
-			foundVK1 = true
-			break
-		}
-	}
-	if !foundVK1 {
-		t.Errorf("vk1 is not found in the result")
-	}
-
-	// Check if vk2 is in the result
-	foundVK2 := false
-	for _, vk := range result {
-		if reflect.DeepEqual(vk, vk2) {
-			foundVK2 = true
-			break
-		}
-	}
-	if !foundVK2 {
-		t.Errorf("vk2 is not found in the result")
+	if !bytes.Equal(returnedPrivateKey, privateKey) {
+		t.Errorf("privateKey mismatch: got %v, want %v", returnedPrivateKey, privateKey)
 	}
 }
 
-func TestMultipleUsersStoringKeys(t *testing.T) {
-	userID1 := "user1"
-	wallet1 := wallet.NewInMemoryWalletFromConfig(
-		"4bfe14725e685901c062ccd4e220c61cf9c189897b6c78bd18d7f51291b2b8f8",
-		777,
-		gethlog.New())
-
-	userID2 := "user2"
-	wallet2 := wallet.NewInMemoryWalletFromConfig(
-		"111114725e685901c062ccd4e220c61cf9c189897b6c78bd18d7f51291b21111",
-		777,
-		gethlog.New())
-
-	vk1, _ := rpc.GenerateAndSignViewingKey(wallet1)
-	vk2, _ := rpc.GenerateAndSignViewingKey(wallet2)
-
-	myStorage, err := New("")
+func TestAddAndGetAccounts(t *testing.T) {
+	storage, err := New("")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = myStorage.SaveUserVK(userID1, vk1)
+	userID := []byte("userID")
+	privateKey := []byte("privateKey")
+	accountAddress1 := []byte("accountAddress1")
+	signature1 := []byte("signature1")
+
+	err = storage.AddUser(userID, privateKey)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = myStorage.SaveUserVK(userID2, vk2)
+	err = storage.AddAccount(userID, accountAddress1, signature1)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// userId1 should get only the item that belongs to him and not an item that belongs to userId2
-	result, err := myStorage.GetUserVKs(userID1)
+	accountAddress2 := []byte("accountAddress2")
+	signature2 := []byte("signature2")
+
+	err = storage.AddAccount(userID, accountAddress2, signature2)
 	if err != nil {
-		t.Errorf("error getting user VKs")
+		t.Fatal(err)
 	}
 
-	// Check if vk1 is in the result
-	foundVK1 := false
-	for _, vk := range result {
-		if reflect.DeepEqual(vk, vk1) {
-			foundVK1 = true
-			break
-		}
-	}
-	if !foundVK1 {
-		t.Errorf("vk1 is not found in the result and it should be in")
-	}
-
-	// Check if vk2 is not in the result
-	foundVK2 := false
-	for _, vk := range result {
-		if reflect.DeepEqual(vk, vk2) {
-			foundVK2 = true
-			break
-		}
-	}
-	if foundVK2 {
-		t.Errorf("vk2 is not found in the result for the wrong user")
-	}
-
-	// userId2 should get only the item that belongs to him and not an item that belongs to userId1
-	result, err = myStorage.GetUserVKs(userID2)
+	accounts, err := storage.GetAccounts(userID)
 	if err != nil {
-		t.Errorf("error getting user VKs")
+		t.Fatal(err)
 	}
 
-	// Check if vk1 is not in the result
-	foundVK1 = false
-	for _, vk := range result {
-		if reflect.DeepEqual(vk, vk1) {
-			foundVK1 = true
-			break
-		}
-	}
-	if foundVK1 {
-		t.Errorf("vk1 is not found in the result for the wrong user")
+	if len(accounts) != 2 {
+		t.Errorf("Expected 2 accounts, got %d", len(accounts))
 	}
 
-	// Check if vk2 is not in the result
-	foundVK2 = false
-	for _, vk := range result {
-		if reflect.DeepEqual(vk, vk2) {
-			foundVK2 = true
-			break
+	foundAccount1 := false
+	foundAccount2 := false
+
+	for _, account := range accounts {
+		if bytes.Equal(account.AccountAddress, accountAddress1) && bytes.Equal(account.Signature, signature1) {
+			foundAccount1 = true
+		}
+		if bytes.Equal(account.AccountAddress, accountAddress2) && bytes.Equal(account.Signature, signature2) {
+			foundAccount2 = true
 		}
 	}
-	if !foundVK2 {
-		t.Errorf("vk2 is not found in the result for the wrong user")
+
+	if !foundAccount1 {
+		t.Errorf("Account 1 was not found in the result")
+	}
+
+	if !foundAccount2 {
+		t.Errorf("Account 2 was not found in the result")
 	}
 }

--- a/tools/walletextension/useraccountmanager/user_account_manager_test.go
+++ b/tools/walletextension/useraccountmanager/user_account_manager_test.go
@@ -1,7 +1,6 @@
 package useraccountmanager
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/log"
@@ -22,7 +21,7 @@ func TestAddingAndGettingUserAccountManagers(t *testing.T) {
 	}
 	// We should get error if we try to get Account manager for User2
 	_, err = userAccountManager.GetUserAccountManager(userID2)
-	fmt.Println(err)
+
 	if err == nil {
 		t.Fatal("expecting error when trying to get AccountManager for user that doesn't exist.")
 	}

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -139,7 +139,11 @@ func (w *WalletExtension) SubmitViewingKey(address gethcommon.Address, signature
 
 	defaultAccountManager.AddClient(address, client)
 
-	err = w.storage.SaveUserVK(common.DefaultUser, vk)
+	err = w.storage.AddAccount([]byte(common.DefaultUser), vk.Account.Bytes(), vk.SignedKey)
+	if err != nil {
+		return fmt.Errorf("error saving account") // todo (@ziga) - improve error messages!
+	}
+
 	if err != nil {
 		return fmt.Errorf("error saving viewing key to the database: %w", err)
 	}

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -139,9 +139,14 @@ func (w *WalletExtension) SubmitViewingKey(address gethcommon.Address, signature
 
 	defaultAccountManager.AddClient(address, client)
 
+	err = w.storage.AddUser([]byte(common.DefaultUser), crypto.FromECDSA(vk.PrivateKey.ExportECDSA()))
+	if err != nil {
+		return fmt.Errorf("error saving user: %s", common.DefaultUser)
+	}
+
 	err = w.storage.AddAccount([]byte(common.DefaultUser), vk.Account.Bytes(), vk.SignedKey)
 	if err != nil {
-		return fmt.Errorf("error saving account") // todo (@ziga) - improve error messages!
+		return fmt.Errorf("error saving account %s for user %s", vk.Account.Hex(), common.DefaultUser)
 	}
 
 	if err != nil {


### PR DESCRIPTION
### Why this change is needed

With Obscuro Gateway we would need to support having multiple users, each with multiple accounts. 
In this PR are changes to the storage and sqlite database that would enable storing data needed for that functionality.

### What changes were made as part of this PR

- New database structure with two tables
- New functions to store and get data (AddUser, GetUserPrivateKey, AddAccount, GetAccounts)
- Removed old functions that were replaced (due to database structure change)
- Replaced old function calls with new one in wallet extension

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


