### PR TITLE
Setup faucet for sepolia env

### DIFF
--- a/.github/workflows/manual-deploy-testnet-faucet.yml
+++ b/.github/workflows/manual-deploy-testnet-faucet.yml
@@ -21,6 +21,7 @@ on:
         options:
           - 'dev-testnet'
           - 'testnet'
+          - 'sepolia-testnet'
 
   workflow_call:
     inputs:
@@ -51,6 +52,12 @@ jobs:
         run: |
           echo "FAUCET_BUILD_TAG=testnetobscuronet.azurecr.io/obscuronet/dev_faucet_testnet:latest" >> $GITHUB_ENV
           echo "TESTNET_ADDR=erpc.dev-testnet.obscu.ro" >> $GITHUB_ENV
+
+      - name: 'Sets env vars for sepolia-testnet'
+        if: ${{ inputs.testnet_type == 'sepolia-testnet' }}
+        run: |
+          echo "FAUCET_BUILD_TAG=testnetobscuronet.azurecr.io/obscuronet/sepolia_faucet_testnet:latest" >> $GITHUB_ENV
+          echo "TESTNET_ADDR=erpc.sepolia-testnet.obscu.ro" >> $GITHUB_ENV
 
       - name: 'Login to Azure docker registry'
         uses: azure/docker-login@v1

--- a/.github/workflows/manual-deploy-testnet-faucet.yml
+++ b/.github/workflows/manual-deploy-testnet-faucet.yml
@@ -46,18 +46,21 @@ jobs:
         run: |
           echo "FAUCET_BUILD_TAG=testnetobscuronet.azurecr.io/obscuronet/faucet_testnet:latest" >> $GITHUB_ENV
           echo "TESTNET_ADDR=erpc.testnet.obscu.ro" >> $GITHUB_ENV
+          echo "DEFAULT_FAUCET_AMOUNT=100" >> $GITHUB_ENV
 
       - name: 'Sets env vars for dev-testnet'
         if: ${{ inputs.testnet_type == 'dev-testnet' }}
         run: |
           echo "FAUCET_BUILD_TAG=testnetobscuronet.azurecr.io/obscuronet/dev_faucet_testnet:latest" >> $GITHUB_ENV
           echo "TESTNET_ADDR=erpc.dev-testnet.obscu.ro" >> $GITHUB_ENV
+          echo "DEFAULT_FAUCET_AMOUNT=100" >> $GITHUB_ENV
 
       - name: 'Sets env vars for sepolia-testnet'
         if: ${{ inputs.testnet_type == 'sepolia-testnet' }}
         run: |
           echo "FAUCET_BUILD_TAG=testnetobscuronet.azurecr.io/obscuronet/sepolia_faucet_testnet:latest" >> $GITHUB_ENV
           echo "TESTNET_ADDR=erpc.sepolia-testnet.obscu.ro" >> $GITHUB_ENV
+          echo "DEFAULT_FAUCET_AMOUNT=0.5" >> $GITHUB_ENV
 
       - name: 'Login to Azure docker registry'
         uses: azure/docker-login@v1
@@ -86,7 +89,7 @@ jobs:
           location: 'uksouth'
           restart-policy: 'Never'
           environment-variables: PORT=80
-          command-line: ./faucet --nodeHost ${{ env.TESTNET_ADDR }} --pk ${{ secrets.FAUCET_PK }} --jwtSecret ${{ secrets.FAUCET_JWT_SECRET }}
+          command-line: ./faucet --nodeHost ${{ env.TESTNET_ADDR }} --pk ${{ secrets.FAUCET_PK }} --jwtSecret ${{ secrets.FAUCET_JWT_SECRET }} --defaultAmount ${{ env.DEFAULT_FAUCET_AMOUNT }}
           ports: '80'
           cpu: 2
           memory: 2

--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ it for an allocation to an externally owned addressed e.g. for the account `0x0d
 the following curl command can be used;
 
 ```bash
