### PR TITLE
Bump eth2network

### DIFF
--- a/contracts/deployment_scripts/testnet/layer2/001_whitelist_tokens.ts
+++ b/contracts/deployment_scripts/testnet/layer2/001_whitelist_tokens.ts
@@ -94,9 +94,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     await new Promise(async (resolve, fail)=> { 
         setTimeout(fail, 30_000)
         const messageBusContract = (await hre.ethers.getContractAt('MessageBus', '0x526c84529b2b8c11f57d93d3f5537aca3aecef9b'));
-        while (await messageBusContract.callStatic.verifyMessageFinalized(messages[1], {
-            gasLimit: 1_000_000,
-        }) != true) {
+        while (await messageBusContract.callStatic.verifyMessageFinalized(messages[1]) != true) {
             console.log(`Messages not stored on L2 yet, retrying...`);
             sleep(1_000);
         }

--- a/contracts/deployment_scripts/testnet/layer2/001_whitelist_tokens.ts
+++ b/contracts/deployment_scripts/testnet/layer2/001_whitelist_tokens.ts
@@ -94,7 +94,9 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     await new Promise(async (resolve, fail)=> { 
         setTimeout(fail, 30_000)
         const messageBusContract = (await hre.ethers.getContractAt('MessageBus', '0x526c84529b2b8c11f57d93d3f5537aca3aecef9b'));
-        while (await messageBusContract.callStatic.verifyMessageFinalized(messages[1]) != true) {
+        while (await messageBusContract.callStatic.verifyMessageFinalized(messages[1], {
+            gasLimit: 1_000_000,
+        }) != true) {
             console.log(`Messages not stored on L2 yet, retrying...`);
             sleep(1_000);
         }

--- a/dockerfiles/enclave.debug.Dockerfile
+++ b/dockerfiles/enclave.debug.Dockerfile
@@ -9,7 +9,7 @@ FROM golang:1.20-alpine as system
 # install build utils
 RUN apk add build-base
 ENV CGO_ENABLED=1
-RUN go install github.com/go-delve/delve/cmd/dlv@v1.9.1
+RUN go install github.com/go-delve/delve/cmd/dlv@v1.20.2
 
 FROM system as get-dependencies
 # setup container data structure

--- a/go/common/gethencoding/geth_encoding.go
+++ b/go/common/gethencoding/geth_encoding.go
@@ -137,8 +137,9 @@ func ExtractEthCall(param interface{}) (*gethapi.TransactionArgs, error) {
 	var value, gasPrice, maxFeePerGas, maxPriorityFeePerGas *hexutil.Big
 	var ok bool
 	zeroUint := hexutil.Uint64(0)
-	gas := &zeroUint
 	nonce := &zeroUint
+	// if gas is not set it should be null
+	gas := (*hexutil.Uint64)(nil)
 
 	for field, val := range param.(map[string]interface{}) {
 		if val == nil {

--- a/integration/eth2network/eth2_binaries.go
+++ b/integration/eth2network/eth2_binaries.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	_gethVersion  = "1.11.6"
+	_gethVersion  = "1.12.2"
 	_prysmVersion = "v4.0.6"
 )
 

--- a/integration/eth2network/eth2_network.go
+++ b/integration/eth2network/eth2_network.go
@@ -459,6 +459,7 @@ func (n *Impl) prysmStartValidator(beaconHTTPPort int, nodeDataDir string) (*exe
 		"--interop-start-index", "0",
 		"--chain-config-file", n.prysmConfigPath,
 		"--config-file", n.prysmConfigPath,
+		"--suggested-fee-recipient", "0x52FfeB84540173B15eEC5a486FdB5c769F50400a", // random address to avoid a continuous warning
 		"--force-clear-db",
 		"--disable-account-metrics",
 		"--accept-terms-of-use",

--- a/integration/simulation/utils.go
+++ b/integration/simulation/utils.go
@@ -67,7 +67,6 @@ func balance(ctx context.Context, client *obsclient.AuthObsClient, address gethc
 		From: address,
 		To:   l2ContractAddress,
 		Data: balanceData,
-		Gas:  uint64(1_000_000),
 	}
 
 	response, err := client.CallContract(ctx, callMsg, nil)

--- a/testnet/launcher/docker.go
+++ b/testnet/launcher/docker.go
@@ -2,12 +2,12 @@ package launcher
 
 import (
 	"fmt"
-	"github.com/obscuronet/go-obscuro/go/obsclient"
-	"github.com/obscuronet/go-obscuro/go/rpc"
 	"time"
 
 	"github.com/obscuronet/go-obscuro/go/common/retry"
 	"github.com/obscuronet/go-obscuro/go/node"
+	"github.com/obscuronet/go-obscuro/go/obsclient"
+	"github.com/obscuronet/go-obscuro/go/rpc"
 	"github.com/obscuronet/go-obscuro/testnet/launcher/eth2network"
 	"github.com/sanity-io/litter"
 

--- a/testnet/launcher/docker.go
+++ b/testnet/launcher/docker.go
@@ -225,7 +225,7 @@ func waitForHealthyNode(port int) error { // todo: hook the cfg
 				return err
 			}
 			if health {
-				fmt.Println("obscuro node is ready")
+				fmt.Println("Obscuro node is ready")
 				return nil
 			}
 


### PR DESCRIPTION
### Why this change is needed

- Bumps geth to 1.12.2 
- Fixes the hardhat deployer static call
- Fixes the way the Health endpoint was called
- Updated the dlv version in the enclave_debug docker image
