### PR TITLE
Testnet github actions: fix clash with secrets

### DIFF
--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -27,10 +27,7 @@ jobs:
       L1_START_HASH: ${{ steps.deployContracts.outputs.L1_START_HASH }}
       HOC_ERC20_ADDR: ${{ steps.deployContracts.outputs.HOC_ERC20_ADDR }}
       POC_ERC20_ADDR: ${{ steps.deployContracts.outputs.POC_ERC20_ADDR }}
-      L2_ENCLAVE_DOCKER_BUILD_TAG: ${{ steps.outputVars.outputs.L2_ENCLAVE_DOCKER_BUILD_TAG }}
-      L2_HOST_DOCKER_BUILD_TAG: ${{ steps.outputVars.outputs.L2_HOST_DOCKER_BUILD_TAG }}
-      L2_CONTRACTDEPLOYER_DOCKER_BUILD_TAG: ${{ steps.outputVars.outputs.L2_CONTRACTDEPLOYER_DOCKER_BUILD_TAG }}
-      L2_HARDHATDEPLOYER_DOCKER_BUILD_TAG: ${{ steps.outputVars.outputs.L2_HARDHATDEPLOYER_DOCKER_BUILD_TAG }}
+      DOCKER_IMAGE_PREFIX: ${{ steps.outputVars.outputs.DOCKER_IMAGE_PREFIX }}
       RESOURCE_TAG_NAME: ${{ steps.outputVars.outputs.RESOURCE_TAG_NAME }}
       RESOURCE_STARTING_NAME: ${{ steps.outputVars.outputs.RESOURCE_STARTING_NAME }}
       RESOURCE_TESTNET_NAME: ${{ steps.outputVars.outputs.RESOURCE_TESTNET_NAME }}
@@ -51,10 +48,7 @@ jobs:
       - name: 'Sets env vars for testnet'
         if: ${{ github.event.inputs.testnet_type  == 'testnet' }}
         run: |
-          echo "L2_ENCLAVE_DOCKER_BUILD_TAG=testnetobscuronet.azurecr.io/obscuronet/enclave:latest" >> $GITHUB_ENV
-          echo "L2_HOST_DOCKER_BUILD_TAG=testnetobscuronet.azurecr.io/obscuronet/host:latest" >> $GITHUB_ENV
-          echo "L2_CONTRACTDEPLOYER_DOCKER_BUILD_TAG=testnetobscuronet.azurecr.io/obscuronet/contractdeployer:latest" >> $GITHUB_ENV
-          echo "L2_HARDHATDEPLOYER_DOCKER_BUILD_TAG=testnetobscuronet.azurecr.io/obscuronet/hardhatdeployer:latest" >> $GITHUB_ENV
+          echo "DOCKER_IMAGE_PREFIX=" >> $GITHUB_ENV
           echo "RESOURCE_TAG_NAME=testnetlatest" >> $GITHUB_ENV
           echo "RESOURCE_STARTING_NAME=T" >> $GITHUB_ENV
           echo "RESOURCE_TESTNET_NAME=testnet" >> $GITHUB_ENV
@@ -63,10 +57,7 @@ jobs:
       - name: 'Sets env vars for dev-testnet'
         if: ${{ (github.event.inputs.testnet_type == 'dev-testnet') }}
         run: |
-          echo "L2_ENCLAVE_DOCKER_BUILD_TAG=testnetobscuronet.azurecr.io/obscuronet/dev_enclave:latest" >> $GITHUB_ENV
-          echo "L2_HOST_DOCKER_BUILD_TAG=testnetobscuronet.azurecr.io/obscuronet/dev_host:latest" >> $GITHUB_ENV
-          echo "L2_CONTRACTDEPLOYER_DOCKER_BUILD_TAG=testnetobscuronet.azurecr.io/obscuronet/dev_contractdeployer:latest" >> $GITHUB_ENV
-          echo "L2_HARDHATDEPLOYER_DOCKER_BUILD_TAG=testnetobscuronet.azurecr.io/obscuronet/dev_hardhatdeployer:latest" >> $GITHUB_ENV
+          echo "DOCKER_IMAGE_PREFIX=dev_" >> $GITHUB_ENV
           echo "RESOURCE_TAG_NAME=devtestnetlatest" >> $GITHUB_ENV
           echo "RESOURCE_STARTING_NAME=D" >> $GITHUB_ENV
           echo "RESOURCE_TESTNET_NAME=devtestnet" >> $GITHUB_ENV
