### PR TITLE
Fix txHash field in SQL

### DIFF
--- a/go/enclave/storage/enclavedb/events.go
+++ b/go/enclave/storage/enclavedb/events.go
@@ -182,7 +182,7 @@ func FilterLogs(
 func DebugGetLogs(db *sql.DB, txHash common.TxHash) ([]*tracers.DebugLogs, error) {
 	var queryParams []any
 
-	query := baseDebugEventsQuerySelect + " " + baseEventsJoin + "AND txHash = ?"
+	query := baseDebugEventsQuerySelect + " " + baseEventsJoin + "AND tx.hash = ?"
 
 	queryParams = append(queryParams, txHash.Bytes())
 


### PR DESCRIPTION
### Why this change is needed

Looks like there's a field change that wasn't updated.
`txHash` no longer exits. Changing it to `tx.hash`


