### PR TITLE
Log block hash rather than pointer for fork debug

### DIFF
--- a/go/common/types.go
+++ b/go/common/types.go
@@ -173,3 +173,8 @@ type ChainFork struct {
 func (cf *ChainFork) IsFork() bool {
 	return len(cf.NonCanonicalPath) > 0
 }
+
+func (cf *ChainFork) String() string {
+	return fmt.Sprintf("ChainFork{NewCanonical: %s, OldCanonical: %s, CommonAncestor: %s, CanonicalPath: %s, NonCanonicalPath: %s}",
+		cf.NewCanonical.Hash(), cf.OldCanonical.Hash(), cf.CommonAncestor.Hash(), cf.CanonicalPath, cf.NonCanonicalPath)
+}

--- a/go/enclave/storage/storage.go
+++ b/go/enclave/storage/storage.go
@@ -138,7 +138,7 @@ func (s *storageImpl) FetchBatchByHeight(height uint64) (*core.Batch, error) {
 func (s *storageImpl) StoreBlock(b *types.Block, chainFork *common.ChainFork) error {
 	dbBatch := s.db.NewDBTransaction()
 	if chainFork != nil && chainFork.IsFork() {
-		s.logger.Info(fmt.Sprintf("Fork. %+v.", chainFork))
+		s.logger.Info(fmt.Sprintf("Fork. %s", chainFork))
 		enclavedb.UpdateCanonicalBlocks(dbBatch, chainFork.CanonicalPath, chainFork.NonCanonicalPath)
 	} else {
 		enclavedb.UpdateCanonicalBlocks(dbBatch, nil, nil)


### PR DESCRIPTION
### Why this change is needed

The fork log message is helpful for debugging but it's logging the block pointers instead of their hashes, like:

`INFO [08-01|14:19:36.896] Fork. &{NewCanonical:0x140873ccab0 OldCanonical:0x140873ccb40 CommonAncestor:0x140873ccbd0 CanonicalPath:[] NonCanonicalPath:[0x79e235428ddedfca0eb3c7ee2bf96a1b7328754d0509bc7cc7b4e9006cec954e]}. component=test_log    node_id=0 component=enclave`

After the change the message logs like:

`INFO [08-01|15:27:57.585] Fork. ChainFork{NewCanonical: 0xd434e10119b1e4d4cd98cc4ea432b663005d90ff1d45ba1f2d13612e0f2e8343, OldCanonical: 0xc10e9a09b6ee651e518ecb637f34bd88c9f3b2d7ff33fdd3e7e98e68ae7fe487, CommonAncestor: 0xabaac0fd96bc9fe9a3c143b66de4f862f935cfbf71cfb3975dca1f816839052c, CanonicalPath: [], NonCanonicalPath: [0xc10e9a09b6ee651e518ecb637f34bd88c9f3b2d7ff33fdd3e7e98e68ae7fe487]}. component=test_log    node_id=4 component=enclave`

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


