### PR TITLE
Respond with latest for pending block number requests

### DIFF
--- a/go/enclave/components/batch_registry.go
+++ b/go/enclave/components/batch_registry.go
@@ -177,10 +177,8 @@ func (br *batchRegistry) GetBatchAtHeight(height gethrpc.BlockNumber) (*core.Bat
 			return nil, fmt.Errorf("could not retrieve genesis rollup. Cause: %w", err)
 		}
 		batch = genesisBatch
-	case gethrpc.PendingBlockNumber:
-		// todo - depends on the current pending rollup; leaving it for a different iteration as it will need more thought
-		return nil, fmt.Errorf("requested balance for pending block. This is not handled currently")
-	case gethrpc.SafeBlockNumber, gethrpc.FinalizedBlockNumber, gethrpc.LatestBlockNumber:
+	// note: our API currently treats all these block statuses the same for obscuro batches
+	case gethrpc.SafeBlockNumber, gethrpc.FinalizedBlockNumber, gethrpc.LatestBlockNumber, gethrpc.PendingBlockNumber:
 		headBatch, err := br.storage.FetchBatchBySeqNo(br.headBatchSeq.Uint64())
 		if err != nil {
 			return nil, fmt.Errorf("batch with requested height %d was not found. Cause: %w", height, err)

--- a/go/host/rpc/clientapi/client_api_eth.go
+++ b/go/host/rpc/clientapi/client_api_eth.go
@@ -9,7 +9,6 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/obscuronet/go-obscuro/go/common"
-	"github.com/obscuronet/go-obscuro/go/common/errutil"
 	"github.com/obscuronet/go-obscuro/go/common/host"
 	"github.com/obscuronet/go-obscuro/go/common/log"
 	"github.com/obscuronet/go-obscuro/go/responses"
@@ -207,17 +206,15 @@ type FeeHistoryResult struct {
 // Given a batch number, returns the hash of the batch with that number.
 func (api *EthereumAPI) batchNumberToBatchHash(batchNumber rpc.BlockNumber) (*gethcommon.Hash, error) {
 	// Handling the special cases first. No special handling is required for rpc.EarliestBlockNumber.
-	if batchNumber == rpc.LatestBlockNumber {
+	// note: our API currently treats all these block statuses the same for obscuro batches
+	if batchNumber == rpc.LatestBlockNumber || batchNumber == rpc.PendingBlockNumber ||
+		batchNumber == rpc.FinalizedBlockNumber || batchNumber == rpc.SafeBlockNumber {
 		batchHeader, err := api.host.DB().GetHeadBatchHeader()
 		if err != nil {
 			return nil, err
 		}
 		batchHash := batchHeader.Hash()
 		return &batchHash, nil
-	}
-
-	if batchNumber == rpc.PendingBlockNumber {
-		return nil, errutil.ErrNoImpl
 	}
 
 	batchNumberBig := big.NewInt(batchNumber.Int64())


### PR DESCRIPTION
### Why this change is needed

Some tools are making RPC requests to us with 'pending' blocknumber which was erroring.

These are the eth block number options:
![image](https://github.com/obscuronet/go-obscuro/assets/98158711/d2760a50-3ec5-43ea-8aa7-32e7b5462c5d)

They don't map that well to obscuro batches. For now this treats those requests the same as for latest block because it's better than failing, and I will create an issue for us to revisit this.

We may eventually want to respond with the latest batch that's been rolled up for the 'finalized' flag but maybe that's not intuitive behaviour when rollups may take hours.

### What changes were made as part of this PR

Handle the nuanced cases of eth block number all as 'latest' batch for now, in particular `pending` which wasn't supported.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


