### PR TITLE
Uses a prebuilt obscuro node image

### DIFF
--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -205,7 +205,7 @@ jobs:
             --public-ip-address-dns-name "obscuronode-${{ matrix.host_id }}-${{needs.build.outputs.RESOURCE_TESTNET_NAME}}-${{ GITHUB.RUN_NUMBER }}" \
             --tags deploygroup=ObscuroNode-${{needs.build.outputs.RESOURCE_TESTNET_NAME}}-${{ GITHUB.RUN_NUMBER }}  ${{needs.build.outputs.RESOURCE_TAG_NAME}}=true \
             --vnet-name ObscuroHost-${{needs.build.outputs.RESOURCE_TESTNET_NAME}}-01VNET --subnet ObscuroHost-${{needs.build.outputs.RESOURCE_TESTNET_NAME}}-01Subnet \
-            --size Standard_DC4s_v2 --image Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:20.04.202206220 \
+            --size Standard_DC4s_v2 --image ObscuroConfUbuntu \
             --public-ip-sku Basic --authentication-type password
 
       - name: 'Open Obscuro node-${{ matrix.host_id }} ports on Azure'
@@ -227,10 +227,6 @@ jobs:
             --command-id RunShellScript \
             --scripts 'mkdir -p /home/obscuro \
             && git clone --depth 1 -b ${{ env.BRANCH_NAME }} https://github.com/obscuronet/go-obscuro.git /home/obscuro/go-obscuro \
-            && sudo apt-get update \
-            && sudo apt-get install -y gcc \
-            && sudo snap refresh && sudo snap install --channel=1.18 go --classic \
-            && curl -fsSL https://get.docker.com -o get-docker.sh && sh ./get-docker.sh \
             && docker network create --driver bridge node_network || true \
             && docker run -d --name datadog-agent \
                --network node_network \

--- a/.github/workflows/runner-scripts/create-vm.txt
+++ b/.github/workflows/runner-scripts/create-vm.txt
@@ -1,0 +1,26 @@
+
+# Steps to create a new image for obscuro nodes
+
+az vm create \
+  --resource-group Testnet \
+  --name MakeImageVM \
+  --image Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:20.04.202206220 \
+  --admin-username obscurouser --admin-password 'PWD'
+
+ssh obscurouser@IPADDRESS
+
+sudo apt-get update \
+ && sudo apt-get install -y gcc \
+ && sudo snap refresh && sudo snap install --channel=1.20 go --classic \
+ && curl -fsSL https://get.docker.com -o get-docker.sh && sh ./get-docker.sh
+
+exit
+
+az vm deallocate --resource-group Testnet --name MakeImageVM
+az vm generalize --resource-group Testnet --name MakeImageVM
+az image create --resource-group Testnet --name ObscuroConfUbuntu --source MakeImageVM --hyper-v-generation V2
+
+az vm delete --resource-group Testnet --name MakeImageVM --yes
+az disk delete --resource-group Testnet --name MakeImageVM_OSDisk --yes
+az network nic delete --resource-group Testnet --name MakeImageVM_NIC
+


### PR DESCRIPTION
### Why this change is needed

https://github.com/obscuronet/obscuro-internal/issues/1449

Improves the deploy time by having a pre-built image instead of installing everything on the fly.
Should also reduce install-time flakyness, like errors on apt-get update / docker install, that we have seen in the past.


### What changes were made as part of this PR

Defaults to using the ObscuroConfUbuntu image
Added a text file on how to create these images for future reference.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


