### PR TITLE
adjust cache cfg

### DIFF
--- a/go/common/batches.go
+++ b/go/common/batches.go
@@ -29,11 +29,6 @@ func (b *ExtBatch) Hash() L2BatchHash {
 	return v
 }
 
-func (b *ExtBatch) Size() (int, error) {
-	bytes, err := rlp.EncodeToBytes(b)
-	return len(bytes), err
-}
-
 func (b *ExtBatch) Encoded() ([]byte, error) {
 	return rlp.EncodeToBytes(b)
 }

--- a/go/enclave/storage/storage.go
+++ b/go/enclave/storage/storage.go
@@ -81,7 +81,9 @@ func NewStorage(backingDB enclavedb.EnclaveDB, chainConfig *params.ChainConfig, 
 
 	// todo (tudor) figure out the context and the config
 	cfg := bigcache.DefaultConfig(2 * time.Minute)
-	cfg.HardMaxCacheSize = 512
+	cfg.Shards = 512
+	// 1GB cache. Max value in a shard is 2MB. No batch or block should be larger than that
+	cfg.HardMaxCacheSize = cfg.Shards * 4
 	bigcacheClient, err := bigcache.New(context.Background(), cfg)
 	if err != nil {
 		logger.Crit("Could not initialise bigcache", log.ErrKey, err)


### PR DESCRIPTION
### Why this change is needed

to avoid errors when storing object in the cache, we need to reduce the shard size.
With the previous setup it was 512K.


### What changes were made as part of this PR

- adjust cache cfg
-Also adjust the "create rollup" logic 

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


