### PR TITLE
hardhat: ensure token script doesn't spin when waiting

### DIFF
--- a/contracts/deployment_scripts/testnet/layer2/001_whitelist_tokens.ts
+++ b/contracts/deployment_scripts/testnet/layer2/001_whitelist_tokens.ts
@@ -95,6 +95,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
         setTimeout(fail, 30_000)
         const messageBusContract = (await hre.ethers.getContractAt('MessageBus', '0x526c84529b2b8c11f57d93d3f5537aca3aecef9b'));
         while (await messageBusContract.callStatic.verifyMessageFinalized(messages[1]) != true) {
+            console.log(`Messages not stored on L2 yet, retrying...`);
             await sleep(1_000);
         }
         resolve(true);

--- a/contracts/deployment_scripts/testnet/layer2/001_whitelist_tokens.ts
+++ b/contracts/deployment_scripts/testnet/layer2/001_whitelist_tokens.ts
@@ -8,7 +8,7 @@ import { Receipt } from 'hardhat-deploy/dist/types';
 */
 
 
-function sleep(ms) {
+async function sleep(ms) {
     return new Promise((resolve) => {
       setTimeout(resolve, ms);
     });
@@ -95,8 +95,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
         setTimeout(fail, 30_000)
         const messageBusContract = (await hre.ethers.getContractAt('MessageBus', '0x526c84529b2b8c11f57d93d3f5537aca3aecef9b'));
         while (await messageBusContract.callStatic.verifyMessageFinalized(messages[1]) != true) {
-            console.log(`Messages not stored on L2 yet, retrying...`);
-            sleep(1_000);
+            await sleep(1_000);
         }
         resolve(true);
     });


### PR DESCRIPTION
### Why this change is needed

Small bug in the sleep in this TS script means that we spin and create lots of promises instead of waiting 1sec between each one.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


