### PR TITLE
sanity check p2p message before sending

### DIFF
--- a/go/host/p2p/p2p.go
+++ b/go/host/p2p/p2p.go
@@ -350,6 +350,17 @@ func (p *Service) broadcast(msg message) error {
 
 // Sends a message to the provided address.
 func (p *Service) send(msg message, to string) error {
+	// sanity check the message to discover bugs
+	if !(msg.Type >= 1 && msg.Type <= 3) {
+		p.logger.Error(fmt.Sprintf("Sending message with wrong message type: %v", msg))
+	}
+	if len(msg.Sender) == 0 {
+		p.logger.Error(fmt.Sprintf("Sending message with wrong sender type: %v", msg))
+	}
+	if len(msg.Contents) == 0 {
+		p.logger.Error(fmt.Sprintf("Sending message with empty contents: %v", msg))
+	}
+
 	msgEncoded, err := rlp.EncodeToBytes(msg)
 	if err != nil {
 		return fmt.Errorf("could not encode message to send to sequencer. Cause: %w", err)


### PR DESCRIPTION
### Why this change is needed

We see occasional p2p message serialisation issues on dev-testnet.
To investigate the cause, this pr adds a sanity check to make sure they are not programming errors



### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


