### PR TITLE
use versioning with Obscuro Gateway API

### DIFF
--- a/tools/walletextension/README.md
+++ b/tools/walletextension/README.md
@@ -27,3 +27,27 @@ It uses a container to wrap the services that are required to allow the wallet e
 To build a docker image use docker build command. Please note that you need to run it from the root of the repository.
 Ro run the container you can use `./docker_run.sh`. You can add parameters to the script, and they are passed to wallet extension 
 (example: `-host=0.0.0.0` to be able to access wallet extension endpoints via localhost).
+
+
+### HTTP Endpoints
+
+For interacting with Obscuro Gateway, there are the following HTTP endpoint available:
+
+- `GET /v1/join`
+
+It generates and returns userID which needs to be added as a query parameter "u" to the URL in your Metamask
+(or another provider) as it identifies you.
+
+- `POST /v1/authenticate?u=$UserId`
+
+With this endpoint, you submit a signed message in a format `Register <userID> for <account>`
+from that account which proves that you hold private keys for it, and it links that account with your userID.
+
+- `GET /v1/query/address?u=$UserId&a=$Address`
+
+This endpoint responds with a json of true or false if the address "a" is already registered for user "u"
+
+
+- `POST "/v1/revoke?u=$UserId"`
+
+When this endpoint is triggered, the userId with the authenticated viewing keys should be deleted.

