### PR TITLE
Avoid panics when sequencer host thinks it is behind the enclave

### DIFF
--- a/go/host/enclave/guardian.go
+++ b/go/host/enclave/guardian.go
@@ -350,6 +350,9 @@ func (g *Guardian) catchupWithL1() error {
 func (g *Guardian) catchupWithL2() error {
 	// while we are behind the L2 head and still running:
 	for g.running.Load() && g.state.GetStatus() == L2Catchup {
+		if g.hostData.IsSequencer {
+			return errors.New("l2 catchup is not supported for sequencer")
+		}
 		// request the next batch by sequence number (based on what the enclave has been fed so far)
 		prevHead := g.state.GetEnclaveL2Head()
 		nextHead := prevHead.Add(prevHead, big.NewInt(1))


### PR DESCRIPTION
### Why this change is needed

Sometimes we hit the following panic while running:
`enclave service is not a validator but validator was requested!`

This is caused by the host attempting to submit a batch to a sequencer enclave. This seems to be caused by the host briefly flickering into an L2 catch-up state because it thinks it is behind on batches (which shouldn't be possible for the sequencer).

### What changes were made as part of this PR

Avoid L2 catchup in the sequencer host so we do not panic. Instead log a warning so we  have visibility to better understand why this is happening.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


