### PR TITLE
Clarify in-mem flag is for host DB

### DIFF
--- a/go/node/config.go
+++ b/go/node/config.go
@@ -247,7 +247,7 @@ func WithPCCSAddr(s string) Option {
 	}
 }
 
-func WithInMemoryDB(b bool) Option {
+func WithInMemoryHostDB(b bool) Option {
 	return func(c *Config) {
 		c.hostInMemDB = b
 	}

--- a/testnet/launcher/docker.go
+++ b/testnet/launcher/docker.go
@@ -62,7 +62,7 @@ func (t *Testnet) Start() error {
 		node.WithManagementContractAddress(networkConfig.ManagementContractAddress),
 		node.WithMessageBusContractAddress(networkConfig.MessageBusAddress),
 		node.WithL1Start(networkConfig.L1StartHash),
-		node.WithInMemoryDB(true),
+		node.WithInMemoryHostDB(true),
 		node.WithDebugNamespaceEnabled(true),
 	)
 
@@ -101,7 +101,7 @@ func (t *Testnet) Start() error {
 		node.WithManagementContractAddress(networkConfig.ManagementContractAddress),
 		node.WithMessageBusContractAddress(networkConfig.MessageBusAddress),
 		node.WithL1Start(networkConfig.L1StartHash),
-		node.WithInMemoryDB(true),
+		node.WithInMemoryHostDB(true),
 	)
 
 	validatorNode := node.NewDockerNode(validatorNodeConfig)


### PR DESCRIPTION
### Why this change is needed

[Issue 2058: WithInMemFlag seemingly ignored](https://github.com/obscuronet/obscuro-internal/issues/2058)

Actually turned out that flag is for the host DB to be in-memory. And think we have found a fix for the persisted sqlite db issues on the enclave so will leave that as hardcoded to persisted for now (lots of the settings are hardcoded where they until the tests need flexibility).

### What changes were made as part of this PR

Rename the in-mem flag method to make it clear it is for the host DB.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


