### PR TITLE
user getStorageAt with parameters "obscuro" and "0" to get userID from request URL

### DIFF
--- a/tools/walletextension/common/constants.go
+++ b/tools/walletextension/common/constants.go
@@ -27,28 +27,27 @@ const (
 )
 
 const (
-	PathRoot                          = "/"
-	PathReady                         = "/ready/"
-	PathViewingKeys                   = "/viewingkeys/"
-	PathGenerateViewingKey            = "/generateviewingkey/"
-	PathSubmitViewingKey              = "/submitviewingkey/"
-	PathJoin                          = "/join/"
-	PathAuthenticate                  = "/authenticate/"
-	PathQuery                         = "/query/"
-	PathRevoke                        = "/revoke/"
-	PathObscuroGateway                = "/og/"
-	PathHealth                        = "/health/"
-	WSProtocol                        = "ws://"
-	DefaultUser                       = "defaultUser"
-	UserQueryParameter                = "u"
-	AddressQueryParameter             = "a"
-	MessageFormatRegex                = `^Register\s(\w+)\sfor\s(\w+)$`
-	MessageUserIDLen                  = 64
-	SignatureLen                      = 65
-	PersonalSignMessagePrefix         = "\x19Ethereum Signed Message:\n%d%s"
-	GetStorageAtUserIDSpecialAddress  = "obscuro"
-	GetStorageAtUserIDSpecialPosition = "0"
-	SuccessMsg                        = "success"
+	PathRoot                            = "/"
+	PathReady                           = "/ready/"
+	PathViewingKeys                     = "/viewingkeys/"
+	PathGenerateViewingKey              = "/generateviewingkey/"
+	PathSubmitViewingKey                = "/submitviewingkey/"
+	PathJoin                            = "/join/"
+	PathAuthenticate                    = "/authenticate/"
+	PathQuery                           = "/query/"
+	PathRevoke                          = "/revoke/"
+	PathObscuroGateway                  = "/og/"
+	PathHealth                          = "/health/"
+	WSProtocol                          = "ws://"
+	DefaultUser                         = "defaultUser"
+	UserQueryParameter                  = "u"
+	AddressQueryParameter               = "a"
+	MessageFormatRegex                  = `^Register\s(\w+)\sfor\s(\w+)$`
+	MessageUserIDLen                    = 64
+	SignatureLen                        = 65
+	PersonalSignMessagePrefix           = "\x19Ethereum Signed Message:\n%d%s"
+	GetStorageAtUserIDRequestMethodName = "getUserID"
+	SuccessMsg                          = "success"
 )
 
 var (

--- a/tools/walletextension/common/constants.go
+++ b/tools/walletextension/common/constants.go
@@ -27,27 +27,28 @@ const (
 )
 
 const (
-	PathRoot                  = "/"
-	PathReady                 = "/ready/"
-	PathViewingKeys           = "/viewingkeys/"
-	PathGenerateViewingKey    = "/generateviewingkey/"
-	PathSubmitViewingKey      = "/submitviewingkey/"
-	PathJoin                  = "/join/"
-	PathAuthenticate          = "/authenticate/"
-	PathQuery                 = "/query/"
-	PathRevoke                = "/revoke/"
-	PathObscuroGateway        = "/og/"
-	PathHealth                = "/health/"
-	WSProtocol                = "ws://"
-	DefaultUser               = "defaultUser"
-	UserQueryParameter        = "u"
-	AddressQueryParameter     = "a"
-	MessageFormatRegex        = `^Register\s(\w+)\sfor\s(\w+)$`
-	MessageUserIDLen          = 64
-	SignatureLen              = 65
-	PersonalSignMessagePrefix = "\x19Ethereum Signed Message:\n%d%s"
-
-	SuccessMsg = "success"
+	PathRoot                          = "/"
+	PathReady                         = "/ready/"
+	PathViewingKeys                   = "/viewingkeys/"
+	PathGenerateViewingKey            = "/generateviewingkey/"
+	PathSubmitViewingKey              = "/submitviewingkey/"
+	PathJoin                          = "/join/"
+	PathAuthenticate                  = "/authenticate/"
+	PathQuery                         = "/query/"
+	PathRevoke                        = "/revoke/"
+	PathObscuroGateway                = "/og/"
+	PathHealth                        = "/health/"
+	WSProtocol                        = "ws://"
+	DefaultUser                       = "defaultUser"
+	UserQueryParameter                = "u"
+	AddressQueryParameter             = "a"
+	MessageFormatRegex                = `^Register\s(\w+)\sfor\s(\w+)$`
+	MessageUserIDLen                  = 64
+	SignatureLen                      = 65
+	PersonalSignMessagePrefix         = "\x19Ethereum Signed Message:\n%d%s"
+	GetStorageAtUserIDSpecialAddress  = "obscuro"
+	GetStorageAtUserIDSpecialPosition = "0"
+	SuccessMsg                        = "success"
 )
 
 var (

--- a/tools/walletextension/test/utils.go
+++ b/tools/walletextension/test/utils.go
@@ -117,6 +117,18 @@ func makeHTTPEthJSONReq(port int, method string, params interface{}) []byte {
 	return makeRequestHTTP(fmt.Sprintf("http://%s:%d", common.Localhost, port), reqBody)
 }
 
+// Makes an Ethereum JSON RPC request over HTTP to specific endpoint and returns the response body.
+func makeHTTPEthJSONReqWithPath(port int, path string) []byte {
+	reqBody := prepareRequestBody("", "")
+	return makeRequestHTTP(fmt.Sprintf("http://%s:%d/%s", common.Localhost, port, path), reqBody)
+}
+
+// Makes an Ethereum JSON RPC request over HTTP and returns the response body with userID query paremeter.
+func makeHTTPEthJSONReqWithUserID(port int, method string, params interface{}, userID string) []byte {
+	reqBody := prepareRequestBody(method, params)
+	return makeRequestHTTP(fmt.Sprintf("http://%s:%d?u=%s", common.Localhost, port, userID), reqBody)
+}
+
 // Makes an Ethereum JSON RPC request over websockets and returns the response body.
 func makeWSEthJSONReq(port int, method string, params interface{}) ([]byte, *websocket.Conn) {
 	reqBody := prepareRequestBody(method, params)

--- a/tools/walletextension/test/wallet_extension_test.go
+++ b/tools/walletextension/test/wallet_extension_test.go
@@ -296,16 +296,16 @@ func TestGetStorageAtForReturningUserID(t *testing.T) {
 	userID := string(respJoin)
 
 	// make a request to GetStorageAt with correct parameters to get userID that exists in the database
-	respBody := makeHTTPEthJSONReqWithUserID(walletHTTPPort, rpc.GetStorageAt, []interface{}{"obscuro", "0", nil}, userID)
+	respBody := makeHTTPEthJSONReqWithUserID(walletHTTPPort, rpc.GetStorageAt, []interface{}{"getUserID", "0", nil}, userID)
 	validateJSONResponse(t, respBody)
 
 	if !strings.Contains(string(respBody), userID) {
 		t.Fatalf("expected response containing '%s', got '%s'", userID, string(respBody))
 	}
 
-	// make a request to GetStorageAt with correct parameters, but userID that is not present in the databse
+	// make a request to GetStorageAt with correct parameters, but userID that is not present in the database
 	invalidUserID := "abc123"
-	respBody2 := makeHTTPEthJSONReqWithUserID(walletHTTPPort, rpc.GetStorageAt, []interface{}{"obscuro", "0", nil}, invalidUserID)
+	respBody2 := makeHTTPEthJSONReqWithUserID(walletHTTPPort, rpc.GetStorageAt, []interface{}{"getUserID", "0", nil}, invalidUserID)
 
 	if !strings.Contains(string(respBody2), "UserAccountManager doesn't exist for user: "+invalidUserID) {
 		t.Fatalf("expected response containing invalid userID '%s', got '%s'", invalidUserID, string(respBody2))
@@ -317,13 +317,8 @@ func TestGetStorageAtForReturningUserID(t *testing.T) {
 		t.Fatalf("expected response not containing userID as the parameters are wrong ")
 	}
 
-	respBody4 := makeHTTPEthJSONReqWithUserID(walletHTTPPort, rpc.GetStorageAt, []interface{}{"obscuro", "1", nil}, userID)
-	if strings.Contains(string(respBody4), userID) {
-		t.Fatalf("expected response not containing userID as the parameters are wrong ")
-	}
-
 	// make a request with wrong rpcMethod
-	respBody5 := makeHTTPEthJSONReqWithUserID(walletHTTPPort, rpc.GetBalance, []interface{}{"obscuro", "0", nil}, userID)
+	respBody5 := makeHTTPEthJSONReqWithUserID(walletHTTPPort, rpc.GetBalance, []interface{}{"getUserID", "0", nil}, userID)
 	if strings.Contains(string(respBody5), userID) {
 		t.Fatalf("expected response not containing userID as the parameters are wrong ")
 	}

--- a/tools/walletextension/test/wallet_extension_test.go
+++ b/tools/walletextension/test/wallet_extension_test.go
@@ -296,7 +296,7 @@ func TestGetStorageAtForReturningUserID(t *testing.T) {
 	userID := string(respJoin)
 
 	// make a request to GetStorageAt with correct parameters to get userID that exists in the database
-	respBody := makeHTTPEthJSONReqWithUserID(walletHTTPPort, rpc.GetStorageAt, []interface{}{map[string]interface{}{"address": "obscuro", "position": "0"}}, userID)
+	respBody := makeHTTPEthJSONReqWithUserID(walletHTTPPort, rpc.GetStorageAt, []interface{}{"obscuro", "0", nil}, userID)
 	validateJSONResponse(t, respBody)
 
 	if !strings.Contains(string(respBody), userID) {
@@ -305,25 +305,25 @@ func TestGetStorageAtForReturningUserID(t *testing.T) {
 
 	// make a request to GetStorageAt with correct parameters, but userID that is not present in the databse
 	invalidUserID := "abc123"
-	respBody2 := makeHTTPEthJSONReqWithUserID(walletHTTPPort, rpc.GetStorageAt, []interface{}{map[string]interface{}{"address": "obscuro", "position": "0"}}, invalidUserID)
+	respBody2 := makeHTTPEthJSONReqWithUserID(walletHTTPPort, rpc.GetStorageAt, []interface{}{"obscuro", "0", nil}, invalidUserID)
 
 	if !strings.Contains(string(respBody2), "UserAccountManager doesn't exist for user: "+invalidUserID) {
 		t.Fatalf("expected response containing invalid userID '%s', got '%s'", invalidUserID, string(respBody2))
 	}
 
 	// make a request to GetStorageAt with userID that is in the database, but wrong parameters
-	respBody3 := makeHTTPEthJSONReqWithUserID(walletHTTPPort, rpc.GetStorageAt, []interface{}{map[string]interface{}{"address": "abc", "position": "0"}}, userID)
+	respBody3 := makeHTTPEthJSONReqWithUserID(walletHTTPPort, rpc.GetStorageAt, []interface{}{"abc", "0", nil}, userID)
 	if strings.Contains(string(respBody3), userID) {
 		t.Fatalf("expected response not containing userID as the parameters are wrong ")
 	}
 
-	respBody4 := makeHTTPEthJSONReqWithUserID(walletHTTPPort, rpc.GetStorageAt, []interface{}{map[string]interface{}{"address": "obscuro", "position": "1"}}, userID)
+	respBody4 := makeHTTPEthJSONReqWithUserID(walletHTTPPort, rpc.GetStorageAt, []interface{}{"obscuro", "1", nil}, userID)
 	if strings.Contains(string(respBody4), userID) {
 		t.Fatalf("expected response not containing userID as the parameters are wrong ")
 	}
 
 	// make a request with wrong rpcMethod
-	respBody5 := makeHTTPEthJSONReqWithUserID(walletHTTPPort, rpc.GetBalance, []interface{}{map[string]interface{}{"address": "obscuro", "position": "1"}}, userID)
+	respBody5 := makeHTTPEthJSONReqWithUserID(walletHTTPPort, rpc.GetBalance, []interface{}{"obscuro", "0", nil}, userID)
 	if strings.Contains(string(respBody5), userID) {
 		t.Fatalf("expected response not containing userID as the parameters are wrong ")
 	}

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -76,7 +76,7 @@ func (w *WalletExtension) ProxyEthRequest(request *accountmanager.RPCRequest, co
 
 	// wallet extension can override the GetStorageAt to retrieve the current userID
 	if request.Method == rpc.GetStorageAt {
-		if w.getStorageAtInterceptor(request, hexUserID) != nil {
+		if interceptedResponse := w.getStorageAtInterceptor(request, hexUserID); interceptedResponse != nil {
 			w.logger.Info("interception successful for getStorageAt, returning userID response")
 			return interceptedResponse, nil
 		}

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -74,7 +74,7 @@ func (w *WalletExtension) ProxyEthRequest(request *accountmanager.RPCRequest, co
 	// proxyRequest will find the correct client to proxy the request (or try them all if appropriate)
 	var rpcResp interface{}
 
-	// check if the requested method is GetStorageAt, since we use for gettingUserID if correct parameters are used
+	// wallet extension can override the GetStorageAt to retrieve the current userID
 	if request.Method == rpc.GetStorageAt {
 		interceptedResponse := w.getStorageAtInterceptor(request, hexUserID)
 		if interceptedResponse != nil {


### PR DESCRIPTION
### Why this change is needed

We need this to get userID to frontent as Metamask does not allow us to look for `rpcURL`. 
We decided to use function `getStorageAt` with predefined parameters address=obscuro, position=0 to return us userID from which it was requested.

### What changes were made as part of this PR

Obscuro Gateway does not forward the request to `getStorageAt` to Obscuro Node if conditions mentioned above are met and responds with userID that was used in the request. It additionally checks if that userID exists in the databse.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


