### PR TITLE
Matt/simplify host health check

### DIFF
--- a/go/common/host/host_healthcheck.go
+++ b/go/common/host/host_healthcheck.go
@@ -6,33 +6,13 @@ type HealthStatus interface {
 	Message() string
 }
 
-// HealthCheck is the object returned by the API with the Health and Status of the Node
+// HealthCheck is the object returned by the host API with the Health of the Node
 type HealthCheck struct {
 	OverallHealth bool
-	*HealthCheckHost
-	*HealthCheckEnclave
+	Errors        []string
 }
 
-// HealthCheckEnclave is the representation of the Health and Status of the Enclave
-type HealthCheckEnclave struct {
-	EnclaveHealthy bool
-}
-
-// HealthCheckHost is the representation of the Health and Status of the Host
-type HealthCheckHost struct {
-	P2PStatus *P2PStatus
-	L1Repo    bool
-	L1Synced  bool
-}
-
-// P2PStatus is the representation of the Status of the P2P layer
-type P2PStatus struct {
-	FailedReceivedMessages int64
-	FailedSendMessage      int64
-	ReceivedMessages       int64
-}
-
-// BasicErrHealthStatus represents the status of a service, if the ErrMsg is non-empty then it reports as "not OK"
+// BasicErrHealthStatus is a simple health status implementation, if the ErrMsg is non-empty then OK() returns false
 type BasicErrHealthStatus struct {
 	ErrMsg string
 }

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -379,35 +379,39 @@ func (h *host) HealthCheck() (*hostcommon.HealthCheck, error) {
 		return nil, responses.ToInternalError(fmt.Errorf("requested HealthCheck with the host stopping"))
 	}
 
+	overallHostHealth := true
+	healthErrors := make([]string, 0)
+
 	// check the enclave health, which in turn checks the DB health
 	enclaveHealthy, err := h.enclaveClient.HealthCheck()
 	if err != nil {
+		overallHostHealth = false
+		healthErrors = append(healthErrors, fmt.Sprintf("unable to HealthCheck enclave - %s", err.Error()))
+
 		// simplest iteration, log the error and just return that it's not healthy
-		h.logger.Error("unable to HealthCheck enclave", log.ErrKey, err)
+		h.logger.Warn("unable to HealthCheck enclave", log.ErrKey, err)
+	} else if !enclaveHealthy {
+		overallHostHealth = false
+		healthErrors = append(healthErrors, "enclave reported itself as not healthy")
 	}
 
-	// todo (@matt) make the host health check more generic, it should just collate the health of all services
-	//   (so at this point we can just loop through all services and call their health check, collate the responses)
-	l1RepoService := h.l1Repo().(hostcommon.Service)
-	l1RepoHealthy := l1RepoService.HealthStatus().OK()
-	p2pService := h.p2p().(hostcommon.Service)
-	p2pHealthy := p2pService.HealthStatus().OK()
+	// loop through all registered services and collect their health statuses
+	for name, service := range h.services {
+		status := service.HealthStatus()
+		if !status.OK() {
+			overallHostHealth = false
+			healthErrors = append(healthErrors, fmt.Sprintf("[%s] not healthy - %s", name, status.Message()))
+		}
+	}
 
-	isL1Synced := h.enclaveState.InSyncWithL1()
-
-	// Overall health is achieved when all parts are healthy
-	obscuroNodeHealth := p2pHealthy && l1RepoHealthy && enclaveHealthy && isL1Synced
+	if !h.enclaveState.InSyncWithL1() {
+		overallHostHealth = false
+		healthErrors = append(healthErrors, "not in sync with L1")
+	}
 
 	return &hostcommon.HealthCheck{
-		HealthCheckHost: &hostcommon.HealthCheckHost{
-			// P2PStatus: h.p2p().Status(),
-			L1Repo:   l1RepoHealthy,
-			L1Synced: isL1Synced,
-		},
-		HealthCheckEnclave: &hostcommon.HealthCheckEnclave{
-			EnclaveHealthy: enclaveHealthy,
-		},
-		OverallHealth: obscuroNodeHealth,
+		OverallHealth: overallHostHealth,
+		Errors:        healthErrors,
 	}, nil
 }
 


### PR DESCRIPTION
### Why this change is needed

Want to be able to collate health statuses from the various services and combine them in simple generic health status for the host.

Removed some of the counts tracking on the P2P service. P2P is something I think we all agreed we want to continue to improve, I hope we can add back in some stats mechanism when we've got a clearer picture of how it will work long-term.

### What changes were made as part of this PR

Removed typed status on host, replaced with boolean health and list of error messages (that reference the service they came from).
Simplified P2P health checks.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


