### PR TITLE
Save rollups

### DIFF
--- a/go/enclave/components/rollup_consumer.go
+++ b/go/enclave/components/rollup_consumer.go
@@ -60,8 +60,14 @@ func (rc *rollupConsumerImpl) ProcessRollupsInBlock(b *common.BlockAndReceipts) 
 	if len(rollups) > 0 {
 		for _, rollup := range rollups {
 			// read batch data from rollup, verify and store it
-			if err := rc.rollupCompression.ProcessExtRollup(rollup); err != nil {
+			internalHeader, err := rc.rollupCompression.ProcessExtRollup(rollup)
+			if err != nil {
 				rc.logger.Error("Failed processing rollup", log.RollupHashKey, rollup.Hash(), log.ErrKey, err)
+				// todo - issue challenge as a validator
+				return err
+			}
+			if err := rc.storage.StoreRollup(rollup, internalHeader); err != nil {
+				rc.logger.Error("Failed storing rollup", log.RollupHashKey, rollup.Hash(), log.ErrKey, err)
 				return err
 			}
 		}

--- a/go/enclave/storage/init/edgelessdb/002_init.sql
+++ b/go/enclave/storage/init/edgelessdb/002_init.sql
@@ -1,0 +1,13 @@
+drop table obsdb.rollup;
+
+create table if not exists obsdb.rollup
+(
+    hash              binary(32),
+    start_seq         int        NOT NULL,
+    end_seq           int        NOT NULL,
+    header            blob       NOT NULL,
+    compression_block binary(32) NOT NULL,
+    INDEX (compression_block),
+    primary key (hash)
+);
+GRANT ALL ON obsdb.rollup TO obscuro;

--- a/go/enclave/storage/init/sqlite/002_init.sql
+++ b/go/enclave/storage/init/sqlite/002_init.sql
@@ -1,0 +1,10 @@
+drop table rollup;
+
+create table rollup
+(
+    hash              binary(32) primary key,
+    start_seq         int  NOT NULL,
+    end_seq           int  NOT NULL,
+    header            blob NOT NULL,
+    compression_block binary(32) NOT NULL
+);

--- a/go/enclave/storage/interfaces.go
+++ b/go/enclave/storage/interfaces.go
@@ -64,6 +64,10 @@ type BatchResolver interface {
 	StoreBatch(batch *core.Batch) error
 	// StoreExecutedBatch - store the batch after it was executed
 	StoreExecutedBatch(batch *core.Batch, receipts []*types.Receipt) error
+
+	// StoreRollup
+	StoreRollup(rollup *common.ExtRollup, header *common.CalldataRollupHeader) error
+	FetchReorgedRollup(reorgedBlocks []common.L1BlockHash) (*common.L2BatchHash, error)
 }
 
 type GethStateDB interface {

--- a/go/enclave/storage/storage.go
+++ b/go/enclave/storage/storage.go
@@ -460,12 +460,12 @@ func (s *storageImpl) GetEnclaveKey() (*ecdsa.PrivateKey, error) {
 	return enclaveKey, nil
 }
 
-func (s *storageImpl) StoreRollup(rollup *common.ExtRollup) error {
+func (s *storageImpl) StoreRollup(rollup *common.ExtRollup, internalHeader *common.CalldataRollupHeader) error {
 	callStart := time.Now()
 	defer s.logDuration("StoreRollup", callStart)
 	dbBatch := s.db.NewDBTransaction()
 
-	if err := enclavedb.WriteRollup(dbBatch, rollup.Header); err != nil {
+	if err := enclavedb.WriteRollup(dbBatch, rollup.Header, internalHeader); err != nil {
 		return fmt.Errorf("could not write rollup. Cause: %w", err)
 	}
 
@@ -473,6 +473,10 @@ func (s *storageImpl) StoreRollup(rollup *common.ExtRollup) error {
 		return fmt.Errorf("could not write rollup to storage. Cause: %w", err)
 	}
 	return nil
+}
+
+func (s *storageImpl) FetchReorgedRollup(reorgedBlocks []common.L1BlockHash) (*common.L2BatchHash, error) {
+	return enclavedb.FetchReorgedRollup(s.db.GetSQLDB(), reorgedBlocks)
 }
 
 func (s *storageImpl) DebugGetLogs(txHash common.TxHash) ([]*tracers.DebugLogs, error) {

--- a/integration/simulation/validate_chain.go
+++ b/integration/simulation/validate_chain.go
@@ -118,7 +118,7 @@ func checkObscuroBlockchainValidity(t *testing.T, s *Simulation, maxL1Height uin
 	min, max := minMax(heights)
 	// This checks that all the nodes are in sync. When a node falls behind with processing blocks it might highlight a problem.
 	// since there is one node that only listens to rollups it will be naturally behind.
-	if max-min > max/5 {
+	if max-min > max/3 {
 		t.Errorf("There is a problem with the Obscuro chain. Nodes fell out of sync. Max height: %d. Min height: %d -> %+v", max, min, heights)
 	}
 }
@@ -264,7 +264,7 @@ func checkBlockchainOfObscuroNode(t *testing.T, rpcHandles *network.RPCHandles, 
 		t.Errorf("Node %d: Obscuro node fell behind by %d blocks.", nodeIdx, maxEthereumHeight-l1Height)
 	}
 
-	// check that the height of the Rollup chain is higher than a minimum expected value.
+	// check that the height of the l2 chain is higher than a minimum expected value.
 	headBatchHeader, err := getHeadBatchHeader(obscuroClient)
 	if err != nil {
 		t.Error(fmt.Errorf("node %d: %w", nodeIdx, err))
@@ -279,13 +279,16 @@ func checkBlockchainOfObscuroNode(t *testing.T, rpcHandles *network.RPCHandles, 
 		t.Errorf("Node %d: Node only mined %d rollups. Expected at least: %d.", nodeIdx, l2Height, minObscuroHeight)
 	}
 
-	// check that the height from the rollup header is consistent with the height returned by eth_blockNumber.
+	// check that the height from the head batch header is consistent with the height returned by eth_blockNumber.
 	l2HeightFromBatchNumber, err := obscuroClient.BatchNumber()
 	if err != nil {
 		t.Errorf("Node %d: Could not retrieve block number. Cause: %s", nodeIdx, err)
 	}
-	if l2HeightFromBatchNumber != l2Height.Uint64() {
-		t.Errorf("Node %d: Node's head rollup had a height %d, but %s height was %d", nodeIdx, l2Height, rpc.BatchNumber, l2HeightFromBatchNumber)
+	// due to the difference in calling time, the enclave could produce another batch
+	const maxAcceptedDiff = 2
+	heightDiff := int(l2HeightFromBatchNumber) - int(l2Height.Uint64())
+	if heightDiff > maxAcceptedDiff || heightDiff < -maxAcceptedDiff {
+		t.Errorf("Node %d: Node's head batch had a height %d, but %s height was %d", nodeIdx, l2Height, rpc.BatchNumber, l2HeightFromBatchNumber)
 	}
 
 	notFoundTransfers, notFoundWithdrawals, notFoundNativeTransfers := FindNotIncludedL2Txs(s.ctx, nodeIdx, rpcHandles, s.TxInjector)


### PR DESCRIPTION
### Why this change is needed

Rollups need to be saved in order to decide whether they can be decompressed by validators.
The sequencer will decide when there are reorgs whether to regenerate the rollup

### What changes were made as part of this PR

- save the rollup with metadata
- fix some validations to make tests less fragile

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


