### PR TITLE
fix issue with host failing to stop after error

### DIFF
--- a/go/host/host.go
+++ b/go/host/host.go
@@ -359,17 +359,17 @@ func (h *host) Stop() error {
 	time.Sleep(time.Second)
 
 	if err := h.enclaveClient.Stop(); err != nil {
-		return fmt.Errorf("failed to stop enclave server - %w", err)
+		h.logger.Error("failed to stop enclave client", log.ErrKey, err)
 	}
 	if err := h.enclaveClient.StopClient(); err != nil {
-		return fmt.Errorf("failed to stop enclave RPC client - %w", err)
+		h.logger.Error("failed to stop enclave client", log.ErrKey, err)
 	}
 
 	if err := h.db.Stop(); err != nil {
-		return fmt.Errorf("failed to stop DB - %w", err)
+		h.logger.Error("failed to stop DB", log.ErrKey, err)
 	}
 
-	h.logger.Info("Host shut down successfully.")
+	h.logger.Info("Host shut down complete.")
 	return nil
 }
 


### PR DESCRIPTION
### Why this change is needed

Seeing issues with node restart tests that suggested host was failing to stop. In particular I saw failure to stop enclave with client causing an error which meant the host didn't finish stopping.

### What changes were made as part of this PR

Log errors while stopping rather than returning them.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


