### PR TITLE
More fixes to get the faucet deployment to work when the upgrade workflow is initiated from a schedule event. 

### DIFF
--- a/.github/workflows/manual-deploy-testnet-faucet.yml
+++ b/.github/workflows/manual-deploy-testnet-faucet.yml
@@ -24,7 +24,7 @@ on:
 
   workflow_call:
     inputs:
-      testnet_type:
+      type:
         description: 'Testnet Type'
         required: true
         type: string
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: echo "Workflow_dispatch inputs ${{ github.event.inputs.testnet_type }}"
-      - run: echo "Workflow_call inputs     ${{ inputs.testnet_type }}"
+      - run: echo "Workflow_call inputs     ${{ inputs.type }}"
 
       - uses: actions/checkout@v3
 
@@ -53,7 +53,7 @@ jobs:
         # inputs.testnet_type is set generally i.e. when L2 [deploy | upgrade] of dev-testnet is performed as a
         # result of a schedule. To ensure the faucet is deployed on a scheduled dev-testnet L2 deployment or
         # upgrade we test for both here.
-        if: ${{ (github.event.inputs.testnet_type == 'dev-testnet') || (inputs.testnet_type == 'dev-testnet') }}
+        if: ${{ (github.event.inputs.testnet_type == 'dev-testnet') || (inputs.type == 'dev-testnet') }}
         run: |
           echo "FAUCET_BUILD_TAG=testnetobscuronet.azurecr.io/obscuronet/dev_faucet_testnet:latest" >> $GITHUB_ENV
           echo "TESTNET_ADDR=dev-testnet.obscu.ro" >> $GITHUB_ENV

--- a/.github/workflows/manual-deploy-testnet-faucet.yml
+++ b/.github/workflows/manual-deploy-testnet-faucet.yml
@@ -33,6 +33,9 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
+      - run: echo "Workflow_dispatch inputs ${{ github.event.inputs.testnet_type }}"
+      - run: echo "Workflow_call inputs     ${{ inputs.testnet_type }}"
+
       - uses: actions/checkout@v3
 
       - name: 'Set up Docker'

--- a/.github/workflows/manual-deploy-testnet-faucet.yml
+++ b/.github/workflows/manual-deploy-testnet-faucet.yml
@@ -9,7 +9,7 @@
 #  dev-testnet-faucet or testnet-faucet.uksouth.azurecontainer.io
 
 name: '[M] Deploy Faucet Testnet'
-run-name: '[M] Deploy Faucet Testnet ( ${{ github.event.inputs.testnet_type }} )'
+run-name: '[M] Deploy Faucet Testnet ( ${{ inputs.testnet_type }} )'
 on:
   workflow_dispatch:
     inputs:
@@ -24,8 +24,7 @@ on:
 
   workflow_call:
     inputs:
-      type:
-        description: 'Testnet Type'
+      testnet_type:
         required: true
         type: string
 
@@ -34,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: echo "Workflow_dispatch inputs ${{ github.event.inputs.testnet_type }}"
-      - run: echo "Workflow_call inputs     ${{ inputs.type }}"
+      - run: echo "Workflow_call inputs     ${{ inputs.testnet_type }}"
 
       - uses: actions/checkout@v3
 
@@ -42,18 +41,13 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - name: 'Sets env vars for testnet'
-        if: ${{ github.event.inputs.testnet_type == 'testnet' }}
+        if: ${{ inputs.testnet_type == 'testnet' }}
         run: |
           echo "FAUCET_BUILD_TAG=testnetobscuronet.azurecr.io/obscuronet/faucet_testnet:latest" >> $GITHUB_ENV
           echo "TESTNET_ADDR=testnet.obscu.ro" >> $GITHUB_ENV
 
       - name: 'Sets env vars for dev-testnet'
