### PR TITLE
ObscuroScan: serve oldest batches first

### DIFF
--- a/go/common/query_types.go
+++ b/go/common/query_types.go
@@ -38,6 +38,7 @@ type PublicTransaction struct {
 
 type PublicBatch struct {
 	BatchHeader
+	TxHashes []TxHash `json:"txHashes"`
 }
 
 type PublicBlock struct {

--- a/go/host/db/batches.go
+++ b/go/host/db/batches.go
@@ -132,24 +132,29 @@ func (db *DB) GetBatchBySequenceNumber(sequenceNumber *big.Int) (*common.ExtBatc
 	return db.GetBatch(*batchHash)
 }
 
-// GetBatchListing returns BatchListingResponse given a pagination
+// GetBatchListing returns latest BatchListingResponse given a pagination. For example, page 0, size 10 will return the
+// latest 10 batches.
 // todo change this when the db changes - this is not super performant
 func (db *DB) GetBatchListing(pagination *common.QueryPagination) (*common.BatchListingResponse, error) {
-	// fetch requested batches
+	// fetch the total batches so we can paginate
+	header, err := db.GetHeadBatchHeader()
+	if err != nil {
+		return nil, err
+	}
+
+	batchesFrom := header.SequencerOrderNo.Uint64() - pagination.Offset
+
 	var batches []common.PublicBatch
-	for i := pagination.Offset; i < pagination.Offset+uint64(pagination.Size); i++ {
+	// fetch requested batches - looping backwards from the latest batch subtracting any pagination offset
+	// (e.g. front-end showing latest batches first, page 3 of size 10 would be skipping the 30 most recent batches)
+	for i := batchesFrom; i > batchesFrom-uint64(pagination.Size); i-- {
 		extBatch, err := db.GetBatchBySequenceNumber(big.NewInt(int64(i)))
 		if err != nil && !errors.Is(err, errutil.ErrNotFound) {
 			return nil, err
 		}
 		if extBatch != nil {
-			batches = append(batches, common.PublicBatch{BatchHeader: *extBatch.Header})
+			batches = append(batches, common.PublicBatch{BatchHeader: *extBatch.Header, TxHashes: extBatch.TxHashes})
 		}
-	}
-	// fetch the total batches so we can paginate
-	header, err := db.GetHeadBatchHeader()
-	if err != nil {
-		return nil, err
 	}
 
 	return &common.BatchListingResponse{

--- a/go/host/db/blocks.go
+++ b/go/host/db/blocks.go
@@ -78,7 +78,7 @@ func (db *DB) GetBlockListing(pagination *common.QueryPagination) (*common.Block
 	var blocks []common.PublicBlock
 	for i := blocksFrom; i > uint64(blocksToInclusive); i-- {
 		header, err := db.GetBlockByHeight(big.NewInt(int64(i)))
-		if err != nil && !errors.Is(err, errutil.ErrNotFound) {
+		if err != nil {
 			return nil, err
 		}
 

--- a/go/host/db/blocks.go
+++ b/go/host/db/blocks.go
@@ -58,11 +58,25 @@ func (db *DB) AddBlock(header *types.Header) error {
 	return nil
 }
 
-// GetBlockListing returns a list of blocks given the pagination
+// GetBlockListing returns latest L1 blocks given the pagination.
+// For example, page 0, size 10 will return the latest 10 blocks.
 func (db *DB) GetBlockListing(pagination *common.QueryPagination) (*common.BlockListingResponse, error) {
+	// fetch the total blocks so we can paginate
+	tipHeader, err := db.GetBlockAtTip()
+	if err != nil {
+		return nil, err
+	}
+
+	blocksFrom := tipHeader.Number.Uint64() - pagination.Offset
+	blocksToInclusive := int(blocksFrom) - int(pagination.Size) + 1
+	// if blocksToInclusive would be negative, set it to 0
+	if blocksToInclusive < 0 {
+		blocksToInclusive = 0
+	}
+
 	// fetch requested batches
 	var blocks []common.PublicBlock
-	for i := pagination.Offset; i < pagination.Offset+uint64(pagination.Size); i++ {
+	for i := blocksFrom; i > uint64(blocksToInclusive); i-- {
 		header, err := db.GetBlockByHeight(big.NewInt(int64(i)))
 		if err != nil && !errors.Is(err, errutil.ErrNotFound) {
 			return nil, err
@@ -74,19 +88,12 @@ func (db *DB) GetBlockListing(pagination *common.QueryPagination) (*common.Block
 			return nil, err
 		}
 
-		if header != nil {
-			listedBlock := common.PublicBlock{BlockHeader: *header}
-			if rollup != nil {
-				listedBlock.RollupHash = rollup.Hash()
-				fmt.Println("added at block: ", header.Number.Int64(), " - ", listedBlock.RollupHash)
-			}
-			blocks = append(blocks, listedBlock)
+		listedBlock := common.PublicBlock{BlockHeader: *header}
+		if rollup != nil {
+			listedBlock.RollupHash = rollup.Hash()
+			fmt.Println("added at block: ", header.Number.Int64(), " - ", listedBlock.RollupHash)
 		}
-	}
-	// fetch the total blocks so we can paginate
-	tipHeader, err := db.GetBlockAtTip()
-	if err != nil {
-		return nil, err
+		blocks = append(blocks, listedBlock)
 	}
 
 	return &common.BlockListingResponse{

--- a/tools/obscuroscan_v2/frontend/src/components/BatchDataGrid.vue
+++ b/tools/obscuroscan_v2/frontend/src/components/BatchDataGrid.vue
@@ -18,7 +18,8 @@
           <Timestamp :unixTimestampSeconds="Number(scope.row.timestamp)" />
         </template>
       </el-table-column>
-      <el-table-column prop="l1Proof" label="Included in Rollup"/>
+      <el-table-column label="No. Transactions" :formatter="function(row) { return row.txHashes ? row.txHashes.length : 0; }" width="180" />
+      <el-table-column prop="l1Proof" label="L1 block"/>
     </el-table>
     <el-pagination
         @size-change="handleSizeChange"
@@ -47,14 +48,9 @@ export default {
   setup() {
     const store = useBatchStore()
 
-    // Start polling when the component is mounted
+    // Reload batch data onMount
     onMounted(() => {
-      store.startPolling()
-    })
-
-    // Ensure to stop polling when component is destroyed or deactivated
-    onUnmounted(() => {
-      store.stopPolling()
+      store.fetch()
     })
 
     return {
@@ -80,21 +76,20 @@ export default {
       const store = useBatchStore()
       store.size = newSize
       store.offset = (this.currentPage - 1) * store.size
+      // reload data
+      store.fetch()
     },
     // Called when the current page is changed
     handleCurrentChange(newPage) {
       const store = useBatchStore()
       this.currentPage = newPage
       store.offset = (newPage - 1) * store.size
+      // reload data
+      store.fetch()
     },
     toggleWindow(data) {
       this.$refs.batchInfoWindowRef.displayData(data.hash);
     },
-  },
-  computed: {
-    tableRowClassName() {
-      return "hover"
-    }
   }
 }
 </script>

--- a/tools/obscuroscan_v2/frontend/src/components/RotatingRollupsItem.vue
+++ b/tools/obscuroscan_v2/frontend/src/components/RotatingRollupsItem.vue
@@ -26,14 +26,9 @@ export default {
   setup() {
     const rollupsStore = useRollupStore()
 
-    // Start polling when the component is mounted
+    // Reload rollup data onMount
     onMounted(() => {
-      rollupsStore.startPolling()
-    })
-
-    // Ensure to stop polling when component is destroyed or deactivated
-    onUnmounted(() => {
-      rollupsStore.stopPolling()
+      rollupsStore.fetch()
     })
 
     return {


### PR DESCRIPTION
### Why this change is needed

We want to show oldest batches first in obscuro scan, very rare that someone would want to look at the first batches of the network.

Also added the batch tx hashes so we can use them for tx count and to link to txs potentially.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


