### PR TITLE
Lock hh-deploy version to fix config compatability bug

### DIFF
--- a/contracts/package.json
+++ b/contracts/package.json
@@ -16,7 +16,7 @@
     "@solidstate/hardhat-bytecode-exporter": "^1.1.1",
     "hardhat": "~2.12.4",
     "hardhat-abi-exporter": "^2.10.1",
-    "hardhat-deploy": "~0.11.22",
+    "hardhat-deploy": "0.11.22",
     "node-docker-api": "^1.1.22",
     "ts-node": "~10.9.1",
     "typescript": "^4.9.4"


### PR DESCRIPTION
### Why this change is needed

Locking hardhat-deploy version fixes an error we see: https://github.com/obscuronet/obscuro-internal/issues/2294

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


