### PR TITLE
Fix bug with unexecuted batch data

### DIFF
--- a/go/enclave/enclave_test.go
+++ b/go/enclave/enclave_test.go
@@ -462,7 +462,11 @@ func createFakeGenesis(enclave common.Enclave, addresses []genesis.Account) erro
 	genesisBatch := dummyBatch(blk.Hash(), common.L2GenesisHeight, genesisPreallocStateDB)
 
 	// We update the database
-	return enclave.(*enclaveImpl).storage.StoreBatch(genesisBatch)
+	err = enclave.(*enclaveImpl).storage.StoreBatch(genesisBatch)
+	if err != nil {
+		return err
+	}
+	return enclave.(*enclaveImpl).storage.StoreExecutedBatch(genesisBatch, nil)
 }
 
 func dummyBatch(blkHash gethcommon.Hash, height uint64, state *state.StateDB) *core.Batch {

--- a/go/enclave/storage/enclavedb/batch.go
+++ b/go/enclave/storage/enclavedb/batch.go
@@ -170,7 +170,7 @@ func ReadBatchHeader(db *sql.DB, hash gethcommon.Hash) (*common.BatchHeader, err
 
 // todo - is there a better way to write this query?
 func ReadCurrentHeadBatch(db *sql.DB) (*core.Batch, error) {
-	return fetchBatch(db, " where b.is_canonical and b.height=(select max(b1.height) from batch b1 where b1.is_canonical)")
+	return fetchBatch(db, " where b.is_canonical and b.height=(select max(b1.height) from batch b1 where b1.is_canonical and b1.executed)")
 }
 
 func ReadBatchesByBlock(db *sql.DB, hash common.L1BlockHash) ([]*core.Batch, error) {
@@ -195,7 +195,7 @@ func ReadCurrentSequencerNo(db *sql.DB) (*big.Int, error) {
 }
 
 func ReadHeadBatchForBlock(db *sql.DB, l1Hash common.L1BlockHash) (*core.Batch, error) {
-	query := " where is_canonical and b.height=(select max(b1.height) from batch b1 where b1.is_canonical and b1.l1_proof=?)"
+	query := " where is_canonical and b.height=(select max(b1.height) from batch b1 where b1.is_canonical and b1.executed and b1.l1_proof=?)"
 	return fetchBatch(db, query, l1Hash.Bytes())
 }
 

--- a/go/enclave/storage/init/edgelessdb/001_init.sql
+++ b/go/enclave/storage/init/edgelessdb/001_init.sql
@@ -80,7 +80,7 @@ create table if not exists obsdb.batch
     header       blob,
     body         binary(32),
     l1_proof     binary(32),
-    executed     boolean,
+    is_executed     boolean,
     INDEX (parent),
     INDEX (body),
     INDEX (l1_proof),

--- a/go/enclave/storage/init/sqlite/001_init.sql
+++ b/go/enclave/storage/init/sqlite/001_init.sql
@@ -64,9 +64,9 @@ create table if not exists batch
     header       blob,
     body         binary(32) REFERENCES batch_body,
     l1_proof     binary(32), -- normally this would be a FK, but there is a weird edge case where an L2 node might not have the block used to create this batch
-    executed     boolean
+    is_executed     boolean
 --   the unique constraint is commented for now because there might be multiple non-canonical batches for the same height
---   unique (height, is_canonical, executed)
+--   unique (height, is_canonical, is_executed)
 );
 create index IDX_BATCH_HEIGHT on batch (height);
 create index IDX_BATCH_SEQ on batch (sequence);

--- a/integration/networktest/runner.go
+++ b/integration/networktest/runner.go
@@ -32,7 +32,7 @@ func Run(testName string, t *testing.T, env Environment, action Action) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	time.Sleep(2 * time.Second) // allow time for latest test transactions to propagate todo (@matt) consider how to configure this sleep
+	time.Sleep(45 * time.Second) // allow time for latest test transactions to propagate todo (@matt) consider how to configure this sleep
 	fmt.Println("Verifying test:", testName)
 	err = action.Verify(ctx, network)
 	if err != nil {

--- a/integration/networktest/runner.go
+++ b/integration/networktest/runner.go
@@ -32,7 +32,7 @@ func Run(testName string, t *testing.T, env Environment, action Action) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	time.Sleep(45 * time.Second) // allow time for latest test transactions to propagate todo (@matt) consider how to configure this sleep
+	time.Sleep(2 * time.Second) // allow time for latest test transactions to propagate todo (@matt) consider how to configure this sleep
 	fmt.Println("Verifying test:", testName)
 	err = action.Verify(ctx, network)
 	if err != nil {


### PR DESCRIPTION
### Why this change is needed

We were hitting errors because couldn't find state for unexecuted batches.

Needed to exclude unexecuted batches from data queries.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


