### PR TITLE
Ensure Error fields on encl RPC resp are captured

### DIFF
--- a/go/host/rpc/enclaverpc/enclave_client.go
+++ b/go/host/rpc/enclaverpc/enclave_client.go
@@ -134,11 +134,13 @@ func (c *Client) InitEnclave(secret common.EncryptedSharedEnclaveSecret) common.
 	timeoutCtx, cancel := context.WithTimeout(context.Background(), c.config.EnclaveRPCTimeout)
 	defer cancel()
 
-	_, err := c.protoClient.InitEnclave(timeoutCtx, &generated.InitEnclaveRequest{EncryptedSharedEnclaveSecret: secret})
+	response, err := c.protoClient.InitEnclave(timeoutCtx, &generated.InitEnclaveRequest{EncryptedSharedEnclaveSecret: secret})
 	if err != nil {
 		return syserr.NewRPCError(err)
 	}
-
+	if response != nil && response.SystemError != nil {
+		return syserr.NewInternalError(fmt.Errorf("%s", response.SystemError.ErrorString))
+	}
 	return nil
 }
 
@@ -190,9 +192,12 @@ func (c *Client) SubmitBatch(batch *common.ExtBatch) common.SystemError {
 	defer cancel()
 
 	batchMsg := rpc.ToExtBatchMsg(batch)
-	_, err := c.protoClient.SubmitBatch(timeoutCtx, &generated.SubmitBatchRequest{Batch: &batchMsg})
+	response, err := c.protoClient.SubmitBatch(timeoutCtx, &generated.SubmitBatchRequest{Batch: &batchMsg})
 	if err != nil {
 		return syserr.NewRPCError(err)
+	}
+	if response != nil && response.SystemError != nil {
+		return syserr.NewInternalError(fmt.Errorf("%s", response.SystemError.ErrorString))
 	}
 	return nil
 }
@@ -235,9 +240,12 @@ func (c *Client) Stop() common.SystemError {
 	timeoutCtx, cancel := context.WithTimeout(context.Background(), c.config.EnclaveRPCTimeout)
 	defer cancel()
 
-	_, err := c.protoClient.Stop(timeoutCtx, &generated.StopRequest{})
+	response, err := c.protoClient.Stop(timeoutCtx, &generated.StopRequest{})
 	if err != nil {
 		return syserr.NewRPCError(fmt.Errorf("could not stop enclave: %w", err))
+	}
+	if response != nil && response.SystemError != nil {
+		return syserr.NewInternalError(fmt.Errorf("%s", response.SystemError.ErrorString))
 	}
 	return nil
 }
@@ -311,12 +319,15 @@ func (c *Client) Subscribe(id gethrpc.ID, encryptedParams common.EncryptedParams
 	timeoutCtx, cancel := context.WithTimeout(context.Background(), c.config.EnclaveRPCTimeout)
 	defer cancel()
 
-	_, err := c.protoClient.Subscribe(timeoutCtx, &generated.SubscribeRequest{
+	response, err := c.protoClient.Subscribe(timeoutCtx, &generated.SubscribeRequest{
 		Id:                    []byte(id),
 		EncryptedSubscription: encryptedParams,
 	})
 	if err != nil {
 		return syserr.NewRPCError(err)
+	}
+	if response != nil && response.SystemError != nil {
+		return syserr.NewInternalError(fmt.Errorf("%s", response.SystemError.ErrorString))
 	}
 	return nil
 }
@@ -325,11 +336,14 @@ func (c *Client) Unsubscribe(id gethrpc.ID) common.SystemError {
 	timeoutCtx, cancel := context.WithTimeout(context.Background(), c.config.EnclaveRPCTimeout)
 	defer cancel()
 
-	_, err := c.protoClient.Unsubscribe(timeoutCtx, &generated.UnsubscribeRequest{
+	response, err := c.protoClient.Unsubscribe(timeoutCtx, &generated.UnsubscribeRequest{
 		Id: []byte(id),
 	})
 	if err != nil {
 		return syserr.NewRPCError(err)
+	}
+	if response != nil && response.SystemError != nil {
+		return syserr.NewInternalError(fmt.Errorf("%s", response.SystemError.ErrorString))
 	}
 	return nil
 }
@@ -388,7 +402,13 @@ func (c *Client) CreateBatch() common.SystemError {
 	timeoutCtx, cancel := context.WithTimeout(context.Background(), c.config.EnclaveRPCTimeout)
 	defer cancel()
 
-	_, err := c.protoClient.CreateBatch(timeoutCtx, &generated.CreateBatchRequest{})
+	response, err := c.protoClient.CreateBatch(timeoutCtx, &generated.CreateBatchRequest{})
+	if err != nil {
+		return syserr.NewInternalError(err)
+	}
+	if response != nil && response.Error != "" {
+		return syserr.NewInternalError(fmt.Errorf("%s", response.Error))
+	}
 	return err
 }
 


### PR DESCRIPTION
### Why this change is needed

Some errors were being swallowed in transit by the enclave RPC communication.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


