### PR TITLE
Reduce log noise from block catchup at startup

### DIFF
--- a/go/host/host.go
+++ b/go/host/host.go
@@ -1104,7 +1104,10 @@ func (h *host) catchUpL1Block() bool {
 	h.logger.Trace("fetching next block", log.BlockHashKey, prevHead)
 	block, isLatest, err := h.l1Repository.FetchNextBlock(prevHead)
 	if err != nil {
-		h.logger.Warn("unable to fetch next L1 block", log.ErrKey, err)
+		// ErrNoNext block occurs sometimes if we caught up with the L1 head, but other errors are unexpected
+		if !errors.Is(err, l1.ErrNoNextBlock) {
+			h.logger.Warn("unexpected error fetching next L1 block", log.ErrKey, err)
+		}
 		return false // nothing to do if we can't fetch the next block
 	}
 	h.submitBlockLock.Lock()

--- a/go/host/l1/blockrepository.go
+++ b/go/host/l1/blockrepository.go
@@ -88,6 +88,9 @@ func (r *Repository) FetchNextBlock(prevBlock gethcommon.Hash) (*types.Block, bo
 	// (which may be a fork, or it may just be the next on the same branch if we are catching-up)
 	blk, err := r.ethClient.BlockByNumber(increment(lca.Number()))
 	if err != nil {
+		if errors.Is(err, ethereum.NotFound) {
+			return nil, false, ErrNoNextBlock
+		}
 		return nil, false, fmt.Errorf("could not find block after latest canon ancestor, height=%s - %w", increment(lca.Number()), err)
 	}
 


### PR DESCRIPTION
### Why this change is needed

We see a lot of messages early in the host lifecycle that look like `could not find block after latest canon ancestor, height=5 - not found`

This happens when the block streaming is getting going and it doesn't realise the enclave is up-to-date so it keeps asking for the next block which isn't there yet.

### What changes were made as part of this PR

Only log for unexpected errors in that method.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


