### PR TITLE
Put in some logging

### DIFF
--- a/.github/workflows/manual-deploy-testnet-faucet.yml
+++ b/.github/workflows/manual-deploy-testnet-faucet.yml
@@ -33,6 +33,9 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
+      - run: echo "Workflow_dispatch inputs ${{ github.event.inputs.testnet_type }}"
+      - run: echo "Workflow_call inputs     ${{ inputs.testnet_type }}"
+
       - uses: actions/checkout@v3
 
       - name: 'Set up Docker'

--- a/.github/workflows/manual-upgrade-testnet-l2.yml
+++ b/.github/workflows/manual-upgrade-testnet-l2.yml
@@ -12,7 +12,7 @@ name: '[M] Upgrade Testnet L2'
 
 on:
   schedule:
-    - cron: '05 3 * * *'
+    - cron: '05 */2 * * *'
   workflow_dispatch:
     inputs:
       testnet_type:


### PR DESCRIPTION
Calling a re-usable workflow from a schedule _should_ pass in the testnet_type in the inputs context according to all documentation, but it doesn't seem to be working. There are reported bugs of if conditions in re-usable workflows called from a workflow_call, so I want to put in a little more logging and up the schedule to try and fix today. 