@@ -75,10 +66,7 @@ jobs:
       - name: 'Output env vars'
         id: outputVars
         run: |
-          echo "L2_ENCLAVE_DOCKER_BUILD_TAG=${{env.L2_ENCLAVE_DOCKER_BUILD_TAG}}" >> $GITHUB_OUTPUT
-          echo "L2_HOST_DOCKER_BUILD_TAG=${{env.L2_HOST_DOCKER_BUILD_TAG}}" >> $GITHUB_OUTPUT
-          echo "L2_CONTRACTDEPLOYER_DOCKER_BUILD_TAG=${{env.L2_CONTRACTDEPLOYER_DOCKER_BUILD_TAG}}" >> $GITHUB_OUTPUT
-          echo "L2_HARDHATDEPLOYER_DOCKER_BUILD_TAG=${{env.L2_HARDHATDEPLOYER_DOCKER_BUILD_TAG}}" >> $GITHUB_OUTPUT
+          echo "DOCKER_IMAGE_PREFIX=${{env.DOCKER_IMAGE_PREFIX}}" >> $GITHUB_OUTPUT
           echo "RESOURCE_TAG_NAME=${{env.RESOURCE_TAG_NAME}}" >> $GITHUB_OUTPUT
           echo "RESOURCE_STARTING_NAME=${{env.RESOURCE_STARTING_NAME}}" >> $GITHUB_OUTPUT
           echo "RESOURCE_TESTNET_NAME=${{env.RESOURCE_TESTNET_NAME}}" >> $GITHUB_OUTPUT
@@ -93,14 +81,14 @@ jobs:
 
       - name: 'Build and push obscuro node images'
         run: |
-          DOCKER_BUILDKIT=1 docker build -t ${{env.L2_ENCLAVE_DOCKER_BUILD_TAG}} -f dockerfiles/enclave.Dockerfile  .
-          docker push ${{env.L2_ENCLAVE_DOCKER_BUILD_TAG}}
-          DOCKER_BUILDKIT=1 docker build -t ${{env.L2_HOST_DOCKER_BUILD_TAG}} -f dockerfiles/host.Dockerfile .
-          docker push ${{env.L2_HOST_DOCKER_BUILD_TAG}}
-          DOCKER_BUILDKIT=1 docker build -t ${{env.L2_CONTRACTDEPLOYER_DOCKER_BUILD_TAG}} -f testnet/contractdeployer.Dockerfile .
-          docker push ${{env.L2_CONTRACTDEPLOYER_DOCKER_BUILD_TAG}}
-          DOCKER_BUILDKIT=1 docker build -t ${{env.L2_HARDHATDEPLOYER_DOCKER_BUILD_TAG}} -f testnet/hardhatdeployer.Dockerfile .
-          docker push ${{env.L2_HARDHATDEPLOYER_DOCKER_BUILD_TAG}}
+          DOCKER_BUILDKIT=1 docker build -t testnetobscuronet.azurecr.io/obscuronet/${{env.DOCKER_IMAGE_PREFIX}}enclave:latest -f dockerfiles/enclave.Dockerfile  .
+          docker push testnetobscuronet.azurecr.io/obscuronet/${{env.DOCKER_IMAGE_PREFIX}}enclave:latest
+          DOCKER_BUILDKIT=1 docker build -t testnetobscuronet.azurecr.io/obscuronet/${{env.DOCKER_IMAGE_PREFIX}}host:latest -f dockerfiles/host.Dockerfile .
+          docker push testnetobscuronet.azurecr.io/obscuronet/${{env.DOCKER_IMAGE_PREFIX}}host:latest
+          DOCKER_BUILDKIT=1 docker build -t testnetobscuronet.azurecr.io/obscuronet/${{env.DOCKER_IMAGE_PREFIX}}contractdeployer:latest -f testnet/contractdeployer.Dockerfile .
+          docker push testnetobscuronet.azurecr.io/obscuronet/${{env.DOCKER_IMAGE_PREFIX}}contractdeployer:latest
+          DOCKER_BUILDKIT=1 docker build -t testnetobscuronet.azurecr.io/obscuronet/${{env.DOCKER_IMAGE_PREFIX}}hardhatdeployer:latest -f testnet/hardhatdeployer.Dockerfile .
+          docker push testnetobscuronet.azurecr.io/obscuronet/${{env.DOCKER_IMAGE_PREFIX}}hardhatdeployer:latest
 
       - name: 'Deploy Contracts'
         id: deployContracts
