### PR TITLE
Add subscription manager for sub/unsub

### DIFF
--- a/go/common/host/services.go
+++ b/go/common/host/services.go
@@ -26,8 +26,8 @@ type Service interface {
 
 // L1BlockRepository provides an interface for the host to request L1 block data (live-streaming and historical)
 type L1BlockRepository interface {
-	// Subscribe will register a block handler to receive new blocks as they arrive
-	Subscribe(handler L1BlockHandler)
+	// Subscribe will register a block handler to receive new blocks as they arrive, returns unsubscribe func
+	Subscribe(handler L1BlockHandler) func()
 
 	FetchBlockByHeight(height int) (*types.Block, error)
 	// FetchNextBlock returns the next canonical block after a given block hash

--- a/go/common/subscription/subscription.go
+++ b/go/common/subscription/subscription.go
@@ -1,0 +1,51 @@
+package subscription
+
+import (
+	"sync"
+
+	"github.com/google/uuid"
+)
+
+// Manager is a subscription manager - allows for thread-safe registering/unregistering subscribers of type T
+type Manager[T any] struct {
+	subscribers map[uuid.UUID]T
+	mx          sync.RWMutex
+}
+
+// NewManager creates a new subscription manager
+func NewManager[T any]() *Manager[T] {
+	return &Manager[T]{
+		subscribers: make(map[uuid.UUID]T),
+		mx:          sync.RWMutex{},
+	}
+}
+
+// Subscribe adds a new subscriber, returns an unsubscribe function
+func (m *Manager[T]) Subscribe(subscriber T) func() {
+	m.mx.Lock()
+	defer m.mx.Unlock()
+
+	id := uuid.New()
+	m.subscribers[id] = subscriber
+
+	return func() {
+		m.mx.Lock()
+		defer m.mx.Unlock()
+
+		delete(m.subscribers, id)
+	}
+}
+
+// Subscribers returns a list of all subscribers
+func (m *Manager[T]) Subscribers() []T {
+	m.mx.RLock()
+	defer m.mx.RUnlock()
+
+	// make a new slice of the subscribers
+	subscribers := make([]T, 0, len(m.subscribers))
+	for _, subscriber := range m.subscribers {
+		subscribers = append(subscribers, subscriber)
+	}
+
+	return subscribers
+}

--- a/go/common/subscription/subscription_test.go
+++ b/go/common/subscription/subscription_test.go
@@ -1,0 +1,52 @@
+package subscription
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type ThingHandler interface {
+	HandleThing()
+}
+
+type TestThingHandler struct {
+	Count int
+}
+
+func (t *TestThingHandler) HandleThing() {
+	t.Count++
+}
+
+// try subscribing and unsubscribing a couple of handlers to a manager
+func TestSubscribeAndUnsubscribe(t *testing.T) {
+	manager := NewManager[ThingHandler]()
+	subscriber1 := &TestThingHandler{}
+	subscriber2 := &TestThingHandler{}
+
+	unsubscribe1 := manager.Subscribe(subscriber1)
+	unsubscribe2 := manager.Subscribe(subscriber2)
+
+	// we should have 2 active subscriptions now
+	assert.Equal(t, 2, len(manager.Subscribers()))
+	for _, s := range manager.Subscribers() {
+		s.HandleThing()
+	}
+	assert.Equal(t, 1, subscriber1.Count)
+	assert.Equal(t, 1, subscriber2.Count)
+
+	unsubscribe1()
+
+	// we should just have one subscription now
+	assert.Equal(t, 1, len(manager.Subscribers()))
+	for _, s := range manager.Subscribers() {
+		s.HandleThing()
+	}
+	assert.Equal(t, 1, subscriber1.Count)
+	assert.Equal(t, 2, subscriber2.Count)
+
+	unsubscribe2()
+
+	// both subscriptions should be gone now
+	assert.Equal(t, 0, len(manager.Subscribers()))
+}

--- a/go/host/l1/blockrepository.go
+++ b/go/host/l1/blockrepository.go
@@ -7,6 +7,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/obscuronet/go-obscuro/go/common/subscription"
+
 	"github.com/obscuronet/go-obscuro/go/common/host"
 
 	"github.com/ethereum/go-ethereum"
@@ -28,7 +30,7 @@ var (
 
 // Repository is a host service for subscribing to new blocks and looking up L1 data
 type Repository struct {
-	subscribers []host.L1BlockHandler
+	blockSubscribers *subscription.Manager[host.L1BlockHandler]
 	// this eth client should only be used by the repository, the repository may "reconnect" it at any time and don't want to interfere with other processes
 	ethClient ethadapter.EthClient
 	logger    gethlog.Logger
@@ -39,9 +41,10 @@ type Repository struct {
 
 func NewL1Repository(ethClient ethadapter.EthClient, logger gethlog.Logger) *Repository {
 	return &Repository{
-		ethClient: ethClient,
-		running:   atomic.Bool{},
-		logger:    logger,
+		blockSubscribers: subscription.NewManager[host.L1BlockHandler](),
+		ethClient:        ethClient,
+		running:          atomic.Bool{},
+		logger:           logger,
 	}
 }
 
@@ -67,12 +70,10 @@ func (r *Repository) HealthStatus() host.HealthStatus {
 	return &host.BasicErrHealthStatus{ErrMsg: errMsg}
 }
 
-// Subscribe will register a new block handler to receive new blocks as they arrive
-func (r *Repository) Subscribe(handler host.L1BlockHandler) {
-	r.subscribers = append(r.subscribers, handler)
+// Subscribe will register a new block handler to receive new blocks as they arrive, returns unsubscribe func
+func (r *Repository) Subscribe(handler host.L1BlockHandler) func() {
+	return r.blockSubscribers.Subscribe(handler)
 }
-
-// todo (@matt) add unsubscribe (+ mutex on subscribers list), will be needed if enclaves can come and go
 
 func (r *Repository) FetchNextBlock(prevBlock gethcommon.Hash) (*types.Block, bool, error) {
 	if prevBlock == r.head {
@@ -140,7 +141,7 @@ func (r *Repository) streamLiveBlocks() {
 		select {
 		case header := <-liveStream:
 			r.head = header.Hash()
-			for _, handler := range r.subscribers {
+			for _, handler := range r.blockSubscribers.Subscribers() {
 				block, err := r.ethClient.BlockByHash(header.Hash())
 				if err != nil {
 					r.logger.Error("error fetching new block", log.ErrKey, err)


### PR DESCRIPTION
### Why this change is needed

A few of these services in host refactor need to subscribe to be notified of things, a basic subscription manager helps keep the code for that tidied away and means they don't need to worry about thread-safety.

### What changes were made as part of this PR

Add a generic sub/unsub subscription manager, use it for block repository.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


