### PR TITLE
rollup compression performance fixes

### DIFF
--- a/go/enclave/nodetype/sequencer.go
+++ b/go/enclave/nodetype/sequencer.go
@@ -264,6 +264,7 @@ func (s *sequencer) CreateRollup(lastBatchNo uint64) (*common.ExtRollup, error) 
 		return nil, err
 	}
 
+	// todo - double-check that this signing approach is secure, and it properly includes the entire payload
 	if err := s.signRollup(rollup); err != nil {
 		return nil, fmt.Errorf("failed to sign created rollup: %w", err)
 	}

--- a/go/enclave/storage/enclavedb/batch.go
+++ b/go/enclave/storage/enclavedb/batch.go
@@ -168,6 +168,10 @@ func ReadCanonicalBatchByHeight(db *sql.DB, height uint64) (*core.Batch, error) 
 	return fetchBatch(db, " where b.height=? and is_canonical=true", height)
 }
 
+func ReadNonCanonicalBatches(db *sql.DB, startAtSeq uint64, endSeq uint64) ([]*core.Batch, error) {
+	return fetchBatches(db, " where b.sequence>=? and b.sequence <=? and b.is_canonical=false order by b.sequence", startAtSeq, endSeq)
+}
+
 func ReadBatchHeader(db *sql.DB, hash gethcommon.Hash) (*common.BatchHeader, error) {
 	return fetchBatchHeader(db, " where hash=?", truncTo16(hash))
 }

--- a/go/enclave/storage/interfaces.go
+++ b/go/enclave/storage/interfaces.go
@@ -50,7 +50,8 @@ type BatchResolver interface {
 	FetchCurrentSequencerNo() (*big.Int, error)
 	// FetchBatchesByBlock returns all batches with the block hash as the L1 proof
 	FetchBatchesByBlock(common.L1BlockHash) ([]*core.Batch, error)
-
+	// FetchNonCanonicalBatchesBetween - returns all reorged batches between the sequences
+	FetchNonCanonicalBatchesBetween(startSeq uint64, endSeq uint64) ([]*core.Batch, error)
 	// FetchCanonicalUnexecutedBatches - return the list of the unexecuted batches that are canonical
 	FetchCanonicalUnexecutedBatches(*big.Int) ([]*core.Batch, error)
 

--- a/go/enclave/storage/storage.go
+++ b/go/enclave/storage/storage.go
@@ -139,6 +139,11 @@ func (s *storageImpl) FetchBatchByHeight(height uint64) (*core.Batch, error) {
 	return enclavedb.ReadCanonicalBatchByHeight(s.db.GetSQLDB(), height)
 }
 
+func (s *storageImpl) FetchNonCanonicalBatchesBetween(startSeq uint64, endSeq uint64) ([]*core.Batch, error) {
+	defer s.logDuration("FetchNonCanonicalBatchesBetween", measure.NewStopwatch())
+	return enclavedb.ReadNonCanonicalBatches(s.db.GetSQLDB(), startSeq, endSeq)
+}
+
 func (s *storageImpl) StoreBlock(b *types.Block, chainFork *common.ChainFork) error {
 	defer s.logDuration("StoreBlock", measure.NewStopwatch())
 	dbTransaction := s.db.NewDBTransaction()


### PR DESCRIPTION
### Why this change is needed

there are some inefficiencies when producing rollups which compound.

### What changes were made as part of this PR

- fix the mutex when submitting an l1 block. It was protecting only part of the logic
- remove the need to read l1 blocks for every batch
- remove the need to check whether a batch is canonical during iteration

