### PR TITLE
1. Improve performance of rollup creation by saving the list of block…

### DIFF
--- a/go/enclave/components/interfaces.go
+++ b/go/enclave/components/interfaces.go
@@ -80,7 +80,7 @@ type BatchExecutor interface {
 
 type BatchRegistry interface {
 	// BatchesAfter - Given a hash, will return batches following it until the head batch
-	BatchesAfter(batchSeqNo uint64, upToL1Height uint64, rollupLimiter limiters.RollupLimiter) ([]*core.Batch, error)
+	BatchesAfter(batchSeqNo uint64, upToL1Height uint64, rollupLimiter limiters.RollupLimiter) ([]*core.Batch, []*types.Block, error)
 
 	// GetBatchStateAtHeight - creates a stateDB that represents the state committed when
 	// the batch with height matching the blockNumber was created and stored.
@@ -104,9 +104,8 @@ type BatchRegistry interface {
 }
 
 type RollupProducer interface {
-	// CreateRollup - creates a rollup starting from the end of the last rollup
-	// that has been stored and continues it towards what we consider the current L2 head.
-	CreateRollup(fromBatchNo uint64, upToL1Height uint64, limiter limiters.RollupLimiter) (*core.Rollup, error)
+	// CreateInternalRollup - creates a rollup starting from the end of the last rollup that has been stored on the L1
+	CreateInternalRollup(fromBatchNo uint64, upToL1Height uint64, limiter limiters.RollupLimiter) (*core.Rollup, error)
 }
 
 type RollupConsumer interface {

--- a/go/enclave/components/rollup_producer.go
+++ b/go/enclave/components/rollup_producer.go
@@ -13,47 +13,30 @@ import (
 	"github.com/obscuronet/go-obscuro/contracts/generated/MessageBus"
 
 	"github.com/obscuronet/go-obscuro/go/common"
-	"github.com/obscuronet/go-obscuro/go/enclave/crypto"
 	"github.com/obscuronet/go-obscuro/go/enclave/limiters"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/obscuronet/go-obscuro/go/enclave/core"
 )
 
-// rollupProducerImpl encapsulates the logic of decoding rollup transactions submitted to the L1 and resolving them
-// to rollups that the enclave can process.
 type rollupProducerImpl struct {
-	// TransactionBlobCrypto- This contains the required properties to encrypt rollups.
-	TransactionBlobCrypto crypto.DataEncryptionService
-
-	ObscuroChainID  int64
-	EthereumChainID int64
-
-	sequencerID gethcommon.Address
-
-	logger gethlog.Logger
-
-	storage storage.Storage
-
-	batchRegistry  BatchRegistry
-	blockProcessor L1BlockProcessor
+	sequencerID   gethcommon.Address
+	storage       storage.Storage
+	batchRegistry BatchRegistry
+	logger        gethlog.Logger
 }
 
-func NewRollupProducer(sequencerID gethcommon.Address, transactionBlobCrypto crypto.DataEncryptionService, obscuroChainID int64, ethereumChainID int64, storage storage.Storage, batchRegistry BatchRegistry, blockProcessor L1BlockProcessor, logger gethlog.Logger) RollupProducer {
+func NewRollupProducer(sequencerID gethcommon.Address, storage storage.Storage, batchRegistry BatchRegistry, logger gethlog.Logger) RollupProducer {
 	return &rollupProducerImpl{
-		TransactionBlobCrypto: transactionBlobCrypto,
-		ObscuroChainID:        obscuroChainID,
-		EthereumChainID:       ethereumChainID,
-		sequencerID:           sequencerID,
-		logger:                logger,
-		batchRegistry:         batchRegistry,
-		blockProcessor:        blockProcessor,
-		storage:               storage,
+		sequencerID:   sequencerID,
+		logger:        logger,
+		batchRegistry: batchRegistry,
+		storage:       storage,
 	}
 }
 
-func (re *rollupProducerImpl) CreateRollup(fromBatchNo uint64, upToL1Height uint64, limiter limiters.RollupLimiter) (*core.Rollup, error) {
-	batches, err := re.batchRegistry.BatchesAfter(fromBatchNo, upToL1Height, limiter)
+func (re *rollupProducerImpl) CreateInternalRollup(fromBatchNo uint64, upToL1Height uint64, limiter limiters.RollupLimiter) (*core.Rollup, error) {
+	batches, blocks, err := re.batchRegistry.BatchesAfter(fromBatchNo, upToL1Height, limiter)
 	if err != nil {
 		return nil, fmt.Errorf("could not fetch 'from' batch (seqNo=%d) for rollup: %w", fromBatchNo, err)
 	}
@@ -68,17 +51,6 @@ func (re *rollupProducerImpl) CreateRollup(fromBatchNo uint64, upToL1Height uint
 	if err != nil {
 		return nil, err
 	}
-	newRollup := re.createNextRollup(batches, block)
-
-	re.logger.Info(fmt.Sprintf("Created new rollup %s with %d batches. From %d to %d", newRollup.Hash(), len(newRollup.Batches), batches[0].SeqNo(), batches[len(batches)-1].SeqNo()))
-
-	return newRollup, nil
-}
-
-// createNextRollup - based on a previous rollup and batches will create a new rollup that encapsulate the state
-// transition from the old rollup to the new one's head batch.
-func (re *rollupProducerImpl) createNextRollup(batches []*core.Batch, block *types.Block) *core.Rollup {
-	lastBatch := batches[len(batches)-1]
 
 	rh := common.RollupHeader{}
 	rh.CompressionL1Head = block.Hash()
@@ -89,9 +61,21 @@ func (re *rollupProducerImpl) createNextRollup(batches []*core.Batch, block *typ
 		rh.CrossChainMessages = append(rh.CrossChainMessages, b.Header.CrossChainMessages...)
 	}
 
+	lastBatch := batches[len(batches)-1]
 	rh.LastBatchSeqNo = lastBatch.SeqNo().Uint64()
-	return &core.Rollup{
+
+	blockMap := map[common.L1BlockHash]*types.Block{}
+	for _, b := range blocks {
+		blockMap[b.Hash()] = b
+	}
+
+	newRollup := &core.Rollup{
 		Header:  &rh,
+		Blocks:  blockMap,
 		Batches: batches,
 	}
+
+	re.logger.Info(fmt.Sprintf("Created new rollup %s with %d batches. From %d to %d", newRollup.Hash(), len(newRollup.Batches), batches[0].SeqNo(), rh.LastBatchSeqNo))
+
+	return newRollup, nil
 }

--- a/go/enclave/core/rollup.go
+++ b/go/enclave/core/rollup.go
@@ -4,13 +4,16 @@ import "C"
 import (
 	"sync/atomic"
 
+	"github.com/ethereum/go-ethereum/core/types"
+
 	"github.com/obscuronet/go-obscuro/go/common"
 )
 
-// todo - This should be a synthetic datastructure
+// Rollup - is an internal data structure useful during creation
 type Rollup struct {
 	Header  *common.RollupHeader
 	Batches []*Batch
+	Blocks  map[common.L1BlockHash]*types.Block // these are the blocks required during compression. The key is the hash
 	hash    atomic.Value
 }
 

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -211,7 +211,7 @@ func NewEnclave(
 	batchExecutor := components.NewBatchExecutor(storage, crossChainProcessors, genesis, gasOracle, &chainConfig, logger)
 	sigVerifier, err := components.NewSignatureValidator(config.SequencerID, storage)
 	registry := components.NewBatchRegistry(storage, logger)
-	rProducer := components.NewRollupProducer(config.SequencerID, dataEncryptionService, config.ObscuroChainID, config.L1ChainID, storage, registry, blockProcessor, logger)
+	rProducer := components.NewRollupProducer(config.SequencerID, storage, registry, logger)
 	if err != nil {
 		logger.Crit("Could not initialise the signature validator", log.ErrKey, err)
 	}

--- a/go/host/enclave/guardian.go
+++ b/go/host/enclave/guardian.go
@@ -552,7 +552,10 @@ func (g *Guardian) periodicRollupProduction() {
 			// produce and issue rollup when either:
 			// it has passed g.rollupInterval from last lastSuccessfulRollup
 			// or the size of accumulated batches is > g.maxRollupSize
-			if time.Since(lastSuccessfulRollup) > g.rollupInterval || availBatchesSumSize >= g.maxRollupSize {
+			timeExpired := time.Since(lastSuccessfulRollup) > g.rollupInterval
+			sizeExceeded := availBatchesSumSize >= g.maxRollupSize
+			if timeExpired || sizeExceeded {
+				g.logger.Info("Trigger rollup production.", "timeExpired", timeExpired, "sizeExceeded", sizeExceeded)
 				producedRollup, err := g.enclaveClient.CreateRollup(fromBatch)
 				if err != nil {
 					g.logger.Error("Unable to create rollup", log.BatchSeqNoKey, fromBatch, log.ErrKey, err)


### PR DESCRIPTION
### Why this change is needed

- testnet is crashing with OOM
- rollup creation takes longer than it should

### What changes were made as part of this PR

1. Improve performance of rollup creation by saving the list of blocks after they are fetched the first time.
2. Set maximum memory for cache.
3. Reduce cache memory consumption by caching a mapping between a batch hash and a batch sequence


### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


