### PR TITLE
some errors, plus extract shared secret processing

### DIFF
--- a/go/common/enclave.go
+++ b/go/common/enclave.go
@@ -104,10 +104,10 @@ type Enclave interface {
 	HealthCheck() (bool, SystemError)
 
 	// GetBatch - retrieve a batch if existing within the enclave db.
-	GetBatch(hash L2BatchHash) (*ExtBatch, error)
+	GetBatch(hash L2BatchHash) (*ExtBatch, SystemError)
 
 	// GetBatchBySeqNo - retrieve batch by sequencer number if it's in the db
-	GetBatchBySeqNo(seqNo uint64) (*ExtBatch, error)
+	GetBatchBySeqNo(seqNo uint64) (*ExtBatch, SystemError)
 
 	// CreateBatch - creates a new head batch extending the previous one for the latest known L1 head if the node is
 	// a sequencer. Will panic otherwise.

--- a/go/enclave/components/attestation.go
+++ b/go/enclave/components/attestation.go
@@ -1,4 +1,4 @@
-package enclave
+package components
 
 import (
 	"bytes"

--- a/go/enclave/components/shared_secret_process.go
+++ b/go/enclave/components/shared_secret_process.go
@@ -1,0 +1,129 @@
+package components
+
+import (
+	"fmt"
+
+	gethcrypto "github.com/ethereum/go-ethereum/crypto"
+	gethlog "github.com/ethereum/go-ethereum/log"
+	"github.com/obscuronet/go-obscuro/go/common"
+	"github.com/obscuronet/go-obscuro/go/common/log"
+	"github.com/obscuronet/go-obscuro/go/enclave/crypto"
+	"github.com/obscuronet/go-obscuro/go/enclave/storage"
+	"github.com/obscuronet/go-obscuro/go/ethadapter"
+	"github.com/obscuronet/go-obscuro/go/ethadapter/mgmtcontractlib"
+)
+
+type SharedSecretProcessor struct {
+	mgmtContractLib     mgmtcontractlib.MgmtContractLib
+	attestationProvider AttestationProvider // interface for producing attestation reports and verifying them
+	storage             storage.Storage
+	logger              gethlog.Logger
+}
+
+func NewSharedSecretProcessor(mgmtcontractlib mgmtcontractlib.MgmtContractLib, attestationProvider AttestationProvider, storage storage.Storage, logger gethlog.Logger) *SharedSecretProcessor {
+	return &SharedSecretProcessor{
+		mgmtContractLib:     mgmtcontractlib,
+		attestationProvider: attestationProvider,
+		storage:             storage,
+		logger:              logger,
+	}
+}
+
+// ProcessNetworkSecretMsgs we watch for all messages that are requesting or receiving the secret and we store the nodes attested keys
+func (ssp *SharedSecretProcessor) ProcessNetworkSecretMsgs(br *common.BlockAndReceipts) []*common.ProducedSecretResponse {
+	var responses []*common.ProducedSecretResponse
+	transactions := br.SuccessfulTransactions()
+	block := br.Block
+	for _, tx := range *transactions {
+		t := ssp.mgmtContractLib.DecodeTx(tx)
+
+		// this transaction is for a node that has joined the network and needs to be sent the network secret
+		if scrtReqTx, ok := t.(*ethadapter.L1RequestSecretTx); ok {
+			ssp.logger.Info("Process shared secret request.", log.BlockHeightKey, block.Number(), log.BlockHashKey, block.Hash(), log.TxKey, tx.Hash())
+			resp, err := ssp.processSecretRequest(scrtReqTx)
+			if err != nil {
+				ssp.logger.Error("Failed to process shared secret request.", log.ErrKey, err)
+				continue
+			}
+			responses = append(responses, resp)
+		}
+
+		// this transaction was created by the genesis node, we need to store their attested key to decrypt their rollup
+		if initSecretTx, ok := t.(*ethadapter.L1InitializeSecretTx); ok {
+			// todo (#1580) - ensure that we don't accidentally skip over the real `L1InitializeSecretTx` message. Otherwise
+			//  our node will never be able to speak to other nodes.
+			// there must be a way to make sure that this transaction can only be sent once.
+			att, err := common.DecodeAttestation(initSecretTx.Attestation)
+			if err != nil {
+				ssp.logger.Error("Could not decode attestation report", log.ErrKey, err)
+			}
+
+			err = ssp.storeAttestation(att)
+			if err != nil {
+				ssp.logger.Error("Could not store the attestation report.", log.ErrKey, err)
+			}
+		}
+	}
+	return responses
+}
+
+func (ssp *SharedSecretProcessor) processSecretRequest(req *ethadapter.L1RequestSecretTx) (*common.ProducedSecretResponse, error) {
+	att, err := common.DecodeAttestation(req.Attestation)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode attestation - %w", err)
+	}
+
+	ssp.logger.Info("received attestation", "attestation", att)
+	secret, err := ssp.verifyAttestationAndEncryptSecret(att)
+	if err != nil {
+		return nil, fmt.Errorf("secret request failed, no response will be published - %w", err)
+	}
+
+	// Store the attested key only if the attestation process succeeded.
+	err = ssp.storeAttestation(att)
+	if err != nil {
+		return nil, fmt.Errorf("could not store attestation, no response will be published. Cause: %w", err)
+	}
+
+	ssp.logger.Trace("Processed secret request.", "owner", att.Owner)
+	return &common.ProducedSecretResponse{
+		Secret:      secret,
+		RequesterID: att.Owner,
+		HostAddress: att.HostAddress,
+	}, nil
+}
+
+// ShareSecret verifies the request and if it trusts the report and the public key it will return the secret encrypted with that public key.
+func (ssp *SharedSecretProcessor) verifyAttestationAndEncryptSecret(att *common.AttestationReport) (common.EncryptedSharedEnclaveSecret, error) {
+	// First we verify the attestation report has come from a valid obscuro enclave running in a verified TEE.
+	data, err := ssp.attestationProvider.VerifyReport(att)
+	if err != nil {
+		return nil, fmt.Errorf("unable to verify report - %w", err)
+	}
+	// Then we verify the public key provided has come from the same enclave as that attestation report
+	if err = VerifyIdentity(data, att); err != nil {
+		return nil, fmt.Errorf("unable to verify identity - %w", err)
+	}
+	ssp.logger.Info(fmt.Sprintf("Successfully verified attestation and identity. Owner: %s", att.Owner))
+
+	secret, err := ssp.storage.FetchSecret()
+	if err != nil {
+		return nil, fmt.Errorf("could not retrieve secret; this should not happen. Cause: %w", err)
+	}
+	return crypto.EncryptSecret(att.PubKey, *secret, ssp.logger)
+}
+
+// storeAttestation stores the attested keys of other nodes so we can decrypt their rollups
+func (ssp *SharedSecretProcessor) storeAttestation(att *common.AttestationReport) error {
+	ssp.logger.Info(fmt.Sprintf("Store attestation. Owner: %s", att.Owner))
+	// Store the attestation
+	key, err := gethcrypto.DecompressPubkey(att.PubKey)
+	if err != nil {
+		return fmt.Errorf("failed to parse public key %w", err)
+	}
+	err = ssp.storage.StoreAttestedKey(att.Owner, key)
+	if err != nil {
+		return fmt.Errorf("could not store attested key. Cause: %w", err)
+	}
+	return nil
+}

--- a/go/host/rpc/enclaverpc/enclave_client.go
+++ b/go/host/rpc/enclaverpc/enclave_client.go
@@ -455,7 +455,7 @@ func (c *Client) DebugTraceTransaction(hash gethcommon.Hash, config *tracers.Tra
 	return json.RawMessage(response.Msg), nil
 }
 
-func (c *Client) GetBatch(hash common.L2BatchHash) (*common.ExtBatch, error) {
+func (c *Client) GetBatch(hash common.L2BatchHash) (*common.ExtBatch, common.SystemError) {
 	timeoutCtx, cancel := context.WithTimeout(context.Background(), c.config.EnclaveRPCTimeout)
 	defer cancel()
 
@@ -467,7 +467,7 @@ func (c *Client) GetBatch(hash common.L2BatchHash) (*common.ExtBatch, error) {
 	return common.DecodeExtBatch(batchMsg.Batch)
 }
 
-func (c *Client) GetBatchBySeqNo(seqNo uint64) (*common.ExtBatch, error) {
+func (c *Client) GetBatchBySeqNo(seqNo uint64) (*common.ExtBatch, common.SystemError) {
 	timeoutCtx, cancel := context.WithTimeout(context.Background(), c.config.EnclaveRPCTimeout)
 	defer cancel()
 


### PR DESCRIPTION
### Why this change is needed
- moves logic with a single responsibility to its own type
- some enclave functions were not respecting the sys error convention

### What changes were made as part of this PR

- fixes 2 enclave methods to return SystemError
- move shared secret logic to a component

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