-        # github.event.inputs.testnet_type is inherited from the L2 [deploy | upgrade] of [testnet | dev-testnet]
-        # when they are called manually.
-        # inputs.testnet_type is set generally i.e. when L2 [deploy | upgrade] of dev-testnet is performed as a
-        # result of a schedule. To ensure the faucet is deployed on a scheduled dev-testnet L2 deployment or
-        # upgrade we test for both here.
-        if: ${{ (github.event.inputs.testnet_type == 'dev-testnet') || (inputs.type == 'dev-testnet') }}
+        if: ${{ inputs.testnet_type == 'dev-testnet' }}
         run: |
           echo "FAUCET_BUILD_TAG=testnetobscuronet.azurecr.io/obscuronet/dev_faucet_testnet:latest" >> $GITHUB_ENV
           echo "TESTNET_ADDR=dev-testnet.obscu.ro" >> $GITHUB_ENV
@@ -79,9 +73,9 @@ jobs:
         uses: 'azure/aci-deploy@v1'
         with:
           resource-group: ${{ secrets.RESOURCE_GROUP }}
-          dns-name-label: ${{ github.event.inputs.testnet_type }}-faucet
+          dns-name-label: ${{ inputs.testnet_type }}-faucet
           image: ${{ env.FAUCET_BUILD_TAG }}
-          name: ${{ github.event.inputs.testnet_type }}-faucet
+          name: ${{ inputs.testnet_type }}-faucet
           location: 'uksouth'
           restart-policy: 'Never'
           environment-variables: PORT=80

--- a/.github/workflows/manual-upgrade-testnet-l2.yml
+++ b/.github/workflows/manual-upgrade-testnet-l2.yml
@@ -12,7 +12,7 @@ name: '[M] Upgrade Testnet L2'
 
 on:
   schedule:
-    - cron: '05 3 * * *'
+    - cron: '05 */2 * * *'
   workflow_dispatch:
     inputs:
       testnet_type:

--- a/.github/workflows/manual-upgrade-testnet-l2.yml
+++ b/.github/workflows/manual-upgrade-testnet-l2.yml
@@ -196,11 +196,22 @@ jobs:
           ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-0-${{needs.build.outputs.RESOURCE_TESTNET_NAME}}-${{needs.build.outputs.VM_BUILD_NUMBER}}.uksouth.cloudapp.azure.com
           ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-1-${{needs.build.outputs.RESOURCE_TESTNET_NAME}}-${{needs.build.outputs.VM_BUILD_NUMBER}}.uksouth.cloudapp.azure.com
 
-  deploy-faucet:
-    name: 'Trigger Faucet deployment for dev- / testnet on a new deployment'
+  deploy-faucet-on-dispatch:
+    name: 'Trigger Faucet deployment for dev- / testnet on a new deployment via dispatch'
     uses: ./.github/workflows/manual-deploy-testnet-faucet.yml
+    if: ${{ (github.event.inputs.testnet_type == 'testnet') }}
     with:
-      type:  ${{ github.event.inputs.testnet_type }}
+      type:  'testnet'
+    secrets: inherit
+    needs:
+      - check-obscuro-is-healthy
+
+  deploy-faucet-on-schedule:
+    name: 'Trigger Faucet deployment for dev- / testnet on a new deployment via schedule'
+    uses: ./.github/workflows/manual-deploy-testnet-faucet.yml
+    if: ${{ (github.event.inputs.testnet_type == 'dev-testnet') || (github.event_name == 'schedule') }}
+    with:
+      type:  'dev-testnet'
     secrets: inherit
     needs:
       - check-obscuro-is-healthy

--- a/.github/workflows/manual-upgrade-testnet-l2.yml
+++ b/.github/workflows/manual-upgrade-testnet-l2.yml
@@ -200,7 +200,7 @@ jobs:
     name: 'Trigger Faucet deployment for dev- / testnet on a new deployment'
     uses: ./.github/workflows/manual-deploy-testnet-faucet.yml
     with:
-      testnet_type: ${{needs.build.outputs.RESOURCE_TESTNET_TYPE}}
+      type: ${{needs.build.outputs.RESOURCE_TESTNET_TYPE}}
     secrets: inherit
     needs:
       - check-obscuro-is-healthy

