### PR TITLE
fix for zero hash geth errors

### DIFF
--- a/go/enclave/storage/storage.go
+++ b/go/enclave/storage/storage.go
@@ -274,7 +274,7 @@ func (s *storageImpl) CreateStateDB(hash common.L2BatchHash) (*state.StateDB, er
 func (s *storageImpl) EmptyStateDB() (*state.StateDB, error) {
 	callStart := time.Now()
 	defer s.logDuration("EmptyStateDB", callStart)
-	statedb, err := state.New(gethcommon.BigToHash(big.NewInt(0)), s.stateDB, nil)
+	statedb, err := state.New(types.EmptyRootHash, s.stateDB, nil)
 	if err != nil {
 		return nil, fmt.Errorf("could not create state DB. Cause: %w", err)
 	}


### PR DESCRIPTION
### Why this change is needed

We've started seeing these errors on latest geth version:
`ERROR[08-25|10:52:20.285] Zero state root hash! `

### What changes were made as part of this PR

Use constant empty root hash instead of zero hash to keep geth happy (no behaviour change - see `newTrieReader()` in geth code, it logs error if it's zero but treats it the same as `EmptyRootHash`).

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


