### PR TITLE
Gateway unsubscribe for multiple subscribed clients

### DIFF
--- a/go/rpc/client.go
+++ b/go/rpc/client.go
@@ -34,6 +34,7 @@ const (
 	Attestation          = "obscuroscan_attestation"
 	StopHost             = "test_stopHost"
 	Subscribe            = "eth_subscribe"
+	Unsubscribe          = "eth_unsubscribe"
 	SubscribeNamespace   = "eth"
 	SubscriptionTypeLogs = "logs"
 

--- a/go/rpc/encrypted_client.go
+++ b/go/rpc/encrypted_client.go
@@ -334,27 +334,6 @@ func (c *EncRPCClient) decryptResponse(encryptedBytes []byte) ([]byte, error) {
 	return decryptedResult, nil
 }
 
-// setResult tries to cast/unmarshal data into the result pointer, based on its type
-func (c *EncRPCClient) setResult(data []byte, result interface{}) error {
-	switch result := result.(type) {
-	case *string:
-		*result = string(data)
-		return nil
-
-	case *interface{}:
-		err := json.Unmarshal(data, result)
-		if err != nil {
-			// if unmarshal failed with generic return we can try to send it back as a string
-			*result = string(data)
-		}
-		return nil
-
-	default:
-		// for any other type we attempt to json unmarshal it
-		return json.Unmarshal(data, result)
-	}
-}
-
 // IsSensitiveMethod indicates whether the RPC method's requests and responses should be encrypted.
 func IsSensitiveMethod(method string) bool {
 	for _, m := range SensitiveMethods {

--- a/go/rpc/encrypted_client.go
+++ b/go/rpc/encrypted_client.go
@@ -89,7 +89,7 @@ func (c *EncRPCClient) CallContext(ctx context.Context, result interface{}, meth
 	return c.executeSensitiveCall(ctx, result, method, args...)
 }
 
-func (c *EncRPCClient) Subscribe(ctx context.Context, result interface{}, namespace string, ch interface{}, args ...interface{}) (*rpc.ClientSubscription, error) {
+func (c *EncRPCClient) Subscribe(ctx context.Context, _ interface{}, namespace string, ch interface{}, args ...interface{}) (*rpc.ClientSubscription, error) {
 	if len(args) == 0 {
 		return nil, fmt.Errorf("subscription did not specify its type")
 	}

--- a/integration/obscurogateway/obscurogateway_test.go
+++ b/integration/obscurogateway/obscurogateway_test.go
@@ -585,7 +585,7 @@ func transferETHToAddress(client *ethclient.Client, wallet wallet.Wallet, toAddr
 	return integrationCommon.AwaitReceiptEth(context.Background(), client, signedTx.Hash(), 2*time.Second)
 }
 
-func subscribeToEvents(addresses []gethcommon.Address, topics [][]gethcommon.Hash, client *ethclient.Client, logs *[]types.Log) ethereum.Subscription {
+func subscribeToEvents(addresses []gethcommon.Address, topics [][]gethcommon.Hash, client *ethclient.Client, logs *[]types.Log) ethereum.Subscription { //nolint:unparam
 	// Make a subscription
 	filterQuery := ethereum.FilterQuery{
 		Addresses: addresses,

--- a/tools/walletextension/accountmanager/account_manager.go
+++ b/tools/walletextension/accountmanager/account_manager.go
@@ -81,7 +81,7 @@ func (m *AccountManager) ProxyRequest(rpcReq *wecommon.RPCRequest, rpcResp *inte
 		}
 		subscriptionID, ok := rpcReq.Params[0].(string)
 		if !ok {
-			return fmt.Errorf("subscriptionID needs to be a string. Got: %d", rpcReq.Params[0])
+			return fmt.Errorf("subscriptionID needs to be a string. Got: %v", rpcReq.Params[0])
 		}
 		m.subscriptionsManager.HandleUnsubscribe(subscriptionID, rpcResp)
 		return nil

--- a/tools/walletextension/accountmanager/account_manager.go
+++ b/tools/walletextension/accountmanager/account_manager.go
@@ -61,6 +61,8 @@ func (m *AccountManager) AddClient(address gethcommon.Address, client *rpc.EncRP
 // ProxyRequest tries to identify the correct EncRPCClient to proxy the request to the Obscuro node, or it will attempt
 // the request with all clients until it succeeds
 func (m *AccountManager) ProxyRequest(rpcReq *wecommon.RPCRequest, rpcResp *interface{}, userConn userconn.UserConn) error {
+	// We need to handle a special case for subscribing and unsubscribing from events,
+	// because we need to handle multiple accounts with a single user request
 	if rpcReq.Method == rpc.Subscribe {
 		clients, err := m.suggestSubscriptionClient(rpcReq)
 		if err != nil {
@@ -71,6 +73,17 @@ func (m *AccountManager) ProxyRequest(rpcReq *wecommon.RPCRequest, rpcResp *inte
 			m.logger.Error("Error subscribing to multiple clients")
 			return err
 		}
+		return nil
+	}
+	if rpcReq.Method == rpc.Unsubscribe {
+		if len(rpcReq.Params) != 1 {
+			return fmt.Errorf("one parameter (subscriptionID) expected, %d parameters received", len(rpcReq.Params))
+		}
+		subscriptionID, ok := rpcReq.Params[0].(string)
+		if !ok {
+			return fmt.Errorf("subscriptionID needs to be a string. Got: %d", rpcReq.Params[0])
+		}
+		m.subscriptionsManager.HandleUnsubscribe(subscriptionID, rpcResp)
 		return nil
 	}
 	return m.executeCall(rpcReq, rpcResp)

--- a/tools/walletextension/subscriptions/subscriptions.go
+++ b/tools/walletextension/subscriptions/subscriptions.go
@@ -108,6 +108,7 @@ func (sm *SubscriptionManager) unsubscribeAndRemove(userSubscriptionID string, s
 
 	subscriptions, exists := sm.subscriptionMappings[userSubscriptionID]
 	if !exists {
+		sm.logger.Error("subscription that needs to be removed is not present in subscriptionMappings for userSubscriptionID: %s", userSubscriptionID)
 		return
 	}
 

--- a/tools/walletextension/subscriptions/subscriptions.go
+++ b/tools/walletextension/subscriptions/subscriptions.go
@@ -56,9 +56,8 @@ func (sm *SubscriptionManager) HandleNewSubscriptions(clients []rpc.Client, req 
 			return fmt.Errorf("could not call %s with params %v. Cause: %w", req.Method, req.Params, err)
 		}
 		sm.UpdateSubscriptionMapping(string(userSubscriptionID), subscription)
-		
+
 		// We periodically check if the websocket is closed, and terminate the subscription.
-		// TODO: test this feature in integration test
 		go checkIfUserConnIsClosedAndUnsubscribe(userConn, subscription, &sm.mu)
 	}
 

--- a/tools/walletextension/subscriptions/subscriptions.go
+++ b/tools/walletextension/subscriptions/subscriptions.go
@@ -186,7 +186,6 @@ func prepareLogResponse(idAndLog common.IDAndLog, userSubscriptionID gethrpc.ID)
 
 func (sm *SubscriptionManager) HandleUnsubscribe(userSubscriptionID string, rpcResp *interface{}) {
 	subscriptions, exists := sm.subscriptionMappings[userSubscriptionID]
-
 	if !exists {
 		*rpcResp = false
 		return


### PR DESCRIPTION
### Why this change is needed

Since we  (can) have multiple accounts/addresses registered per user and Obscuro Gateway subscribes for all of them. We return  new subscriptionID. And in case users wants to unsubscribe we want to make sure the gateway also unsubscribes from all subscriptions to the node that are/were related to that specific subscriptionID.

### What changes were made as part of this PR

Please provide a high level list of the changes made

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


