### PR TITLE
Bug: L1 start hash was overwritten so catching up from genesis

### DIFF
--- a/go/host/enclave/state.go
+++ b/go/host/enclave/state.go
@@ -126,7 +126,12 @@ func (s *StateTracker) OnEnclaveStatus(es common.Status) {
 	s.m.Lock()
 	defer s.m.Unlock()
 	s.enclaveStatusCode = es.StatusCode
-	s.enclaveL1Head = es.L1Head
+	if es.L1Head != gethutil.EmptyHash {
+		// when host starts for the first time it assumes the enclave is at the Obscuro management contract deployment block
+		// this is safe because blocks before then are irrelevant to the Obscuro network.
+		// We don't want to overwrite that value here when the enclave hasn't processed any blocks yet.
+		s.hostL1Head = es.L1Head
+	}
 	s.enclaveL2Head = es.L2Head
 
 	s.setStatus(s.calculateStatus())

--- a/go/host/enclave/state.go
+++ b/go/host/enclave/state.go
@@ -130,7 +130,7 @@ func (s *StateTracker) OnEnclaveStatus(es common.Status) {
 		// when host starts for the first time it assumes the enclave is at the Obscuro management contract deployment block
 		// this is safe because blocks before then are irrelevant to the Obscuro network.
 		// We don't want to overwrite that value here when the enclave hasn't processed any blocks yet.
-		s.hostL1Head = es.L1Head
+		s.enclaveL1Head = es.L1Head
 	}
 	s.enclaveL2Head = es.L2Head
 


### PR DESCRIPTION
### Why this change is needed

testnet startup was taking a long time because it had to submit blocks from L1 genesis.

There was a bug where the enclave status before it had processed a block would reset the hash to start catch-up from.

### What changes were made as part of this PR

Make it so the L1 head hash is never overwritten with an empty hash.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


