### PR TITLE
fix paths for testnet local build

### DIFF
--- a/testnet/docker-compose.local.yml
+++ b/testnet/docker-compose.local.yml
@@ -26,19 +26,19 @@ services:
     image: "testnetobscuronet.azurecr.io/obscuronet/obscuroscan:latest"
     build:
       context: $ROOT_PATH
-      dockerfile: ./../tools/obscuroscan/Dockerfile
+      dockerfile: ./tools/obscuroscan/Dockerfile
   hardhat-deployer:
     image: "testnetobscuronet.azurecr.io/obscuronet/hardhatdeployer:latest"
     build:
       context: $ROOT_PATH
-      dockerfile: ./../tools/contractdeployer/Dockerfile
+      dockerfile: ./tools/hardhatdeployer/Dockerfile
   wallet-extension:
     image: "testnetobscuronet.azurecr.io/obscuronet/walletextension:latest"
     build:
       context: $ROOT_PATH
-      dockerfile: ./../tools/walletextension/Dockerfile
+      dockerfile: ./tools/walletextension/Dockerfile
   faucet:
     image: "testnetobscuronet.azurecr.io/obscuronet/faucet:latest"
     build:
       context: $ROOT_PATH
-      dockerfile: ./../tools/faucet/Dockerfile
+      dockerfile: ./tools/faucet/Dockerfile

--- a/testnet/testnet-local-build_images.sh
+++ b/testnet/testnet-local-build_images.sh
@@ -48,7 +48,7 @@ command docker build -t testnetobscuronet.azurecr.io/obscuronet/host:latest -f "
 command docker build -t testnetobscuronet.azurecr.io/obscuronet/hardhatdeployer:latest -f "${tools_path}/hardhatdeployer/Dockerfile" "${root_path}" &
 command docker build -t testnetobscuronet.azurecr.io/obscuronet/enclave:latest -f "${root_path}/dockerfiles/enclave.Dockerfile" "${root_path}" &
 command docker build -t testnetobscuronet.azurecr.io/obscuronet/enclave_debug:latest -f "${root_path}/dockerfiles/enclave.debug.Dockerfile" "${root_path}" &
-command docker build -t testnetobscuronet.azurecr.io/obscuronet/obscuroscan:latest -f "${tools_path}/obscuroscan/obscuroscan.Dockerfile" "${root_path}" &
+command docker build -t testnetobscuronet.azurecr.io/obscuronet/obscuroscan:latest -f "${tools_path}/obscuroscan/Dockerfile" "${root_path}" &
 command docker build -t testnetobscuronet.azurecr.io/obscuronet/faucet:latest -f "${tools_path}/faucet/Dockerfile" "${root_path}" &
 
 wait


### PR DESCRIPTION
### Why this change is needed

To be able to build local images for testnet

### What changes were made as part of this PR

Fixed some relative paths

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


