### PR TITLE
Fix wiring of L1 start hash

### DIFF
--- a/go/host/enclave/state.go
+++ b/go/host/enclave/state.go
@@ -126,12 +126,7 @@ func (s *StateTracker) OnEnclaveStatus(es common.Status) {
 	s.m.Lock()
 	defer s.m.Unlock()
 	s.enclaveStatusCode = es.StatusCode
-	if es.L1Head != gethutil.EmptyHash {
-		// when host starts for the first time it assumes the enclave is at the Obscuro management contract deployment block
-		// this is safe because blocks before then are irrelevant to the Obscuro network.
-		// We don't want to overwrite that value here when the enclave hasn't processed any blocks yet.
-		s.enclaveL1Head = es.L1Head
-	}
+	s.enclaveL1Head = es.L1Head
 	s.enclaveL2Head = es.L2Head
 
 	s.setStatus(s.calculateStatus())

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -3,7 +3,6 @@ package host
 import (
 	"encoding/json"
 	"fmt"
-	"math/big"
 	"os"
 
 	"github.com/kamilsk/breaker"
@@ -27,7 +26,6 @@ import (
 	"github.com/obscuronet/go-obscuro/go/responses"
 	"github.com/obscuronet/go-obscuro/go/wallet"
 
-	gethcommon "github.com/ethereum/go-ethereum/common"
 	gethlog "github.com/ethereum/go-ethereum/log"
 	gethmetrics "github.com/ethereum/go-ethereum/metrics"
 	hostcommon "github.com/obscuronet/go-obscuro/go/common/host"
@@ -61,16 +59,6 @@ func NewHost(config *config.HostConfig, hostServices *ServicesRegistry, p2p P2PH
 		logger.Crit("unable to create database for host", log.ErrKey, err)
 	}
 	l1Repo := l1.NewL1Repository(ethClient, logger)
-	l1StartHash := config.L1StartHash
-	if l1StartHash == (gethcommon.Hash{}) {
-		startBlock, err := l1Repo.FetchBlockByHeight(big.NewInt(0))
-		if err != nil {
-			logger.Crit("unable to fetch start block so stream from", log.ErrKey, err)
-		}
-		l1StartHash = startBlock.Hash()
-	}
-	enclStateTracker := enclave.NewStateTracker(logger)
-	enclStateTracker.OnProcessedBlock(l1StartHash) // this makes sure we start streaming from the right block, will be less clunky in the enclave guardian
 	hostIdentity := hostcommon.NewIdentity(config)
 	host := &host{
 		// config


### PR DESCRIPTION
### Why this change is needed

Configured L1 start hash wasn't making it to the enclave guardian so we were still streaming from genesis of L1.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