-curl --location --request POST 'http://127.0.0.1:8080/fund/obx' \
+curl --location --request POST 'http://127.0.0.1:8080/fund/eth' \
 --header 'Content-Type: application/json' \
 --data-raw '{ "address":"0x0d2166b7b3A1522186E809e83d925d7b0B6db084" }'
 ```

--- a/docs/_docs/testnet/deploying-a-smart-contract-programmatically.py
+++ b/docs/_docs/testnet/deploying-a-smart-contract-programmatically.py
@@ -12,7 +12,7 @@ WPORT = 3000
 WHOST = '127.0.0.1'
 LOWER = 0
 UPPER = 100
-FAUCET_URL = 'http://testnet-faucet.uksouth.azurecontainer.io/fund/obx'
+FAUCET_URL = 'http://testnet-faucet.uksouth.azurecontainer.io/fund/eth'
 
 guesser = '''
 // SPDX-License-Identifier: MIT

--- a/docs/_docs/testnet/faucet.md
+++ b/docs/_docs/testnet/faucet.md
@@ -30,6 +30,6 @@ the faucet server using the below;
 1. Make a note of your wallet address or copy it to your clipboard.
 2. Open a command shell and issue the below command, where `<address>` should be replaced with the value stored in your clipboard (e.g. `0x75Ad715443e1E2EBdaFA33ABB3B08443966019A6`). The faucet server will credit 100,000 OBX by default.
 ```bash
-curl --location --request POST 'http://testnet-faucet.uksouth.azurecontainer.io/fund/obx' --header 'Content-Type: application/json' --data-raw '{ "address":"<your address>" }'
+curl --location --request POST 'http://testnet-faucet.uksouth.azurecontainer.io/fund/eth' --header 'Content-Type: application/json' --data-raw '{ "address":"<your address>" }'
 ```
 3. After a short period of time the curl command will return `{"status":"ok"}` confirming OBX have been credited to your wallet.

--- a/integration/faucet/faucet_test.go
+++ b/integration/faucet/faucet_test.go
@@ -99,7 +99,7 @@ func createObscuroNetwork(t *testing.T, startPort int) {
 }
 
 func fundWallet(port int, w wallet.Wallet) error {
-	url := fmt.Sprintf("http://localhost:%d/fund/obx", port)
+	url := fmt.Sprintf("http://localhost:%d/fund/eth", port)
 	method := "POST"
 
 	payload := strings.NewReader(fmt.Sprintf(`{"address":"%s"}`, w.Address()))

--- a/integration/faucet/faucet_test.go
+++ b/integration/faucet/faucet_test.go
@@ -45,13 +45,14 @@ func TestFaucet(t *testing.T) {
 	time.Sleep(2 * time.Second)
 
 	faucetConfig := &faucet.Config{
-		Port:       startPort,
-		Host:       "localhost",
-		HTTPPort:   startPort + integration.DefaultHostRPCHTTPOffset,
-		PK:         "0x" + contractDeployerPrivateKeyHex,
-		JWTSecret:  "This_is_secret",
-		ChainID:    big.NewInt(integration.ObscuroChainID),
-		ServerPort: integration.StartPortFaucetHTTPUnitTest,
+		Port:              startPort,
+		Host:              "localhost",
+		HTTPPort:          startPort + integration.DefaultHostRPCHTTPOffset,
+		PK:                "0x" + contractDeployerPrivateKeyHex,
+		JWTSecret:         "This_is_secret",
+		ChainID:           big.NewInt(integration.ObscuroChainID),
+		ServerPort:        integration.StartPortFaucetHTTPUnitTest,
+		DefaultFundAmount: new(big.Int).Mul(big.NewInt(100), big.NewInt(1e18)),
 	}
 	faucetContainer, err := container.NewFaucetContainerFromConfig(faucetConfig)
 	assert.NoError(t, err)

--- a/integration/networktest/env/network_setup.go
+++ b/integration/networktest/env/network_setup.go
@@ -9,7 +9,7 @@ func Testnet() networktest.Environment {
 	connector := NewTestnetConnector(
 		"http://erpc.testnet.obscu.ro:80",
 		[]string{"http://erpc.testnet.obscu.ro:80"}, // for now we'll just use sequencer as validator node... todo (@matt)
-		"http://testnet-faucet.uksouth.azurecontainer.io/fund/obx",
+		"http://testnet-faucet.uksouth.azurecontainer.io/fund/eth",
 		"ws://testnet-eth2network.uksouth.cloudapp.azure.com:9000",
 	)
 	return &testnetEnv{connector}
@@ -19,7 +19,7 @@ func DevTestnet() networktest.Environment {
 	connector := NewTestnetConnector(
 		"http://erpc.dev-testnet.obscu.ro:80",
 		[]string{"http://erpc.dev-testnet.obscu.ro:80"}, // for now we'll just use sequencer as validator node... todo (@matt)
-		"http://dev-testnet-faucet.uksouth.azurecontainer.io/fund/obx",
+		"http://dev-testnet-faucet.uksouth.azurecontainer.io/fund/eth",
 		"ws://dev-testnet-eth2network.uksouth.cloudapp.azure.com:9000",
 	)
 	return &testnetEnv{connector}

--- a/integration/networktest/tests/helpful/availability_test.go
+++ b/integration/networktest/tests/helpful/availability_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/obscuronet/go-obscuro/integration/networktest/env"
 )
 
-const _testTimeSpan = 120 * time.Second
+const _testTimeSpan = 20 * time.Second
 
 // basic test that verifies it can connect the L1 client and L2 client and sees block numbers increasing (useful to sanity check testnet issues etc.)
 func TestNetworkAvailability(t *testing.T) {
@@ -21,7 +21,7 @@ func TestNetworkAvailability(t *testing.T) {
 	networktest.Run(
 		"network-availability",
 		t,
-		env.DevTestnet(),
+		env.Testnet(),
 		actions.RunOnlyAction(func(ctx context.Context, network networktest.NetworkConnector) (context.Context, error) {
 			client, err := network.GetL1Client()
 			if err != nil {

--- a/integration/networktest/tests/helpful/availability_test.go
+++ b/integration/networktest/tests/helpful/availability_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/obscuronet/go-obscuro/integration/networktest/env"
 )
 
-const _testTimeSpan = 20 * time.Second
+const _testTimeSpan = 120 * time.Second
 
 // basic test that verifies it can connect the L1 client and L2 client and sees block numbers increasing (useful to sanity check testnet issues etc.)
 func TestNetworkAvailability(t *testing.T) {
@@ -21,7 +21,7 @@ func TestNetworkAvailability(t *testing.T) {
 	networktest.Run(
 		"network-availability",
 		t,
-		env.Testnet(),
+		env.DevTestnet(),
 		actions.RunOnlyAction(func(ctx context.Context, network networktest.NetworkConnector) (context.Context, error) {
 			client, err := network.GetL1Client()
 			if err != nil {

--- a/tools/faucet/README.md
+++ b/tools/faucet/README.md
@@ -31,11 +31,11 @@ on port `80` within the container, but maps port `8080` on the host machine to t
 
 
 ## Allocating OBX to an EOA on a local testnet
-Allocating OBX to an externally owned account is done through a POST command to the `/fund/obx` endpoint, where the 
+Allocating OBX to an externally owned account is done through a POST command to the `/fund/eth` endpoint, where the 
 data in the POST command specifies the address e.g. for the account `0x0d2166b7b3A1522186E809e83d925d7b0B6db084`
 
 ```bash