@@ -109,7 +97,7 @@ jobs:
           go run ./testnet/launcher/l1contractdeployer/cmd \
           -l1_host=${{ env.L1_HOST }} \
           -private_key=${{ secrets.GETHNETWORK_PREFUNDED_PKSTR_WORKER }} \
-          -docker_image=${{env.L2_HARDHATDEPLOYER_DOCKER_BUILD_TAG}} \
+          -docker_image=testnetobscuronet.azurecr.io/obscuronet/${{env.DOCKER_IMAGE_PREFIX}}hardhatdeployer:latest \
           -contracts_env_file=./testnet/.env
           source ./testnet/.env
           echo "Contracts deployed to $MGMTCONTRACTADDR"
@@ -263,8 +251,8 @@ jobs:
                -sequencer_id=${{ secrets.GETHNETWORK_PREFUNDED_ADDR_0 }} \
                -host_public_p2p_addr=obscuronode-${{ matrix.host_id }}-${{needs.build.outputs.RESOURCE_TESTNET_NAME}}-${{ GITHUB.RUN_NUMBER }}.uksouth.cloudapp.azure.com:10000 \
                -host_p2p_port=10000 \
-               -enclave_docker_image=${{needs.build.outputs.L2_ENCLAVE_DOCKER_BUILD_TAG}} \
-               -host_docker_image=${{needs.build.outputs.L2_HOST_DOCKER_BUILD_TAG}} \
+               -enclave_docker_image=testnetobscuronet.azurecr.io/obscuronet/${{needs.build.outputs.DOCKER_IMAGE_PREFIX}}enclave:latest \
+               -host_docker_image=testnetobscuronet.azurecr.io/obscuronet/${{needs.build.outputs.DOCKER_IMAGE_PREFIX}}host:latest \
                -is_debug_namespace_enabled=true \
                start'
 
@@ -331,7 +319,7 @@ jobs:
           -l2_hoc_private_key=6e384a07a01263518a09a5424c7b6bbfc3604ba7d93f47e3a455cbdd7f9f0682 \
           -l2_poc_private_key=4bfe14725e685901c062ccd4e220c61cf9c189897b6c78bd18d7f51291b2b8f8 \
           -message_bus_contract_addr=${{ needs.build.outputs.MSG_BUS_CONTRACT_ADDR }} \
-          -docker_image=${{needs.build.outputs.L2_HARDHATDEPLOYER_DOCKER_BUILD_TAG}}
+          -docker_image=testnetobscuronet.azurecr.io/obscuronet/${{needs.build.outputs.DOCKER_IMAGE_PREFIX}}hardhatdeployer:latest
 
       - name: 'Save container logs on failure'
         if: failure()

--- a/.github/workflows/manual-upgrade-testnet-l2.yml
+++ b/.github/workflows/manual-upgrade-testnet-l2.yml
@@ -29,8 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     # Map a step output to a job output
     outputs:
-      L2_ENCLAVE_DOCKER_BUILD_TAG: ${{ steps.outputVars.outputs.L2_ENCLAVE_DOCKER_BUILD_TAG }}
-      L2_HOST_DOCKER_BUILD_TAG: ${{ steps.outputVars.outputs.L2_HOST_DOCKER_BUILD_TAG }}
+      DOCKER_IMAGE_PREFIX: ${{ steps.outputVars.outputs.DOCKER_IMAGE_PREFIX }}
       RESOURCE_TAG_NAME: ${{ steps.outputVars.outputs.RESOURCE_TAG_NAME }}
       RESOURCE_STARTING_NAME: ${{ steps.outputVars.outputs.RESOURCE_STARTING_NAME }}
       RESOURCE_TESTNET_NAME: ${{ steps.outputVars.outputs.RESOURCE_TESTNET_NAME }}
@@ -52,8 +51,7 @@ jobs:
       - name: 'Sets env vars for testnet'
         if: ${{ github.event.inputs.testnet_type  == 'testnet' }}
         run: |
-          echo "L2_ENCLAVE_DOCKER_BUILD_TAG=testnetobscuronet.azurecr.io/obscuronet/enclave:latest" >> $GITHUB_ENV
-          echo "L2_HOST_DOCKER_BUILD_TAG=testnetobscuronet.azurecr.io/obscuronet/host:latest" >> $GITHUB_ENV
+          echo "DOCKER_IMAGE_PREFIX=" >> $GITHUB_ENV
           echo "RESOURCE_TAG_NAME=testnetlatest" >> $GITHUB_ENV
           echo "RESOURCE_STARTING_NAME=T" >> $GITHUB_ENV
           echo "RESOURCE_TESTNET_NAME=testnet" >> $GITHUB_ENV
