### PR TITLE
Reduce tx retries and increase price on retry

### DIFF
--- a/go/ethadapter/interface.go
+++ b/go/ethadapter/interface.go
@@ -38,6 +38,7 @@ type EthClient interface {
 
 	// PrepareTransactionToSend updates the tx with from address, current nonce and current estimates for the gas and the gas price
 	PrepareTransactionToSend(txData types.TxData, from gethcommon.Address, nonce uint64) (types.TxData, error)
+	PrepareTransactionToRetry(txData types.TxData, from gethcommon.Address, nonce uint64, retries int) (types.TxData, error)
 
 	FetchLastBatchSeqNo(address gethcommon.Address) (*big.Int, error)
 

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -74,7 +74,7 @@ func NewHost(config *config.HostConfig, hostServices *ServicesRegistry, p2p host
 
 	hostServices.RegisterService(hostcommon.P2PName, p2p)
 	hostServices.RegisterService(hostcommon.L1BlockRepositoryName, l1Repo)
-	maxWaitForL1Receipt := 4 * config.L1BlockTime   // wait ~4 blocks to see if tx gets published before retrying
+	maxWaitForL1Receipt := 6 * config.L1BlockTime   // wait ~10 blocks to see if tx gets published before retrying
 	retryIntervalForL1Receipt := config.L1BlockTime // retry ~every block
 	l1Publisher := l1.NewL1Publisher(hostIdentity, ethWallet, ethClient, mgmtContractLib, l1Repo, host.stopControl, logger, maxWaitForL1Receipt, retryIntervalForL1Receipt)
 	hostServices.RegisterService(hostcommon.L1PublisherName, l1Publisher)

--- a/integration/ethereummock/node.go
+++ b/integration/ethereummock/node.go
@@ -98,6 +98,10 @@ func (m *Node) PrepareTransactionToSend(txData types.TxData, _ gethcommon.Addres
 	}, nil
 }
 
+func (m *Node) PrepareTransactionToRetry(txData types.TxData, from gethcommon.Address, nonce uint64, _ int) (types.TxData, error) {
+	return m.PrepareTransactionToSend(txData, from, nonce)
+}
+
 func (m *Node) SendTransaction(tx *types.Transaction) error {
 	m.Network.BroadcastTx(tx)
 	return nil


### PR DESCRIPTION
### Why this change is needed

- We are retrying slightly too aggressively, especially for sims
- We need to increase the price on retry. If the price is not noticeably increased from submitted tx with the same nonce then the mempool will reject the retry transaction. Most nodes use 10% increase as the cut-off so I've added 20%.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


