### PR TITLE
Add SepoliaTestnet as an environment for network tests

### DIFF
--- a/integration/networktest/env/network_setup.go
+++ b/integration/networktest/env/network_setup.go
@@ -5,10 +5,20 @@ import (
 	"github.com/obscuronet/go-obscuro/integration/networktest"
 )
 
+func SepoliaTestnet() networktest.Environment {
+	connector := NewTestnetConnector(
+		"http://erpc.sepolia-testnet.obscu.ro:80", // this is actually a validator...
+		[]string{"http://erpc.sepolia-testnet.obscu.ro:80"},
+		"http://sepolia-testnet-faucet.uksouth.azurecontainer.io/fund/eth",
+		"https://rpc.sepolia.org/",
+	)
+	return &testnetEnv{connector}
+}
+
 func Testnet() networktest.Environment {
 	connector := NewTestnetConnector(
-		"http://erpc.testnet.obscu.ro:80",
-		[]string{"http://erpc.testnet.obscu.ro:80"}, // for now we'll just use sequencer as validator node... todo (@matt)
+		"http://erpc.testnet.obscu.ro:80", // this is actually a validator...
+		[]string{"http://erpc.testnet.obscu.ro:80"},
 		"http://testnet-faucet.uksouth.azurecontainer.io/fund/eth",
 		"ws://testnet-eth2network.uksouth.cloudapp.azure.com:9000",
 	)
@@ -17,8 +27,8 @@ func Testnet() networktest.Environment {
 
 func DevTestnet() networktest.Environment {
 	connector := NewTestnetConnector(
-		"http://erpc.dev-testnet.obscu.ro:80",
-		[]string{"http://erpc.dev-testnet.obscu.ro:80"}, // for now we'll just use sequencer as validator node... todo (@matt)
+		"http://erpc.dev-testnet.obscu.ro:80", // this is actually a validator...
+		[]string{"http://erpc.dev-testnet.obscu.ro:80"},
 		"http://dev-testnet-faucet.uksouth.azurecontainer.io/fund/eth",
 		"ws://dev-testnet-eth2network.uksouth.cloudapp.azure.com:9000",
 	)

--- a/integration/networktest/env/testnet.go
+++ b/integration/networktest/env/testnet.go
@@ -28,7 +28,7 @@ type testnetConnector struct {
 	seqRPCAddress         string
 	validatorRPCAddresses []string
 	faucetHTTPAddress     string
-	l1WSURL               string
+	l1RPCURL              string
 	faucetWallet          *userwallet.UserWallet
 }
 
@@ -37,7 +37,7 @@ func NewTestnetConnector(seqRPCAddr string, validatorRPCAddressses []string, fau
 		seqRPCAddress:         seqRPCAddr,
 		validatorRPCAddresses: validatorRPCAddressses,
 		faucetHTTPAddress:     faucetHTTPAddress,
-		l1WSURL:               l1WSURL,
+		l1RPCURL:              l1WSURL,
 	}
 }
 
@@ -50,7 +50,7 @@ func NewTestnetConnectorWithFaucetAccount(seqRPCAddr string, validatorRPCAddress
 		seqRPCAddress:         seqRPCAddr,
 		validatorRPCAddresses: validatorRPCAddressses,
 		faucetWallet:          userwallet.NewUserWallet(ecdsaKey, validatorRPCAddressses[0], testlog.Logger(), userwallet.WithChainID(big.NewInt(integration.ObscuroChainID))),
-		l1WSURL:               l1RPCAddress,
+		l1RPCURL:              l1RPCAddress,
 	}
 }
 
@@ -94,7 +94,7 @@ func (t *testnetConnector) NumValidators() int {
 }
 
 func (t *testnetConnector) GetL1Client() (ethadapter.EthClient, error) {
-	client, err := ethadapter.NewEthClientFromURL(t.l1WSURL, time.Minute, gethcommon.Address{}, testlog.Logger())
+	client, err := ethadapter.NewEthClientFromURL(t.l1RPCURL, time.Minute, gethcommon.Address{}, testlog.Logger())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Why this change is needed

Now that the sepolia faucet is working we can use SepoliaTestnet as an environment on the network tests.

Renamed the RPC URL field as there's no requirement for it to be websocket for testing unless the test is doing some subscription stuff. This means we can configure a public sepolia URL instead of an infura URL requiring API key.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


