### PR TITLE
Add flag to configure L1 chainID for docker nodes

### DIFF
--- a/go/node/cmd/cli.go
+++ b/go/node/cmd/cli.go
@@ -43,6 +43,7 @@ type NodeConfigCLI struct {
 	isInboundP2PDisabled    bool
 	batchInterval           string // format like 500ms or 2s (any time parsable by time.ParseDuration())
 	rollupInterval          string // format like 500ms or 2s (any time parsable by time.ParseDuration())
+	l1ChainID               int
 }
 
 // ParseConfigCLI returns a NodeConfigCLI based the cli params and defaults.
@@ -77,6 +78,7 @@ func ParseConfigCLI() *NodeConfigCLI {
 	isInboundP2PDisabled := flag.Bool(isInboundP2PDisabledFlag, false, flagUsageMap[isInboundP2PDisabledFlag])
 	batchInterval := flag.String(batchIntervalFlag, "1s", flagUsageMap[batchIntervalFlag])
 	rollupInterval := flag.String(rollupIntervalFlag, "3s", flagUsageMap[rollupIntervalFlag])
+	l1ChainID := flag.Int(l1ChainIDFlag, 1337, flagUsageMap[l1ChainIDFlag])
 
 	flag.Parse()
 	cfg.nodeName = *nodeName
@@ -106,6 +108,7 @@ func ParseConfigCLI() *NodeConfigCLI {
 	cfg.isInboundP2PDisabled = *isInboundP2PDisabled
 	cfg.batchInterval = *batchInterval
 	cfg.rollupInterval = *rollupInterval
+	cfg.l1ChainID = *l1ChainID
 
 	cfg.nodeAction = flag.Arg(0)
 	if !validateNodeAction(cfg.nodeAction) {

--- a/go/node/cmd/cli_flags.go
+++ b/go/node/cmd/cli_flags.go
@@ -29,6 +29,7 @@ const (
 	isInboundP2PDisabledFlag    = "is_inbound_p2p_disabled"
 	batchIntervalFlag           = "batch_interval"
 	rollupIntervalFlag          = "rollup_interval"
+	l1ChainIDFlag               = "l1_chain_id"
 )
 
 // Returns a map of the flag usages.
@@ -62,5 +63,6 @@ func getFlagUsageMap() map[string]string {
 		isInboundP2PDisabledFlag:    "Disables inbound p2p (for testing)",
 		batchIntervalFlag:           "Duration between each batch. Can be formatted like 500ms or 1s",
 		rollupIntervalFlag:          "Duration between each rollup. Can be formatted like 500ms or 1s",
+		l1ChainIDFlag:               "Chain ID of the L1 network",
 	}
 }

--- a/go/node/cmd/main.go
+++ b/go/node/cmd/main.go
@@ -35,6 +35,7 @@ func main() {
 		node.WithInboundP2PDisabled(cliConfig.isInboundP2PDisabled),
 		node.WithBatchInterval(cliConfig.batchInterval),
 		node.WithRollupInterval(cliConfig.rollupInterval),
+		node.WithL1ChainID(cliConfig.l1ChainID),
 	)
 
 	dockerNode := node.NewDockerNode(nodeCfg)

--- a/go/node/config.go
+++ b/go/node/config.go
@@ -55,7 +55,11 @@ type Config struct {
 }
 
 func NewNodeConfig(opts ...Option) *Config {
-	defaultConfig := &Config{}
+	defaultConfig := &Config{
+		batchInterval:  "1s",
+		rollupInterval: "3s",
+		l1ChainID:      1337,
+	}
 
 	for _, opt := range opts {
 		opt(defaultConfig)

--- a/go/node/config.go
+++ b/go/node/config.go
@@ -51,6 +51,7 @@ type Config struct {
 	l1BlockTime               time.Duration
 	batchInterval             string
 	rollupInterval            string
+	l1ChainID                 int
 }
 
 func NewNodeConfig(opts ...Option) *Config {
@@ -114,6 +115,7 @@ func (c *Config) ToHostConfig() *config.HostInputConfig {
 	cfg.SequencerID = gethcommon.HexToAddress(c.sequencerID)
 	cfg.IsInboundP2PDisabled = c.isInboundP2PDisabled
 	cfg.L1BlockTime = c.l1BlockTime
+	cfg.L1ChainID = int64(c.l1ChainID)
 
 	return cfg
 }
@@ -309,5 +311,11 @@ func WithBatchInterval(d string) Option {
 func WithRollupInterval(d string) Option {
 	return func(c *Config) {
 		c.rollupInterval = d
+	}
+}
+
+func WithL1ChainID(i int) Option {
+	return func(c *Config) {
+		c.l1ChainID = i
 	}
 }

--- a/go/node/docker_node.go
+++ b/go/node/docker_node.go
@@ -119,6 +119,7 @@ func (d *DockerNode) startHost() error {
 		fmt.Sprintf("-rollupInterval=%s", d.cfg.rollupInterval),
 		fmt.Sprintf("-logLevel=%d", d.cfg.logLevel),
 		fmt.Sprintf("-isInboundP2PDisabled=%t", d.cfg.isInboundP2PDisabled),
+		fmt.Sprintf("-l1ChainID=%d", d.cfg.l1ChainID),
 	}
 	if !d.cfg.hostInMemDB {
 		cmd = append(cmd, "-levelDBPath", _hostDataDir)


### PR DESCRIPTION
### Why this change is needed

We need to wire sepolia chain ID from the github action script but it's not a CLI option at that level :(

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


