### PR TITLE
Bug: nil pointer when eth new block not found

### DIFF
--- a/go/host/l1/blockrepository.go
+++ b/go/host/l1/blockrepository.go
@@ -23,11 +23,9 @@ import (
 
 var (
 	// todo (@matt) make this configurable?
-	_timeoutNoBlocks        = 30 * time.Second
-	_newBlockLookupTimeout  = 20 * time.Second
-	_newBlockLookupInterval = 1 * time.Second
-	one                     = big.NewInt(1)
-	ErrNoNextBlock          = errors.New("no next block")
+	_timeoutNoBlocks = 30 * time.Second
+	one              = big.NewInt(1)
+	ErrNoNextBlock   = errors.New("no next block")
 )
 
 // Repository is a host service for subscribing to new blocks and looking up L1 data


### PR DESCRIPTION
### Why this change is needed

When using Infura RPC endpoint for sepolia data we were getting nil pointers with the new block lookup. This shouldn't happen but if it does we shouldn't nil pointer and should be able to recover.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


