### PR TITLE
Fix the build tests

### DIFF
--- a/integration/eth2network/eth2_binaries.go
+++ b/integration/eth2network/eth2_binaries.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	_gethVersion  = "1.11.6"
-	_prysmVersion = "v4.0.5"
+	_prysmVersion = "v4.0.6"
 )
 
 var (


### PR DESCRIPTION
### Why this change is needed

Fix build tests
- Update prysm to 4.0.6 to avoid the `prefix="rpc/validator" slot=45 validatorIndex=0 fatal error: concurrent map read and map write`

### What changes were made as part of this PR

Please provide a high level list of the changes made

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


