### PR TITLE
Update some OBX references in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ Once started Obscuroscan is available on `http://0.0.0.0:8098`.
 
 
 ### Building and running a local faucet
-Deploying and interacting with contracts on Obscuro requires OBX to be allocated to an account via the faucet.
+Deploying and interacting with contracts on Obscuro requires ETH to be allocated to an account on the L2 via the faucet (or bridged across from the L1).
 The faucet image should be pulled (or optionally built from scratch), and the container built and started to allow requests to be made to it. 
 To pull the testnet faucet and run use;
 

--- a/docs/_docs/testnet/deploying-a-smart-contract-programmatically.md
+++ b/docs/_docs/testnet/deploying-a-smart-contract-programmatically.md
@@ -24,8 +24,8 @@ account stored for later usage.
     logging.info('Using account with address %s' % account.address)
 ```
 
-## Request OBX from the faucet server for native OBX
-An account needs gas to perform transactions on Obscuro, where gas is paid in native OBX. Requests of native OBX can be 
+## Request ETH from the faucet server for native ETH
+An account needs gas to perform transactions on Obscuro, where gas is paid in native ETH. Requests of native ETH can be 
 made through a POST to the faucet server where the address is supplied in the data payload.
 ```python
     headers = {'Content-Type': 'application/json'}

--- a/docs/_docs/testnet/deploying-a-smart-contract-programmatically.py
+++ b/docs/_docs/testnet/deploying-a-smart-contract-programmatically.py
@@ -66,7 +66,7 @@ def run():
     account = w3.eth.account.privateKeyToAccount(private_key)
     logging.info('Using account with address %s' % account.address)
 
-    # request native OBX from the faucet server
+    # request native ETH from the faucet server
     headers = {'Content-Type': 'application/json'}
     data = {"address": account.address}
     requests.post(FAUCET_URL, data=json.dumps(data), headers=headers)

--- a/docs/_docs/testnet/faucet.md
+++ b/docs/_docs/testnet/faucet.md
@@ -1,21 +1,21 @@
 ---
 ---
 # Using the Testnet Token Faucet
