### PR TITLE
Add timeout to wait for L1 merge

### DIFF
--- a/integration/eth2network/eth2_network.go
+++ b/integration/eth2network/eth2_network.go
@@ -303,8 +303,9 @@ func (n *Impl) Start() error {
 		}()
 	}
 
-	// this locks the process waiting for the event to happen
-	return n.waitForMergeEvent(startTime)
+	// this locks the process waiting up to one minute for the event to happen
+	timeoutCtx, _ := context.WithTimeout(context.Background(), 1*time.Minute)
+	return n.waitForMergeEvent(timeoutCtx, startTime)
 }
 
 // Stop stops the network
@@ -468,18 +469,22 @@ func (n *Impl) prysmStartValidator(beaconHTTPPort int, nodeDataDir string) (*exe
 }
 
 // waitForMergeEvent connects to the geth node and waits until block 2 (the merge block) is reached
-func (n *Impl) waitForMergeEvent(startTime time.Time) error {
+func (n *Impl) waitForMergeEvent(ctx context.Context, startTime time.Time) error {
 	dial, err := ethclient.Dial(fmt.Sprintf("http://127.0.0.1:%d", n.gethHTTPPorts[0]))
 	if err != nil {
 		return err
 	}
-	number, err := dial.BlockNumber(context.Background())
+	number, err := dial.BlockNumber(ctx)
 	if err != nil {
 		return err
 	}
 
-	for ; number != 7; time.Sleep(time.Second) {
-		number, err = dial.BlockNumber(context.Background())
+	// wait for the merge block (exit if context closes)
+	for ; number <= 7; time.Sleep(time.Second) {
+		if ctx.Err() == nil {
+			return fmt.Errorf("failed to reach merge block - context closed: %w", ctx.Err())
+		}
+		number, err = dial.BlockNumber(ctx)
 		if err != nil {
 			return err
 		}

--- a/integration/eth2network/eth2_network.go
+++ b/integration/eth2network/eth2_network.go
@@ -482,9 +482,6 @@ func (n *Impl) waitForMergeEvent(ctx context.Context, startTime time.Time) error
 
 	// wait for the merge block (exit if context closes)
 	for ; number <= 7; time.Sleep(time.Second) {
-		if ctx.Err() != nil {
-			return fmt.Errorf("failed to reach merge block - context closed: %w", ctx.Err())
-		}
 		number, err = dial.BlockNumber(ctx)
 		if err != nil {
 			return err

--- a/integration/eth2network/eth2_network.go
+++ b/integration/eth2network/eth2_network.go
@@ -304,7 +304,8 @@ func (n *Impl) Start() error {
 	}
 
 	// this locks the process waiting up to one minute for the event to happen
-	timeoutCtx, _ := context.WithTimeout(context.Background(), 1*time.Minute)
+	timeoutCtx, cancelCtx := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancelCtx()
 	return n.waitForMergeEvent(timeoutCtx, startTime)
 }
 
@@ -481,7 +482,7 @@ func (n *Impl) waitForMergeEvent(ctx context.Context, startTime time.Time) error
 
 	// wait for the merge block (exit if context closes)
 	for ; number <= 7; time.Sleep(time.Second) {
-		if ctx.Err() == nil {
+		if ctx.Err() != nil {
 			return fmt.Errorf("failed to reach merge block - context closed: %w", ctx.Err())
 		}
 		number, err = dial.BlockNumber(ctx)


### PR DESCRIPTION
### Why this change is needed

I saw a goroutine waiting for merge in one of the thread dumps in a timed out build.

Not sure it's a problem (and if it is, not sure it's the only problem), but seems worthwhile to rule it out with a timeout.

Also, changed the condition to `<= 7` rather than `!= 7`, I think this is the intention and just wanted to rule out any edgecase if timings mean it skipped a number.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


