### PR TITLE
simplify block processing logic

### DIFF
--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -66,6 +66,8 @@ type enclaveImpl struct {
 	config               *config.EnclaveConfig
 	storage              db.Storage
 	blockResolver        db.BlockResolver
+	l1BlockProcessor     components.L1BlockProcessor
+	rollupConsumer       components.RollupConsumer
 	l1Blockchain         *gethcore.BlockChain
 	rpcEncryptionManager rpc.EncryptionManager
 	subscriptionManager  *events.SubscriptionManager
@@ -250,6 +252,8 @@ func NewEnclave(
 		config:                 config,
 		storage:                storage,
 		blockResolver:          storage,
+		l1BlockProcessor:       blockProcessor,
+		rollupConsumer:         rConsumer,
 		l1Blockchain:           l1Blockchain,
 		rpcEncryptionManager:   rpcEncryptionManager,
 		subscriptionManager:    subscriptionManager,
@@ -409,19 +413,41 @@ func (e *enclaveImpl) SubmitL1Block(block types.Block, receipts types.Receipts, 
 		return nil, e.rejectBlockErr(fmt.Errorf("could not submit L1 block. Cause: %w", err))
 	}
 
-	result, err := e.service.ReceiveBlock(br, isLatest)
+	result, err := e.ingestL1Block(br, isLatest)
 	if err != nil {
 		return nil, e.rejectBlockErr(fmt.Errorf("could not submit L1 block. Cause: %w", err))
 	}
 
 	if result.Fork {
-		e.logger.Info("Forked")
+		e.logger.Info(fmt.Sprintf("Detected forked at block %s with height %d", block.Hash(), block.Number()))
 	}
 
 	bsr := e.produceBlockSubmissionResponse(nil, nil)
 
 	bsr.ProducedSecretResponses = e.processNetworkSecretMsgs(br)
 	return bsr, nil
+}
+
+func (e *enclaveImpl) ingestL1Block(br *common.BlockAndReceipts, isLatest bool) (*components.BlockIngestionType, error) {
+	ingestion, err := e.l1BlockProcessor.Process(br, isLatest)
+	if err != nil {
+		return nil, err
+	}
+
+	rollup, err := e.rollupConsumer.ProcessL1Block(br)
+	if err != nil && !errors.Is(err, components.ErrDuplicateRollup) {
+		e.logger.Error("Encountered error while processing l1 block", log.ErrKey, err)
+		// Unsure what to do here; block has been stored
+	}
+
+	if rollup != nil {
+		// read batch data from rollup, verify and store it
+		if err = e.rollupConsumer.ProcessRollup(rollup); err != nil {
+			return nil, err
+		}
+	}
+
+	return ingestion, nil
 }
 
 func (e *enclaveImpl) SubmitTx(tx common.EncryptedTx) (*responses.RawTx, common.SystemError) {

--- a/go/enclave/nodetype/interfaces.go
+++ b/go/enclave/nodetype/interfaces.go
@@ -2,18 +2,12 @@ package nodetype
 
 import (
 	"github.com/obscuronet/go-obscuro/go/common"
-	"github.com/obscuronet/go-obscuro/go/enclave/components"
 	"github.com/obscuronet/go-obscuro/go/enclave/core"
 )
 
 // NodeType - the interface for any service type running in Obscuro nodes.
 // Should only contain the shared functionality that every service type needs to have.
 type NodeType interface {
-	//	ReceiveBlock - function that accepts L1 blocks and their receipts along with a flag
-	// that signals if the block is the latest one or not. Processing of those blocks and
-	// resulting actions differ between the service types.
-	ReceiveBlock(*common.BlockAndReceipts, bool) (*components.BlockIngestionType, error)
-
 	// SubmitTransaction - L2 obscuro transactions need to be passed here. Sequencers
 	// will put them in the mempool while validators might put them in a queue and monitor
 	// for censorship.

--- a/go/enclave/nodetype/sequencer.go
+++ b/go/enclave/nodetype/sequencer.go
@@ -237,21 +237,6 @@ func (s *sequencer) CreateRollup() (*common.ExtRollup, error) {
 	return rollup.ToExtRollup(s.dataEncryptionService, s.dataCompressionService)
 }
 
-func (s *sequencer) ReceiveBlock(br *common.BlockAndReceipts, isLatest bool) (*components.BlockIngestionType, error) {
-	ingestion, err := s.blockProcessor.Process(br, isLatest)
-	if err != nil {
-		return nil, err
-	}
-
-	_, err = s.rollupConsumer.ProcessL1Block(br)
-	if err != nil && !errors.Is(err, components.ErrDuplicateRollup) {
-		s.logger.Error("Encountered error while processing l1 block", log.ErrKey, err)
-		// Unsure what to do here; block has been stored
-	}
-
-	return ingestion, nil
-}
-
 func (s *sequencer) handleFork(block *common.L1Block, ancestralBatch *core.Batch) error {
 	headBatch, err := s.batchRegistry.GetHeadBatch()
 	if err != nil {

--- a/go/enclave/nodetype/validator.go
+++ b/go/enclave/nodetype/validator.go
@@ -1,14 +1,12 @@
 package nodetype
 
 import (
-	"errors"
 	"fmt"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	gethlog "github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/obscuronet/go-obscuro/go/common"
-	"github.com/obscuronet/go-obscuro/go/common/log"
 	"github.com/obscuronet/go-obscuro/go/enclave/components"
 	"github.com/obscuronet/go-obscuro/go/enclave/core"
 	"github.com/obscuronet/go-obscuro/go/enclave/db"
@@ -61,29 +59,6 @@ func (val *obsValidator) ValidateAndStoreBatch(incomingBatch *core.Batch) error 
 	}
 
 	return val.batchRegistry.StoreBatch(incomingBatch, receipts)
-}
-
-func (val *obsValidator) ReceiveBlock(br *common.BlockAndReceipts, isLatest bool) (*components.BlockIngestionType, error) {
-	ingestion, err := val.blockProcessor.Process(br, isLatest)
-	if err != nil {
-		return nil, err
-	}
-
-	rollup, err := val.rollupConsumer.ProcessL1Block(br)
-	if err != nil && !errors.Is(err, components.ErrDuplicateRollup) {
-		// todo - log err?
-		val.logger.Error("Encountered error processing l1 block", log.ErrKey, err)
-		return ingestion, nil
-	}
-
-	if rollup != nil {
-		// read batch data from rollup, verify and store it
-		if err = val.rollupConsumer.ProcessRollup(rollup); err != nil {
-			return nil, err
-		}
-	}
-
-	return ingestion, nil
 }
 
 func (val *obsValidator) SubmitTransaction(transaction *common.L2Tx) error {


### PR DESCRIPTION
### Why this change is needed

Sequencers and validators should process rollups using the same code.
In practice, sequencers will never execute the batches, because they produced them, and they are already in the db.

### What changes were made as part of this PR

- move the l1 block ingestion logic out of the "Node Type"

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