-Using the steps below you will request testnet OBX from the faucet available on the Obscuro Discord server.
+Using the steps below you will request testnet ETH from the faucet available on the Obscuro Discord server.
 
 ## Prerequisites
 * Access to the [Obscuro Discord server](https://discord.gg/yQfmKeNzNd).
 * (Optional) [MetaMask](https://metamask.io/) wallet installed in your browser.
 * (Optional) A local copy of the [Obscuro MetaMask wallet extension](https://docs.obscu.ro/wallet-extension/wallet-extension/).
 
-## Requesting Testnet OBX
+## Requesting Testnet ETH
 1. Make a note of your wallet address or copy it to your clipboard.
 2. Open the [_faucet-requests_ channel](https://discord.gg/5qyj3qraaH) on Obscuro Discord.
-3. Request OBX using the `/faucet` command. The faucet will credit 100,000 OBX by default:
+3. Request ETH using the `/faucet` command. The faucet will credit 0.5 ETH by default:
    ![faucet command](../../assets/images/faucet-cmd.png)
 4. Provide your wallet address and hit Enter. The faucet will acknowledge your request:
    ![faucet ack](../../assets/images/faucet-ack.png)
-5. After a short period of time the faucet will confirm the Testnet OBX have been credited to your wallet:
+5. After a short period of time the faucet will confirm the Testnet ETH have been credited to your wallet:
    ![faucet complete](../../assets/images/faucet-done.png)
 
 ## Viewing Your Wallet Balance
@@ -23,13 +23,13 @@ To view the balance of your wallet you will need to establish a connection from 
 
 Use the steps [here](https://docs.obscu.ro/testnet/deploying-a-smart-contract/#prepare-your-metamask-wallet-for-obscuro-testnet) to prepare your MetaMask wallet for Obscuro Testnet.
 
-## Requesting Testnet OBX directly
-In the event that you do not have access to Discord, or the faucet bot is not working, you can request OBX directly from 
+## Requesting Testnet ETH directly
+In the event that you do not have access to Discord, or the faucet bot is not working, you can request ETH directly from 
 the faucet server using the below; 
 
 1. Make a note of your wallet address or copy it to your clipboard.
-2. Open a command shell and issue the below command, where `<address>` should be replaced with the value stored in your clipboard (e.g. `0x75Ad715443e1E2EBdaFA33ABB3B08443966019A6`). The faucet server will credit 100,000 OBX by default.
+2. Open a command shell and issue the below command, where `<address>` should be replaced with the value stored in your clipboard (e.g. `0x75Ad715443e1E2EBdaFA33ABB3B08443966019A6`). The faucet server will credit 0.5 ETH by default.
 ```bash
 curl --location --request POST 'http://testnet-faucet.uksouth.azurecontainer.io/fund/eth' --header 'Content-Type: application/json' --data-raw '{ "address":"<your address>" }'
 ```
-3. After a short period of time the curl command will return `{"status":"ok"}` confirming OBX have been credited to your wallet.
+3. After a short period of time the curl command will return `{"status":"ok"}` confirming ETH have been credited to your wallet.

--- a/docs/_docs/wallet-extension/wallet-extension.md
+++ b/docs/_docs/wallet-extension/wallet-extension.md
@@ -73,7 +73,7 @@ tools.
 5. Visit `http://localhost:3000/viewingkeys/` to generate a new viewing key, and sign the viewing key when prompted by
    MetaMask. Responses to sensitive RPC requests will now be encrypted with the viewing key and decrypted
    automatically by the wallet extension. Your balance in MetaMask will be set to 0 at the beginning.
-   You can get testnet OBX from [faucet](https://docs.obscu.ro/testnet/faucet/) (you may need to switch to another network and back again to force MetaMask to refresh balance).
+   You can get testnet ETH from [faucet](https://docs.obscu.ro/testnet/faucet/) (you may need to switch to another network and back again to force MetaMask to refresh balance).
    
    Once a viewing key is generated it will be persisted across restarts of the wallet extension, saved in the user home space under `~/.obscuro/wallet_extension_persistence`.
 

--- a/go/common/denomination.go
+++ b/go/common/denomination.go
@@ -4,7 +4,7 @@ import "math/big"
 
 // Analogous to denomination.go constants in geth
 
-// These are the multipliers for ERC20 and native OBX value denominations
+// These are the multipliers for ERC20 and native ETH value denominations
 // Example: To get the wei value of an amount in whole tokens, use
 //
 //	new(big.Int).Mul(value, big.NewInt(common.Token))

--- a/tools/faucet/README.md
+++ b/tools/faucet/README.md
@@ -1,6 +1,6 @@
 # Obscuro Faucet
 
-This tools contains a Faucet to allow allocation of OBX tokens within an Obscuro network. For more information 
+This tools contains a Faucet to allow allocation of ETH tokens within an Obscuro network. For more information 
 on Obscuro see the [Obscuro repo](https://github.com/obscuronet/go-obscuro) and [documentation](https://docs.obscu.ro/).
 
 ## Repository Structure
@@ -30,8 +30,8 @@ to the Obscuro node running within the local testnet on host `validator-host` an
 on port `80` within the container, but maps port `8080` on the host machine to this.
 
 
-## Allocating OBX to an EOA on a local testnet
-Allocating OBX to an externally owned account is done through a POST command to the `/fund/eth` endpoint, where the 
+## Allocating ETH to an EOA on a local testnet
+Allocating ETH to an externally owned account is done through a POST command to the `/fund/eth` endpoint, where the 
 data in the POST command specifies the address e.g. for the account `0x0d2166b7b3A1522186E809e83d925d7b0B6db084`
 
 ```bash


### PR DESCRIPTION
### Why this change is needed

We want docs for users and devs to be clear that users will receive native ETH from the L2 faucet, not OBX.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