-curl --location --request POST 'http://127.0.0.1:8080/fund/obx' \
+curl --location --request POST 'http://127.0.0.1:8080/fund/eth' \
 --header 'Content-Type: application/json' \
 --data-raw '{ "address":"0x0d2166b7b3A1522186E809e83d925d7b0B6db084" }'
 ```

--- a/tools/faucet/cmd/cli.go
+++ b/tools/faucet/cmd/cli.go
@@ -2,8 +2,9 @@ package main
 
 import (
 	"flag"
-	"github.com/ethereum/go-ethereum/params"
 	"math/big"
+
+	"github.com/ethereum/go-ethereum/params"
 
 	"github.com/obscuronet/go-obscuro/tools/faucet/faucet"
 )

--- a/tools/faucet/cmd/cli.go
+++ b/tools/faucet/cmd/cli.go
@@ -32,6 +32,10 @@ const (
 	serverPortName    = "serverPort"
 	serverPortDefault = 80
 	serverPortUsage   = "Port where the web server binds to"
+
+	defaultAmountName    = "defaultAmount"
+	defaultAmountDefault = 100.0
+	defaultAmountUsage   = "Default amount of token to fund (in ETH)"
 )
 
 func parseCLIArgs() *faucet.Config {
@@ -41,15 +45,25 @@ func parseCLIArgs() *faucet.Config {
 	faucetPK := flag.String(faucetPKName, faucetPKDefault, faucetPKUsage)
 	jwtSecret := flag.String(jwtSecretName, jwtSecretDefault, jwtSecretUsage)
 	serverPort := flag.Int(serverPortName, serverPortDefault, serverPortUsage)
+	defaultAmount := flag.Float64(defaultAmountName, defaultAmountDefault, defaultAmountUsage)
 	flag.Parse()
 
 	return &faucet.Config{
-		Port:       *faucetPort,
-		Host:       *nodeHost,
-		HTTPPort:   *nodeHTTPPort,
-		PK:         *faucetPK,
-		JWTSecret:  *jwtSecret,
-		ServerPort: *serverPort,
-		ChainID:    big.NewInt(443), // TODO make this configurable
+		Port:              *faucetPort,
+		Host:              *nodeHost,
+		HTTPPort:          *nodeHTTPPort,
+		PK:                *faucetPK,
+		JWTSecret:         *jwtSecret,
+		ServerPort:        *serverPort,
+		ChainID:           big.NewInt(443), // TODO make this configurable
+		DefaultFundAmount: toWei(defaultAmount),
 	}
+}
+
+func toWei(amount *float64) *big.Int {
+	amtFloat := new(big.Float).SetFloat64(*amount)
+	weiFloat := new(big.Float).Mul(amtFloat, big.NewFloat(1e18))
+	// don't care about the accuracy here, float should have less than 18 decimal places
+	wei, _ := weiFloat.Int(nil)
+	return wei
 }

--- a/tools/faucet/cmd/cli.go
+++ b/tools/faucet/cmd/cli.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"github.com/ethereum/go-ethereum/params"
 	"math/big"
 
 	"github.com/obscuronet/go-obscuro/tools/faucet/faucet"
@@ -62,7 +63,7 @@ func parseCLIArgs() *faucet.Config {
 
 func toWei(amount *float64) *big.Int {
 	amtFloat := new(big.Float).SetFloat64(*amount)
-	weiFloat := new(big.Float).Mul(amtFloat, big.NewFloat(1e18))
+	weiFloat := new(big.Float).Mul(amtFloat, big.NewFloat(params.Ether))
 	// don't care about the accuracy here, float should have less than 18 decimal places
 	wei, _ := weiFloat.Int(nil)
 	return wei

--- a/tools/faucet/container/faucet_container.go
+++ b/tools/faucet/container/faucet_container.go
@@ -21,7 +21,7 @@ func NewFaucetContainerFromConfig(cfg *faucet.Config) (*FaucetContainer, error) 
 		return nil, err
 	}
 	bindAddress := fmt.Sprintf(":%d", cfg.ServerPort)
-	server := webserver.NewWebServer(f, bindAddress, []byte(cfg.JWTSecret))
+	server := webserver.NewWebServer(f, bindAddress, []byte(cfg.JWTSecret), cfg.DefaultFundAmount)
 
 	return NewFaucetContainer(f, server)
 }

--- a/tools/faucet/faucet/faucet.go
+++ b/tools/faucet/faucet/faucet.go
@@ -19,9 +19,10 @@ import (
 )
 
 const (
-	_timeout              = 60 * time.Second
-	NativeToken           = "eth"
-	DeprecatedNativeToken = "obx" // leaving this in temporarily for tooling that is getting native funds using `/obx` URL
+	_timeout    = 60 * time.Second
+	NativeToken = "eth"
+	// DeprecatedNativeToken is left in temporarily for tooling that is getting native funds using `/obx` URL
+	DeprecatedNativeToken = "obx" // todo (@matt) remove this once we have fixed the /obx usages
 	WrappedOBX            = "wobx"
 	WrappedEth            = "weth"
 	WrappedUSDC           = "usdc"

--- a/tools/faucet/faucet/faucet.go
+++ b/tools/faucet/faucet/faucet.go
@@ -19,11 +19,12 @@ import (
 )
 
 const (
-	_timeout    = 60 * time.Second
-	NativeToken = "eth"
-	WrappedOBX  = "wobx"
-	WrappedEth  = "weth"
-	WrappedUSDC = "usdc"
+	_timeout              = 60 * time.Second
+	NativeToken           = "eth"
+	DeprecatedNativeToken = "obx" // leaving this in temporarily for tooling that is getting native funds using `/obx` URL
+	WrappedOBX            = "wobx"
+	WrappedEth            = "weth"
+	WrappedUSDC           = "usdc"
 )
 
 type Faucet struct {
@@ -53,7 +54,7 @@ func (f *Faucet) Fund(address *common.Address, token string, amount *big.Int) er
 	var err error
 	var signedTx *types.Transaction
 
-	if token == NativeToken {
+	if token == NativeToken || token == DeprecatedNativeToken {
 		signedTx, err = f.fundNativeToken(address, amount)
 	} else {
 		return fmt.Errorf("token not fundable atm")

--- a/tools/faucet/faucet/faucet.go
+++ b/tools/faucet/faucet/faucet.go
@@ -13,18 +13,17 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/params"
 	"github.com/obscuronet/go-obscuro/go/obsclient"
 	"github.com/obscuronet/go-obscuro/go/rpc"
 	"github.com/obscuronet/go-obscuro/go/wallet"
 )
 
 const (
-	_timeout       = 60 * time.Second
-	OBXNativeToken = "obx"
-	WrappedOBX     = "wobx"
-	WrappedEth     = "weth"
-	WrappedUSDC    = "usdc"
+	_timeout    = 60 * time.Second
+	NativeToken = "eth"
+	WrappedOBX  = "wobx"
+	WrappedEth  = "weth"
+	WrappedUSDC = "usdc"
 )
 
 type Faucet struct {
@@ -50,11 +49,11 @@ func NewFaucet(rpcURL string, chainID int64, pkString string) (*Faucet, error) {
 	}, nil
 }
 
-func (f *Faucet) Fund(address *common.Address, token string, amount int64) error {
+func (f *Faucet) Fund(address *common.Address, token string, amount *big.Int) error {
 	var err error
 	var signedTx *types.Transaction
 
-	if token == OBXNativeToken {
+	if token == NativeToken {
 		signedTx, err = f.fundNativeToken(address, amount)
 	} else {
 		return fmt.Errorf("token not fundable atm")
@@ -105,7 +104,7 @@ func (f *Faucet) validateTx(tx *types.Transaction) error {
 	return fmt.Errorf("unable to fetch tx receipt after %s", _timeout)
 }
 
-func (f *Faucet) fundNativeToken(address *common.Address, amount int64) (*types.Transaction, error) {
+func (f *Faucet) fundNativeToken(address *common.Address, amount *big.Int) (*types.Transaction, error) {
 	// only one funding at the time
 	f.fundMutex.Lock()
 	defer f.fundMutex.Unlock()
@@ -125,7 +124,7 @@ func (f *Faucet) fundNativeToken(address *common.Address, amount int64) (*types.
 		GasPrice: big.NewInt(225),
 		Gas:      gas,
 		To:       address,
-		Value:    new(big.Int).Mul(big.NewInt(amount), big.NewInt(params.Ether)),
+		Value:    amount,
 	}
 
 	signedTx, err := f.wallet.SignTransaction(tx)

--- a/tools/faucet/faucet/faucet_config.go
+++ b/tools/faucet/faucet/faucet_config.go
@@ -3,11 +3,12 @@ package faucet
 import "math/big"
 
 type Config struct {
-	Port       int
-	Host       string
-	HTTPPort   int
-	PK         string
-	JWTSecret  string
-	ChainID    *big.Int
-	ServerPort int
+	Port              int
+	Host              string
+	HTTPPort          int
+	PK                string
+	JWTSecret         string
+	ChainID           *big.Int
+	ServerPort        int
+	DefaultFundAmount *big.Int // how much token to fund by default (in wei)
 }

--- a/tools/faucet/webserver/web_server.go
+++ b/tools/faucet/webserver/web_server.go
@@ -115,6 +115,9 @@ func fundingHandler(faucetServer *faucet.Faucet, defaultAmount *big.Int) gin.Han
 		switch tokenReq {
 		case faucet.NativeToken:
 			token = faucet.NativeToken
+		// we leave this option in temporarily for tools that are still using `/obx` endpoint for native funds
+		case faucet.DeprecatedNativeToken:
+			token = faucet.NativeToken
 		case faucet.WrappedOBX:
 			token = faucet.WrappedOBX
 		case faucet.WrappedEth:

--- a/tools/faucet/webserver/web_server.go
+++ b/tools/faucet/webserver/web_server.go
@@ -32,6 +32,7 @@ func NewWebServer(faucetServer *faucet.Faucet, bindAddress string, jwtSecret []b
 	// authed endpoint
 	r.POST("/auth/fund/:token", jwtTokenChecker(jwtSecret, faucetServer.Logger), fundingHandler(faucetServer, defaultAmount))
 
+	// todo (@matt) we need to remove this unsecure endpoint before we provide a fully public sepolia faucet
 	r.POST("/fund/:token", fundingHandler(faucetServer, defaultAmount))
 
 	return &WebServer{


### PR DESCRIPTION
### Why this change is needed

- Sepolia testing is easier with a faucet.
- We can probably use this faucet for early partners and users too.
- The testnet deploy was showing red for sepolia because of the faucet step

### What changes were made as part of this PR

Add config

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


