### PR TITLE
Filter for tx receipts with any obscuro interactions

### DIFF
--- a/go/common/host/services.go
+++ b/go/common/host/services.go
@@ -86,7 +86,7 @@ type L1BlockRepository interface {
 	// It returns the new block, a bool which is true if the block is the current L1 head and a bool if the block is on a different fork to prevBlock
 	FetchNextBlock(prevBlock gethcommon.Hash) (*types.Block, bool, error)
 	// FetchObscuroReceipts returns the receipts for a given L1 block
-	FetchObscuroReceipts(block *common.L1Block) types.Receipts
+	FetchObscuroReceipts(block *common.L1Block) (types.Receipts, error)
 }
 
 // L1BlockHandler is an interface for receiving new blocks from the repository as they arrive

--- a/go/ethadapter/geth_rpc_client.go
+++ b/go/ethadapter/geth_rpc_client.go
@@ -215,6 +215,13 @@ func (e *gethRPCClient) BalanceAt(address gethcommon.Address, blockNum *big.Int)
 	return e.client.BalanceAt(ctx, address, blockNum)
 }
 
+func (e *gethRPCClient) GetLogs(q ethereum.FilterQuery) ([]types.Log, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), e.timeout)
+	defer cancel()
+
+	return e.client.FilterLogs(ctx, q)
+}
+
 func (e *gethRPCClient) Stop() {
 	e.client.Close()
 }

--- a/go/ethadapter/interface.go
+++ b/go/ethadapter/interface.go
@@ -26,6 +26,7 @@ type EthClient interface {
 	TransactionReceipt(hash gethcommon.Hash) (*types.Receipt, error)              // fetches the ethereum transaction receipt
 	Nonce(address gethcommon.Address) (uint64, error)                             // fetches the account nonce to use in the next transaction
 	BalanceAt(account gethcommon.Address, blockNumber *big.Int) (*big.Int, error) // fetches the balance of the account
+	GetLogs(q ethereum.FilterQuery) ([]types.Log, error)                          // fetches the logs for a given query
 
 	Info() Info                                                         // retrieves the node Info
 	FetchHeadBlock() (*types.Block, error)                              // retrieves the block at head height

--- a/go/host/enclave/guardian.go
+++ b/go/host/enclave/guardian.go
@@ -381,11 +381,14 @@ func (g *Guardian) catchupWithL2() error {
 // todo - @matt - think about removing the TryLock
 func (g *Guardian) submitL1Block(block *common.L1Block, isLatest bool) (bool, error) {
 	g.logger.Trace("submitting L1 block", log.BlockHashKey, block.Hash(), log.BlockHeightKey, block.Number())
-	receipts := g.sl.L1Repo().FetchObscuroReceipts(block)
 	if !g.submitDataLock.TryLock() {
 		g.logger.Info("Unable to submit block, already submitting another block")
 		// we are already submitting a block, and we don't want to leak goroutines, we wil catch up with the block later
 		return false, nil
+	}
+	receipts, err := g.sl.L1Repo().FetchObscuroReceipts(block)
+	if err != nil {
+		return false, fmt.Errorf("could not fetch obscuro receipts for block=%s - %w", block.Hash(), err)
 	}
 	resp, err := g.enclaveClient.SubmitL1Block(*block, receipts, isLatest)
 	g.submitDataLock.Unlock()

--- a/integration/ethereummock/node.go
+++ b/integration/ethereummock/node.go
@@ -219,6 +219,27 @@ func (m *Node) BalanceAt(gethcommon.Address, *big.Int) (*big.Int, error) {
 	panic("not implemented")
 }
 
+// GetLogs is a mock method - we don't really have logs on the mock transactions, so it returns a basic log for every tx
+// so the host recognises them as relevant
+func (m *Node) GetLogs(fq ethereum.FilterQuery) ([]types.Log, error) {
+	logs := make([]types.Log, 0)
+	if fq.BlockHash == nil {
+		return logs, nil
+	}
+	blk, err := m.BlockByHash(*fq.BlockHash)
+	if err != nil {
+		return nil, fmt.Errorf("could not retrieve block. Cause: %w", err)
+	}
+	for _, tx := range blk.Transactions() {
+		dummyLog := types.Log{
+			BlockHash: blk.Hash(),
+			TxHash:    tx.Hash(),
+		}
+		logs = append(logs, dummyLog)
+	}
+	return logs, nil
+}
+
 // Start runs an infinite loop that listens to the two block producing channels and processes them.
 func (m *Node) Start() {
 	if m.mining {


### PR DESCRIPTION
### Why this change is needed

Currently we only send tx receipts to the enclave for L1 transactions addressed `to` an obscuro contract (message bus or management contract).

However we need to capture receipts for any transaction that interacts with those contracts even if the transaction is not addressed `to` the contract directly.

This was breaking local network and testnet networks deployments because the whitelist ERC20 bridge script was failing.

### What changes were made as part of this PR

Make an `eth_getLogs` call to fetch all logs in the block and scan through them to see if they come from the obscuro relevant contracts.

Send receipts for those transactions.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


