### PR TITLE
ObscuroScan: load eth price on init

### DIFF
--- a/tools/obscuroscan_v2/backend/cmd/cli.go
+++ b/tools/obscuroscan_v2/backend/cmd/cli.go
@@ -9,7 +9,7 @@ import (
 func parseCLIArgs() *config.Config {
 	defaultConfig := &config.Config{
 		NodeHostAddress: "http://erpc.dev-testnet.obscu.ro:80",
-		ServerAddress:   "0.0.0.0:80",
+		ServerAddress:   "0.0.0.0:43910",
 		LogPath:         "obscuroscan_logs.txt",
 	}
 

--- a/tools/obscuroscan_v2/backend/cmd/cli.go
+++ b/tools/obscuroscan_v2/backend/cmd/cli.go
@@ -9,7 +9,7 @@ import (
 func parseCLIArgs() *config.Config {
 	defaultConfig := &config.Config{
 		NodeHostAddress: "http://erpc.dev-testnet.obscu.ro:80",
-		ServerAddress:   "0.0.0.0:43910",
+		ServerAddress:   "0.0.0.0:80",
 		LogPath:         "obscuroscan_logs.txt",
 	}
 

--- a/tools/obscuroscan_v2/frontend/src/lib/config.dev.js
+++ b/tools/obscuroscan_v2/frontend/src/lib/config.dev.js
@@ -1,7 +1,7 @@
 class Config {
     static backendServerAddress = "http://127.0.0.1:43910"
     static pollingInterval = 1000
-    static pricePollingInterval = 10000*10000
+    static pricePollingInterval = 60*1000 // 1 minute
     static version = "dev"
 }
 

--- a/tools/obscuroscan_v2/frontend/src/lib/config.js
+++ b/tools/obscuroscan_v2/frontend/src/lib/config.js
@@ -1,7 +1,7 @@
 class Config {
     static backendServerAddress = "http://127.0.0.1:43910"
     static pollingInterval = 1000
-    static pricePollingInterval = 10000*10000
+    static pricePollingInterval = 60*1000 // 1 minute
     static version = "dev"
 }
 

--- a/tools/obscuroscan_v2/frontend/src/lib/config.prod.js
+++ b/tools/obscuroscan_v2/frontend/src/lib/config.prod.js
@@ -2,7 +2,7 @@ class Config {
     // VITE_APIHOSTADDRESS should be used as an env var at the prod server
     static backendServerAddress = import.meta.env.VITE_APIHOSTADDRESS
     static pollingInterval = 1000
-    static pricePollingInterval = 10*this.pollingInterval
+    static pricePollingInterval = 60*1000 // 1 minute
     static version = import.meta.env.VITE_FE_VERSION
 }
 

--- a/tools/obscuroscan_v2/frontend/src/lib/poller.js
+++ b/tools/obscuroscan_v2/frontend/src/lib/poller.js
@@ -5,8 +5,10 @@ class Poller {
         this.timer = null;
     }
 
+    // Start polling - executes the fetchCallback immediately and every interval thereafter
     start() {
         this.stop(); // Ensure previous intervals are cleared
+        this.fetchCallback();
         this.timer = setInterval(async () => {
             await this.fetchCallback();
         }, this.interval);

--- a/tools/obscuroscan_v2/frontend/src/stores/priceStore.js
+++ b/tools/obscuroscan_v2/frontend/src/stores/priceStore.js
@@ -24,7 +24,7 @@ export const usePriceStore = defineStore({
             }
         },
 
-        async startPolling() {
+        startPolling() {
             this.poller.start();
         },
 

--- a/tools/obscuroscan_v2/frontend/src/stores/priceStore.js
+++ b/tools/obscuroscan_v2/frontend/src/stores/priceStore.js
@@ -9,7 +9,7 @@ export const usePriceStore = defineStore({
         poller: new Poller(() => {
             const store = usePriceStore();
             store.fetch();
-        }, 60*Config.pollingInterval)
+        }, Config.pricePollingInterval)
     }),
     actions: {
         async fetch() {
@@ -18,13 +18,13 @@ export const usePriceStore = defineStore({
                 const data = await response.json();
                 this.ethPriceUSD = data.ethereum.usd;
 
-                console.log("Fetched "+this.ethPriceUSD);
+                console.log("Fetched " + this.ethPriceUSD);
             } catch (error) {
                 console.error("Failed to fetch count:", error);
             }
         },
 
-        startPolling() {
+        async startPolling() {
             this.poller.start();
         },
 


### PR DESCRIPTION
### Why this change is needed

Currently it takes one minute before the eth price is requested so we see a loading circle. The other data also has a slight (1 second) delay before it loads because it waits for its polling interval.

### What changes were made as part of this PR

Change the poller semantics to make the request immediately when started and then at the interval thereafter.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


