### PR TITLE
Use latest patch version, not latest minor version

### DIFF
--- a/contracts/package.json
+++ b/contracts/package.json
@@ -14,9 +14,9 @@
     "@openzeppelin/contracts": "4.5.0",
     "@openzeppelin/hardhat-upgrades": "^1.21.0",
     "@solidstate/hardhat-bytecode-exporter": "^1.1.1",
-    "hardhat": "^2.12.4",
+    "hardhat": "~2.12.4",
     "hardhat-abi-exporter": "^2.10.1",
-    "hardhat-deploy": "^0.11.22",
+    "hardhat-deploy": "~0.11.22",
     "node-docker-api": "^1.1.22",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.4"


### PR DESCRIPTION
Limits the hardhat and hardhat deployer versions to the latest patch version only 