### PR TITLE
remove costly select

### DIFF
--- a/go/enclave/components/batch_registry.go
+++ b/go/enclave/components/batch_registry.go
@@ -79,16 +79,7 @@ func (br *batchRegistry) OnBatchExecuted(batch *core.Batch, receipts types.Recei
 }
 
 func (br *batchRegistry) HasGenesisBatch() (bool, error) {
-	genesisBatchStored := true
-	_, err := br.storage.FetchHeadBatch()
-	if err != nil {
-		if !errors.Is(err, errutil.ErrNotFound) {
-			return false, fmt.Errorf("could not retrieve current head batch. Cause: %w", err)
-		}
-		genesisBatchStored = false
-	}
-
-	return genesisBatchStored, nil
+	return br.headBatchSeq.Uint64() > common.L2GenesisSeqNo, nil
 }
 
 func (br *batchRegistry) BatchesAfter(batchSeqNo uint64, upToL1Height uint64, rollupLimiter limiters.RollupLimiter) ([]*core.Batch, []*types.Block, error) {

--- a/go/enclave/components/batch_registry.go
+++ b/go/enclave/components/batch_registry.go
@@ -6,8 +6,6 @@ import (
 	"math/big"
 	"sync"
 
-	"github.com/obscuronet/go-obscuro/go/common"
-
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/obscuronet/go-obscuro/go/enclave/storage"
 
@@ -35,8 +33,9 @@ func NewBatchRegistry(storage storage.Storage, logger gethlog.Logger) BatchRegis
 	headBatch, err := storage.FetchHeadBatch()
 	if err != nil {
 		if errors.Is(err, errutil.ErrNotFound) {
-			headBatchSeq = big.NewInt(int64(common.L2GenesisSeqNo))
+			headBatchSeq = nil
 		} else {
+			logger.Crit("Could not create batch registry", log.ErrKey, err)
 			return nil
 		}
 	} else {
@@ -79,7 +78,7 @@ func (br *batchRegistry) OnBatchExecuted(batch *core.Batch, receipts types.Recei
 }
 
 func (br *batchRegistry) HasGenesisBatch() (bool, error) {
-	return br.headBatchSeq.Uint64() > common.L2GenesisSeqNo, nil
+	return br.headBatchSeq != nil, nil
 }
 
 func (br *batchRegistry) BatchesAfter(batchSeqNo uint64, upToL1Height uint64, rollupLimiter limiters.RollupLimiter) ([]*core.Batch, []*types.Block, error) {

--- a/go/enclave/nodetype/sequencer.go
+++ b/go/enclave/nodetype/sequencer.go
@@ -151,6 +151,9 @@ func (s *sequencer) initGenesis(block *common.L1Block) error {
 
 func (s *sequencer) createNewHeadBatch(l1HeadBlock *common.L1Block) error {
 	headBatchSeq := s.batchRegistry.HeadBatchSeq()
+	if headBatchSeq == nil {
+		headBatchSeq = big.NewInt(int64(common.L2GenesisSeqNo))
+	}
 	headBatch, err := s.storage.FetchBatchBySeqNo(headBatchSeq.Uint64())
 	if err != nil {
 		return err

--- a/go/enclave/nodetype/validator.go
+++ b/go/enclave/nodetype/validator.go
@@ -74,7 +74,11 @@ func (val *obsValidator) VerifySequencerSignature(b *core.Batch) error {
 }
 
 func (val *obsValidator) ExecuteStoredBatches() error {
-	batches, err := val.storage.FetchCanonicalUnexecutedBatches(val.batchRegistry.HeadBatchSeq())
+	headBatchSeq := val.batchRegistry.HeadBatchSeq()
+	if headBatchSeq == nil {
+		headBatchSeq = big.NewInt(int64(common.L2GenesisSeqNo))
+	}
+	batches, err := val.storage.FetchCanonicalUnexecutedBatches(headBatchSeq)
 	if err != nil {
 		if errors.Is(err, errutil.ErrNotFound) {
 			return nil


### PR DESCRIPTION
### Why this change is needed

To improve the performance of "create batch", remove costly select called for each batch.

It also fixes a small flakyness that was causing sim tests to fail due to duplicated genesis

