### PR TITLE
L1 client - Change client to only reconnect if dead

### DIFF
--- a/go/ethadapter/geth_rpc_client.go
+++ b/go/ethadapter/geth_rpc_client.go
@@ -256,8 +256,12 @@ func (e *gethRPCClient) EstimateGasAndGasPrice(txData types.TxData, from gethcom
 	}, nil
 }
 
-// Reconnect closes the existing client connection and creates a new connection to the same address:port
-func (e *gethRPCClient) Reconnect() error {
+// ReconnectIfClosed closes the existing client connection and creates a new connection to the same address:port
+func (e *gethRPCClient) ReconnectIfClosed() error {
+	if e.Alive() {
+		// connection is not closed
+		return nil
+	}
 	e.client.Close()
 
 	client, err := connect(e.rpcAddress, e.timeout)

--- a/go/ethadapter/interface.go
+++ b/go/ethadapter/interface.go
@@ -42,7 +42,7 @@ type EthClient interface {
 	Stop() // tries to cleanly stop the client and release any resources
 
 	EthClient() *ethclient.Client // returns the underlying eth client
-	Reconnect() error             // closes and creates a new connection
+	ReconnectIfClosed() error     // closes and creates a new connection
 	Alive() bool                  // returns whether the connection is live or not
 }
 

--- a/go/host/l1/blockrepository.go
+++ b/go/host/l1/blockrepository.go
@@ -180,7 +180,7 @@ func (r *Repository) resetLiveStream() (chan *types.Header, ethereum.Subscriptio
 			// break out of the loop if repository has stopped
 			return retry.FailFast(errors.New("repository is stopped"))
 		}
-		err := r.ethClient.Reconnect()
+		err := r.ethClient.ReconnectIfClosed()
 		if err != nil {
 			r.logger.Warn("failed to reconnect to L1", log.ErrKey, err)
 			return err

--- a/go/host/l1/publisher.go
+++ b/go/host/l1/publisher.go
@@ -110,7 +110,7 @@ func (p *Publisher) RequestSecret(attestation *common.AttestationReport) (gethco
 	// record the L1 head height before we submit the secret request, so we know which block to watch from
 	l1Head, err := p.ethClient.FetchHeadBlock()
 	if err != nil {
-		err = p.ethClient.Reconnect()
+		err = p.ethClient.ReconnectIfClosed()
 		if err != nil {
 			panic(errors.Wrap(err, "could not reconnect to eth client"))
 		}

--- a/integration/ethereummock/node.go
+++ b/integration/ethereummock/node.go
@@ -467,7 +467,7 @@ func (m *Node) RemoveSubscription(id uuid.UUID) {
 	delete(m.subs, id)
 }
 
-func (m *Node) Reconnect() error {
+func (m *Node) ReconnectIfClosed() error {
 	return nil
 }
 


### PR DESCRIPTION
### Why this change is needed

Aggressive reconnects were unnecessary and interfering with slower connections (infura)

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