--- a/.github/workflows/manual-upgrade-testnet-l2.yml
+++ b/.github/workflows/manual-upgrade-testnet-l2.yml
@@ -196,22 +196,11 @@ jobs:
           ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-0-${{needs.build.outputs.RESOURCE_TESTNET_NAME}}-${{needs.build.outputs.VM_BUILD_NUMBER}}.uksouth.cloudapp.azure.com
           ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-1-${{needs.build.outputs.RESOURCE_TESTNET_NAME}}-${{needs.build.outputs.VM_BUILD_NUMBER}}.uksouth.cloudapp.azure.com
 
-  deploy-faucet-on-dispatch:
-    name: 'Trigger Faucet deployment for dev- / testnet on a new deployment via dispatch'
+  deploy-faucet:
     uses: ./.github/workflows/manual-deploy-testnet-faucet.yml
-    if: ${{ (github.event.inputs.testnet_type == 'testnet') }}
+    if: ${{github.event_name == 'workflow_dispatch'}}
     with:
-      type:  'testnet'
-    secrets: inherit
-    needs:
-      - check-obscuro-is-healthy
-
-  deploy-faucet-on-schedule:
-    name: 'Trigger Faucet deployment for dev- / testnet on a new deployment via schedule'
-    uses: ./.github/workflows/manual-deploy-testnet-faucet.yml
-    if: ${{ (github.event.inputs.testnet_type == 'dev-testnet') || (github.event_name == 'schedule') }}
-    with:
-      type:  'dev-testnet'
+      type:  ${{github.event.inputs.testnet_type}}
     secrets: inherit
     needs:
       - check-obscuro-is-healthy

--- a/.github/workflows/manual-upgrade-testnet-l2.yml
+++ b/.github/workflows/manual-upgrade-testnet-l2.yml
@@ -12,7 +12,7 @@ name: '[M] Upgrade Testnet L2'
 
 on:
   schedule:
-    - cron: '05 */2 * * *'
+    - cron: '05 3 * * *'
   workflow_dispatch:
     inputs:
       testnet_type:
@@ -34,7 +34,6 @@ jobs:
       RESOURCE_TAG_NAME: ${{ steps.outputVars.outputs.RESOURCE_TAG_NAME }}
       RESOURCE_STARTING_NAME: ${{ steps.outputVars.outputs.RESOURCE_STARTING_NAME }}
       RESOURCE_TESTNET_NAME: ${{ steps.outputVars.outputs.RESOURCE_TESTNET_NAME }}
-      RESOURCE_TESTNET_TYPE: ${{ steps.outputVars.outputs.RESOURCE_TESTNET_TYPE }}
       L1_HOST: ${{ steps.outputVars.outputs.L1_HOST }}
       VM_BUILD_NUMBER: ${{ steps.outputVars.outputs.VM_BUILD_NUMBER }}
 
@@ -58,7 +57,6 @@ jobs:
           echo "RESOURCE_TAG_NAME=testnetlatest" >> $GITHUB_ENV
           echo "RESOURCE_STARTING_NAME=T" >> $GITHUB_ENV
           echo "RESOURCE_TESTNET_NAME=testnet" >> $GITHUB_ENV
-          echo "RESOURCE_TESTNET_TYPE=testnet" >> $GITHUB_ENV
           echo "L1_HOST=testnet-eth2network.uksouth.cloudapp.azure.com" >> $GITHUB_ENV
           
       - name: 'Sets env vars for dev-testnet'
@@ -69,7 +67,6 @@ jobs:
           echo "RESOURCE_TAG_NAME=devtestnetlatest" >> $GITHUB_ENV
           echo "RESOURCE_STARTING_NAME=D" >> $GITHUB_ENV
           echo "RESOURCE_TESTNET_NAME=devtestnet" >> $GITHUB_ENV
-          echo "RESOURCE_TESTNET_TYPE=dev-testnet" >> $GITHUB_ENV
           echo "L1_HOST=dev-testnet-eth2network.uksouth.cloudapp.azure.com" >> $GITHUB_ENV
 
       - name: 'Fetch latest VM hostnames by env tag and extract build number'
@@ -93,7 +90,6 @@ jobs:
           echo "RESOURCE_TAG_NAME=${{env.RESOURCE_TAG_NAME}}" >> $GITHUB_OUTPUT
           echo "RESOURCE_STARTING_NAME=${{env.RESOURCE_STARTING_NAME}}" >> $GITHUB_OUTPUT
           echo "RESOURCE_TESTNET_NAME=${{env.RESOURCE_TESTNET_NAME}}" >> $GITHUB_OUTPUT
