### PR TITLE
Enable websockets on hosted Obscuro Gateway

### DIFF
--- a/.github/workflows/manual-deploy-obscuro-gateway.yml
+++ b/.github/workflows/manual-deploy-obscuro-gateway.yml
@@ -64,6 +64,6 @@ jobs:
           restart-policy: 'Never'
           environment-variables: PORT=80
           command-line: ./wallet_extension_linux -host=0.0.0.0 -port=80 -portWS=81 -nodeHost=${{ env.OBSCURO_GATEWAY_NODE_HOST }}
-          ports: '80,81'
+          ports: 81 80
           cpu: 2
           memory: 2


### PR DESCRIPTION
### Why this change is needed

On hosted gateway port 81 was not open and event subscriptions failed to work because of that.

### What changes were made as part of this PR

Open port 81 on the deployed container.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


