### PR TITLE
Reduce retention to 1 day on failure only

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Store simulation logs
         uses: actions/upload-artifact@v3
-        if: always()
+        if: failure()
         with:
           name: ci-logs
           path: |
@@ -41,6 +41,6 @@ jobs:
             integration/.build/noderunner/noderunner-*.txt
             integration/.build/wallet_extension/wal-ext-*.txt
             integration/.build/eth2/*
-          retention-days: 2
+          retention-days: 1
 
 


### PR DESCRIPTION
### Why this change is needed

We regularly fill up our usage on actions storage and it looks like the ci-logs are the culprit. This PR only uploads the logs as artifacts on failure, and only with a retention of 1 day. 
