### PR TITLE
Sepolia prep: add batch + rollup interval CLI options

### DIFF
--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -40,6 +40,8 @@ jobs:
       RESOURCE_TESTNET_NAME: ${{ steps.outputVars.outputs.RESOURCE_TESTNET_NAME }}
       L1_WS_URL: ${{ steps.outputVars.outputs.L1_WS_URL }}
       L1_HTTP_URL: ${{ steps.outputVars.outputs.L1_HTTP_URL }}
+      BATCH_INTERVAL: ${{ steps.deployL2Contracts.outputs.BATCH_INTERVAL }}
+      ROLLUP_INTERVAL: ${{ steps.deployL2Contracts.outputs.ROLLUP_INTERVAL }}
 
 
     steps:
@@ -65,6 +67,8 @@ jobs:
           echo "RESOURCE_TESTNET_NAME=testnet" >> $GITHUB_ENV
           echo "L1_WS_URL=ws://testnet-eth2network.uksouth.cloudapp.azure.com:9000" >> $GITHUB_ENV
           echo "L1_HTTP_URL=http://testnet-eth2network.uksouth.cloudapp.azure.com:8025" >> $GITHUB_ENV
+          echo "BATCH_INTERVAL=1s" >> $GITHUB_ENV
+          echo "ROLLUP_INTERVAL=10s" >> $GITHUB_ENV
 
       - name: 'Sets env vars for dev-testnet'
         if: ${{ (github.event.inputs.testnet_type == 'dev-testnet') }}
@@ -77,6 +81,8 @@ jobs:
           echo "RESOURCE_TESTNET_NAME=devtestnet" >> $GITHUB_ENV
           echo "L1_WS_URL=ws://dev-testnet-eth2network.uksouth.cloudapp.azure.com:9000" >> $GITHUB_ENV
           echo "L1_HTTP_URL=http://dev-testnet-eth2network.uksouth.cloudapp.azure.com:8025" >> $GITHUB_ENV
+          echo "BATCH_INTERVAL=1s" >> $GITHUB_ENV
+          echo "ROLLUP_INTERVAL=10s" >> $GITHUB_ENV
 
       - name: 'Output env vars'
         id: outputVars
@@ -89,6 +95,8 @@ jobs:
           echo "RESOURCE_TESTNET_NAME=${{env.RESOURCE_TESTNET_NAME}}" >> $GITHUB_OUTPUT
           echo "L1_WS_URL=${{env.L1_WS_URL}}" >> $GITHUB_OUTPUT
           echo "L1_HTTP_URL=${{env.L1_HTTP_URL}}" >> $GITHUB_OUTPUT
+          echo "BATCH_INTERVAL=${{env.BATCH_INTERVAL}}" >> $GITHUB_OUTPUT
+          echo "ROLLUP_INTERVAL=${{env.ROLLUP_INTERVAL}}" >> $GITHUB_OUTPUT
 
       - name: 'Login to Azure docker registry'
         uses: azure/docker-login@v1
@@ -268,6 +276,8 @@ jobs:
                -host_docker_image=${{needs.build.outputs.L2_HOST_DOCKER_BUILD_TAG}} \
                -is_debug_namespace_enabled=true \
                -log_level=${{ github.event.inputs.log_level }} \
+               -batch_interval=${{needs.build.outputs.BATCH_INTERVAL}} \
+               -rollup_interval=${{needs.build.outputs.ROLLUP_INTERVAL}} \
                start'
 
 

--- a/.github/workflows/manual-upgrade-testnet-l2.yml
+++ b/.github/workflows/manual-upgrade-testnet-l2.yml
@@ -41,6 +41,8 @@ jobs:
       RESOURCE_TESTNET_NAME: ${{ steps.outputVars.outputs.RESOURCE_TESTNET_NAME }}
       L1_WS_URL: ${{ steps.outputVars.outputs.L1_WS_URL }}
       VM_BUILD_NUMBER: ${{ steps.outputVars.outputs.VM_BUILD_NUMBER }}
+      BATCH_INTERVAL: ${{ steps.deployL2Contracts.outputs.BATCH_INTERVAL }}
+      ROLLUP_INTERVAL: ${{ steps.deployL2Contracts.outputs.ROLLUP_INTERVAL }}
 
     steps:
       - uses: actions/checkout@v3