@@ -62,8 +60,7 @@ jobs:
       - name: 'Sets env vars for dev-testnet'
         if: ${{ (github.event.inputs.testnet_type == 'dev-testnet') || (github.event_name == 'schedule') }}
         run: |
-          echo "L2_ENCLAVE_DOCKER_BUILD_TAG=testnetobscuronet.azurecr.io/obscuronet/dev_enclave:latest" >> $GITHUB_ENV
-          echo "L2_HOST_DOCKER_BUILD_TAG=testnetobscuronet.azurecr.io/obscuronet/dev_host:latest" >> $GITHUB_ENV
+          echo "DOCKER_IMAGE_PREFIX=dev_" >> $GITHUB_ENV
           echo "RESOURCE_TAG_NAME=devtestnetlatest" >> $GITHUB_ENV
           echo "RESOURCE_STARTING_NAME=D" >> $GITHUB_ENV
           echo "RESOURCE_TESTNET_NAME=devtestnet" >> $GITHUB_ENV
@@ -85,8 +82,7 @@ jobs:
       - name: 'Output env vars'
         id: outputVars
         run: |
-          echo "L2_ENCLAVE_DOCKER_BUILD_TAG=${{env.L2_ENCLAVE_DOCKER_BUILD_TAG}}" >> $GITHUB_OUTPUT
-          echo "L2_HOST_DOCKER_BUILD_TAG=${{env.L2_HOST_DOCKER_BUILD_TAG}}" >> $GITHUB_OUTPUT
+          echo "DOCKER_IMAGE_PREFIX=${{env.DOCKER_IMAGE_PREFIX}}" >> $GITHUB_OUTPUT
           echo "RESOURCE_TAG_NAME=${{env.RESOURCE_TAG_NAME}}" >> $GITHUB_OUTPUT
           echo "RESOURCE_STARTING_NAME=${{env.RESOURCE_STARTING_NAME}}" >> $GITHUB_OUTPUT
           echo "RESOURCE_TESTNET_NAME=${{env.RESOURCE_TESTNET_NAME}}" >> $GITHUB_OUTPUT
@@ -102,10 +98,10 @@ jobs:
 
       - name: 'Build and push obscuro node images'
         run: |
-          DOCKER_BUILDKIT=1 docker build -t ${{env.L2_ENCLAVE_DOCKER_BUILD_TAG}} -f dockerfiles/enclave.Dockerfile  .
-          docker push ${{env.L2_ENCLAVE_DOCKER_BUILD_TAG}}
-          DOCKER_BUILDKIT=1 docker build -t ${{env.L2_HOST_DOCKER_BUILD_TAG}} -f dockerfiles/host.Dockerfile .
-          docker push ${{env.L2_HOST_DOCKER_BUILD_TAG}}
+          DOCKER_BUILDKIT=1 docker build -t testnetobscuronet.azurecr.io/obscuronet/${{env.DOCKER_IMAGE_PREFIX}}enclave:latest -f dockerfiles/enclave.Dockerfile  .
+          docker push testnetobscuronet.azurecr.io/obscuronet/${{env.DOCKER_IMAGE_PREFIX}}enclave:latest
+          DOCKER_BUILDKIT=1 docker build -t testnetobscuronet.azurecr.io/obscuronet/${{env.DOCKER_IMAGE_PREFIX}}host:latest -f dockerfiles/host.Dockerfile .
+          docker push testnetobscuronet.azurecr.io/obscuronet/${{env.DOCKER_IMAGE_PREFIX}}host:latest
 
   deploy:
     needs: build
@@ -158,8 +154,8 @@ jobs:
             az vm run-command invoke -g Testnet -n "${{needs.build.outputs.RESOURCE_STARTING_NAME}}-${{ matrix.host_id }}-${{needs.build.outputs.VM_BUILD_NUMBER}}"  \
             --command-id RunShellScript \
             --scripts '
-               docker pull ${{needs.build.outputs.L2_HOST_DOCKER_BUILD_TAG}} \
-            && docker pull ${{needs.build.outputs.L2_ENCLAVE_DOCKER_BUILD_TAG}} \
+               docker pull testnetobscuronet.azurecr.io/obscuronet/${{env.DOCKER_IMAGE_PREFIX}}host:latest \
+            && docker pull testnetobscuronet.azurecr.io/obscuronet/${{env.DOCKER_IMAGE_PREFIX}}enclave:latest \
             && rm -rf /home/obscuro/go-obscuro \
             && git clone --depth 1 -b ${{ steps.extract_branch.outputs.branch }} https://github.com/obscuronet/go-obscuro.git /home/obscuro/go-obscuro \
             && cd /home/obscuro/go-obscuro/ \