-          echo "RESOURCE_TESTNET_TYPE=${{env.RESOURCE_TESTNET_TYPE}}" >> $GITHUB_OUTPUT
           echo "L1_HOST=${{env.L1_HOST}}" >> $GITHUB_OUTPUT
           echo "VM_BUILD_NUMBER=${{env.VM_BUILD_NUMBER}}" >> $GITHUB_OUTPUT
 
@@ -196,7 +192,7 @@ jobs:
           ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-0-${{needs.build.outputs.RESOURCE_TESTNET_NAME}}-${{needs.build.outputs.VM_BUILD_NUMBER}}.uksouth.cloudapp.azure.com
           ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-1-${{needs.build.outputs.RESOURCE_TESTNET_NAME}}-${{needs.build.outputs.VM_BUILD_NUMBER}}.uksouth.cloudapp.azure.com
 
-  deploy-faucet-dispatch:
+  deploy-faucet-on-dispatch:
     uses: ./.github/workflows/manual-deploy-testnet-faucet.yml
     if: ${{ github.event_name == 'workflow_dispatch' }}
     with:
@@ -205,7 +201,7 @@ jobs:
     needs:
       - check-obscuro-is-healthy
 
-  deploy-faucet-schedule:
+  deploy-faucet-on-schedule:
     uses: ./.github/workflows/manual-deploy-testnet-faucet.yml
     if: ${{ github.event_name == 'schedule' }}
     with:
@@ -214,10 +210,10 @@ jobs:
     needs:
       - check-obscuro-is-healthy
 
-  obscuro-test-repository-dispatch:
+  obscuro-test-signal-on-dispatch:
     runs-on: ubuntu-latest
     needs:
-      - deploy-faucet-dispatch
+      - deploy-faucet-on-dispatch
     steps:
       - name: 'Send a repository dispatch to obscuro-test on upgrade of dev-testnet'
         if: ${{ github.event.inputs.testnet_type == 'dev-testnet' }}
@@ -229,10 +225,10 @@ jobs:
         run: |
           curl -XPOST -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" -H "Accept:application/vnd.github" -H "Content-Type:application/json" https://api.github.com/repos/obscuronet/obscuro-test/dispatches --data '{ "event_type": "testnet_upgraded", "client_payload": { "ref": "${{ github.ref_name }}" }'
 
-  obscuro-test-repository-schedule:
+  obscuro-test-signal-on-schedule:
     runs-on: ubuntu-latest
     needs:
-      - deploy-faucet-schedule
+      - deploy-faucet-on-schedule
     steps:
       - name: 'Send a repository dispatch to obscuro-test on upgrade of dev-testnet'
         run: |

--- a/.github/workflows/manual-upgrade-testnet-l2.yml
+++ b/.github/workflows/manual-upgrade-testnet-l2.yml
@@ -200,7 +200,7 @@ jobs:
     uses: ./.github/workflows/manual-deploy-testnet-faucet.yml
     if: ${{github.event_name == 'workflow_dispatch'}}
     with:
-      type:  ${{github.event.inputs.testnet_type}}
+      type:  'dev-testnet'
     secrets: inherit
     needs:
       - check-obscuro-is-healthy

--- a/.github/workflows/manual-upgrade-testnet-l2.yml
+++ b/.github/workflows/manual-upgrade-testnet-l2.yml
@@ -200,7 +200,7 @@ jobs:
     name: 'Trigger Faucet deployment for dev- / testnet on a new deployment'
     uses: ./.github/workflows/manual-deploy-testnet-faucet.yml
     with:
-      type: ${{needs.build.outputs.RESOURCE_TESTNET_TYPE}}
+      type:  ${{ github.event.inputs.testnet_type }}
     secrets: inherit
     needs:
       - check-obscuro-is-healthy

