### PR TITLE
use compressed pub key

### DIFF
--- a/tools/walletextension/common/common.go
+++ b/tools/walletextension/common/common.go
@@ -16,11 +16,11 @@ import (
 
 var authenticateMessageRegex = regexp.MustCompile(MessageFormatRegex)
 
-// PublicKeyBytesFromPrivateKey converts *ecies.PrivateKey to []bytes
-func PublicKeyBytesFromPrivateKey(prvKey *ecies.PrivateKey) []byte {
+// PrivateKeyToCompressedPubKey converts *ecies.PrivateKey to compressed PubKey ([]byte with length 33)
+func PrivateKeyToCompressedPubKey(prvKey *ecies.PrivateKey) []byte {
 	ecdsaPublicKey := prvKey.PublicKey.ExportECDSA()
-	pubKeyBytes := crypto.FromECDSAPub(ecdsaPublicKey)
-	return pubKeyBytes
+	compressedPubKey := crypto.CompressPubkey(ecdsaPublicKey)
+	return compressedPubKey
 }
 
 // BytesToPrivateKey converts []bytes to *ecies.PrivateKey
@@ -74,7 +74,7 @@ func CreateEncClient(hostRPCBindAddr string, addressBytes []byte, privateKeyByte
 	vk := &viewingkey.ViewingKey{
 		Account:    &address,
 		PrivateKey: privateKey,
-		PublicKey:  PublicKeyBytesFromPrivateKey(privateKey),
+		PublicKey:  PrivateKeyToCompressedPubKey(privateKey),
 		Signature:  signature,
 	}
 	encClient, err := rpc.NewEncNetworkClient(hostRPCBindAddr, vk, nil)

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -176,7 +176,7 @@ func (w *WalletExtension) GenerateAndStoreNewUser() (string, error) {
 	}
 
 	// create UserID and store it in the database with the private key
-	userID := common.CalculateUserID(common.PublicKeyBytesFromPrivateKey(viewingPrivateKeyEcies))
+	userID := common.CalculateUserID(common.PrivateKeyToCompressedPubKey(viewingPrivateKeyEcies))
 	err = w.storage.AddUser(userID, crypto.FromECDSA(viewingPrivateKeyEcies.ExportECDSA()))
 	if err != nil {
 		w.Logger().Error(fmt.Sprintf("failed to save user to the database: %s", err))


### PR DESCRIPTION
### Why this change is needed

Obscuro Gateway was sending uncompressed public keys to the enclave, which is not optimal (64 bytes vs 33 bytes in each request).
It was also a cause of issues with Obscuro Gateway, since legacy code (Wallet Extension) was using compressed format unlike OG. 
To avoid additional if statements and sending larger messages than necessary I changed a format to compressed (which gets decompressed in the enclave - as with WE).

### What changes were made as part of this PR

Compressed public key is used (in EncRpcClient -> and sent to the enclave)

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