@@ -63,6 +65,8 @@ jobs:
           echo "RESOURCE_STARTING_NAME=T" >> $GITHUB_ENV
           echo "RESOURCE_TESTNET_NAME=testnet" >> $GITHUB_ENV
           echo "L1_WS_URL=ws://testnet-eth2network.uksouth.cloudapp.azure.com:9000" >> $GITHUB_ENV
+          echo "BATCH_INTERVAL=1s" >> $GITHUB_ENV
+          echo "ROLLUP_INTERVAL=10s" >> $GITHUB_ENV
 
       - name: 'Sets env vars for dev-testnet'
         if: ${{ (github.event.inputs.testnet_type == 'dev-testnet') || (github.event_name == 'schedule') }}
@@ -73,6 +77,8 @@ jobs:
           echo "RESOURCE_STARTING_NAME=D" >> $GITHUB_ENV
           echo "RESOURCE_TESTNET_NAME=devtestnet" >> $GITHUB_ENV
           echo "L1_WS_URL=ws://dev-testnet-eth2network.uksouth.cloudapp.azure.com:9000" >> $GITHUB_ENV
+          echo "BATCH_INTERVAL=1s" >> $GITHUB_ENV
+          echo "ROLLUP_INTERVAL=10s" >> $GITHUB_ENV
 
       - name: 'Fetch latest VM hostnames by env tag and extract build number'
         id: fetch_hostnames
@@ -97,6 +103,8 @@ jobs:
           echo "RESOURCE_TESTNET_NAME=${{env.RESOURCE_TESTNET_NAME}}" >> $GITHUB_OUTPUT
           echo "L1_WS_URL=${{env.L1_WS_URL}}" >> $GITHUB_OUTPUT
           echo "VM_BUILD_NUMBER=${{env.VM_BUILD_NUMBER}}" >> $GITHUB_OUTPUT
+          echo "BATCH_INTERVAL=${{env.BATCH_INTERVAL}}" >> $GITHUB_OUTPUT
+          echo "ROLLUP_INTERVAL=${{env.ROLLUP_INTERVAL}}" >> $GITHUB_OUTPUT
 
       - name: 'Login to Azure docker registry'
         uses: azure/docker-login@v1
@@ -182,6 +190,8 @@ jobs:
               -enclave_docker_image=${{needs.build.outputs.L2_ENCLAVE_DOCKER_BUILD_TAG}} \
               -host_docker_image=${{needs.build.outputs.L2_HOST_DOCKER_BUILD_TAG}} \
               -log_level=${{ github.event.inputs.log_level }} \
+              -batch_interval=${{needs.build.outputs.BATCH_INTERVAL}} \
+              -rollup_interval=${{needs.build.outputs.ROLLUP_INTERVAL}} \
               upgrade'
 
   check-obscuro-is-healthy:

