### PR TITLE
Ensure p2p peer list resync after restart

### DIFF
--- a/go/host/p2p/p2p.go
+++ b/go/host/p2p/p2p.go
@@ -112,6 +112,10 @@ func (p *Service) Start() error {
 	p.listener = listener
 
 	go p.handleConnections()
+
+	// ensure we have re-synced the peer list from management contract after startup
+	go p.RefreshPeerList()
+
 	return nil
 }
 

--- a/go/host/p2p/p2p.go
+++ b/go/host/p2p/p2p.go
@@ -152,10 +152,21 @@ func (p *Service) SubscribeForBatchRequests(handler host.P2PBatchRequestHandler)
 	return p.batchReqHandlers.Subscribe(handler)
 }
 
+// RefreshPeerList - fetches the latest peer list from L1 and updates the peerAddresses.
+// Note: this is designed to be run in a separate goroutine, it will retry a few times before giving up.
 func (p *Service) RefreshPeerList() {
-	newPeers, err := p.sl.L1Publisher().FetchLatestPeersList()
+	var newPeers []string
+	err := retry.Do(func() error {
+		var retryErr error
+		newPeers, retryErr = p.sl.L1Publisher().FetchLatestPeersList()
+		if retryErr != nil {
+			p.logger.Error("failed to fetch latest peer list from L1", log.ErrKey, retryErr)
+			return retryErr
+		}
+		return nil
+	}, retry.NewTimeoutStrategy(1*time.Minute, 5*time.Second))
 	if err != nil {
-		p.logger.Error(fmt.Sprintf("unable to fetch latest peer list from L1 - %s", err.Error()))
+		p.logger.Error("unable to fetch latest peer list from L1", log.ErrKey, err)
 		return
 	}
 


### PR DESCRIPTION
### Why this change is needed

Ensure p2p peer list resync after restart because the list is empty at startup and only resynced when secret responses are seen.

### What changes were made as part of this PR

Have p2p service resync at startup.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


