### PR TITLE
Add balance endpoint to faucet for monitoring

### DIFF
--- a/tools/faucet/faucet/faucet.go
+++ b/tools/faucet/faucet/faucet.go
@@ -140,3 +140,7 @@ func (f *Faucet) fundNativeToken(address *common.Address, amount *big.Int) (*typ
 
 	return signedTx, nil
 }
+
+func (f *Faucet) Balance(ctx context.Context) (*big.Int, error) {
+	return f.client.BalanceAt(ctx, nil)
+}


### PR DESCRIPTION
### Why this change is needed

We need to be notified when sepolia faucet is getting low on funds but the account balance can't be easily monitored because you need signed viewing key.

Endpoint will let us add it to the periodic monitoring.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


