### PR TITLE
Downgrade spammy log messages

### DIFF
--- a/go/enclave/nodetype/sequencer.go
+++ b/go/enclave/nodetype/sequencer.go
@@ -189,7 +189,8 @@ func (s *sequencer) createNewHeadBatch(l1HeadBlock *common.L1Block, skipBatchIfE
 	if _, err := s.produceBatch(sequencerNo.Add(sequencerNo, big.NewInt(1)), l1HeadBlock.Hash(), headBatch.Hash(), transactions, uint64(time.Now().Unix()), skipBatchIfEmpty); err != nil {
 		if errors.Is(err, components.ErrNoTransactionsToProcess) {
 			// skip batch production when there are no transactions to process
-			s.logger.Info("Skipping batch production, no transactions to execute")
+			// todo: this might be a useful event to track for metrics (skipping batch production because empty batch)
+			s.logger.Debug("Skipping batch production, no transactions to execute")
 			return nil
 		}
 		return fmt.Errorf(" failed producing batch. Cause: %w", err)

--- a/go/host/enclave/guardian.go
+++ b/go/host/enclave/guardian.go
@@ -388,8 +388,8 @@ func (g *Guardian) catchupWithL2() error {
 func (g *Guardian) submitL1Block(block *common.L1Block, isLatest bool) (bool, error) {
 	g.logger.Trace("submitting L1 block", log.BlockHashKey, block.Hash(), log.BlockHeightKey, block.Number())
 	if !g.submitDataLock.TryLock() {
-		g.logger.Info("Unable to submit block, already submitting another block")
-		// we are already submitting a block, and we don't want to leak goroutines, we wil catch up with the block later
+		g.logger.Debug("Unable to submit block, enclave is busy processing data")
+		// we are waiting for the enclave to process other data, and we don't want to leak goroutines, we wil catch up with the block later
 		return false, nil
 	}
 	receipts, err := g.sl.L1Repo().FetchObscuroReceipts(block)

--- a/integration/networktest/tests/helpful/availability_test.go
+++ b/integration/networktest/tests/helpful/availability_test.go
@@ -21,7 +21,7 @@ func TestNetworkAvailability(t *testing.T) {
 	networktest.Run(
 		"network-availability",
 		t,
-		env.SepoliaTestnet(),
+		env.DevTestnet(),
 		actions.RunOnlyAction(func(ctx context.Context, network networktest.NetworkConnector) (context.Context, error) {
 			client, err := network.GetL1Client()
 			if err != nil {

--- a/integration/networktest/tests/helpful/availability_test.go
+++ b/integration/networktest/tests/helpful/availability_test.go
@@ -21,7 +21,7 @@ func TestNetworkAvailability(t *testing.T) {
 	networktest.Run(
 		"network-availability",
 		t,
-		env.DevTestnet(),
+		env.SepoliaTestnet(),
 		actions.RunOnlyAction(func(ctx context.Context, network networktest.NetworkConnector) (context.Context, error) {
 			client, err := network.GetL1Client()
 			if err != nil {


### PR DESCRIPTION
### Why this change is needed

To reduce our datadog log volume these non-critical messages can be downgraded to debug.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