@@ -173,8 +169,8 @@ jobs:
               -sequencer_id=${{ secrets.GETHNETWORK_PREFUNDED_ADDR_0 }} \
               -host_public_p2p_addr=obscuronode-${{ matrix.host_id }}-${{needs.build.outputs.RESOURCE_TESTNET_NAME}}-${{needs.build.outputs.VM_BUILD_NUMBER}}.uksouth.cloudapp.azure.com:10000 \
               -host_p2p_port=10000 \
-              -enclave_docker_image=${{needs.build.outputs.L2_ENCLAVE_DOCKER_BUILD_TAG}} \
-              -host_docker_image=${{needs.build.outputs.L2_HOST_DOCKER_BUILD_TAG}} \
+              -enclave_docker_image=testnetobscuronet.azurecr.io/obscuronet/${{env.DOCKER_IMAGE_PREFIX}}enclave:latest \
+              -host_docker_image=testnetobscuronet.azurecr.io/obscuronet/${{env.DOCKER_IMAGE_PREFIX}}host:latest \
               upgrade'
 
   check-obscuro-is-healthy:

--- a/.github/workflows/manual-upgrade-testnet-l2.yml
+++ b/.github/workflows/manual-upgrade-testnet-l2.yml
@@ -154,8 +154,8 @@ jobs:
             az vm run-command invoke -g Testnet -n "${{needs.build.outputs.RESOURCE_STARTING_NAME}}-${{ matrix.host_id }}-${{needs.build.outputs.VM_BUILD_NUMBER}}"  \
             --command-id RunShellScript \
             --scripts '
-               docker pull testnetobscuronet.azurecr.io/obscuronet/${{env.DOCKER_IMAGE_PREFIX}}host:latest \
-            && docker pull testnetobscuronet.azurecr.io/obscuronet/${{env.DOCKER_IMAGE_PREFIX}}enclave:latest \
+               docker pull testnetobscuronet.azurecr.io/obscuronet/${{needs.build.outputs.DOCKER_IMAGE_PREFIX}}host:latest \
+            && docker pull testnetobscuronet.azurecr.io/obscuronet/${{needs.build.outputs.DOCKER_IMAGE_PREFIX}}enclave:latest \
             && rm -rf /home/obscuro/go-obscuro \
             && git clone --depth 1 -b ${{ steps.extract_branch.outputs.branch }} https://github.com/obscuronet/go-obscuro.git /home/obscuro/go-obscuro \
             && cd /home/obscuro/go-obscuro/ \
@@ -169,8 +169,8 @@ jobs:
               -sequencer_id=${{ secrets.GETHNETWORK_PREFUNDED_ADDR_0 }} \
               -host_public_p2p_addr=obscuronode-${{ matrix.host_id }}-${{needs.build.outputs.RESOURCE_TESTNET_NAME}}-${{needs.build.outputs.VM_BUILD_NUMBER}}.uksouth.cloudapp.azure.com:10000 \
               -host_p2p_port=10000 \
-              -enclave_docker_image=testnetobscuronet.azurecr.io/obscuronet/${{env.DOCKER_IMAGE_PREFIX}}enclave:latest \
-              -host_docker_image=testnetobscuronet.azurecr.io/obscuronet/${{env.DOCKER_IMAGE_PREFIX}}host:latest \
+              -enclave_docker_image=testnetobscuronet.azurecr.io/obscuronet/${{needs.build.outputs.DOCKER_IMAGE_PREFIX}}enclave:latest \
+              -host_docker_image=testnetobscuronet.azurecr.io/obscuronet/${{needs.build.outputs.DOCKER_IMAGE_PREFIX}}host:latest \
               upgrade'
 
   check-obscuro-is-healthy:


### PR DESCRIPTION
### Why this change is needed

Both the manual deploy and upgrade scripts have been failing because the docker image vars are not being output successfully, this seems to be because the hardcoded part clashes with part of one of our secret usernames.

### What changes were made as part of this PR

To fix this I've written out the full image names all over the place and just had a simple var to toggle the `dev_` prefix on the image name.

This comes out quite verbose, there must be a simple way to have a constant for things that are declared in the script (like the hostname in the docker image) but I just wanted to prove this fixes it for now.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


