### PR TITLE
ObscuroScan: MetaMask button show connected

### DIFF
--- a/tools/obscuroscan_v2/frontend/src/components/MetaMaskConnectButton.vue
+++ b/tools/obscuroscan_v2/frontend/src/components/MetaMaskConnectButton.vue
@@ -1,7 +1,8 @@
 <template>
   <el-button @click="connectMetamask" size="large" >
     <img src="@/assets/imgs/icon_metamask.png" alt="Connect with MetaMask" class="metamask-icon" />
-    Connect with MetaMask
+    <div v-if="walletStore.provider">Connected!</div>
+    <div v-else>Connect with MetaMask</div>
   </el-button>
 </template>
 
@@ -36,7 +37,8 @@ export default {
     }
 
     return {
-      connectMetamask
+      connectMetamask,
+      walletStore
     };
   }
 }

--- a/tools/obscuroscan_v2/frontend/src/components/PersonalTxsGrid.vue
+++ b/tools/obscuroscan_v2/frontend/src/components/PersonalTxsGrid.vue
@@ -10,7 +10,7 @@
     </el-table-column>
     <el-table-column prop="status" label="Status" width="180" >
       <template #default="scope">
-        <span style="margin-left: 10px">{{ (Number(scope.row.status) === 1) ? "Sucess" : "Failed" }}</span>
+        <span style="margin-left: 10px">{{ (Number(scope.row.status) === 1) ? "Success" : "Failed" }}</span>
       </template>
     </el-table-column>
     <el-table-column prop="gasUsed" label="Gas Cost" width="180" >


### PR DESCRIPTION
### Why this change is needed

Not obvious that wallet is connected on obscuro scan atm.

Before:
<img width="1539" alt="image" src="https://github.com/obscuronet/go-obscuro/assets/98158711/becba17e-852a-44df-91e2-b316c187006b">

After:
<img width="1492" alt="image" src="https://github.com/obscuronet/go-obscuro/assets/98158711/bac853f3-5dd2-49d2-a74e-baeef69a25a6">

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


