### PR TITLE
Separate p2p sub methods from host interface

### DIFF
--- a/go/common/host/host.go
+++ b/go/common/host/host.go
@@ -23,12 +23,6 @@ type Host interface {
 	Start() error
 	// SubmitAndBroadcastTx submits an encrypted transaction to the enclave, and broadcasts it to the other hosts on the network.
 	SubmitAndBroadcastTx(encryptedParams common.EncryptedParamsSendRawTx) (*responses.RawTx, error)
-	// ReceiveTx processes a transaction received from a peer host.
-	ReceiveTx(tx common.EncryptedTx)
-	// ReceiveBatches receives a set of batches from a peer host.
-	ReceiveBatches(batches common.EncodedBatchMsg)
-	// ReceiveBatchRequest receives a batch request from a peer host. Used during catch-up.
-	ReceiveBatchRequest(batchRequest common.EncodedBatchRequest)
 	// Subscribe feeds logs matching the encrypted log subscription to the matchedLogs channel.
 	Subscribe(id rpc.ID, encryptedLogSubscription common.EncryptedParamsLogSubscription, matchedLogs chan []byte) error
 	// Unsubscribe terminates a log subscription between the host and the enclave.
@@ -38,11 +32,22 @@ type Host interface {
 
 	// HealthCheck returns the health status of the host + enclave + db
 	HealthCheck() (*HealthCheck, error)
+
+	P2PSubscriber // todo (@matt) remove this from host interface and host tests when it's done at a per-enclave level
+}
+
+type P2PSubscriber interface {
+	// ReceiveTx processes a transaction received from a peer host.
+	ReceiveTx(tx common.EncryptedTx)
+	// ReceiveBatches receives a set of batches from a peer host.
+	ReceiveBatches(batches common.EncodedBatchMsg)
+	// ReceiveBatchRequest receives a batch request from a peer host. Used during catch-up.
+	ReceiveBatchRequest(batchRequest common.EncodedBatchRequest)
 }
 
 // P2P is the layer responsible for sending and receiving messages to Obscuro network peers.
 type P2P interface {
-	StartListening(callback Host)
+	StartListening(callback P2PSubscriber)
 	StopListening() error
 	UpdatePeerList([]string)
 	// SendTxToSequencer sends the encrypted transaction to the sequencer.

--- a/go/host/p2p/p2p.go
+++ b/go/host/p2p/p2p.go
@@ -81,7 +81,7 @@ type p2pImpl struct {
 	metricsRegistry gethmetrics.Registry
 }
 
-func (p *p2pImpl) StartListening(callback host.Host) {
+func (p *p2pImpl) StartListening(callback host.P2PSubscriber) {
 	// We listen for P2P connections.
 	listener, err := net.Listen("tcp", p.ourAddress)
 	if err != nil {
@@ -197,7 +197,7 @@ func (p *p2pImpl) HealthCheck() bool {
 }
 
 // Listens for connections and handles them in a separate goroutine.
-func (p *p2pImpl) handleConnections(callback host.Host) {
+func (p *p2pImpl) handleConnections(subscriber host.P2PSubscriber) {
 	for {
 		conn, err := p.listener.Accept()
 		if err != nil {
@@ -206,12 +206,12 @@ func (p *p2pImpl) handleConnections(callback host.Host) {
 			}
 			return
 		}
-		go p.handle(conn, callback)
+		go p.handle(conn, subscriber)
 	}
 }
 
 // Receives and decodes a P2P message, and pushes it to the correct channel.
-func (p *p2pImpl) handle(conn net.Conn, callback host.Host) {
+func (p *p2pImpl) handle(conn net.Conn, subscriber host.P2PSubscriber) {
 	if conn != nil {
 		defer conn.Close()
 	}
@@ -234,11 +234,11 @@ func (p *p2pImpl) handle(conn net.Conn, callback host.Host) {
 	switch msg.Type {
 	case msgTypeTx:
 		// The transaction is encrypted, so we cannot check that it's correctly formed.
-		callback.ReceiveTx(msg.Contents)
+		subscriber.ReceiveTx(msg.Contents)
 	case msgTypeBatches:
-		callback.ReceiveBatches(msg.Contents)
+		subscriber.ReceiveBatches(msg.Contents)
 	case msgTypeBatchRequest:
-		callback.ReceiveBatchRequest(msg.Contents)
+		subscriber.ReceiveBatchRequest(msg.Contents)
 	}
 	p.incHostGaugeMetric(msg.Sender, _receivedMessage)
 	p.peerTracker.receivedPeerMsg(msg.Sender)

--- a/integration/simulation/p2p/mock_l2_network.go
+++ b/integration/simulation/p2p/mock_l2_network.go
@@ -37,7 +37,7 @@ func NewMockP2P(avgBlockDuration time.Duration, avgLatency time.Duration) *MockP
 	}
 }
 
-func (netw *MockP2P) StartListening(host.Host) {
+func (netw *MockP2P) StartListening(_ host.P2PSubscriber) {
 	// nothing to do here, since communication is direct through the in memory objects
 }
 


### PR DESCRIPTION
### Why this change is needed

Small PR laying the ground work for enclave-guardian and HA.

P2P subscriptions only need the narrow P2PSubscriber interface, not a full Host interface.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