--- a/go/node/cmd/cli.go
+++ b/go/node/cmd/cli.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"time"
 )
 
 var (
@@ -106,15 +105,7 @@ func ParseConfigCLI() *NodeConfigCLI {
 	cfg.logLevel = *logLevel
 	cfg.isInboundP2PDisabled = *isInboundP2PDisabled
 	cfg.batchInterval = *batchInterval
-	if _, err := time.ParseDuration(cfg.batchInterval); err != nil {
-		fmt.Printf("invalid batch interval: %s\n", err)
-		os.Exit(1)
-	}
 	cfg.rollupInterval = *rollupInterval
-	if _, err := time.ParseDuration(cfg.rollupInterval); err != nil {
-		fmt.Printf("invalid rollup interval: %s\n", err)
-		os.Exit(1)
-	}
 
 	cfg.nodeAction = flag.Arg(0)
 	if !validateNodeAction(cfg.nodeAction) {

--- a/go/node/cmd/cli.go
+++ b/go/node/cmd/cli.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 )
 
 var (
@@ -41,6 +42,8 @@ type NodeConfigCLI struct {
 	isDebugNamespaceEnabled bool
 	logLevel                int
 	isInboundP2PDisabled    bool
+	batchInterval           string // format like 500ms or 2s (any time parsable by time.ParseDuration())
+	rollupInterval          string // format like 500ms or 2s (any time parsable by time.ParseDuration())
 }
 
 // ParseConfigCLI returns a NodeConfigCLI based the cli params and defaults.
@@ -73,6 +76,8 @@ func ParseConfigCLI() *NodeConfigCLI {
 	isDebugNamespaceEnabled := flag.Bool(isDebugNamespaceEnabledFlag, false, flagUsageMap[isDebugNamespaceEnabledFlag])
 	logLevel := flag.Int(logLevelFlag, 3, flagUsageMap[logLevelFlag])
 	isInboundP2PDisabled := flag.Bool(isInboundP2PDisabledFlag, false, flagUsageMap[isInboundP2PDisabledFlag])
+	batchInterval := flag.String(batchIntervalFlag, "1s", flagUsageMap[batchIntervalFlag])
+	rollupInterval := flag.String(rollupIntervalFlag, "3s", flagUsageMap[rollupIntervalFlag])
 
 	flag.Parse()
 	cfg.nodeName = *nodeName
@@ -100,6 +105,16 @@ func ParseConfigCLI() *NodeConfigCLI {
 	cfg.isDebugNamespaceEnabled = *isDebugNamespaceEnabled
 	cfg.logLevel = *logLevel
 	cfg.isInboundP2PDisabled = *isInboundP2PDisabled
+	cfg.batchInterval = *batchInterval
+	if _, err := time.ParseDuration(cfg.batchInterval); err != nil {
+		fmt.Printf("invalid batch interval: %s\n", err)
+		os.Exit(1)
+	}
+	cfg.rollupInterval = *rollupInterval
+	if _, err := time.ParseDuration(cfg.rollupInterval); err != nil {
+		fmt.Printf("invalid rollup interval: %s\n", err)
+		os.Exit(1)
+	}
 
 	cfg.nodeAction = flag.Arg(0)
 	if !validateNodeAction(cfg.nodeAction) {

--- a/go/node/cmd/cli_flags.go
+++ b/go/node/cmd/cli_flags.go
@@ -27,6 +27,8 @@ const (
 	isDebugNamespaceEnabledFlag = "is_debug_namespace_enabled"
 	logLevelFlag                = "log_level"
 	isInboundP2PDisabledFlag    = "is_inbound_p2p_disabled"
+	batchIntervalFlag           = "batch_interval"
+	rollupIntervalFlag          = "rollup_interval"
 )
 
 // Returns a map of the flag usages.
@@ -58,5 +60,7 @@ func getFlagUsageMap() map[string]string {
 		isDebugNamespaceEnabledFlag: "Enables the debug namespace for both enclave and host",
 		logLevelFlag:                "Sets the log level 1-Error, 5-Trace",
 		isInboundP2PDisabledFlag:    "Disables inbound p2p (for testing)",
+		batchIntervalFlag:           "Duration between each batch. Can be formatted like 500ms or 1s",
+		rollupIntervalFlag:          "Duration between each rollup. Can be formatted like 500ms or 1s",
 	}
 }

--- a/go/node/cmd/main.go
+++ b/go/node/cmd/main.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	"github.com/obscuronet/go-obscuro/go/node"
 	"time"
+
+	"github.com/obscuronet/go-obscuro/go/node"
 )
 
 func main() {

--- a/go/node/cmd/main.go
+++ b/go/node/cmd/main.go
@@ -2,11 +2,16 @@ package main
 
 import (
 	"github.com/obscuronet/go-obscuro/go/node"
+	"time"
 )
 
 func main() {
 	cliConfig := ParseConfigCLI()
 	// todo (#1618) - allow for multiple operation (start, stop, status)
+
+	// we already validated the config in ParseConfigCLI, so we can safely ignore the error here
+	batchInterval, _ := time.ParseDuration(cliConfig.batchInterval)
+	rollupInterval, _ := time.ParseDuration(cliConfig.rollupInterval)
 
 	nodeCfg := node.NewNodeConfig(
 		node.WithNodeName(cliConfig.nodeName),
@@ -33,6 +38,8 @@ func main() {
 		node.WithDebugNamespaceEnabled(cliConfig.isDebugNamespaceEnabled), // false
 		node.WithLogLevel(cliConfig.logLevel),
 		node.WithInboundP2PDisabled(cliConfig.isInboundP2PDisabled),
+		node.WithBatchInterval(batchInterval),
+		node.WithRollupInterval(rollupInterval),
 	)
 
 	dockerNode := node.NewDockerNode(nodeCfg)

--- a/go/node/cmd/main.go
+++ b/go/node/cmd/main.go
@@ -1,18 +1,12 @@
 package main
 
 import (
-	"time"
-
 	"github.com/obscuronet/go-obscuro/go/node"
 )
 
 func main() {
 	cliConfig := ParseConfigCLI()
 	// todo (#1618) - allow for multiple operation (start, stop, status)
-
-	// we already validated the config in ParseConfigCLI, so we can safely ignore the error here
-	batchInterval, _ := time.ParseDuration(cliConfig.batchInterval)
-	rollupInterval, _ := time.ParseDuration(cliConfig.rollupInterval)
 
 	nodeCfg := node.NewNodeConfig(
 		node.WithNodeName(cliConfig.nodeName),
@@ -39,8 +33,8 @@ func main() {
 		node.WithDebugNamespaceEnabled(cliConfig.isDebugNamespaceEnabled), // false
 		node.WithLogLevel(cliConfig.logLevel),
 		node.WithInboundP2PDisabled(cliConfig.isInboundP2PDisabled),
-		node.WithBatchInterval(batchInterval),
-		node.WithRollupInterval(rollupInterval),
+		node.WithBatchInterval(cliConfig.batchInterval),
+		node.WithRollupInterval(cliConfig.rollupInterval),
 	)
 
 	dockerNode := node.NewDockerNode(nodeCfg)

--- a/go/node/config.go
+++ b/go/node/config.go
@@ -48,8 +48,8 @@ type Config struct {
 	logLevel                  int
 	isInboundP2PDisabled      bool
 	l1BlockTime               time.Duration
-	batchInterval             time.Duration
-	rollupInterval            time.Duration
+	batchInterval             string
+	rollupInterval            string
 }
 
 func NewNodeConfig(opts ...Option) *Config {
@@ -289,13 +289,13 @@ func WithL1BlockTime(d time.Duration) Option {
 	}
 }
 
-func WithBatchInterval(d time.Duration) Option {
+func WithBatchInterval(d string) Option {
 	return func(c *Config) {
 		c.batchInterval = d
 	}
 }
 
-func WithRollupInterval(d time.Duration) Option {
+func WithRollupInterval(d string) Option {
 	return func(c *Config) {
 		c.rollupInterval = d
 	}

--- a/go/node/config.go
+++ b/go/node/config.go
@@ -48,6 +48,8 @@ type Config struct {
 	logLevel                  int
 	isInboundP2PDisabled      bool
 	l1BlockTime               time.Duration
+	batchInterval             time.Duration
+	rollupInterval            time.Duration
 }
 
 func NewNodeConfig(opts ...Option) *Config {
@@ -284,5 +286,17 @@ func WithInboundP2PDisabled(b bool) Option {
 func WithL1BlockTime(d time.Duration) Option {
 	return func(c *Config) {
 		c.l1BlockTime = d
+	}
+}
+
+func WithBatchInterval(d time.Duration) Option {
+	return func(c *Config) {
+		c.batchInterval = d
+	}
+}
+
+func WithRollupInterval(d time.Duration) Option {
+	return func(c *Config) {
+		c.rollupInterval = d
 	}
 }

--- a/go/node/docker_node.go
+++ b/go/node/docker_node.go
@@ -115,8 +115,8 @@ func (d *DockerNode) startHost() error {
 		fmt.Sprintf("-useInMemoryDB=%t", d.cfg.hostInMemDB),
 		fmt.Sprintf("-debugNamespaceEnabled=%t", d.cfg.debugNamespaceEnabled),
 		// todo (@stefan): once the limiter is in, increase it back to 5 or 10s
-		"-batchInterval=1s",
-		"-rollupInterval=3s",
+		fmt.Sprintf("-batchInterval=%s", d.cfg.batchInterval),
+		fmt.Sprintf("-rollupInterval=%s", d.cfg.rollupInterval),
 		fmt.Sprintf("-logLevel=%d", d.cfg.logLevel),
 		fmt.Sprintf("-isInboundP2PDisabled=%t", d.cfg.isInboundP2PDisabled),
 	}


### PR DESCRIPTION
### Why this change is needed

We want to configure slower rollup rate for sepolia-testnet

### What changes were made as part of this PR

Wire through CLI options for the docker node starter to set batch/rollup intervals.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


