### PR TITLE
p2p batch request data is historic not live

### DIFF
--- a/go/host/p2p/p2p.go
+++ b/go/host/p2p/p2p.go
@@ -221,7 +221,7 @@ func (p *Service) RespondToBatchRequest(requestID string, batches []*common.ExtB
 	}
 	batchMsg := &host.BatchMsg{
 		Batches: batches,
-		IsLive:  true,
+		IsLive:  false,
 	}
 
 	encodedBatchMsg, err := rlp.EncodeToBytes(batchMsg)


### PR DESCRIPTION
### Why this change is needed

Response batches message has flag live=true which isn't catastrophic but might make L2 catch up much slower because L2 repo won't realise that p2p response came back.

### What changes were made as part of this PR

Correct the `live` flag to `false` in batch data response.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


