### PR TITLE
Setup generic services in the host

### DIFF
--- a/go/common/host/host_healthcheck.go
+++ b/go/common/host/host_healthcheck.go
@@ -21,7 +21,7 @@ type HealthCheckEnclave struct {
 // HealthCheckHost is the representation of the Health and Status of the Host
 type HealthCheckHost struct {
 	P2PStatus *P2PStatus
-	L1Repo    *L1RepositoryStatus
+	L1Repo    bool
 	L1Synced  bool
 }
 

--- a/go/common/host/services.go
+++ b/go/common/host/services.go
@@ -6,6 +6,11 @@ import (
 	"github.com/obscuronet/go-obscuro/go/common"
 )
 
+const (
+	// service names - these are the keys used to register known services with the host
+	L1BlockRepositoryName = "l1-block-repo"
+)
+
 // The host has a number of services that encapsulate the various responsibilities of the host.
 // This file contains service-level abstractions and utilities, as well as all the interfaces for these services, code
 // should depend on these interfaces rather than the concrete implementations.

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -116,8 +116,9 @@ func NewHost(
 	enclStateTracker.OnProcessedBlock(l1StartHash) // this makes sure we start streaming from the right block, will be less clunky in the enclave guardian
 	host := &host{
 		// config
-		config:  config,
-		shortID: common.ShortAddress(config.ID),
+		config:   config,
+		shortID:  common.ShortAddress(config.ID),
+		services: make(map[string]hostcommon.Service),
 
 		// Communication layers.
 		p2p:           p2p,

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -163,6 +163,13 @@ func NewHost(
 	return host
 }
 
+func (h *host) RegisterService(name string, service hostcommon.Service) {
+	if _, ok := h.services[name]; ok {
+		h.logger.Crit("service already registered", "name", name)
+	}
+	h.services[name] = service
+}
+
 // Start validates the host config and starts the Host in a go routine - immediately returns after
 func (h *host) Start() error {
 	if h.stopControl.IsStopping() {
@@ -1126,14 +1133,7 @@ func (h *host) catchUpL1Block() bool {
 	return true
 }
 
-func (h *host) RegisterService(name string, service hostcommon.Service) {
-	if _, ok := h.services[name]; ok {
-		h.logger.Crit("service already registered", "name", name)
-	}
-	h.services[name] = service
-}
-
-func (h *host) GetService(name string) hostcommon.Service {
+func (h *host) getService(name string) hostcommon.Service {
 	service, ok := h.services[name]
 	if !ok {
 		h.logger.Crit("requested service not registered", "name", name)
@@ -1142,5 +1142,5 @@ func (h *host) GetService(name string) hostcommon.Service {
 }
 
 func (h *host) l1Repo() hostcommon.L1BlockRepository {
-	return h.GetService(hostcommon.L1BlockRepositoryName).(hostcommon.L1BlockRepository)
+	return h.getService(hostcommon.L1BlockRepositoryName).(hostcommon.L1BlockRepository)
 }

--- a/go/host/l1/blockrepository.go
+++ b/go/host/l1/blockrepository.go
@@ -58,7 +58,7 @@ func (r *Repository) Stop() error {
 	return nil
 }
 
-func (r *Repository) HealthStatus() *host.L1RepositoryStatus {
+func (r *Repository) HealthStatus() host.HealthStatus {
 	// todo (@matt) do proper health status based on last received block or something
 	errMsg := ""
 	if !r.running.Load() {


### PR DESCRIPTION
### Why this change is needed

We want the host to be a container that wires together a bunch of services running that depend on each other. It shouldn't have much logic itself.

So it's useful for the host to be able to treat these services the same as each other for starting/stopping/health checks.

### What changes were made as part of this PR

Add a way to register services on the host. Make start/stop loop through services that are registered.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


