### PR TITLE
allow enclave to produce handlers for both old and new message types

### DIFF
--- a/go/common/viewingkey/viewing_key.go
+++ b/go/common/viewingkey/viewing_key.go
@@ -97,6 +97,14 @@ func Sign(userPrivKey *ecdsa.PrivateKey, vkPubKey []byte) ([]byte, error) {
 
 // GenerateSignMessage creates the message to be signed
 // vkPubKey is expected to be a []byte("0x....") to create the signing message
+// todo (@ziga) Remove this method once old WE endpoints are removed
 func GenerateSignMessage(vkPubKey []byte) string {
 	return SignedMsgPrefix + hex.EncodeToString(vkPubKey)
+}
+
+// GenerateSignMessageOG creates the message to be signed by Obscuro Gateway (new format)
+// format is expected to be "Register <userID> for <Account>"
+func GenerateSignMessageOG(vkPubKey []byte, addr *gethcommon.Address) string {
+	userID := crypto.Keccak256Hash(vkPubKey).Bytes()
+	return fmt.Sprintf("Register %s for %s", hex.EncodeToString(userID), addr.Hex())
 }

--- a/go/enclave/vkhandler/vk_handler.go
+++ b/go/enclave/vkhandler/vk_handler.go
@@ -25,9 +25,10 @@ type VKHandler struct {
 // New creates a new viewing key handler
 // checks if the signature is valid
 // as well if signature matches account address
+// todo (@ziga) - function now accepts both old and new messages
 func New(requestedAddr *gethcommon.Address, vkPubKeyBytes, accountSignatureHexBytes []byte) (*VKHandler, error) {
 	// Recalculate the message signed by MetaMask.
-	msgToSign := viewingkey.GenerateSignMessage(vkPubKeyBytes)
+	msgToSign := viewingkey.GenerateSignMessageOG(vkPubKeyBytes, requestedAddr)
 
 	// We recover the key based on the signed message and the signature.
 	recoveredAccountPublicKey, err := crypto.SigToPub(accounts.TextHash([]byte(msgToSign)), accountSignatureHexBytes)
@@ -36,8 +37,19 @@ func New(requestedAddr *gethcommon.Address, vkPubKeyBytes, accountSignatureHexBy
 	}
 	recoveredAccountAddress := crypto.PubkeyToAddress(*recoveredAccountPublicKey)
 
+	// We recover the key based on the signed message and the signature (same as before, but with legacy message format "vk"+<vk>"
+	// todo (@ziga) remove this once old WE message format is deprecated
+	msgToSignLegacy := viewingkey.GenerateSignMessage(vkPubKeyBytes)
+	recoveredAccountPublicKeyLegacy, err := crypto.SigToPub(accounts.TextHash([]byte(msgToSignLegacy)), accountSignatureHexBytes)
+	if err != nil {
+		return nil, fmt.Errorf("viewing key but could not validate its signature - %w", err)
+	}
+	recoveredAccountAddressLegacy := crypto.PubkeyToAddress(*recoveredAccountPublicKeyLegacy)
+
 	// is the requested account address the same as the address recovered from the signature
-	if requestedAddr.Hash() != recoveredAccountAddress.Hash() {
+	// todo (@ziga) - we currently check also for legacy address and allow both (remove this after transition period)
+	if requestedAddr.Hash() != recoveredAccountAddress.Hash() &&
+		requestedAddr.Hash() != recoveredAccountAddressLegacy.Hash() {
 		return nil, ErrInvalidAddressSignature
 	}
 

--- a/go/enclave/vkhandler/vk_handler_test.go
+++ b/go/enclave/vkhandler/vk_handler_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestVKHandler(t *testing.T) {
+func TestVKHandlerWEMessageFormat(t *testing.T) {
 	// generate user private Key
 	userPrivKey, err := crypto.GenerateKey()
 	if err != nil {
@@ -34,7 +34,64 @@ func TestVKHandler(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestSignAndCheckSignature(t *testing.T) {
+func TestVKHandlerOGMessageFormat(t *testing.T) {
+	// generate user private Key
+	userPrivKey, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	userAddr := crypto.PubkeyToAddress(userPrivKey.PublicKey)
+
+	// generate ViewingKey private Key
+	vkPrivKey, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	vkPubKeyBytes := crypto.CompressPubkey(ecies.ImportECDSAPublic(&vkPrivKey.PublicKey).ExportECDSA())
+
+	// Sign key
+	msgToSign := viewingkey.GenerateSignMessageOG(vkPubKeyBytes, &userAddr)
+	signature, err := crypto.Sign(accounts.TextHash([]byte(msgToSign)), userPrivKey)
+	assert.NoError(t, err)
+
+	// Create a new vk Handler
+	_, err = New(&userAddr, vkPubKeyBytes, signature)
+	assert.NoError(t, err)
+}
+
+func TestSignAndCheckSignatureOGMessageFormat(t *testing.T) {
+	// generate user private Key
+	userPrivKey, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	userAddr := crypto.PubkeyToAddress(userPrivKey.PublicKey)
+
+	// generate ViewingKey private Key
+	vkPrivKey, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	vkPubKeyByte := crypto.CompressPubkey(ecies.ImportECDSAPublic(&vkPrivKey.PublicKey).ExportECDSA())
+	// sign the message
+	msgToSign := viewingkey.GenerateSignMessageOG(vkPubKeyByte, &userAddr)
+	signature, err := crypto.Sign(accounts.TextHash([]byte(msgToSign)), userPrivKey)
+	assert.NoError(t, err)
+
+	// Recover the key based on the signed message and the signature.
+	recoveredAccountPublicKey, err := crypto.SigToPub(accounts.TextHash([]byte(msgToSign)), signature)
+	assert.NoError(t, err)
+	recoveredAccountAddress := crypto.PubkeyToAddress(*recoveredAccountPublicKey)
+
+	if recoveredAccountAddress.Hex() != userAddr.Hex() {
+		t.Errorf("unable to recover user address from signature")
+	}
+
+	_, err = crypto.DecompressPubkey(vkPubKeyByte)
+	assert.NoError(t, err)
+}
+
+func TestSignAndCheckSignatureWEMessageFormat(t *testing.T) {
 	// generate user private Key
 	userPrivKey, err := crypto.GenerateKey()
 	if err != nil {


### PR DESCRIPTION
### Why this change is needed

This change is needed, because current implementation only allows for old message formats signed by users (`vk<vk>`) and returns following error for new format used by Obscuro Gateway `Register <userID> for <account>`.

`unable to create VK encryptor - unable to create vk encryption for request - invalid viewing key signature for requested address`

For the transition period I want to allow all formats not to break compatibility with WE and will delete the support when WE endpoints are removed and Obscuro Gateway is the only way to use it.

### What changes were made as part of this PR

Changes in the constructor for `VKHandler` + added and updated tests

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


