### PR TITLE
Add l1 block time config for host

### DIFF
--- a/go/config/host_config.go
+++ b/go/config/host_config.go
@@ -87,6 +87,9 @@ type HostInputConfig struct {
 	// Min interval before creating the next rollup (only used by Sequencer nodes)
 	RollupInterval time.Duration
 
+	// The expected time between blocks on the L1 network
+	L1BlockTime time.Duration
+
 	// Whether inbound p2p is enabled or not
 	IsInboundP2PDisabled bool
 }
@@ -126,6 +129,7 @@ func (p HostInputConfig) ToHostConfig() *HostConfig {
 		DebugNamespaceEnabled:     p.DebugNamespaceEnabled,
 		BatchInterval:             p.BatchInterval,
 		RollupInterval:            p.RollupInterval,
+		L1BlockTime:               p.L1BlockTime,
 		IsInboundP2PDisabled:      p.IsInboundP2PDisabled,
 	}
 }
@@ -152,6 +156,8 @@ type HostConfig struct {
 	BatchInterval time.Duration
 	// Min interval before creating the next rollup (only used by Sequencer nodes)
 	RollupInterval time.Duration
+	// The expected time between blocks on the L1 network
+	L1BlockTime time.Duration
 
 	/////
 	// NODE CONFIG
@@ -247,6 +253,7 @@ func DefaultHostParsedConfig() *HostInputConfig {
 		DebugNamespaceEnabled:     false,
 		BatchInterval:             1 * time.Second,
 		RollupInterval:            5 * time.Second,
+		L1BlockTime:               15 * time.Second,
 		IsInboundP2PDisabled:      false,
 	}
 }

--- a/go/host/container/cli.go
+++ b/go/host/container/cli.go
@@ -49,6 +49,7 @@ type HostConfigToml struct {
 	BatchInterval             string
 	RollupInterval            string
 	IsInboundP2PDisabled      bool
+	L1BlockTime               int
 }
 
 // ParseConfig returns a config.HostInputConfig based on either the file identified by the `config` flag, or the flags with
@@ -200,5 +201,6 @@ func fileBasedConfig(configPath string) (*config.HostInputConfig, error) {
 		BatchInterval:             batchInterval,
 		RollupInterval:            rollupInterval,
 		IsInboundP2PDisabled:      tomlConfig.IsInboundP2PDisabled,
+		L1BlockTime:               time.Duration(tomlConfig.L1BlockTime) * time.Second,
 	}, nil
 }

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -74,7 +74,10 @@ func NewHost(config *config.HostConfig, hostServices *ServicesRegistry, p2p host
 
 	hostServices.RegisterService(hostcommon.P2PName, p2p)
 	hostServices.RegisterService(hostcommon.L1BlockRepositoryName, l1Repo)
-	hostServices.RegisterService(hostcommon.L1PublisherName, l1.NewL1Publisher(hostIdentity, ethWallet, ethClient, mgmtContractLib, l1Repo, logger))
+	maxWaitForL1Receipt := 4 * config.L1BlockTime   // wait ~4 blocks to see if tx gets published before retrying
+	retryIntervalForL1Receipt := config.L1BlockTime // retry ~every block
+	l1Publisher := l1.NewL1Publisher(hostIdentity, ethWallet, ethClient, mgmtContractLib, l1Repo, host.stopControl, logger, maxWaitForL1Receipt, retryIntervalForL1Receipt)
+	hostServices.RegisterService(hostcommon.L1PublisherName, l1Publisher)
 	hostServices.RegisterService(hostcommon.L2BatchRepositoryName, l2Repo)
 	hostServices.RegisterService(hostcommon.EnclaveServiceName, enclService)
 	hostServices.RegisterService(hostcommon.LogSubscriptionServiceName, subsService)

--- a/go/node/config.go
+++ b/go/node/config.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/obscuronet/go-obscuro/go/common"
 	"github.com/obscuronet/go-obscuro/go/config"
@@ -46,6 +47,7 @@ type Config struct {
 	profilerEnabled           bool
 	logLevel                  int
 	isInboundP2PDisabled      bool
+	l1BlockTime               time.Duration
 }
 
 func NewNodeConfig(opts ...Option) *Config {
@@ -104,6 +106,7 @@ func (c *Config) ToHostConfig() *config.HostInputConfig {
 	cfg.LogLevel = c.logLevel
 	cfg.SequencerID = gethcommon.HexToAddress(c.sequencerID)
 	cfg.IsInboundP2PDisabled = c.isInboundP2PDisabled
+	cfg.L1BlockTime = c.l1BlockTime
 
 	return cfg
 }
@@ -275,5 +278,11 @@ func WithLogLevel(i int) Option {
 func WithInboundP2PDisabled(b bool) Option {
 	return func(c *Config) {
 		c.isInboundP2PDisabled = b
+	}
+}
+
+func WithL1BlockTime(d time.Duration) Option {
+	return func(c *Config) {
+		c.l1BlockTime = d
 	}
 }

--- a/integration/simulation/network/inmemory.go
+++ b/integration/simulation/network/inmemory.go
@@ -67,6 +67,7 @@ func (n *basicNetworkOfInMemoryNodes) Create(params *params.SimParams, stats *st
 			common.Hash{},
 			params.AvgBlockDuration/2,
 			incomingP2PDisabled,
+			params.AvgBlockDuration,
 		)
 		obscuroClient := p2p.NewInMemObscuroClient(agg)
 

--- a/integration/simulation/network/network_utils.go
+++ b/integration/simulation/network/network_utils.go
@@ -59,6 +59,7 @@ func createInMemObscuroNode(
 	l1StartBlk gethcommon.Hash,
 	batchInterval time.Duration,
 	incomingP2PDisabled bool,
+	l1BlockTime time.Duration,
 ) *container.HostContainer {
 	mgtContractAddress := mgmtContractLib.GetContractAddr()
 
@@ -74,6 +75,7 @@ func createInMemObscuroNode(
 		MessageBusAddress:         l1BusAddress,
 		BatchInterval:             batchInterval,
 		IsInboundP2PDisabled:      incomingP2PDisabled,
+		L1BlockTime:               l1BlockTime,
 	}
 
 	enclaveConfig := &config.EnclaveConfig{

--- a/integration/simulation/network/obscuro_node_utils.go
+++ b/integration/simulation/network/obscuro_node_utils.go
@@ -52,6 +52,7 @@ func startInMemoryObscuroNodes(params *params.SimParams, genesisJSON []byte, l1C
 			params.L1SetupData.ObscuroStartBlock,
 			params.AvgBlockDuration/3,
 			true,
+			params.AvgBlockDuration,
 		)
 		obscuroHosts[i] = obscuroNodes[i].Host()
 	}

--- a/integration/simulation/network/socket.go
+++ b/integration/simulation/network/socket.go
@@ -98,6 +98,7 @@ func (n *networkOfSocketNodes) Create(simParams *params.SimParams, _ *stats.Stat
 				node.WithInboundP2PDisabled(isInboundP2PDisabled),
 				node.WithLogLevel(4),
 				node.WithDebugNamespaceEnabled(true),
+				node.WithL1BlockTime(simParams.AvgBlockDuration),
 			),
 		)
 


### PR DESCRIPTION
### Why this change is needed

Timings around retries and timeouts on the host depend on the host block size.

These times are very different between testnets and sims.

The hardcoded times we got by with are causing problems for the sepolia readiness work.

### What changes were made as part of this PR

- Add L1 block time field to host config
- Default to 15s
- Overridden by sims and tests

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


