### PR TITLE
Add versions to calls to the Obscuro Gateway

### DIFF
--- a/contracts/config/networks.json
+++ b/contracts/config/networks.json
@@ -13,7 +13,7 @@
     },
     "localObscuro": {
       "chainId": 777,
-      "url": "http://127.0.0.1:3000",
+      "url": "http://127.0.0.1:3000/v1",
       "obscuroEncRpcUrl": "ws://127.0.0.1:81",
       "gasPrice": 2000000000,
       "companionNetworks" : {

--- a/testnet/launcher/l2contractdeployer/docker.go
+++ b/testnet/launcher/l2contractdeployer/docker.go
@@ -49,7 +49,7 @@ func (n *ContractDeployer) Start() error {
         },
         "layer2" : {
             "obscuroEncRpcUrl" : "ws://%s:%d",
-            "url": "http://127.0.0.1:3000",
+            "url": "http://127.0.0.1:3000/v1",
             "live" : false,
             "saveDeployments" : true,
             "companionNetworks" : { "layer1" : "layer1" },

--- a/tools/obscuroscan/main/cli.go
+++ b/tools/obscuroscan/main/cli.go
@@ -30,7 +30,7 @@ func defaultObscuroClientConfig() obscuroscanConfig {
 	return obscuroscanConfig{
 		nodeID:        "",
 		rpcServerAddr: "http://testnet.obscu.ro:80",
-		address:       "127.0.0.1:3000",
+		address:       "127.0.0.1:3000/v1",
 		logPath:       "obscuroscan_logs.txt",
 	}
 }


### PR DESCRIPTION
### Why this change is needed

After introduction of versions some calls failed as they did not have the correct URL (with version included)

### What changes were made as part of this PR

Added versions to the URLs

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