--- a/tools/walletextension/api/routes.go
+++ b/tools/walletextension/api/routes.go
@@ -26,7 +26,7 @@ type Route struct {
 func NewHTTPRoutes(walletExt *walletextension.WalletExtension) []Route {
 	return []Route{
 		{
-			Name: common.PathRoot,
+			Name: common.APIVersion_1 + common.PathRoot,
 			Func: httpHandler(walletExt, ethRequestHandler),
 		},
 		{
@@ -43,19 +43,19 @@ func NewHTTPRoutes(walletExt *walletextension.WalletExtension) []Route {
 			Func: httpHandler(walletExt, submitViewingKeyRequestHandler),
 		},
 		{
-			Name: common.PathJoin,
+			Name: common.APIVersion_1 + common.PathJoin,
 			Func: httpHandler(walletExt, joinRequestHandler),
 		},
 		{
-			Name: common.PathAuthenticate,
+			Name: common.APIVersion_1 + common.PathAuthenticate,
 			Func: httpHandler(walletExt, authenticateRequestHandler),
 		},
 		{
-			Name: common.PathQuery,
+			Name: common.APIVersion_1 + common.PathQuery,
 			Func: httpHandler(walletExt, queryRequestHandler),
 		},
 		{
-			Name: common.PathRevoke,
+			Name: common.APIVersion_1 + common.PathRevoke,
 			Func: httpHandler(walletExt, revokeRequestHandler),
 		},
 		{

--- a/tools/walletextension/api/routes.go
+++ b/tools/walletextension/api/routes.go
@@ -26,7 +26,7 @@ type Route struct {
 func NewHTTPRoutes(walletExt *walletextension.WalletExtension) []Route {
 	return []Route{
 		{
-			Name: common.APIVersion_1 + common.PathRoot,
+			Name: common.APIVersion1 + common.PathRoot,
 			Func: httpHandler(walletExt, ethRequestHandler),
 		},
 		{
@@ -43,19 +43,19 @@ func NewHTTPRoutes(walletExt *walletextension.WalletExtension) []Route {
 			Func: httpHandler(walletExt, submitViewingKeyRequestHandler),
 		},
 		{
-			Name: common.APIVersion_1 + common.PathJoin,
+			Name: common.APIVersion1 + common.PathJoin,
 			Func: httpHandler(walletExt, joinRequestHandler),
 		},
 		{
-			Name: common.APIVersion_1 + common.PathAuthenticate,
+			Name: common.APIVersion1 + common.PathAuthenticate,
 			Func: httpHandler(walletExt, authenticateRequestHandler),
 		},
 		{
-			Name: common.APIVersion_1 + common.PathQuery,
+			Name: common.APIVersion1 + common.PathQuery,
 			Func: httpHandler(walletExt, queryRequestHandler),
 		},
 		{
-			Name: common.APIVersion_1 + common.PathRevoke,
+			Name: common.APIVersion1 + common.PathRevoke,
 			Func: httpHandler(walletExt, revokeRequestHandler),
 		},
 		{

--- a/tools/walletextension/api/staticOG/javascript.js
+++ b/tools/walletextension/api/staticOG/javascript.js
@@ -6,10 +6,10 @@ const idAddAllAccounts = "addAllAccounts";
 const idRevokeUserID = "revokeUserID";
 const idStatus = "status";
 const idUserID = "userID";
-const pathJoin = "/join/";
-const pathAuthenticate = "/authenticate/";
-const pathQuery = "/query/";
-const pathRevoke = "/revoke/";
+const pathJoin = "/v1/join/";
+const pathAuthenticate = "/v1/authenticate/";
+const pathQuery = "/v1/query/";
+const pathRevoke = "/v1/revoke/";
 const obscuroChainIDDecimal = 777;
 const methodPost = "post";
 const methodGet = "get";
@@ -25,6 +25,7 @@ function isValidUserIDFormat(value) {
 }
 
 let obscuroGatewayAddress = window.location.protocol + "//" + window.location.host;
+let obscutoGatewayVersion = "v1"
 
 async function addNetworkToMetaMask(ethereum, userID, chainIDDecimal) {
     // add network to MetaMask
@@ -42,7 +43,7 @@ async function addNetworkToMetaMask(ethereum, userID, chainIDDecimal) {
                         symbol: 'OBX',
                         decimals: 18
                     },
-                    rpcUrls: [obscuroGatewayAddress+'/?u='+userID],
+                    rpcUrls: [obscuroGatewayAddress+"/"+obscutoGatewayVersion+'/?u='+userID],
                     blockExplorerUrls: null,
                 },
             ],

--- a/tools/walletextension/api/staticOG/javascript.js
+++ b/tools/walletextension/api/staticOG/javascript.js
@@ -6,10 +6,11 @@ const idAddAllAccounts = "addAllAccounts";
 const idRevokeUserID = "revokeUserID";
 const idStatus = "status";
 const idUserID = "userID";
-const pathJoin = "/v1/join/";
-const pathAuthenticate = "/v1/authenticate/";
-const pathQuery = "/v1/query/";
-const pathRevoke = "/v1/revoke/";
+const obscuroGatewayVersion = "v1"
+const pathJoin = obscuroGatewayVersion + "/join/";
+const pathAuthenticate = obscuroGatewayVersion + "/authenticate/";
+const pathQuery = obscuroGatewayVersion + "/query/";
+const pathRevoke = obscuroGatewayVersion + "/revoke/";
 const obscuroChainIDDecimal = 777;
 const methodPost = "post";
 const methodGet = "get";
@@ -25,7 +26,7 @@ function isValidUserIDFormat(value) {
 }
 
 let obscuroGatewayAddress = window.location.protocol + "//" + window.location.host;
-let obscutoGatewayVersion = "v1"
+
 
 async function addNetworkToMetaMask(ethereum, userID, chainIDDecimal) {
     // add network to MetaMask
@@ -43,7 +44,7 @@ async function addNetworkToMetaMask(ethereum, userID, chainIDDecimal) {
                         symbol: 'OBX',
                         decimals: 18
                     },
-                    rpcUrls: [obscuroGatewayAddress+"/"+obscutoGatewayVersion+'/?u='+userID],
+                    rpcUrls: [obscuroGatewayAddress+"/"+obscuroGatewayVersion+'/?u='+userID],
                     blockExplorerUrls: null,
                 },
             ],

--- a/tools/walletextension/common/constants.go
+++ b/tools/walletextension/common/constants.go
@@ -36,7 +36,7 @@ const (
 	PathAuthenticate                    = "/authenticate/"
 	PathQuery                           = "/query/"
 	PathRevoke                          = "/revoke/"
-	PathObscuroGateway                  = "/og/"
+	PathObscuroGateway                  = "/"
 	PathHealth                          = "/health/"
 	WSProtocol                          = "ws://"
 	DefaultUser                         = "defaultUser"

--- a/tools/walletextension/common/constants.go
+++ b/tools/walletextension/common/constants.go
@@ -48,7 +48,7 @@ const (
 	PersonalSignMessagePrefix           = "\x19Ethereum Signed Message:\n%d%s"
 	GetStorageAtUserIDRequestMethodName = "getUserID"
 	SuccessMsg                          = "success"
-	APIVersion_1                        = "/v1"
+	APIVersion1                         = "/v1"
 )
 
 var (

--- a/tools/walletextension/common/constants.go
+++ b/tools/walletextension/common/constants.go
@@ -48,6 +48,7 @@ const (
 	PersonalSignMessagePrefix           = "\x19Ethereum Signed Message:\n%d%s"
 	GetStorageAtUserIDRequestMethodName = "getUserID"
 	SuccessMsg                          = "success"
+	APIVersion_1                        = "/v1"
 )
 
 var (

--- a/tools/walletextension/main/main.go
+++ b/tools/walletextension/main/main.go
@@ -75,7 +75,7 @@ func main() {
 
 	walletExtensionAddr := fmt.Sprintf("%s:%d", common.Localhost, config.WalletExtensionPortHTTP)
 	fmt.Printf("💡 Wallet extension started - visit http://%s/viewingkeys/ to generate an ephemeral viewing key.\n", walletExtensionAddr)
-	fmt.Printf("💡 Obscuro Gateway started - visit http://%s/og/ to use it.\n", walletExtensionAddr)
+	fmt.Printf("💡 Obscuro Gateway started - visit http://%s to use it.\n", walletExtensionAddr)
 
 	select {}
 }

--- a/tools/walletextension/test/utils.go
+++ b/tools/walletextension/test/utils.go
@@ -114,7 +114,7 @@ func waitForEndpoint(addr string) error {
 // Makes an Ethereum JSON RPC request over HTTP and returns the response body.
 func makeHTTPEthJSONReq(port int, method string, params interface{}) []byte {
 	reqBody := prepareRequestBody(method, params)
-	return makeRequestHTTP(fmt.Sprintf("http://%s:%d", common.Localhost, port), reqBody)
+	return makeRequestHTTP(fmt.Sprintf("http://%s:%d/v1/", common.Localhost, port), reqBody)
 }
 
 // Makes an Ethereum JSON RPC request over HTTP to specific endpoint and returns the response body.
@@ -126,7 +126,7 @@ func makeHTTPEthJSONReqWithPath(port int, path string) []byte {
 // Makes an Ethereum JSON RPC request over HTTP and returns the response body with userID query paremeter.
 func makeHTTPEthJSONReqWithUserID(port int, method string, params interface{}, userID string) []byte {
 	reqBody := prepareRequestBody(method, params)
-	return makeRequestHTTP(fmt.Sprintf("http://%s:%d?u=%s", common.Localhost, port, userID), reqBody)
+	return makeRequestHTTP(fmt.Sprintf("http://%s:%d/v1/?u=%s", common.Localhost, port, userID), reqBody)
 }
 
 // Makes an Ethereum JSON RPC request over websockets and returns the response body.

--- a/tools/walletextension/test/wallet_extension_test.go
+++ b/tools/walletextension/test/wallet_extension_test.go
@@ -292,7 +292,7 @@ func TestGetStorageAtForReturningUserID(t *testing.T) {
 	createWalExt(t, walExtCfg)
 
 	// create userID
-	respJoin := makeHTTPEthJSONReqWithPath(walletHTTPPort, "join")
+	respJoin := makeHTTPEthJSONReqWithPath(walletHTTPPort, "v1/join")
 	userID := string(respJoin)
 
 	// make a request to GetStorageAt with correct parameters to get userID that exists in the database

--- a/tools/walletextension/test/wallet_extension_test.go
+++ b/tools/walletextension/test/wallet_extension_test.go
@@ -318,8 +318,8 @@ func TestGetStorageAtForReturningUserID(t *testing.T) {
 	}
 
 	// make a request with wrong rpcMethod
-	respBody5 := makeHTTPEthJSONReqWithUserID(walletHTTPPort, rpc.GetBalance, []interface{}{"getUserID", "0", nil}, userID)
-	if strings.Contains(string(respBody5), userID) {
+	respBody4 := makeHTTPEthJSONReqWithUserID(walletHTTPPort, rpc.GetBalance, []interface{}{"getUserID", "0", nil}, userID)
+	if strings.Contains(string(respBody4), userID) {
 		t.Fatalf("expected response not containing userID as the parameters are wrong ")
 	}
 }


### PR DESCRIPTION
### Why this change is needed

We want to have versions in the Obscuro Gateway API to allow new versions in the future.

As path for `eth` requests change to `/v1` we can serve frontend on `/` instead of `/og`

### What changes were made as part of this PR

/v1/ is used before Obscuro Gateway endpoints (except health, ready and old walletExtension endpoints that will be removed soon)

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


