### PR TITLE
Enclave should report latest batch received even if unexecuted

### DIFF
--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -323,12 +323,13 @@ func (e *enclaveImpl) Status() (common.Status, common.SystemError) {
 	}
 	// we use zero when there's no head batch yet, the first seq number is 1
 	l2HeadSeqNo := _noHeadBatch
-	l2Head, err := e.storage.FetchHeadBatch()
+	// this is the highest seq number that has been received and stored on the enclave (it may not have been executed)
+	currSeqNo, err := e.storage.FetchCurrentSequencerNo()
 	if err != nil {
 		// this might be normal while enclave is starting up, just send empty hash
 		e.logger.Debug("failed to fetch L2 head batch for status response", log.ErrKey, err)
 	} else {
-		l2HeadSeqNo = l2Head.Header.SequencerOrderNo
+		l2HeadSeqNo = currSeqNo
 	}
 	return common.Status{StatusCode: common.Running, L1Head: l1HeadHash, L2Head: l2HeadSeqNo}, nil
 }


### PR DESCRIPTION
### Why this change is needed

The enclave reports in its status to the host what the latest L2 batch it has received is. But we recently updated that head batch query used for the status to only include executed batches.

So the host gets this status and thinks the enclave has lost the batch it just sent somehow and puts it into catchup. This means the host is constantly flickering to catchup unnecessarily.

### What changes were made as part of this PR

 Use current seq number for the status reporting instead of head batch.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


