### PR TITLE
Correct ws to http on the deployers flag name

### DIFF
--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -111,7 +111,7 @@ jobs:
         shell: bash
         run: |
           go run ./testnet/launcher/l1contractdeployer/cmd \
-          -l1_ws_url=${{ env.L1_HTTP_URL }} \
+          -l1_http_url=${{ env.L1_HTTP_URL }} \
           -private_key=${{ secrets.GETHNETWORK_PREFUNDED_PKSTR_WORKER }} \
           -docker_image=${{env.L2_HARDHATDEPLOYER_DOCKER_BUILD_TAG}} \
           -contracts_env_file=./testnet/.env
@@ -326,7 +326,7 @@ jobs:
         run: |
           go run ./testnet/launcher/l2contractdeployer/cmd \
           -l2_host=obscuronode-0-${{needs.build.outputs.RESOURCE_TESTNET_NAME}}-${{ GITHUB.RUN_NUMBER }}.uksouth.cloudapp.azure.com \
-          -l1_ws_url=${{ needs.build.outputs.L1_HTTP_URL }} \
+          -l1_http_url=${{ needs.build.outputs.L1_HTTP_URL }} \
           -l2_ws_port=81 \
           -private_key=${{ secrets.GETHNETWORK_PREFUNDED_PKSTR_WORKER }} \
           -l2_private_key=8dfb8083da6275ae3e4f41e3e8a8c19d028d32c9247e24530933782f2a05035b \

--- a/testnet/launcher/l1contractdeployer/cmd/cli_flags.go
+++ b/testnet/launcher/l1contractdeployer/cmd/cli_flags.go
@@ -2,7 +2,7 @@ package main
 
 // Flag names.
 const (
-	l1HTTPURLFlag        = "l1_ws_url"
+	l1HTTPURLFlag        = "l1_http_url"
 	privateKeyFlag       = "private_key"
 	dockerImageFlag      = "docker_image"
 	contractsEnvFileFlag = "contracts_env_file"

--- a/testnet/launcher/l2contractdeployer/cmd/cli_flags.go
+++ b/testnet/launcher/l2contractdeployer/cmd/cli_flags.go
@@ -2,7 +2,7 @@ package main
 
 // Flag names.
 const (
-	l1HTTPURLFlag              = "l1_ws_url"
+	l1HTTPURLFlag              = "l1_http_url"
 	privateKeyFlag             = "private_key"
 	dockerImageFlag            = "docker_image"
 	l2HostFlag                 = "l2_host"


### PR DESCRIPTION
### Why this change is needed

The http_url CLI flag for the deployers said ws_url by accident.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


