### PR TITLE
Fixes for tests using persistent sqlite db

### DIFF
--- a/go/enclave/storage/init/sqlite/001_init.sql
+++ b/go/enclave/storage/init/sqlite/001_init.sql
@@ -23,7 +23,7 @@ create table if not exists attestation_key
 create table if not exists block
 (
     hash         binary(32) primary key,
-    parent       binary(32) REFERENCES block,
+    parent       binary(32),
     is_canonical boolean,
     header       blob,
     height       int

--- a/go/enclave/storage/init/sqlite/sqlite.go
+++ b/go/enclave/storage/init/sqlite/sqlite.go
@@ -51,10 +51,7 @@ func CreateTemporarySQLiteDB(dbPath string, dbOptions string, logger gethlog.Log
 		return nil, fmt.Errorf("couldn't open sqlite db - %w", err)
 	}
 
-	// Sqlite in memory fails with table locks when there are multiple connections
-	if inMem {
-		db.SetMaxOpenConns(1)
-	}
+	db.SetMaxOpenConns(1)
 
 	if !initialsed {
 		err = initialiseDB(db)

--- a/go/enclave/storage/init/sqlite/sqlite.go
+++ b/go/enclave/storage/init/sqlite/sqlite.go
@@ -51,6 +51,7 @@ func CreateTemporarySQLiteDB(dbPath string, dbOptions string, logger gethlog.Log
 		return nil, fmt.Errorf("couldn't open sqlite db - %w", err)
 	}
 
+	// Sqlite fails with table locks when there are multiple connections
 	db.SetMaxOpenConns(1)
 
 	if !initialsed {

--- a/go/obsclient/obsclient.go
+++ b/go/obsclient/obsclient.go
@@ -1,12 +1,13 @@
 package obsclient
 
 import (
-	"math/big"
-
+	"errors"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/obscuronet/go-obscuro/go/common"
 	"github.com/obscuronet/go-obscuro/go/rpc"
+	"math/big"
+	"strings"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	hostcommon "github.com/obscuronet/go-obscuro/go/common/host"
@@ -78,7 +79,13 @@ func (oc *ObsClient) BatchHeaderByHash(hash gethcommon.Hash) (*common.BatchHeade
 func (oc *ObsClient) Health() (bool, error) {
 	var healthy *hostcommon.HealthCheck
 	err := oc.rpcClient.Call(&healthy, rpc.Health)
-	return healthy.OverallHealth, err
+	if err != nil {
+		return false, err
+	}
+	if !healthy.OverallHealth {
+		return false, errors.New(strings.Join(healthy.Errors, ", "))
+	}
+	return healthy.OverallHealth, nil
 }
 
 // GetTotalContractCount returns the total count of created contracts

--- a/go/obsclient/obsclient.go
+++ b/go/obsclient/obsclient.go
@@ -2,12 +2,13 @@ package obsclient
 
 import (
 	"errors"
+	"math/big"
+	"strings"
+
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/obscuronet/go-obscuro/go/common"
 	"github.com/obscuronet/go-obscuro/go/rpc"
-	"math/big"
-	"strings"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	hostcommon "github.com/obscuronet/go-obscuro/go/common/host"

--- a/integration/networktest/env/dev_network.go
+++ b/integration/networktest/env/dev_network.go
@@ -2,11 +2,12 @@ package env
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/obscuronet/go-obscuro/go/common/retry"
 	"github.com/obscuronet/go-obscuro/go/obsclient"
 	"github.com/obscuronet/go-obscuro/integration/networktest"
 	"github.com/obscuronet/go-obscuro/integration/simulation/devnetwork"
-	"time"
 )
 
 type devNetworkEnv struct{}
@@ -23,7 +24,7 @@ func (d *devNetworkEnv) Prepare() (networktest.NetworkConnector, func(), error) 
 	return devNet, devNet.CleanUp, nil
 }
 
-func awaitNodesAvailable(nc networktest.NetworkConnector) error { //nolint:unparam
+func awaitNodesAvailable(nc networktest.NetworkConnector) error {
 	err := awaitHealthStatus(nc.GetSequencerNode().HostRPCAddress(), 30*time.Second)
 	if err != nil {
 		return err

--- a/integration/networktest/env/dev_network.go
+++ b/integration/networktest/env/dev_network.go
@@ -1,10 +1,12 @@
 package env
 
 import (
-	"time"
-
+	"fmt"
+	"github.com/obscuronet/go-obscuro/go/common/retry"
+	"github.com/obscuronet/go-obscuro/go/obsclient"
 	"github.com/obscuronet/go-obscuro/integration/networktest"
 	"github.com/obscuronet/go-obscuro/integration/simulation/devnetwork"
+	"time"
 )
 
 type devNetworkEnv struct{}
@@ -21,12 +23,38 @@ func (d *devNetworkEnv) Prepare() (networktest.NetworkConnector, func(), error) 
 	return devNet, devNet.CleanUp, nil
 }
 
-func awaitNodesAvailable(_ networktest.NetworkConnector) error { //nolint:unparam
-	// todo (@matt) - create RPC clients for all the nodes and wait until their health checks pass
-
-	// for now we just sleep
-	time.Sleep(15 * time.Second)
+func awaitNodesAvailable(nc networktest.NetworkConnector) error { //nolint:unparam
+	err := awaitHealthStatus(nc.GetSequencerNode().HostRPCAddress(), 30*time.Second)
+	if err != nil {
+		return err
+	}
+	for i := 0; i < nc.NumValidators(); i++ {
+		err := awaitHealthStatus(nc.GetValidatorNode(i).HostRPCAddress(), 30*time.Second)
+		if err != nil {
+			return err
+		}
+	}
 	return nil
+}
+
+// awaitHealthStatus waits for the host to be healthy until timeout
+func awaitHealthStatus(rpcAddress string, timeout time.Duration) error {
+	fmt.Println("Awaiting health status:", rpcAddress)
+	return retry.Do(func() error {
+		c, err := obsclient.Dial(rpcAddress)
+		if err != nil {
+			return fmt.Errorf("failed dial host (%s): %w", rpcAddress, err)
+		}
+		defer c.Close()
+		healthy, err := c.Health()
+		if err != nil {
+			return fmt.Errorf("failed to get host health (%s): %w", rpcAddress, err)
+		}
+		if !healthy {
+			return fmt.Errorf("host is not healthy (%s)", rpcAddress)
+		}
+		return nil
+	}, retry.NewTimeoutStrategy(timeout, 200*time.Millisecond))
 }
 
 func LocalDevNetwork() networktest.Environment {


### PR DESCRIPTION
### Why this change is needed

1. Tests were failing with 'database is locked' in the errors. We need to limit the connections for persistent sqlite like we do for in-mem.

2. The strict `REFERENCE` check of parent lookup in the db schema is breaking when using l1StartHash and starting mid-chain. Since this doesn't exist on the prod config I thought it was ok to remove for now (it's still checked in the code in `ingestBlock()`).

3. We were just waiting 15secs for network to start instead of waiting for node health checks in network tests.


### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


