### PR TITLE
Tweak WE/OG start flags for local testnet

### DIFF
--- a/testnet/docker-compose.local.yml
+++ b/testnet/docker-compose.local.yml
@@ -33,7 +33,7 @@ services:
       context: $ROOT_PATH
       dockerfile: ./tools/hardhatdeployer/Dockerfile
   wallet-extension:
-    image: "testnetobscuronet.azurecr.io/obscuronet/walletextension:latest"
+    image: "testnetobscuronet.azurecr.io/obscuronet/obscuro_gateway:latest"
     build:
       context: $ROOT_PATH
       dockerfile: ./tools/walletextension/Dockerfile

--- a/testnet/testnet-local-build_images.sh
+++ b/testnet/testnet-local-build_images.sh
@@ -50,6 +50,7 @@ command docker build -t testnetobscuronet.azurecr.io/obscuronet/enclave:latest -
 command docker build -t testnetobscuronet.azurecr.io/obscuronet/enclave_debug:latest -f "${root_path}/dockerfiles/enclave.debug.Dockerfile" "${root_path}" &
 command docker build -t testnetobscuronet.azurecr.io/obscuronet/obscuroscan:latest -f "${tools_path}/obscuroscan/Dockerfile" "${root_path}" &
 command docker build -t testnetobscuronet.azurecr.io/obscuronet/faucet:latest -f "${tools_path}/faucet/Dockerfile" "${root_path}" &
+command docker build -t testnetobscuronet.azurecr.io/obscuronet/obscuro_gateway:latest -f "${tools_path}/walletextension/Dockerfile" "${root_path}" &
 
 wait
 

--- a/tools/walletextension/container_run.sh
+++ b/tools/walletextension/container_run.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 # Define defaults
 port=3000
 portWS=3001
-host="127.0.0.1"
+host="0.0.0.0"
 nodeHost="testnet.obscu.ro"
 nodePortHTTP=13000
 nodePortWS=13001
@@ -45,6 +45,7 @@ docker rm -f  obscuro_gateway_testnet 2>/dev/null
 echo "Starting Obscuro Gateway..."
 docker run -p 3000:"${port}" --name=obscuro_gateway_testnet \
     --detach \
+    --network=node_network \
     --entrypoint ./wallet_extension_linux \
       "${image}" \
       -host="${host}" -port="${port}" -portWS="${portWS}" -nodeHost="${nodeHost}" -nodePortHTTP="${nodePortHTTP}" \


### PR DESCRIPTION
### Why this change is needed

Part of https://github.com/obscuronet/obscuro-internal/issues/1941 

Makes sure the container joins the node network (for docker connectivity) and a few other minor blips.


### What changes were made as part of this PR

Please provide a high level list of the changes made

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


