### PR TITLE
Fix missing mutex lock for block submission

### DIFF
--- a/go/host/host.go
+++ b/go/host/host.go
@@ -220,6 +220,8 @@ func (h *host) HandleBlock(block *types.Block) {
 	if !h.enclaveState.InSyncWithL1() {
 		return // ignore blocks until we're up-to-date
 	}
+	h.submitBlockLock.Lock()
+	defer h.submitBlockLock.Unlock()
 	err := h.processL1Block(block, true)
 	if err != nil {
 		h.logger.Warn("error processing L1 block", log.ErrKey, err)

--- a/integration/simulation/simulation_in_mem_test.go
+++ b/integration/simulation/simulation_in_mem_test.go
@@ -37,7 +37,7 @@ func TestInMemoryMonteCarloSimulation(t *testing.T) {
 		StartPort:                 integration.StartPortSimulationInMem,
 		IsInMem:                   true,
 		L1SetupData:               &params.L1SetupData{},
-		ReceiptTimeout:            5 * time.Second,
+		ReceiptTimeout:            10 * time.Second,
 		StoppingDelay:             2 * time.Second,
 	}
 


### PR DESCRIPTION
### Why this change is needed

Stefan spotted that I wasn't locking the mutex when new blocks arrive, only when processing catch-up blocks.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


