### PR TITLE
Fix encoding of userID

### DIFF
--- a/tools/walletextension/api/routes.go
+++ b/tools/walletextension/api/routes.go
@@ -160,7 +160,7 @@ func ethRequestHandler(walletExt *walletextension.WalletExtension, conn userconn
 	hexUserID, err := getQueryParameter(conn.ReadRequestParams(), common.UserQueryParameter)
 	if err != nil {
 		walletExt.Logger().Error(fmt.Errorf("user not found in the query params: %w. Using the default user", err).Error())
-		hexUserID = common.DefaultUser // todo (@ziga) - this can be removed once old WE endpoints are removed
+		hexUserID = hex.EncodeToString([]byte(common.DefaultUser)) // todo (@ziga) - this can be removed once old WE endpoints are removed
 	}
 
 	// todo (@pedro) remove this conn dependency

--- a/tools/walletextension/container/walletextension_container.go
+++ b/tools/walletextension/container/walletextension_container.go
@@ -51,7 +51,7 @@ func NewWalletExtensionContainerFromConfig(config config.Config, logger gethlog.
 	// todo (@ziga) - implement lazy loading for clients to reduce number of connections and speed up loading
 
 	// add default user (when no UserID is provided in the query parameter - for WE endpoints)
-	userAccountManager.AddAndReturnAccountManager(wecommon.DefaultUser)
+	userAccountManager.AddAndReturnAccountManager(hex.EncodeToString([]byte(wecommon.DefaultUser)))
 
 	// get all users and their private keys from the database
 	allUsers, err := databaseStorage.GetAllUsers()

--- a/tools/walletextension/container/walletextension_container.go
+++ b/tools/walletextension/container/walletextension_container.go
@@ -61,7 +61,7 @@ func NewWalletExtensionContainerFromConfig(config config.Config, logger gethlog.
 
 	// iterate over users create accountManagers and add all accounts to them per user
 	for _, user := range allUsers {
-		currentUserAccountManager := userAccountManager.AddAndReturnAccountManager(string(user.UserID))
+		currentUserAccountManager := userAccountManager.AddAndReturnAccountManager(hex.EncodeToString(user.UserID))
 
 		accounts, err := databaseStorage.GetAccounts(user.UserID)
 		if err != nil {

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -138,7 +138,7 @@ func (w *WalletExtension) SubmitViewingKey(address gethcommon.Address, signature
 	if err != nil {
 		return fmt.Errorf("failed to create encrypted RPC client for account %s - %w", address, err)
 	}
-	defaultAccountManager, err := w.userAccountManager.GetUserAccountManager(common.DefaultUser)
+	defaultAccountManager, err := w.userAccountManager.GetUserAccountManager(hex.EncodeToString([]byte(common.DefaultUser)))
 	if err != nil {
 		return fmt.Errorf(fmt.Sprintf("error getting default user account manager: %s", err))
 	}


### PR DESCRIPTION
### Why this change is needed

In the Obscuro Gateway userID is generated as hash of a publicKey.
It is stored in the database (and returned from it) as []byte, however users use hex-encoded version of it in the query parameter and the same hex format is used also in UserAccountManager `make(map[string]*accountmanager.AccountManager)`.

There is a special userID (`defaultUser`) which is needed to support old Wallet Extension endpoints (for now - and will be removed in the future). It is saved as a constant string in the code (and is also added to the database as all other users).  This string also needs to be hex encoded to standardise things and avoid additional if statements in multiple places for that default user.


### What changes were made as part of this PR

There was a mistake in the encoding when loading all clients at the startup (which caused them to have different name in the map of account managers) and were because of this not used correctly.
`
for _, user := range allUsers {
		currentUserAccountManager := userAccountManager.AddAndReturnAccountManager(string(user.UserID))
`

Here `user.UserID` needs to be encoded as `hex.EncodeToString`.
Encoding `defaultUser` the same way on all the places is also needed to avoid mismatch between hex encoded and non-hex encoded default user (as it is also loaded from the database as all other users)

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


