### PR TITLE
add hash integrity checks

### DIFF
--- a/go/common/batches.go
+++ b/go/common/batches.go
@@ -22,7 +22,13 @@ type ExtBatch struct {
 // The hash is computed on the first call and cached thereafter.
 func (b *ExtBatch) Hash() L2BatchHash {
 	if hash := b.hash.Load(); hash != nil {
-		return hash.(L2BatchHash)
+		// todo (tudor) - remove this
+		v := b.Header.Hash()
+		cv := hash.(L2BatchHash)
+		if v != cv {
+			panic("cached ExtBatch hash is wrong!")
+		}
+		return v
 	}
 	v := b.Header.Hash()
 	b.hash.Store(v)

--- a/go/enclave/core/batch.go
+++ b/go/enclave/core/batch.go
@@ -25,7 +25,13 @@ type Batch struct {
 // The hash is computed on the first call and cached thereafter.
 func (b *Batch) Hash() common.L2BatchHash {
 	if hash := b.hash.Load(); hash != nil {
-		return hash.(common.L2BatchHash)
+		// todo (tudor) - remove this
+		v := b.Header.Hash()
+		cv := hash.(common.L2BatchHash)
+		if v != cv {
+			panic("cached Batch hash is wrong!")
+		}
+		return v
 	}
 	v := b.Header.Hash()
 	b.hash.Store(v)

--- a/go/enclave/storage/enclavedb/batch.go
+++ b/go/enclave/storage/enclavedb/batch.go
@@ -27,7 +27,8 @@ const (
 	bInsert             = "insert into batch values (?,?,?,?,?,?,?,?,?)"
 	updateBatchExecuted = "update batch set executed=true where hash=?"
 
-	selectBatch  = "select b.header, bb.content from batch b join batch_body bb on b.body=bb.hash"
+	// todo - (tudor) - remove the hash
+	selectBatch  = "select b.hash, b.header, bb.content from batch b join batch_body bb on b.body=bb.hash"
 	selectHeader = "select b.header from batch b"
 
 	txExecInsert      = "insert into exec_tx values "
@@ -199,14 +200,15 @@ func ReadHeadBatchForBlock(db *sql.DB, l1Hash common.L1BlockHash) (*core.Batch, 
 }
 
 func fetchBatch(db *sql.DB, whereQuery string, args ...any) (*core.Batch, error) {
+	var hashBytes []byte
 	var header string
 	var body []byte
 	query := selectBatch + " " + whereQuery
 	var err error
 	if len(args) > 0 {
-		err = db.QueryRow(query, args...).Scan(&header, &body)
+		err = db.QueryRow(query, args...).Scan(&hashBytes, &header, &body)
 	} else {
-		err = db.QueryRow(query).Scan(&header, &body)
+		err = db.QueryRow(query).Scan(&hashBytes, &header, &body)
 	}
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -224,6 +226,12 @@ func fetchBatch(db *sql.DB, whereQuery string, args ...any) (*core.Batch, error)
 		return nil, fmt.Errorf("could not decode L2 transactions %v. Cause: %w", body, err)
 	}
 
+	// todo - tudor - remove once fixed
+	hash := common.L2BatchHash{}
+	hash.SetBytes(hashBytes)
+	if h.Hash() != hash {
+		panic("The hash of the batch stored in the db is invalid")
+	}
 	return &core.Batch{
 		Header:       h,
 		Transactions: *txs,
@@ -246,9 +254,10 @@ func fetchBatches(db *sql.DB, whereQuery string, args ...any) ([]*core.Batch, er
 		return nil, err
 	}
 	for rows.Next() {
+		var hashBytes []byte
 		var header string
 		var body []byte
-		err := rows.Scan(&header, &body)
+		err := rows.Scan(&hashBytes, &header, &body)
 		if err != nil {
 			return nil, err
 		}
@@ -259,6 +268,12 @@ func fetchBatches(db *sql.DB, whereQuery string, args ...any) ([]*core.Batch, er
 		txs := new([]*common.L2Tx)
 		if err := rlp.DecodeBytes(body, txs); err != nil {
 			return nil, fmt.Errorf("could not decode L2 transactions %v. Cause: %w", body, err)
+		}
+		// todo - tudor - remove once fixed
+		hash := common.L2BatchHash{}
+		hash.SetBytes(hashBytes)
+		if h.Hash() != hash {
+			panic("The hash of the batch stored in the db is invalid")
 		}
 
 		result = append(result,

--- a/integration/simulation/simulation_in_mem_test.go
+++ b/integration/simulation/simulation_in_mem_test.go
@@ -26,7 +26,7 @@ func TestInMemoryMonteCarloSimulation(t *testing.T) {
 	simParams := params.SimParams{
 		NumberOfNodes: numberOfNodes,
 		//  todo (#718) - try reducing this back to 50 milliseconds once faster-finality model is optimised
-		AvgBlockDuration:          100 * time.Millisecond,
+		AvgBlockDuration:          125 * time.Millisecond,
 		SimulationTime:            30 * time.Second,
 		L1EfficiencyThreshold:     0.2,
 		L2EfficiencyThreshold:     0.5,


### PR DESCRIPTION
### Why this change is needed

Temporary add hash integrity checks.
These will affect performance, but will hopefully help investigate issues

### What changes were made as part of this PR

panic if there are unexpected mutations

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


