### PR TITLE
bump enclave heap size

### DIFF
--- a/go/enclave/main/enclave.json
+++ b/go/enclave/main/enclave.json
@@ -2,7 +2,7 @@
   "exe": "main",
   "key": "testnet.pem",
   "debug": true,
-  "heapSize": 2048,
+  "heapSize": 4096,
   "executableHeap": true,
   "productID": 1,
   "securityVersion": 1,


### PR DESCRIPTION
### Why this change is needed

to avoid OOM on the enclave


