### PR TITLE
add not null constraints

### DIFF
--- a/go/enclave/storage/init/edgelessdb/001_init.sql
+++ b/go/enclave/storage/init/edgelessdb/001_init.sql
@@ -4,7 +4,7 @@ CREATE DATABASE obsdb;
 create table if not exists obsdb.keyvalue
 (
     ky  varbinary(64),
-    val mediumblob,
+    val mediumblob NOT NULL,
     primary key (ky)
 );
 GRANT ALL ON obsdb.keyvalue TO obscuro;
@@ -12,7 +12,7 @@ GRANT ALL ON obsdb.keyvalue TO obscuro;
 create table if not exists obsdb.config
 (
     ky  varchar(64),
-    val mediumblob,
+    val mediumblob NOT NULL,
     primary key (ky)
 );
 GRANT ALL ON obsdb.config TO obscuro;
@@ -23,7 +23,7 @@ values ('CURRENT_SEQ', -1);
 create table if not exists obsdb.attestation_key
 (
     party binary(20),
-    ky    binary(33)
+    ky    binary(33) NOT NULL
 );
 GRANT ALL ON obsdb.attestation_key TO obscuro;
 
@@ -31,9 +31,9 @@ create table if not exists obsdb.block
 (
     hash         binary(32),
     parent       binary(32),
-    is_canonical boolean,
-    header       blob,
-    height       int,
+    is_canonical boolean NOT NULL,
+    header       blob    NOT NULL,
+    height       int     NOT NULL,
     INDEX (parent),
     primary key (hash),
     INDEX (height)
@@ -43,8 +43,8 @@ GRANT ALL ON obsdb.block TO obscuro;
 create table if not exists obsdb.l1_msg
 (
     id      INTEGER AUTO_INCREMENT,
-    message varbinary(1024),
-    block   binary(32),
+    message varbinary(1024) NOT NULL,
+    block   binary(32)      NOT NULL,
     INDEX (block),
     primary key (id)
 );
@@ -53,10 +53,10 @@ GRANT ALL ON obsdb.l1_msg TO obscuro;
 create table if not exists obsdb.rollup
 (
     id        INTEGER AUTO_INCREMENT,
-    start_seq int,
-    end_seq   int,
-    header    blob,
-    block     binary(32),
+    start_seq int        NOT NULL,
+    end_seq   int        NOT NULL,
+    header    blob       NOT NULL,
+    block     binary(32) NOT NULL,
     INDEX (block),
     primary key (id)
 );
@@ -65,7 +65,7 @@ GRANT ALL ON obsdb.rollup TO obscuro;
 create table if not exists obsdb.batch_body
 (
     hash    binary(32),
-    content mediumblob,
+    content mediumblob NOT NULL,
     primary key (hash)
 );
 GRANT ALL ON obsdb.batch_body TO obscuro;
@@ -74,13 +74,13 @@ create table if not exists obsdb.batch
 (
     hash         binary(32),
     parent       binary(32),
-    sequence     int,
-    height       int,
-    is_canonical boolean,
-    header       blob,
-    body         binary(32),
-    l1_proof     binary(32),
-    is_executed     boolean,
+    sequence     int        NOT NULL,
+    height       int        NOT NULL,
+    is_canonical boolean    NOT NULL,
+    header       blob       NOT NULL,
+    body         binary(32) NOT NULL,
+    l1_proof     binary(32) NOT NULL,
+    is_executed  boolean    NOT NULL,
     INDEX (parent),
     INDEX (body),
     INDEX (l1_proof),
@@ -93,11 +93,11 @@ GRANT ALL ON obsdb.batch TO obscuro;
 create table if not exists obsdb.tx
 (
     hash           binary(32),
-    content        mediumblob,
-    sender_address binary(20),
-    nonce          int,
-    idx            int,
-    body           binary(32),
+    content        mediumblob NOT NULL,
+    sender_address binary(20) NOT NULL,
+    nonce          int        NOT NULL,
+    idx            int        NOT NULL,
+    body           binary(32) NOT NULL,
     INDEX (body),
     primary key (hash)
 );
@@ -108,8 +108,8 @@ create table if not exists obsdb.exec_tx
     id                       binary(64),
     created_contract_address binary(20),
     receipt                  mediumblob,
-    tx                       binary(32),
-    batch                    binary(32),
+    tx                       binary(32) NOT NULL,
+    batch                    binary(32) NOT NULL,
     INDEX (batch),
     INDEX (tx),
     primary key (id)
@@ -118,20 +118,20 @@ GRANT ALL ON obsdb.exec_tx TO obscuro;
 
 create table if not exists obsdb.events
 (
-    topic0          binary(32),
+    topic0          binary(32) NOT NULL,
     topic1          binary(32),
     topic2          binary(32),
     topic3          binary(32),
     topic4          binary(32),
     datablob        mediumblob,
-    log_idx         int,
-    address         binary(20),
-    lifecycle_event boolean,
+    log_idx         int        NOT NULL,
+    address         binary(20) NOT NULL,
+    lifecycle_event boolean    NOT NULL,
     rel_address1    binary(20),
     rel_address2    binary(20),
     rel_address3    binary(20),
     rel_address4    binary(20),
-    exec_tx_id      binary(64),
+    exec_tx_id      binary(64) NOT NULL,
     INDEX (exec_tx_id),
     INDEX (address),
     INDEX (rel_address1),

--- a/go/enclave/storage/init/sqlite/001_init.sql
+++ b/go/enclave/storage/init/sqlite/001_init.sql
@@ -1,13 +1,13 @@
 create table if not exists keyvalue
 (
     ky  varbinary(64) primary key,
-    val mediumblob
+    val mediumblob NOT NULL
 );
 
 create table if not exists config
 (
     ky  varchar(64) primary key,
-    val mediumblob
+    val mediumblob NOT NULL
 );
 
 insert into config
@@ -17,16 +17,16 @@ create table if not exists attestation_key
 (
 --     party  binary(20) primary key, // todo -pk
     party binary(20),
-    ky    binary(33)
+    ky    binary(33) NOT NULL
 );
 
 create table if not exists block
 (
     hash         binary(32) primary key,
     parent       binary(32),
-    is_canonical boolean,
-    header       blob,
-    height       int
+    is_canonical boolean NOT NULL,
+    header       blob    NOT NULL,
+    height       int     NOT NULL
 --   the unique constraint is commented for now because there might be multiple non-canonical blocks for the same height
 --     unique (height, is_canonical)
 );
@@ -35,36 +35,36 @@ create index IDX_BLOCK_HEIGHT on block (height);
 create table if not exists l1_msg
 (
     id      INTEGER PRIMARY KEY AUTOINCREMENT,
-    message varbinary(1024),
-    block   binary(32) REFERENCES block
+    message varbinary(1024) NOT NULL,
+    block   binary(32)      NOT NULL REFERENCES block
 );
 
 create table if not exists rollup
 (
     id        INTEGER PRIMARY KEY AUTOINCREMENT,
-    start_seq int,
-    end_seq   int,
-    header    blob,
-    block     binary(32) REFERENCES block
+    start_seq int        NOT NULL,
+    end_seq   int        NOT NULL,
+    header    blob       NOT NULL,
+    block     binary(32) NOT NULL REFERENCES block
 );
 
 create table if not exists batch_body
 (
     hash    binary(32) primary key,
-    content mediumblob
+    content mediumblob NOT NULL
 );
 
 create table if not exists batch
 (
     hash         binary(32) primary key,
     parent       binary(32),-- REFERENCES batch,
-    sequence     int NOT NULL unique,
-    height       int,
-    is_canonical boolean,
-    header       blob,
-    body         binary(32) REFERENCES batch_body,
-    l1_proof     binary(32), -- normally this would be a FK, but there is a weird edge case where an L2 node might not have the block used to create this batch
-    is_executed     boolean
+    sequence     int     NOT NULL unique,
+    height int NOT NULL,
+    is_canonical boolean NOT NULL,
+    header blob NOT NULL,
+    body binary(32) NOT NULL REFERENCES batch_body,
+    l1_proof binary(32) NOT NULL, -- normally this would be a FK, but there is a weird edge case where an L2 node might not have the block used to create this batch
+    is_executed  boolean NOT NULL
 --   the unique constraint is commented for now because there might be multiple non-canonical batches for the same height
 --   unique (height, is_canonical, is_executed)
 );
@@ -75,10 +75,10 @@ create index IDX_BATCH_Block on batch (l1_proof);
 create table if not exists tx
 (
     hash           binary(32) primary key,
-    content        mediumblob,
-    sender_address binary(20),
-    nonce          int,
-    idx            int,
+    content        mediumblob NOT NULL,
+    sender_address binary(20) NOT NULL,
+    nonce          int        NOT NULL,
+    idx            int        NOT NULL,
     body           binary(32) REFERENCES batch_body
 );
 
@@ -89,22 +89,22 @@ create table if not exists exec_tx
     receipt                  mediumblob,
 --     commenting out the fk until synthetic transactions are also stored
 --     tx                       binary(32) REFERENCES tx,
-    tx                       binary(32),
-    batch                    binary(32) REFERENCES batch
+    tx                       binary(32) NOT NULL,
+    batch                    binary(32) NOT NULL REFERENCES batch
 );
 create index IX_EX_TX1 on exec_tx (tx);
 
 create table if not exists events
 (
-    topic0          binary(32),
+    topic0          binary(32) NOT NULL,
     topic1          binary(32),
     topic2          binary(32),
     topic3          binary(32),
     topic4          binary(32),
     datablob        mediumblob,
-    log_idx         int,
-    address         binary(20),
-    lifecycle_event boolean,
+    log_idx         int        NOT NULL,
+    address         binary(20) NOT NULL,
+    lifecycle_event boolean    NOT NULL,
     rel_address1    binary(20),
     rel_address2    binary(20),
     rel_address3    binary(20),


### PR DESCRIPTION
### Why this change is needed

The database indexes works better if columns are explicitly marked as "not null"

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