--- a/.github/workflows/manual-upgrade-testnet-l2.yml
+++ b/.github/workflows/manual-upgrade-testnet-l2.yml
@@ -196,9 +196,18 @@ jobs:
           ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-0-${{needs.build.outputs.RESOURCE_TESTNET_NAME}}-${{needs.build.outputs.VM_BUILD_NUMBER}}.uksouth.cloudapp.azure.com
           ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-1-${{needs.build.outputs.RESOURCE_TESTNET_NAME}}-${{needs.build.outputs.VM_BUILD_NUMBER}}.uksouth.cloudapp.azure.com
 
-  deploy-faucet:
+  deploy-faucet-dispatch:
     uses: ./.github/workflows/manual-deploy-testnet-faucet.yml
-    if: ${{github.event_name == 'workflow_dispatch'}}
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    with:
+      testnet_type:  ${{ github.event.inputs.testnet_type }}
+    secrets: inherit
+    needs:
+      - check-obscuro-is-healthy
+
+  deploy-faucet-schedule:
+    uses: ./.github/workflows/manual-deploy-testnet-faucet.yml
+    if: ${{ github.event_name == 'schedule' }}
     with:
       testnet_type:  'dev-testnet'
     secrets: inherit
@@ -208,14 +217,23 @@ jobs:
   obscuro-test-repository-dispatch:
     runs-on: ubuntu-latest
     needs:
-      - deploy-faucet
+      - deploy-faucet-dispatch
     steps:
       - name: 'Send a repository dispatch to obscuro-test on upgrade of dev-testnet'
-        if: ${{ (github.event.inputs.testnet_type == 'dev-testnet') || (github.event_name == 'schedule') }}
+        if: ${{ github.event.inputs.testnet_type == 'dev-testnet' }}
         run: |
           curl -XPOST -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" -H "Accept:application/vnd.github" -H "Content-Type:application/json" https://api.github.com/repos/obscuronet/obscuro-test/dispatches --data '{ "event_type": "dev_testnet_upgraded", "client_payload": { "ref": "${{ github.ref_name }}" }'
 
       - name: 'Send a repository dispatch to obscuro-test on upgrade of testnet'
-        if: ${{ (github.event.inputs.testnet_type == 'testnet') }}
+        if: ${{ github.event.inputs.testnet_type == 'testnet' }}
         run: |
           curl -XPOST -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" -H "Accept:application/vnd.github" -H "Content-Type:application/json" https://api.github.com/repos/obscuronet/obscuro-test/dispatches --data '{ "event_type": "testnet_upgraded", "client_payload": { "ref": "${{ github.ref_name }}" }'
+
+  obscuro-test-repository-schedule:
+    runs-on: ubuntu-latest
+    needs:
+      - deploy-faucet-schedule
+    steps:
+      - name: 'Send a repository dispatch to obscuro-test on upgrade of dev-testnet'
+        run: |
+          curl -XPOST -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" -H "Accept:application/vnd.github" -H "Content-Type:application/json" https://api.github.com/repos/obscuronet/obscuro-test/dispatches --data '{ "event_type": "dev_testnet_upgraded", "client_payload": { "ref": "${{ github.ref_name }}" }'

--- a/.github/workflows/manual-upgrade-testnet-l2.yml
+++ b/.github/workflows/manual-upgrade-testnet-l2.yml
@@ -200,7 +200,7 @@ jobs:
     uses: ./.github/workflows/manual-deploy-testnet-faucet.yml
     if: ${{github.event_name == 'workflow_dispatch'}}
     with:
-      type:  'dev-testnet'
+      testnet_type:  'dev-testnet'
     secrets: inherit
     needs:
       - check-obscuro-is-healthy


### PR DESCRIPTION
Fixes to get the workflow_call working when the calling workflow is started from a schedule. This required the following;

1. The faucet workflow should use the inputs context, and not inherit the events.inputs context as this is only set when the calling workflow is started from a workflow_dispatch (i.e. manually through the portal). The inputs context is shared across both workflow_dispatch and workflow_calls. 
2. The upgrade workflow has to have two streams for the faucet deployment, and for sending the repository dispatch to the E2E tests. It looks like the build output approach cannot be used for a reason that is unclear to me (perhaps a bug in the workflow actions) - it is not passed through when referenced as an input in the workflow call. 

