### PR TITLE
enclave-guardian: add enclave status tracker to host

### DIFF
--- a/go/common/gethutil/gethutil.go
+++ b/go/common/gethutil/gethutil.go
@@ -4,12 +4,16 @@ import (
 	"bytes"
 	"fmt"
 
+	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/obscuronet/go-obscuro/go/common"
 	"github.com/obscuronet/go-obscuro/go/enclave/db"
 )
 
 // Utilities for working with geth structures
+
+// EmptyHash is useful for comparisons to check if hash has been set
+var EmptyHash = gethcommon.Hash{}
 
 // LCA - returns the latest common ancestor of the 2 blocks or an error if no common ancestor is found
 func LCA(blockA *types.Block, blockB *types.Block, resolver db.BlockResolver) (*types.Block, error) {

--- a/go/host/enclave/state.go
+++ b/go/host/enclave/state.go
@@ -1,0 +1,184 @@
+package enclave
+
+import (
+	"fmt"
+	"sync"
+
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	gethlog "github.com/ethereum/go-ethereum/log"
+	"github.com/obscuronet/go-obscuro/go/common"
+	"github.com/obscuronet/go-obscuro/go/common/gethutil"
+)
+
+// This state machine compares the state of the enclave to the state of the world and is used to determine what actions can be taken with the enclave.
+// It records the last known status code of the enclave. It also records the l1 head and the l2 head that it believes the
+// enclave has processed, optimistically updating these after successful actions and verifying the status when errors occur.
+
+// Usage notes:
+// - The status is updated by the host when the enclave successfully processed blocks and batches
+// - The status is updated when we receive a status from the enclave
+// - The status is **not** updated immediately when it receives blocks/batches from the outside world (this is to avoid flickering between catch-up and live when new blocks/batches arrive)
+// - The state should be notified of a live block/batch arrival before notifying if it is successfully processed
+// - If unexpected error occurs when interacting with the enclave, then status should be requested and this state updated with the result
+
+// Status is the status of the enclave from the host's perspective (including what it knows of the outside world)
+type Status int
+
+const (
+	// Live - enclave is up-to-date with known external data. It can process L1 and L2 blocks as they arrive and respond to requests.
+	Live Status = iota
+	// Disconnected - enclave is unreachable or not returning a valid status (this overrides state calculations)
+	Disconnected
+	// Unavailable - enclave responding with 'Unavailable' status code
+	Unavailable
+	// AwaitingSecret - enclave is waiting for host to request and provide secret
+	AwaitingSecret
+	// L1Catchup - enclave is behind on L1 data, host should submit L1 blocks to catch up
+	L1Catchup
+	// L2Catchup - enclave is behind on L2 data, host should request and submit L2 batches to catch up
+	L2Catchup
+)
+
+func (es Status) String() string {
+	return [...]string{"Live", "Disconnected", "Unavailable", "AwaitingSecret", "L1Catchup", "L2Catchup"}[es]
+}
+
+// StateTracker is the state machine for the enclave
+type StateTracker struct {
+	// status is the cached status of the enclave
+	// It is a function of the properties below and recalculated when any of them change
+	status Status
+
+	// enclave states (updated when enclave returns Status and optimistically after successful actions)
+	enclaveStatusCode common.StatusCode
+	enclaveL1Head     gethcommon.Hash
+	enclaveL2Head     gethcommon.Hash
+
+	// latest seen heads of L1 and L2 chains from external sources
+	hostL1Head gethcommon.Hash
+	hostL2Head gethcommon.Hash
+
+	m      *sync.RWMutex
+	logger gethlog.Logger
+}
+
+func NewStateTracker(logger gethlog.Logger) *StateTracker {
+	return &StateTracker{status: Disconnected, m: &sync.RWMutex{}, logger: logger}
+}
+
+func (s *StateTracker) String() string {
+	return fmt.Sprintf("StateTracker: [%s] enclave(StatusCode=%d, L1Head=%s, L2Head=%s), Host(L1Head=%s, L2Head=%s)",
+		s.status, s.enclaveStatusCode, s.enclaveL1Head, s.enclaveL2Head, s.hostL1Head, s.hostL2Head)
+}
+
+func (s *StateTracker) GetStatus() Status {
+	s.m.RLock()
+	defer s.m.RUnlock()
+	return s.status
+}
+
+func (s *StateTracker) OnProcessedBlock(enclL1Head gethcommon.Hash) {
+	s.m.Lock()
+	s.enclaveL1Head = enclL1Head
+	s.m.Unlock()
+	s.recalculateStatus()
+}
+
+func (s *StateTracker) OnReceivedBlock(l1Head gethcommon.Hash) {
+	s.m.Lock()
+	defer s.m.Unlock()
+	s.hostL1Head = l1Head
+}
+
+func (s *StateTracker) OnProcessedBatch(enclL2Head gethcommon.Hash) {
+	s.m.Lock()
+	s.enclaveL2Head = enclL2Head
+	s.m.Unlock()
+	s.recalculateStatus()
+}
+
+func (s *StateTracker) OnReceivedBatch(l2Head gethcommon.Hash) {
+	s.m.Lock()
+	defer s.m.Unlock()
+	s.hostL2Head = l2Head
+}
+
+func (s *StateTracker) OnSecretProvided() {
+	s.m.Lock()
+	if s.enclaveStatusCode == common.AwaitingSecret {
+		s.enclaveStatusCode = common.Running
+	}
+	s.m.Unlock()
+	s.recalculateStatus()
+}
+
+func (s *StateTracker) OnEnclaveStatus(es common.Status) {
+	s.m.Lock()
+	s.enclaveStatusCode = es.StatusCode
+	s.enclaveL1Head = es.L1Head
+	s.enclaveL2Head = es.L2Head
+	s.m.Unlock()
+
+	s.recalculateStatus()
+}
+
+// OnDisconnected is called if the enclave is unreachable/not returning a valid Status
+func (s *StateTracker) OnDisconnected() {
+	s.m.Lock()
+	defer s.m.Unlock()
+	s.setStatus(Disconnected)
+}
+
+// when enclave is operational, this method will update the status based on comparison of current chain heads with enclave heads
+func (s *StateTracker) recalculateStatus() {
+	s.m.Lock()
+	defer s.m.Unlock()
+	switch s.enclaveStatusCode {
+	case common.AwaitingSecret:
+		s.setStatus(AwaitingSecret)
+	case common.Unavailable:
+		s.setStatus(Unavailable)
+	case common.Running:
+		if s.hostL1Head != s.enclaveL1Head || s.enclaveL1Head == gethutil.EmptyHash {
+			s.setStatus(L1Catchup)
+			return
+		}
+		if s.hostL2Head != s.enclaveL2Head || s.enclaveL2Head == gethutil.EmptyHash {
+			s.setStatus(L2Catchup)
+			return
+		}
+		s.setStatus(Live)
+	}
+}
+
+// InSyncWithL1 returns true if the enclave is up-to-date with L1 data so guardian can process L1 blocks as they arrive
+func (s *StateTracker) InSyncWithL1() bool {
+	s.m.RLock()
+	defer s.m.RUnlock()
+	return s.status == Live || s.status == L2Catchup
+}
+
+func (s *StateTracker) IsUpToDate() bool {
+	return s.status == Live
+}
+
+func (s *StateTracker) GetEnclaveL1Head() gethcommon.Hash {
+	s.m.RLock()
+	defer s.m.RUnlock()
+	return s.enclaveL1Head
+}
+
+func (s *StateTracker) GetEnclaveL2Head() gethcommon.Hash {
+	s.m.RLock()
+	defer s.m.RUnlock()
+	return s.enclaveL2Head
+}
+
+// this must be called from within write-lock
+func (s *StateTracker) setStatus(newStatus Status) {
+	if s.status == newStatus {
+		return
+	}
+	s.logger.Debug(fmt.Sprintf("Updating enclave status from [%s] to [%s]", s.status, newStatus))
+	s.status = newStatus
+}

--- a/go/host/enclave/state_test.go
+++ b/go/host/enclave/state_test.go
@@ -1,0 +1,74 @@
+package enclave
+
+import (
+	"testing"
+
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	gethlog "github.com/ethereum/go-ethereum/log"
+	"github.com/obscuronet/go-obscuro/go/common/log"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	_l1Block123        = gethcommon.BytesToHash([]byte{1, 2, 3})
+	_l1Block124        = gethcommon.BytesToHash([]byte{1, 2, 4})
+	_l2Batch456        = gethcommon.BytesToHash([]byte{4, 5, 6})
+	_l2Batch457        = gethcommon.BytesToHash([]byte{4, 5, 7})
+	stateTrackerLogger = log.New("stateTracker", int(gethlog.LvlWarn), log.SysOut)
+)
+
+func TestStateTracker_InSyncWithL1(t *testing.T) {
+	s := NewStateTracker(stateTrackerLogger)
+	// state tracker is up-to-date with L1
+	s.OnReceivedBlock(_l1Block123)
+	s.OnProcessedBlock(_l1Block123)
+	// but not processed L2 yet
+	s.OnReceivedBatch(_l2Batch456)
+	assert.Equal(t, L2Catchup, s.GetStatus())
+}
+
+func TestStateTracker_InSyncWithL2(t *testing.T) {
+	s := NewStateTracker(stateTrackerLogger)
+	// state tracker is up-to-date with L1
+	s.OnReceivedBlock(_l1Block123)
+	s.OnProcessedBlock(_l1Block123)
+	// state tracker is up-to-date with L2
+	s.OnReceivedBatch(_l2Batch456)
+	s.OnProcessedBatch(_l2Batch456)
+	assert.Equal(t, Live, s.GetStatus())
+}
+
+func TestStateTracker_InSyncL2ButBehindL1(t *testing.T) {
+	s := NewStateTracker(stateTrackerLogger)
+	// block 124 is received before block 123 is processed
+	s.OnReceivedBlock(_l1Block124)
+	// state tracker becomes aware that it is behind (it works this way to avoid flickering to catch-up every time a block arrives)
+	s.OnProcessedBlock(_l1Block123)
+	// batches are up-to-date
+	s.OnReceivedBatch(_l2Batch456)
+	s.OnProcessedBatch(_l2Batch456)
+	assert.Equal(t, L1Catchup, s.GetStatus())
+}
+
+func TestStateTracker_InSyncWithL1ButBehindL2(t *testing.T) {
+	s := NewStateTracker(stateTrackerLogger)
+	s.OnReceivedBlock(_l1Block123)
+	s.OnProcessedBlock(_l1Block123)
+	// batch 457 is received before batch 456 is processed
+	s.OnReceivedBatch(_l2Batch457)
+	// state tracker becomes aware that it is behind (it works this way to avoid flickering to catch-up every time a batch arrives)
+	s.OnProcessedBatch(_l2Batch456)
+	assert.Equal(t, L2Catchup, s.GetStatus())
+}
+
+func TestStateTracker_Disconnected(t *testing.T) {
+	s := NewStateTracker(stateTrackerLogger)
+	// state tracker is up-to-date with L1 and L2
+	s.OnReceivedBlock(_l1Block123)
+	s.OnProcessedBlock(_l1Block123)
+	s.OnReceivedBatch(_l2Batch456)
+	s.OnProcessedBatch(_l2Batch456)
+	// but it gets disconnected
+	s.OnDisconnected()
+	assert.Equal(t, Disconnected, s.GetStatus())
+}

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -7,8 +7,9 @@ import (
 	"math/big"
 	"os"
 	"sync"
-	"sync/atomic"
 	"time"
+
+	"github.com/obscuronet/go-obscuro/go/host/enclave"
 
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -54,9 +55,11 @@ type host struct {
 	config  *config.HostConfig
 	shortID uint64
 
-	p2p           hostcommon.P2P       // For communication with other Obscuro nodes
-	ethClient     ethadapter.EthClient // For communication with the L1 node
-	enclaveClient common.Enclave       // For communication with the enclave
+	p2p           hostcommon.P2P        // For communication with other Obscuro nodes
+	ethClient     ethadapter.EthClient  // For communication with the L1 node
+	enclaveClient common.Enclave        // For communication with the enclave
+	enclaveState  *enclave.StateTracker // StateTracker machine that maintains the current state of enclave (stepping stone to enclave-guardian)
+	statusReqLock sync.Mutex            // Lock to ensure that only one enclave status request is sent at a time (the requests are triggered in separate threads when unexpected enclave errors occur)
 
 	// control the host lifecycle
 	interrupter   breaker.Interface
@@ -66,7 +69,6 @@ type host struct {
 	stopControl *stopcontrol.StopControl
 
 	l1BlockProvider hostcommon.ReconnectingBlockProvider
-	l1UpToDate      atomic.Bool                     // Whether the last submitted L1 block was the head L1 block
 	txP2PCh         chan common.EncryptedTx         // The channel that new transactions from peers are sent to
 	batchP2PCh      chan common.EncodedBatchMsg     // The channel that new batches from peers are sent to
 	batchRequestCh  chan common.EncodedBatchRequest // The channel that batch requests from peers are sent to
@@ -106,10 +108,10 @@ func NewHost(
 		p2p:           p2p,
 		ethClient:     ethClient,
 		enclaveClient: enclaveClient,
+		enclaveState:  enclave.NewStateTracker(logger),
 
 		// incoming data
 		l1BlockProvider: ethadapter.NewEthBlockProvider(ethClient, logger),
-		l1UpToDate:      atomic.Bool{},
 		txP2PCh:         make(chan common.EncryptedTx),
 		batchP2PCh:      make(chan common.EncodedBatchMsg),
 		batchRequestCh:  make(chan common.EncodedBatchRequest),
@@ -227,6 +229,7 @@ func (h *host) generateAndBroadcastSecret() error {
 		return fmt.Errorf("failed to initialise enclave secret. Cause: %w", err)
 	}
 	h.logger.Info("Node is genesis node. Secret was broadcast.")
+	h.enclaveState.OnSecretProvided()
 	return nil
 }
 
@@ -347,7 +350,7 @@ func (h *host) HealthCheck() (*hostcommon.HealthCheck, error) {
 	}
 
 	l1BlockProviderStatus := h.l1BlockProvider.HealthStatus()
-	isL1Synced := h.l1UpToDate.Load()
+	isL1Synced := h.enclaveState.InSyncWithL1()
 
 	// Overall health is achieved when all parts are healthy
 	obscuroNodeHealth := h.p2p.HealthCheck() && l1BlockProviderStatus.Healthy && enclaveHealthy && isL1Synced
@@ -413,16 +416,20 @@ func (h *host) startProcessing() {
 	for {
 		select {
 		case b := <-blockStream.Stream:
-			isLive := h.l1BlockProvider.IsLatest(b) // checks whether the block is the current head of the L1 (false if there is a newer block available)
+			l1Head, err := h.ethClient.FetchHeadBlock()
+			if err != nil {
+				h.logger.Warn("unable to fetch head eth block", log.ErrKey, err)
+			}
+			h.enclaveState.OnReceivedBlock(l1Head.Hash())
+			isLive := l1Head.Hash() == b.Hash()
 			err = h.processL1Block(b, isLive)
 			if err != nil {
 				// handle the error, replace the blockStream if necessary (e.g. if stream needs resetting based on enclave's reported L1 head)
 				blockStream = h.handleProcessBlockErr(b, blockStream, err)
-				// failed to update the L1 head, so assume we're behind
-				h.l1UpToDate.Store(false)
+				// failed to update the L1 head, check enclave state
+				go h.checkEnclaveStatus()
 				continue
 			}
-			h.l1UpToDate.Store(isLive)
 
 		case tx := <-h.txP2PCh:
 			resp, sysError := h.enclaveClient.SubmitTx(tx)
@@ -500,8 +507,10 @@ func (h *host) processL1Block(block *types.Block, isLatestBlock bool) error {
 	// submit each block to the enclave for ingestion plus validation
 	blockSubmissionResponse, err := h.enclaveClient.SubmitL1Block(*block, h.extractReceipts(block), isLatestBlock)
 	if err != nil {
+		go h.checkEnclaveStatus()
 		return fmt.Errorf("did not ingest block %s. Cause: %w", block.Hash(), err)
 	}
+	h.enclaveState.OnProcessedBlock(block.Hash())
 	if blockSubmissionResponse == nil {
 		return fmt.Errorf("no block submission response given for a submitted l1 block")
 	}
@@ -581,6 +590,9 @@ func (h *host) publishRollup(producedRollup *common.ExtRollup) {
 func (h *host) storeBatch(producedBatch *common.ExtBatch) {
 	defer h.logger.Info("Batch stored", log.BatchHashKey, producedBatch.Hash(), log.DurationKey, measure.NewStopwatch())
 
+	// todo (@matt) these are bundled together temporarily so the status is accurate, this will be fixed by the l2 data service PR
+	h.enclaveState.OnReceivedBatch(producedBatch.Hash())
+	h.enclaveState.OnProcessedBatch(producedBatch.Hash())
 	err := h.db.AddBatch(producedBatch)
 	if err != nil {
 		h.logger.Error("could not store batch", log.BatchHashKey, producedBatch.Hash(), log.ErrKey, err)
@@ -711,6 +723,7 @@ func (h *host) requestSecret() error {
 	if err != nil {
 		h.logger.Crit("could not receive the secret", log.ErrKey, err)
 	}
+	h.enclaveState.OnSecretProvided()
 	return nil
 }
 
@@ -914,8 +927,12 @@ func (h *host) handleBatches(encodedBatchMsg *common.EncodedBatchMsg) error {
 		// todo (@stefan) - edge case when the enclave is restarted and loses some state; move to having enclave as source
 		//  of truth re: stored batches
 		if err = h.enclaveClient.SubmitBatch(batch); err != nil {
+			go h.checkEnclaveStatus()
 			return fmt.Errorf("could not submit batch. Cause: %w", err)
 		}
+		// todo (@matt) these are bundled together temporarily so the status is accurate, this will be fixed by the l2 data service PR
+		h.enclaveState.OnReceivedBatch(batch.Hash())
+		h.enclaveState.OnProcessedBatch(batch.Hash())
 		if err = h.db.AddBatch(batch); err != nil {
 			return fmt.Errorf("could not store batch header. Cause: %w", err)
 		}
@@ -938,7 +955,7 @@ func (h *host) startBatchProduction() {
 	for {
 		select {
 		case <-batchProdTicker.C:
-			if !h.l1UpToDate.Load() {
+			if !h.enclaveState.InSyncWithL1() {
 				// if we're behind the L1, we don't want to produce batches
 				h.logger.Debug("skipping batch production because L1 is not up to date")
 				continue
@@ -967,6 +984,7 @@ func (h *host) startBatchStreaming() {
 	} else {
 		batchHash := header.Hash()
 		startingBatch = &batchHash
+		h.enclaveState.OnReceivedBatch(header.Hash())
 		h.logger.Info("Streaming from latest known head batch", log.BatchHashKey, startingBatch)
 	}
 
@@ -999,6 +1017,7 @@ func (h *host) startBatchStreaming() {
 					h.logger.Info("Batch produced", log.RollupHeightKey, resp.Batch.Header.Number, log.RollupHashKey, resp.Batch.Hash())
 					h.storeAndDistributeBatch(resp.Batch)
 				} else {
+					h.logger.Info("Batch streamed on validator?!", log.RollupHeightKey, resp.Batch.Header.Number, log.RollupHashKey, resp.Batch.Hash())
 					h.storeBatch(resp.Batch)
 				}
 			}
@@ -1024,9 +1043,9 @@ func (h *host) startRollupProduction() {
 	for {
 		select {
 		case <-rollupTicker.C:
-			if !h.l1UpToDate.Load() {
+			if !h.enclaveState.IsUpToDate() {
 				// if we're behind the L1, we don't want to produce rollups
-				h.logger.Debug("skipping rollup production because L1 is not up to date")
+				h.logger.Debug("skipping rollup production because L1 is not up to date", "enclaveState", h.enclaveState)
 				continue
 			}
 			producedRollup, err := h.enclaveClient.CreateRollup()
@@ -1072,5 +1091,22 @@ func (h *host) validateConfig() {
 
 	if h.config.P2PPublicAddress == "" {
 		h.logger.Crit("the host must specify a public P2P address")
+	}
+}
+
+// this function should be fired off in a new goroutine whenever the status of the enclave needs to be verified
+// (e.g. if we've seen unexpected errors from the enclave client)
+func (h *host) checkEnclaveStatus() {
+	// only allow one status request at a time, if lock unavailable then abandon attempt
+	if h.statusReqLock.TryLock() {
+		defer h.statusReqLock.Unlock()
+		s, err := h.enclaveClient.Status()
+		if err != nil {
+			h.logger.Error("could not get enclave status", log.ErrKey, err)
+			// we record this as a disconnection, we can't get any more info from the enclave about status currently
+			h.enclaveState.OnDisconnected()
+			return
+		}
+		h.enclaveState.OnEnclaveStatus(s)
 	}
 }


### PR DESCRIPTION
### Why this change is needed

Added a simple state machine that tracks the state of an enclave so host can change its behaviour accordingly. This will be within the enclave-guardian package but getting it in early because it makes the PRs for the other services easier.

### What changes were made as part of this PR

Add an enclave status tracker that gets updated based on the hosts data about the enclave. Not being used for much yet but eventually it drives and guards all behaviour of host towards enclave.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


